### PR TITLE
docs: mark the generated schema page as auto-generated

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -4,6 +4,10 @@ sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
 
+{/* AUTO-GENERATED — DO NOT EDIT BY HAND.
+    Generated from spec/v1/schema.md by docs/scripts/sync-spec.mjs.
+    Regenerate: node docs/scripts/sync-spec.mjs */}
+
 <Note>
 This page is generated from [`spec/v1/schema.md`](https://github.com/sightmap/sightmap/blob/main/spec/v1/schema.md) —
 do not edit it here. The canonical file and

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -7,14 +7,6 @@ sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
 
-<Note>
-This page is generated from [`spec/v1/schema.md`](https://github.com/sightmap/sightmap/blob/main/spec/v1/schema.md) —
-do not edit it here. The canonical file and
-[`sightmap.schema.json`](https://github.com/sightmap/sightmap/blob/main/spec/v1/sightmap.schema.json) win on any
-disagreement. Regenerate with `node docs/scripts/sync-spec.mjs`.
-</Note>
-
-
 > **Status**: spec stream `1`, project semver **0.1.0** (pre-1.0). In-place tightening allowed until the project hits 1.0.0. See [the versioning policy](/reference/versioning).
 
 A sightmap is a directory of YAML files at the root of a project, under `.sightmap/`. It describes the app's **views**, **components**, and **requests**, with optional **memory** entries that carry notes agents can use at runtime.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -7,6 +7,14 @@ sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
 
+<Note>
+This page is generated from [`spec/v1/schema.md`](https://github.com/sightmap/sightmap/blob/main/spec/v1/schema.md) —
+do not edit it here. The canonical file and
+[`sightmap.schema.json`](https://github.com/sightmap/sightmap/blob/main/spec/v1/sightmap.schema.json) win on any
+disagreement. Regenerate with `node docs/scripts/sync-spec.mjs`.
+</Note>
+
+
 > **Status**: spec stream `1`, project semver **0.1.0** (pre-1.0). In-place tightening allowed until the project hits 1.0.0. See [the versioning policy](/reference/versioning).
 
 A sightmap is a directory of YAML files at the root of a project, under `.sightmap/`. It describes the app's **views**, **components**, and **requests**, with optional **memory** entries that carry notes agents can use at runtime.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,12 +1,11 @@
 ---
+# AUTO-GENERATED — DO NOT EDIT BY HAND.
+# Generated from spec/v1/schema.md by docs/scripts/sync-spec.mjs.
+# Regenerate: node docs/scripts/sync-spec.mjs
 title: "Sightmap Schema Reference"
 sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
-
-{/* AUTO-GENERATED — DO NOT EDIT BY HAND.
-    Generated from spec/v1/schema.md by docs/scripts/sync-spec.mjs.
-    Regenerate: node docs/scripts/sync-spec.mjs */}
 
 <Note>
 This page is generated from [`spec/v1/schema.md`](https://github.com/sightmap/sightmap/blob/main/spec/v1/schema.md) —

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -7,13 +7,6 @@ sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
 
-<Note>
-This page is generated from [`spec/v1/schema.md`](https://github.com/sightmap/sightmap/blob/main/spec/v1/schema.md) —
-do not edit it here. The canonical file and
-[`sightmap.schema.json`](https://github.com/sightmap/sightmap/blob/main/spec/v1/sightmap.schema.json) win on any
-disagreement. Regenerate with `node docs/scripts/sync-spec.mjs`.
-</Note>
-
 
 > **Status**: spec stream `1`, project semver **0.1.0** (pre-1.0). In-place tightening allowed until the project hits 1.0.0. See [the versioning policy](/reference/versioning).
 

--- a/docs/scripts/sync-spec.mjs
+++ b/docs/scripts/sync-spec.mjs
@@ -36,14 +36,13 @@ body = body
   .replace(/\]\(sightmap\.schema\.json\)/g, `](${BLOB}/spec/v1/sightmap.schema.json)`);
 
 const frontmatter = `---
+# AUTO-GENERATED — DO NOT EDIT BY HAND.
+# Generated from spec/v1/schema.md by docs/scripts/sync-spec.mjs.
+# Regenerate: node docs/scripts/sync-spec.mjs
 title: "Sightmap Schema Reference"
 sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
-
-{/* AUTO-GENERATED — DO NOT EDIT BY HAND.
-    Generated from spec/v1/schema.md by docs/scripts/sync-spec.mjs.
-    Regenerate: node docs/scripts/sync-spec.mjs */}
 
 <Note>
 This page is generated from [\`spec/v1/schema.md\`](${BLOB}/spec/v1/schema.md) —

--- a/docs/scripts/sync-spec.mjs
+++ b/docs/scripts/sync-spec.mjs
@@ -41,6 +41,10 @@ sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
 
+{/* AUTO-GENERATED — DO NOT EDIT BY HAND.
+    Generated from spec/v1/schema.md by docs/scripts/sync-spec.mjs.
+    Regenerate: node docs/scripts/sync-spec.mjs */}
+
 <Note>
 This page is generated from [\`spec/v1/schema.md\`](${BLOB}/spec/v1/schema.md) —
 do not edit it here. The canonical file and

--- a/docs/scripts/sync-spec.mjs
+++ b/docs/scripts/sync-spec.mjs
@@ -43,13 +43,6 @@ title: "Sightmap Schema Reference"
 sidebarTitle: "Schema"
 description: "Exhaustive field-level reference for the Sightmap v1 YAML format, generated from the canonical spec."
 ---
-
-<Note>
-This page is generated from [\`spec/v1/schema.md\`](${BLOB}/spec/v1/schema.md) —
-do not edit it here. The canonical file and
-[\`sightmap.schema.json\`](${BLOB}/spec/v1/sightmap.schema.json) win on any
-disagreement. Regenerate with \`node docs/scripts/sync-spec.mjs\`.
-</Note>
 `;
 
 mkdirSync(dirname(out), { recursive: true });


### PR DESCRIPTION
`docs/scripts/sync-spec.mjs` now emits an MDX `{/* AUTO-GENERATED … */}` banner at the top of the body when it writes `docs/reference/schema.md`, so anyone opening the raw file sees it's generated from `spec/v1/schema.md`.

The comment uses the same MDX machinery as the existing `<Note>` in that file, so Mintlify should strip it from the rendered page.

**Why the PR:** to eyeball the Mintlify deploy preview and confirm the comment does not leak into the rendered docs (Zed's plain-markdown preview shows it, which doesn't reflect MDX behavior).

Regenerated the checked-in page so CI's drift check stays green.