### PR TITLE
chore(skills): sweep orphaned copies, add Cursor manifest, sync plugin versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "sightmap",
       "source": "./",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "description": "Author and maintain .sightmap/ corpora and drive a live browser via annotated component snapshots",
       "category": "development",
       "keywords": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sightmap",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Author and maintain .sightmap/ corpora and drive a live browser via annotated component snapshots",
   "author": {
     "name": "Sightmap",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,12 +1,10 @@
 {
   "name": "sightmap",
-  "version": "0.14.0",
   "description": "Author and maintain .sightmap/ corpora and drive a live browser via annotated component snapshots",
+  "version": "0.14.0",
   "license": "MIT",
-  "homepage": "https://sightmap.org",
   "author": {
     "name": "Sightmap",
     "url": "https://sightmap.org"
-  },
-  "skills": "./skills/"
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,13 +49,21 @@ Never change spec semantics without an SEP (`spec/seps/`).
   pattern as the docs schema page). Regenerate with `go generate ./skills/...`
   from `go/`; CI fails on any drift.
 - Three delivery paths, one source: (1) **plugin** — root manifests
-  (`.claude-plugin/`, `.codex-plugin/`) expose `skills/` so the repo installs like
-  any plugin; (2) **CLI** — `sightmap skills install` extracts the embedded copy;
-  (3) **npm** — the skills ship inside the `@sightmap/sightmap` package (`files`
-  includes `skills/`; `go/npm/scripts/build-npm-packages.mjs` copies them into the
-  meta package) so downstream tools like Subtext vendor them from a pinned version.
+  (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`) expose `skills/` so the
+  repo installs like any plugin; (2) **CLI** — `sightmap skills install` extracts
+  the embedded copy; (3) **npm** — the skills ship inside the `@sightmap/sightmap`
+  package (`files` includes `skills/`; `go/npm/scripts/build-npm-packages.mjs`
+  copies them into the meta package) so downstream tools like Subtext vendor them
+  from a pinned version.
 - When adding a new skill, create `skills/<name>/`, add it to the `//go:embed`
-  list in `go/skills/embed.go`, and regenerate.
+  list in `go/skills/embed.go`, and regenerate. (`go generate` also removes any
+  `go/skills/<name>` copy whose canonical source was renamed or dropped.)
+- The plugin manifests carry their own `version` fields (shown in harness UIs)
+  that the tag-driven release does **not** touch. Keep them in sync from
+  `go/npm/package.json` with `node scripts/sync-plugin-versions.mjs`. Release
+  prep: bump `go/npm/package.json`, run the sync, commit, then tag. (Gemini is
+  intentionally not a target — its extension manifest is MCP-only and has no
+  skills concept.)
 
 ### `docs/`
 - Mintlify site: `npm i -g mint`, then `mint dev` from `docs/`. See `docs/AGENTS.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Never change spec semantics without an SEP (`spec/seps/`).
   `go/skills/<name>` copy whose canonical source was renamed or dropped.)
 - The plugin manifests carry their own `version` fields (shown in harness UIs)
   that the tag-driven release does **not** touch. Keep them in sync from
-  `go/npm/package.json` with `node scripts/sync-plugin-versions.mjs`. Release
+  `go/npm/package.json` with `node scripts/sync-manifest-versions.mjs`. Release
   prep: bump `go/npm/package.json`, run the sync, commit, then tag. (Gemini is
   intentionally not a target — its extension manifest is MCP-only and has no
   skills concept.)

--- a/go/npm/package.json
+++ b/go/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sightmap/sightmap",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "sightmap authoring toolkit — live browser capture, annotated component snapshots, and coverage (native binary, no Go toolchain required)",
   "license": "MIT",
   "homepage": "https://sightmap.org",

--- a/go/skills/internal/gen/main.go
+++ b/go/skills/internal/gen/main.go
@@ -48,6 +48,35 @@ func run() error {
 		return fmt.Errorf("read canonical skills %s: %w", srcRoot, err)
 	}
 
+	// Names of the canonical skills. Everything else under pkgDir that looks like
+	// a generated skill copy is an orphan (a skill renamed or dropped upstream)
+	// and must be removed — otherwise a stale copy lingers and CI drift checks
+	// would not catch it.
+	canonical := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() {
+			canonical[e.Name()] = true
+		}
+	}
+
+	// pkgKeep are non-skill entries in pkgDir that the generator must never touch.
+	pkgKeep := map[string]bool{"internal": true}
+
+	pkgEntries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		return fmt.Errorf("read package dir %s: %w", pkgDir, err)
+	}
+	for _, e := range pkgEntries {
+		if !e.IsDir() || pkgKeep[e.Name()] || canonical[e.Name()] {
+			continue
+		}
+		orphan := filepath.Join(pkgDir, e.Name())
+		if err := os.RemoveAll(orphan); err != nil {
+			return fmt.Errorf("remove orphaned skill %s: %w", orphan, err)
+		}
+		fmt.Printf("gen-skills: removed orphaned skill copy %s\n", e.Name())
+	}
+
 	var synced []string
 	for _, e := range entries {
 		if !e.IsDir() {

--- a/scripts/sync-manifest-versions.mjs
+++ b/scripts/sync-manifest-versions.mjs
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
-// Sync the plugin manifest versions to the sightmap package version.
+// Sync the per-harness manifest versions to the sightmap package version.
 //
-// The release is tag-driven (goreleaser + the npm publish take the version from
-// the pushed git tag), but the root plugin manifests carry their own `version`
-// fields that the harness UIs display. Those are not touched by the release
-// flow, so they drift. This script writes a single source-of-truth version into
-// every manifest.
+// The root plugin manifests (.claude-plugin/, .codex-plugin/, .cursor-plugin/)
+// and the marketplace listing carry their own `version` fields that the
+// harnesses' UIs display. This script writes a single source-of-truth version
+// into every manifest.
 //
-// Source of truth: go/npm/package.json's `version` (override with --version).
+// This is the sightmap counterpart to subtext's scripts/sync-manifest-versions.mjs
+// and behaves identically. It differs only where the two repos legitimately
+// differ:
+//   - Version source: subtext reads the root package.json (bumped by changesets);
+//     sightmap's release is tag-driven, so the source of truth is
+//     go/npm/package.json's `version` (override with --version, e.g. from a tag).
+//   - Manifest set: sightmap ships no Gemini extension (its manifest is MCP-only
+//     and has no skills concept), so gemini-extension.json is not in the list.
+//
 // Release prep: bump go/npm/package.json, run this, commit, then tag.
 //
 // Pure Node.js (no deps). Idempotent.
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -23,11 +30,12 @@ function arg(name) {
   return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : undefined;
 }
 
-const metaPkg = JSON.parse(readFileSync(join(REPO_ROOT, 'go', 'npm', 'package.json'), 'utf8'));
-const version = (arg('version') ?? metaPkg.version).replace(/^v/, '');
+const { version: pkgVersion } = JSON.parse(
+  readFileSync(join(REPO_ROOT, 'go', 'npm', 'package.json'), 'utf8'),
+);
+const version = (arg('version') ?? pkgVersion).replace(/^v/, '');
 
-// Manifests whose top-level `version` field mirrors the package version.
-const TOP_LEVEL_MANIFESTS = [
+const PER_HARNESS_MANIFESTS = [
   '.claude-plugin/plugin.json',
   '.codex-plugin/plugin.json',
   '.cursor-plugin/plugin.json',
@@ -35,7 +43,7 @@ const TOP_LEVEL_MANIFESTS = [
 
 let touched = 0;
 
-for (const rel of TOP_LEVEL_MANIFESTS) {
+for (const rel of PER_HARNESS_MANIFESTS) {
   const path = join(REPO_ROOT, rel);
   if (!existsSync(path)) continue;
   const json = JSON.parse(readFileSync(path, 'utf8'));
@@ -59,5 +67,5 @@ if (existsSync(marketplacePath)) {
 }
 
 if (touched === 0) {
-  console.log(`sync: all plugin manifests already at ${version}`);
+  console.log(`sync: all manifests already at ${version}`);
 }

--- a/scripts/sync-plugin-versions.mjs
+++ b/scripts/sync-plugin-versions.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Sync the plugin manifest versions to the sightmap package version.
+//
+// The release is tag-driven (goreleaser + the npm publish take the version from
+// the pushed git tag), but the root plugin manifests carry their own `version`
+// fields that the harness UIs display. Those are not touched by the release
+// flow, so they drift. This script writes a single source-of-truth version into
+// every manifest.
+//
+// Source of truth: go/npm/package.json's `version` (override with --version).
+// Release prep: bump go/npm/package.json, run this, commit, then tag.
+//
+// Pure Node.js (no deps). Idempotent.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function arg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : undefined;
+}
+
+const metaPkg = JSON.parse(readFileSync(join(REPO_ROOT, 'go', 'npm', 'package.json'), 'utf8'));
+const version = (arg('version') ?? metaPkg.version).replace(/^v/, '');
+
+// Manifests whose top-level `version` field mirrors the package version.
+const TOP_LEVEL_MANIFESTS = [
+  '.claude-plugin/plugin.json',
+  '.codex-plugin/plugin.json',
+  '.cursor-plugin/plugin.json',
+];
+
+let touched = 0;
+
+for (const rel of TOP_LEVEL_MANIFESTS) {
+  const path = join(REPO_ROOT, rel);
+  if (!existsSync(path)) continue;
+  const json = JSON.parse(readFileSync(path, 'utf8'));
+  if (json.version === version) continue;
+  json.version = version;
+  writeFileSync(path, JSON.stringify(json, null, 2) + '\n');
+  console.log(`sync: ${rel} → ${version}`);
+  touched++;
+}
+
+// marketplace.json: version lives under plugins[0].
+const marketplacePath = join(REPO_ROOT, '.claude-plugin/marketplace.json');
+if (existsSync(marketplacePath)) {
+  const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
+  if (marketplace.plugins?.[0] && marketplace.plugins[0].version !== version) {
+    marketplace.plugins[0].version = version;
+    writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + '\n');
+    console.log(`sync: .claude-plugin/marketplace.json (plugins[0]) → ${version}`);
+    touched++;
+  }
+}
+
+if (touched === 0) {
+  console.log(`sync: all plugin manifests already at ${version}`);
+}


### PR DESCRIPTION
Follow-ups to the skills-layout work (#6), addressing a Bugbot-style orphan bug and rounding out the standalone-plugin story.

## Changes

- **Generator sweeps orphans.** `go generate ./skills/...` now removes any `go/skills/<name>` copy whose canonical source at `skills/<name>` was renamed or dropped (preserving `embed.go` and `internal/`). Previously a stale embedded copy would linger, and the CI drift check wouldn't catch it. Same class of bug that Cursor Bugbot flagged in the Subtext vendoring script — fixed symmetrically here. Verified: a planted `sightmap-oldname` orphan is removed; real skills, `internal/`, and `embed.go` are preserved.
- **Cursor manifest.** Added `.cursor-plugin/plugin.json` alongside Claude + Codex. **Gemini is intentionally omitted** — its extension manifest is MCP-only and has no skills concept, so a skills-only, MCP-less Gemini extension would be a no-op.
- **Plugin version sync.** Added `scripts/sync-plugin-versions.mjs`, which writes a single source-of-truth version (`go/npm/package.json`) into all plugin manifests (Claude `plugin.json` + `marketplace.json`, Codex, Cursor). The manifest versions had drifted to `0.13.1`; bumped `go/npm/package.json` and the manifests to `0.14.0` to match the published release. Documented the release-prep step in `AGENTS.md`.

## Validation

`gofmt` clean; `go build ./...`; `go test ./skills/... ./cmd/...` green; `go generate` idempotent with no embedded-skill drift; `sync-plugin-versions.mjs` idempotent.
