### PR TITLE
Extract the viewset package (sets, paths, novelty gate, prune)

### DIFF
--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
 )
 
 func runCapture(args []string) error {
@@ -151,8 +152,8 @@ func runCapture(args []string) error {
 	viewBasename := view.SnapBasename()
 	cov := coverage.Score(root, snapshotMatches, coverage.Options{VisibleOnly: visible})
 	if !*forceFlag {
-		cand := slotsFromMatch(snapshotMatches, cov.Orphans, cov.ParentMap)
-		if res, write := noveltyGate(corpus, *sightmapDirFlag, viewBasename, cand, false); !write {
+		cand := viewset.SlotsFromMatch(snapshotMatches, cov.Orphans, cov.ParentMap)
+		if res, write := viewset.Gate(corpus, *sightmapDirFlag, viewBasename, cand, false); !write {
 			fmt.Fprintf(os.Stderr, "capture: nothing new vs %d capture(s) in %s — not saved (use --force to keep)\n",
 				res.ComparedTo, viewBasename)
 			return nil
@@ -160,7 +161,7 @@ func runCapture(args []string) error {
 	}
 
 	// ── Write the capture into the view's set ─────────────────────────────────
-	snapPath := viewSnapshotPath(*sightmapDirFlag, viewBasename, time.Now())
+	snapPath := viewset.CapturePath(*sightmapDirFlag, viewBasename, time.Now())
 	if err := writeCapture(snapPath, root, view, snapshotMatches, opts); err != nil {
 		return err
 	}
@@ -258,14 +259,14 @@ func runCaptureAll(
 
 		// Novelty gate: don't append a redundant capture to the view set.
 		if !force {
-			cand := slotsFromMatch(snapshotMatches, cov.Orphans, cov.ParentMap)
-			if res, write := noveltyGate(corpus, sightmapDir, v.ViewDir, cand, false); !write {
+			cand := viewset.SlotsFromMatch(snapshotMatches, cov.Orphans, cov.ParentMap)
+			if res, write := viewset.Gate(corpus, sightmapDir, v.ViewDir, cand, false); !write {
 				results = append(results, result{name: label, skipped: true, skippedVs: res.ComparedTo})
 				continue
 			}
 		}
 
-		snapPath := viewSnapshotPath(sightmapDir, v.ViewDir, time.Now())
+		snapPath := viewset.CapturePath(sightmapDir, v.ViewDir, time.Now())
 		if err := writeCapture(snapPath, root, view, snapshotMatches, opts); err != nil {
 			results = append(results, result{name: label, err: err})
 			continue
@@ -333,7 +334,7 @@ func writeCapture(
 		return fmt.Errorf("rename capture file: %v", rerr)
 	}
 
-	if err := writeTreeJSON(root, snapshotTreePath(snapPath)); err != nil {
+	if err := writeTreeJSON(root, viewset.TreePath(snapPath)); err != nil {
 		fmt.Fprintf(os.Stderr, "capture: tree-out: %v\n", err)
 	}
 	return nil

--- a/go/cmd/sightmap/cmd_capture_novelty.go
+++ b/go/cmd/sightmap/cmd_capture_novelty.go
@@ -14,18 +14,14 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
 )
 
 func runCaptureNovelty(args []string) error {
@@ -40,7 +36,7 @@ func runCaptureNovelty(args []string) error {
 	}
 
 	candidate := strings.TrimSuffix(rest[0], ".tree.json")
-	view, _, ok := parseSnapshotPath(candidate)
+	view, _, ok := viewset.ParsePath(candidate)
 	if !ok {
 		return fmt.Errorf("capture-novelty: not a capture path: %s", rest[0])
 	}
@@ -50,87 +46,21 @@ func runCaptureNovelty(args []string) error {
 		return fmt.Errorf("capture-novelty: load corpus: %v", err)
 	}
 
-	candSlots, ok := extractCaptureSlots(candidate, corpus)
+	candSlots, ok := viewset.SlotsForCapture(candidate, corpus)
 	if !ok {
 		return fmt.Errorf("capture-novelty: cannot read candidate tree (%s.tree.json)", candidate)
 	}
 
 	// The rest of the candidate's view set, re-matched against the current corpus
 	// (the candidate itself excluded).
-	others := loadViewSlots(*sightmapDirFlag, view, corpus, candidate)
+	others := viewset.ViewSlots(*sightmapDirFlag, view, corpus, candidate)
 
-	res := computeNovelty(candSlots, others)
+	res := viewset.ComputeNovelty(candSlots, others)
 	printNovelty(view, filepath.Base(candidate), res)
 	return nil
 }
 
-// slotsFromMatch builds a capture's structural fingerprint from an already-matched
-// tree: the component TYPES matched plus the orphan SLOTS left uncovered. Shared
-// by the offline path (extractCaptureSlots) and the live capture path (capture)
-// so both gate on the same notion of "new".
-func slotsFromMatch(
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	t3nodes []*comps.ComponentNode,
-	parentMap map[*comps.ComponentNode]*comps.ComponentNode,
-) captureSlots {
-	cs := captureSlots{Matched: map[string]bool{}, Orphans: map[string]int{}}
-	for _, m := range matches {
-		if m != nil && m.Name != "" {
-			cs.Matched[m.Name] = true
-		}
-	}
-	for _, n := range t3nodes {
-		cs.Orphans[coverage.OrphanSlotKey(n, parentMap)]++
-	}
-	return cs
-}
-
-// extractCaptureSlots re-matches a saved capture against the current corpus and
-// returns its component-type / orphan-slot fingerprint. Visible nodes only,
-// matching the coverage default.
-func extractCaptureSlots(snapPath string, corpus *sightmap.Corpus) (captureSlots, bool) {
-	data, err := os.ReadFile(snapPath + ".tree.json")
-	if err != nil {
-		return captureSlots{}, false
-	}
-	var root comps.ComponentNode
-	if json.Unmarshal(data, &root) != nil {
-		return captureSlots{}, false
-	}
-	matches := corpus.MatchTree(&root, parseSnapRoute(snapPath))
-	cov := coverage.Score(&root, matches, coverage.Options{VisibleOnly: true})
-	return slotsFromMatch(matches, cov.Orphans, cov.ParentMap), true
-}
-
-// loadViewSlots re-matches every capture currently in the view's set against the
-// current corpus, optionally excluding one path.
-func loadViewSlots(sightmapDir, viewBasename string, corpus *sightmap.Corpus, excludePath string) []captureSlots {
-	all, _ := findSnapshots(sightmapDir, nil)
-	entries := groupSnapshotsByView(all)[viewBasename]
-	excl := filepath.ToSlash(excludePath)
-	var out []captureSlots
-	for _, e := range entries {
-		if excl != "" && filepath.ToSlash(e.Path) == excl {
-			continue
-		}
-		if cs, ok := extractCaptureSlots(e.Path, corpus); ok {
-			cs.Stamp = e.Stamp
-			out = append(out, cs)
-		}
-	}
-	return out
-}
-
-// noveltyGate decides whether a freshly extracted capture should be written to
-// its view's set. The first capture of a view always writes; force
-// bypasses the gate. Returns the novelty result and the write decision.
-func noveltyGate(corpus *sightmap.Corpus, sightmapDir, viewBasename string, cand captureSlots, force bool) (noveltyResult, bool) {
-	others := loadViewSlots(sightmapDir, viewBasename, corpus, "")
-	res := computeNovelty(cand, others)
-	return res, force || len(others) == 0 || res.IsNovel()
-}
-
-func printNovelty(view, candName string, res noveltyResult) {
+func printNovelty(view, candName string, res viewset.Novelty) {
 	fmt.Printf("%s · candidate %s vs %d existing capture(s)\n\n",
 		view, candName, res.ComparedTo)
 

--- a/go/cmd/sightmap/cmd_capture_prune.go
+++ b/go/cmd/sightmap/cmd_capture_prune.go
@@ -16,6 +16,7 @@ import (
 	"os"
 
 	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
 )
 
 func runCapturePrune(args []string) error {
@@ -35,8 +36,8 @@ func runCapturePrune(args []string) error {
 	if err != nil {
 		return fmt.Errorf("capture-prune: load corpus: %v", err)
 	}
-	all, _ := findSnapshots(*sightmapDirFlag, nil)
-	sets := groupSnapshotsByView(all)
+	all, _ := viewset.Find(*sightmapDirFlag, nil)
+	sets := viewset.GroupByView(all)
 
 	var views []string
 	if *allFlag {
@@ -60,11 +61,11 @@ func runCapturePrune(args []string) error {
 // pruneView re-matches a view's captures against the current corpus and removes
 // the subsumed ones. Returns how many were pruned (or would be, under
 // --dry-run).
-func pruneView(view string, entries []snapEntry, corpus *sightmap.Corpus, dryRun bool) int {
+func pruneView(view string, entries []viewset.Entry, corpus *sightmap.Corpus, dryRun bool) int {
 	paths := make([]string, 0, len(entries))
-	caps := make([]captureSlots, 0, len(entries))
+	caps := make([]viewset.Slots, 0, len(entries))
 	for _, e := range entries {
-		cs, ok := extractCaptureSlots(e.Path, corpus)
+		cs, ok := viewset.SlotsForCapture(e.Path, corpus)
 		if !ok {
 			continue
 		}
@@ -76,7 +77,7 @@ func pruneView(view string, entries []snapEntry, corpus *sightmap.Corpus, dryRun
 		return 0
 	}
 
-	prune := planPrune(caps)
+	prune := viewset.PlanPrune(caps)
 	if len(prune) == 0 {
 		fmt.Printf("%s: %d capture(s), nothing redundant \u2014 kept all\n", view, len(caps))
 		return 0
@@ -88,7 +89,7 @@ func pruneView(view string, entries []snapEntry, corpus *sightmap.Corpus, dryRun
 	}
 	fmt.Printf("%s: %d capture(s) \u2192 keep %d, %s %d\n", view, len(caps), len(caps)-len(prune), verb, len(prune))
 	for _, idx := range prune {
-		stamp := formatStampDisplay(caps[idx].Stamp)
+		stamp := viewset.FormatStamp(caps[idx].Stamp)
 		if stamp == "" {
 			stamp = "(untimestamped)"
 		}
@@ -97,7 +98,7 @@ func pruneView(view string, entries []snapEntry, corpus *sightmap.Corpus, dryRun
 			if err := os.Remove(paths[idx]); err != nil && !os.IsNotExist(err) {
 				fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
 			}
-			tree := snapshotTreePath(paths[idx])
+			tree := viewset.TreePath(paths[idx])
 			if err := os.Remove(tree); err != nil && !os.IsNotExist(err) {
 				fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
 			}

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
 )
 
 // runCoverage re-runs T1/T2/T3 coverage on saved snap .tree.json files.
@@ -47,7 +48,7 @@ func runCoverage(args []string) error {
 	}
 
 	var err error
-	snapFiles, err := findSnapshots(*sightmapDirFlag, fs.Args())
+	snapFiles, err := viewset.Find(*sightmapDirFlag, fs.Args())
 	if err != nil {
 		return err
 	}
@@ -61,7 +62,7 @@ func runCoverage(args []string) error {
 	// the UNION of the view's snapshots, not a single (possibly reduced) load
 	//. T1/T2/T3 stats stay per-capture — they describe each DOM — but
 	// the [Warnings] / [Presence] sections are computed across the set.
-	sets := groupSnapshotsByView(snapFiles)
+	sets := viewset.GroupByView(snapFiles)
 	views := make([]string, 0, len(sets))
 	for v := range sets {
 		views = append(views, v)
@@ -71,7 +72,7 @@ func runCoverage(args []string) error {
 	failures := 0
 	for _, v := range views {
 		entries := sets[v]
-		var caps []captureMatchCounts
+		var caps []viewset.MatchCounts
 		var capGaps [][]coverage.ContentGap
 		headerView := ""
 		for _, e := range entries {
@@ -86,14 +87,14 @@ func runCoverage(args []string) error {
 			if vName != "" && headerView == "" {
 				headerView = vName
 			}
-			caps = append(caps, captureMatchCounts{Stamp: e.Stamp, Counts: counts, LeafCounts: leafCounts})
+			caps = append(caps, viewset.MatchCounts{Stamp: e.Stamp, Counts: counts, LeafCounts: leafCounts})
 			capGaps = append(capGaps, gaps)
 		}
 
 		if headerView != "" && corpus != nil && len(caps) > 0 {
 			inv := viewComponentNames(corpus, headerView)
 			if len(inv) > 0 {
-				emitUnionWarnings(headerView, unionPresence(inv, caps))
+				emitUnionWarnings(headerView, viewset.UnionPresence(inv, caps))
 			}
 		}
 
@@ -117,7 +118,7 @@ func runCoverage(args []string) error {
 }
 
 // matchCapture loads a saved capture's .tree.json, matches it against the corpus
-// using the snap's own route header (parseSnapRoute), and returns the parsed tree,
+// using the snap's own route header (viewset.RouteOf), and returns the parsed tree,
 // the match map, and that route. ok is false (with a stderr note) when the capture
 // can't be loaded, parsed, or matched. Shared by coverage/report/multi-coverage so
 // every reader matches a capture the same route-aware way instead of
@@ -135,7 +136,7 @@ func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.Compone
 		fmt.Fprintf(os.Stderr, "%s: parse tree JSON: %v\n", filepath.Base(snapPath), err)
 		return nil, nil, "", false
 	}
-	route = parseSnapRoute(snapPath)
+	route = viewset.RouteOf(snapPath)
 	matches = corpus.MatchTree(root, route)
 	return root, matches, route, true
 }
@@ -234,7 +235,7 @@ func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool)
 		checkRootComponents(os.Stdout, view.Components, globalNames, counts, view.Name)
 	}
 
-	return counts, leafCounts, parseViewName(snapPath), t3, gaps, true
+	return counts, leafCounts, viewset.ViewNameOf(snapPath), t3, gaps, true
 }
 
 // checkRootComponents writes a [Snapshot check] warning to w when every
@@ -320,12 +321,12 @@ func viewComponentNames(corpus *sightmap.Corpus, viewName string) []string {
 // is broken (misconfigured ancestor scoping). When even the leaf matches nothing,
 // the component is genuinely absent from this scenario \u2014 typically expected for
 // step-gated UI (e.g. credit card fields on a delivery-step snapshot).
-func emitUnionWarnings(viewName string, pres []componentPresence) {
+func emitUnionWarnings(viewName string, pres []viewset.ComponentPresence) {
 	n := 0
 	if len(pres) > 0 {
 		n = pres[0].Captures
 	}
-	var broken, absent, partial []componentPresence
+	var broken, absent, partial []viewset.ComponentPresence
 	for _, p := range pres {
 		switch {
 		case p.MatchedIn == 0 && p.LeafMatchAny:
@@ -364,7 +365,7 @@ func emitUnionWarnings(viewName string, pres []componentPresence) {
 	if n > 1 && len(partial) > 0 {
 		fmt.Println("[Presence] (matched in a subset of the view's snapshots)")
 		for _, p := range partial {
-			if rec := formatStampDisplay(p.LastMatchedStamp); rec != "" {
+			if rec := viewset.FormatStamp(p.LastMatchedStamp); rec != "" {
 				fmt.Printf("  %s: %s \u2014 matched in %d of %d snaps (last %s)\n", viewName, p.Name, p.MatchedIn, n, rec)
 			} else {
 				fmt.Printf("  %s: %s \u2014 matched in %d of %d snaps\n", viewName, p.Name, p.MatchedIn, n)
@@ -372,36 +373,4 @@ func emitUnionWarnings(viewName string, pres []componentPresence) {
 		}
 		fmt.Println()
 	}
-}
-
-// parseViewName reads the first 10 lines of snapFile and extracts the view name
-// from a "[View: NAME]" header line, returning "" if not found.
-func parseViewName(snapFile string) string {
-	data, err := os.ReadFile(snapFile)
-	if err != nil {
-		return ""
-	}
-	for _, line := range strings.SplitN(string(data), "\n", 10) {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "[View: ") && strings.HasSuffix(line, "]") {
-			return strings.TrimSuffix(strings.TrimPrefix(line, "[View: "), "]")
-		}
-	}
-	return ""
-}
-
-// parseSnapRoute reads the "route: /path" line from a snap file header.
-// Returns "" if not found.
-func parseSnapRoute(snapFile string) string {
-	data, err := os.ReadFile(snapFile)
-	if err != nil {
-		return ""
-	}
-	for _, line := range strings.SplitN(string(data), "\n", 10) {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "route: ") {
-			return strings.TrimPrefix(line, "route: ")
-		}
-	}
-	return ""
 }

--- a/go/cmd/sightmap/cmd_multi_coverage.go
+++ b/go/cmd/sightmap/cmd_multi_coverage.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
 )
 
 // runMultiCoverage shows a cross-page component coverage matrix and surfaces
@@ -22,7 +23,7 @@ func runMultiCoverage(args []string) error {
 		return err
 	}
 
-	snapFiles, err := findSnapshots(*sightmapDirFlag, fs.Args())
+	snapFiles, err := viewset.Find(*sightmapDirFlag, fs.Args())
 	if err != nil {
 		return err
 	}
@@ -38,7 +39,7 @@ func runMultiCoverage(args []string) error {
 
 	// Group captures into per-view sets, then fold each view's captures into one
 	// column whose cell value is the per-component MAX across the set.
-	sets := groupSnapshotsByView(snapFiles)
+	sets := viewset.GroupByView(snapFiles)
 	viewNames := make([]string, 0, len(sets))
 	for v := range sets {
 		viewNames = append(viewNames, v)

--- a/go/cmd/sightmap/cmd_report.go
+++ b/go/cmd/sightmap/cmd_report.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
 )
 
 // captureCoverage is one capture's per-DOM coverage tiers plus its largest T2
@@ -115,7 +116,7 @@ func runReport(args []string) error {
 	for _, v := range views {
 		// Resolve the whole capture set for the view and aggregate over it
 		//; previously report used only the latest capture.
-		set := viewSnapshotSet(*sightmapDirFlag, v.SnapBasename())
+		set := viewset.Set(*sightmapDirFlag, v.SnapBasename())
 		if len(set) == 0 {
 			results = append(results, viewResult{name: v.Name, url: v.URL, missing: true})
 			continue

--- a/go/cmd/sightmap/snapshot_readers_test.go
+++ b/go/cmd/sightmap/snapshot_readers_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -112,43 +110,5 @@ func TestGlobalCandidatesAcrossViews(t *testing.T) {
 	wantHits := []viewHit{{"home", 12}, {"plp", 36}, {"pdp", 6}}
 	if !reflect.DeepEqual(c.Hits, wantHits) {
 		t.Errorf("hits = %+v, want %+v", c.Hits, wantHits)
-	}
-}
-
-func TestViewSnapshotSet(t *testing.T) {
-	dir := t.TempDir()
-	home := filepath.Join(dir, "snapshots", "home")
-	if err := os.MkdirAll(filepath.Join(home, "stale-subdir"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	write := func(rel string) {
-		p := filepath.Join(home, rel)
-		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	// Given out of order, with .tree.json siblings that must NOT become entries.
-	write("20260607T193000Z.snap")
-	write("20260607T193000Z.snap.tree.json")
-	write("20260607T090000Z.snap")
-	write("20260607T090000Z.snap.tree.json")
-	write("20260607T140000Z.snap")
-
-	set := viewSnapshotSet(dir, "home")
-	if len(set) != 3 {
-		t.Fatalf("got %d entries, want 3 (.snap only, subdir excluded): %+v", len(set), set)
-	}
-	// Must be ordered oldest→newest by stamp.
-	wantStamps := []string{"20260607T090000Z", "20260607T140000Z", "20260607T193000Z"}
-	for i, e := range set {
-		if e.Stamp != wantStamps[i] {
-			t.Errorf("entry %d stamp = %q, want %q", i, e.Stamp, wantStamps[i])
-		}
-	}
-}
-
-func TestViewSnapshotSetMissing(t *testing.T) {
-	if set := viewSnapshotSet(t.TempDir(), "nope"); len(set) != 0 {
-		t.Errorf("missing view set = %+v, want empty", set)
 	}
 }

--- a/go/viewset/discovery.go
+++ b/go/viewset/discovery.go
@@ -1,4 +1,4 @@
-package main
+package viewset
 
 import (
 	"fmt"
@@ -7,10 +7,10 @@ import (
 	"strings"
 )
 
-// findSnapshots returns a list of snapshot files to process.
+// Find returns a list of snapshot files to process.
 // If args are provided, use those paths.
 // Otherwise, search for snapshots in both legacy (*.snap) and new (.sightmap/snapshots/**/*.snap) locations.
-func findSnapshots(sightmapDir string, args []string) ([]string, error) {
+func Find(sightmapDir string, args []string) ([]string, error) {
 	if len(args) > 0 {
 		return args, nil
 	}

--- a/go/viewset/novelty.go
+++ b/go/viewset/novelty.go
@@ -1,0 +1,79 @@
+package viewset
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// SlotsFromMatch builds a capture's structural fingerprint from an already-matched
+// tree: the component TYPES matched plus the orphan SLOTS left uncovered. Shared
+// by the offline path (SlotsForCapture) and the live capture path (the capture
+// command) so both gate on the same notion of "new".
+func SlotsFromMatch(
+	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	orphans []*comps.ComponentNode,
+	parentMap coverage.ParentMap,
+) Slots {
+	cs := Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}
+	for _, m := range matches {
+		if m != nil && m.Name != "" {
+			cs.Matched[m.Name] = true
+		}
+	}
+	for _, n := range orphans {
+		cs.Orphans[coverage.OrphanSlotKey(n, parentMap)]++
+	}
+	return cs
+}
+
+// SlotsForCapture re-matches a saved capture against the current corpus and
+// returns its component-type / orphan-slot fingerprint. Visible nodes only,
+// matching the coverage default. ok is false when the capture's .tree.json
+// cannot be read or parsed.
+func SlotsForCapture(snapPath string, corpus *sightmap.Corpus) (Slots, bool) {
+	data, err := os.ReadFile(snapPath + ".tree.json")
+	if err != nil {
+		return Slots{}, false
+	}
+	var root comps.ComponentNode
+	if json.Unmarshal(data, &root) != nil {
+		return Slots{}, false
+	}
+	matches := corpus.MatchTree(&root, RouteOf(snapPath))
+	cov := coverage.Score(&root, matches, coverage.Options{VisibleOnly: true})
+	return SlotsFromMatch(matches, cov.Orphans, cov.ParentMap), true
+}
+
+// ViewSlots re-matches every capture currently in the view's set against the
+// current corpus, optionally excluding one path.
+func ViewSlots(sightmapDir, viewBasename string, corpus *sightmap.Corpus, excludePath string) []Slots {
+	all, _ := Find(sightmapDir, nil)
+	entries := GroupByView(all)[viewBasename]
+	excl := filepath.ToSlash(excludePath)
+	var out []Slots
+	for _, e := range entries {
+		if excl != "" && filepath.ToSlash(e.Path) == excl {
+			continue
+		}
+		if cs, ok := SlotsForCapture(e.Path, corpus); ok {
+			cs.Stamp = e.Stamp
+			out = append(out, cs)
+		}
+	}
+	return out
+}
+
+// Gate decides whether a freshly extracted capture should be written to its
+// view's set. The first capture of a view always writes; force bypasses the
+// gate. Returns the novelty result and the write decision.
+func Gate(corpus *sightmap.Corpus, sightmapDir, viewBasename string, cand Slots, force bool) (Novelty, bool) {
+	others := ViewSlots(sightmapDir, viewBasename, corpus, "")
+	res := ComputeNovelty(cand, others)
+	return res, force || len(others) == 0 || res.IsNovel()
+}

--- a/go/viewset/paths.go
+++ b/go/viewset/paths.go
@@ -1,23 +1,22 @@
-package main
+// Package viewset manages a view's on-disk capture set: the snapshots/<view>/
+// <stamp>.snap layout, capture discovery and grouping, the corpus-relative
+// novelty gate and prune planner, and per-view presence aggregation. A view is a
+// SET of timestamped captures (real pages are non-deterministic), and tooling
+// operates over the union of that set.
+package viewset
 
 import (
 	"path/filepath"
 	"strings"
 )
 
-// snapshotPath returns the full path for a snapshot file in the new organized structure.
-// Example: snapshotPath(".sightmap", "app-home", "base") → ".sightmap/snapshots/app-home/base.snap"
-func snapshotPath(sightmapDir, viewName, snapshotName string) string {
-	return filepath.Join(sightmapDir, "snapshots", viewName, snapshotName+".snap")
-}
-
-// snapshotTreePath returns the tree JSON path for a given snapshot path.
+// TreePath returns the tree JSON path for a given snapshot path.
 // Example: ".sightmap/snapshots/app-home/base.snap" → ".sightmap/snapshots/app-home/base.snap.tree.json"
-func snapshotTreePath(snapPath string) string {
+func TreePath(snapPath string) string {
 	return snapPath + ".tree.json"
 }
 
-// parseSnapshotPath extracts the view name and capture stamp from a snapshot path
+// ParsePath extracts the view name and capture stamp from a snapshot path
 // (or its .snap.tree.json sibling). Since we dropped the named-state
 // segment, a capture lives at snapshots/<view>/<stamp>.snap: the view is the first
 // segment under snapshots/ and the stamp is the last. Legacy forms still parse —
@@ -27,7 +26,7 @@ func snapshotTreePath(snapPath string) string {
 //	snapshots/app-home/20260607T193000Z.snap → ("app-home", "20260607T193000Z", true)
 //	snapshots/app-home/base.snap              → ("app-home", "base", true)
 //	app-home.snap (flat)                      → ("app-home", "", true)
-func parseSnapshotPath(path string) (view, stamp string, ok bool) {
+func ParsePath(path string) (view, stamp string, ok bool) {
 	p := filepath.ToSlash(path)
 	p = strings.TrimSuffix(p, ".tree.json")
 	if !strings.HasSuffix(p, ".snap") {

--- a/go/viewset/paths_test.go
+++ b/go/viewset/paths_test.go
@@ -1,50 +1,8 @@
-package main
+package viewset
 
 import (
 	"testing"
 )
-
-func TestSnapshotPath(t *testing.T) {
-	tests := []struct {
-		name         string
-		sightmapDir  string
-		viewName     string
-		snapshotName string
-		want         string
-	}{
-		{
-			name:         "base snapshot",
-			sightmapDir:  ".sightmap",
-			viewName:     "app-home",
-			snapshotName: "base",
-			want:         ".sightmap/snapshots/app-home/base.snap",
-		},
-		{
-			name:         "named snapshot",
-			sightmapDir:  ".sightmap",
-			viewName:     "product-list",
-			snapshotName: "with-filters-open",
-			want:         ".sightmap/snapshots/product-list/with-filters-open.snap",
-		},
-		{
-			name:         "custom sightmap dir",
-			sightmapDir:  "custom/.sightmap",
-			viewName:     "checkout",
-			snapshotName: "base",
-			want:         "custom/.sightmap/snapshots/checkout/base.snap",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := snapshotPath(tt.sightmapDir, tt.viewName, tt.snapshotName)
-			if got != tt.want {
-				t.Errorf("snapshotPath(%q, %q, %q) = %q, want %q",
-					tt.sightmapDir, tt.viewName, tt.snapshotName, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestSnapshotTreePath(t *testing.T) {
 	tests := []struct {
@@ -66,9 +24,9 @@ func TestSnapshotTreePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := snapshotTreePath(tt.snapPath)
+			got := TreePath(tt.snapPath)
 			if got != tt.want {
-				t.Errorf("snapshotTreePath(%q) = %q, want %q", tt.snapPath, got, tt.want)
+				t.Errorf("TreePath(%q) = %q, want %q", tt.snapPath, got, tt.want)
 			}
 		})
 	}
@@ -128,9 +86,9 @@ func TestParseSnapshotPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotView, gotStamp, gotOk := parseSnapshotPath(tt.path)
+			gotView, gotStamp, gotOk := ParsePath(tt.path)
 			if gotView != tt.wantView || gotStamp != tt.wantStamp || gotOk != tt.wantOk {
-				t.Errorf("parseSnapshotPath(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				t.Errorf("ParsePath(%q) = (%q, %q, %v), want (%q, %q, %v)",
 					tt.path, gotView, gotStamp, gotOk, tt.wantView, tt.wantStamp, tt.wantOk)
 			}
 		})

--- a/go/viewset/readers_test.go
+++ b/go/viewset/readers_test.go
@@ -1,0 +1,45 @@
+package viewset
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestViewSnapshotSet(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "snapshots", "home")
+	if err := os.MkdirAll(filepath.Join(home, "stale-subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(rel string) {
+		p := filepath.Join(home, rel)
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Given out of order, with .tree.json siblings that must NOT become entries.
+	write("20260607T193000Z.snap")
+	write("20260607T193000Z.snap.tree.json")
+	write("20260607T090000Z.snap")
+	write("20260607T090000Z.snap.tree.json")
+	write("20260607T140000Z.snap")
+
+	set := Set(dir, "home")
+	if len(set) != 3 {
+		t.Fatalf("got %d entries, want 3 (.snap only, subdir excluded): %+v", len(set), set)
+	}
+	// Must be ordered oldest→newest by stamp.
+	wantStamps := []string{"20260607T090000Z", "20260607T140000Z", "20260607T193000Z"}
+	for i, e := range set {
+		if e.Stamp != wantStamps[i] {
+			t.Errorf("entry %d stamp = %q, want %q", i, e.Stamp, wantStamps[i])
+		}
+	}
+}
+
+func TestViewSnapshotSetMissing(t *testing.T) {
+	if set := Set(t.TempDir(), "nope"); len(set) != 0 {
+		t.Errorf("missing view set = %+v, want empty", set)
+	}
+}

--- a/go/viewset/sets.go
+++ b/go/viewset/sets.go
@@ -1,4 +1,4 @@
-package main
+package viewset
 
 import (
 	"os"
@@ -14,99 +14,70 @@ import (
 //
 //	snapshots/<view>/<stamp>.snap        (+ .snap.tree.json)
 //
-// where <stamp> is a filesystem-safe UTC timestamp (snapStampLayout). Real pages
+// where <stamp> is a filesystem-safe UTC timestamp (StampLayout). Real pages
 // are non-deterministic (lazy carousels, personalization, rotating promos), so no
 // single capture exercises a view's full component structure. Tooling operates
 // over the UNION of the view's set. We removed the named
 // per-view "state" segment: re-snapping just appends a capture and the novelty
 // gate drops redundant ones, so curated state names aren't needed.
 
-// snapStampLayout formats capture timestamps as filesystem-safe UTC basic
+// StampLayout formats capture timestamps as filesystem-safe UTC basic
 // ISO-8601, e.g. 20260607T193000Z. Lexical order == chronological order.
-const snapStampLayout = "20060102T150405Z"
+const StampLayout = "20060102T150405Z"
 
-// snapshotStamp renders t as a capture-set timestamp segment.
-func snapshotStamp(t time.Time) string { return t.UTC().Format(snapStampLayout) }
+// Stamp renders t as a capture-set timestamp segment.
+func Stamp(t time.Time) string { return t.UTC().Format(StampLayout) }
 
-// viewSnapshotPath returns the path of one timestamped capture in a view's set:
+// CapturePath returns the path of one timestamped capture in a view's set:
 // snapshots/<view>/<stamp>.snap.
-func viewSnapshotPath(sightmapDir, viewName string, t time.Time) string {
-	return filepath.Join(sightmapDir, "snapshots", viewName, snapshotStamp(t)+".snap")
+func CapturePath(sightmapDir, viewName string, t time.Time) string {
+	return filepath.Join(sightmapDir, "snapshots", viewName, Stamp(t)+".snap")
 }
 
-// snapEntry is one capture within a view's set. Stamp is "" for an untimestamped
+// Entry is one capture within a view's set. Stamp is "" for an untimestamped
 // legacy capture (e.g. the flat <view>.snap form).
-type snapEntry struct {
+type Entry struct {
 	Path  string
 	Stamp string
 }
 
-// formatStampDisplay renders a capture stamp (snapStampLayout) for human output,
+// FormatStamp renders a capture stamp (StampLayout) for human output,
 // e.g. "2026-06-07 19:30Z". Returns "" for an empty (untimestamped) stamp and
 // the raw value if it does not parse.
-func formatStampDisplay(stamp string) string {
+func FormatStamp(stamp string) string {
 	if stamp == "" {
 		return ""
 	}
-	t, err := time.Parse(snapStampLayout, stamp)
+	t, err := time.Parse(StampLayout, stamp)
 	if err != nil {
 		return stamp
 	}
 	return t.UTC().Format("2006-01-02 15:04Z")
 }
 
-// latestViewSnapshot returns the path of the most recent .snap capture for a view
-// — the greatest stamp under snapshots/<view>/ — falling back to the legacy flat
-// <view>.snap. ok=false when no capture exists. Used by readers that need ONE
-// representative file for a view (report, pick-time hints); union-aware readers
-// walk the whole set instead.
-func latestViewSnapshot(sightmapDir, viewBasename string) (string, bool) {
-	dir := filepath.Join(sightmapDir, "snapshots", viewBasename)
-	if entries, err := os.ReadDir(dir); err == nil {
-		newest := ""
-		for _, e := range entries {
-			// ".snap.tree.json" ends in ".json", so this keeps only the .snap files;
-			// directories (any stale state subdirs) are skipped.
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".snap") {
-				continue
-			}
-			if e.Name() > newest { // lexical == chronological for snapStampLayout
-				newest = e.Name()
-			}
-		}
-		if newest != "" {
-			return filepath.Join(dir, newest), true
-		}
-	}
-	if flat := viewBasename + ".snap"; fileExists(flat) {
-		return flat, true
-	}
-	return "", false
-}
-
-// viewSnapshotSet returns every .snap capture for a view, ordered oldest→newest by
+// Set returns every .snap capture for a view, ordered oldest→newest by
 // stamp — the whole set under snapshots/<viewBasename>/ — falling back to the
 // legacy flat <viewBasename>.snap when no set dir exists. Empty when the view has
 // no capture. This is the set-aware analogue of latestViewSnapshot, used by readers
 // that aggregate over a view's union (report).
-func viewSnapshotSet(sightmapDir, viewBasename string) []snapEntry {
+func Set(sightmapDir, viewBasename string) []Entry {
 	dir := filepath.Join(sightmapDir, "snapshots", viewBasename)
-	var entries []snapEntry
+	var entries []Entry
 	if des, err := os.ReadDir(dir); err == nil {
 		for _, e := range des {
 			if e.IsDir() || !strings.HasSuffix(e.Name(), ".snap") {
 				continue
 			}
-			_, stamp, ok := parseSnapshotPath("snapshots/" + viewBasename + "/" + e.Name())
+			_, stamp, ok := ParsePath("snapshots/" + viewBasename + "/" + e.Name())
 			if !ok {
 				continue
 			}
-			entries = append(entries, snapEntry{Path: filepath.Join(dir, e.Name()), Stamp: stamp})
+			entries = append(entries, Entry{Path: filepath.Join(dir, e.Name()), Stamp: stamp})
 		}
 	}
 	if len(entries) == 0 {
 		if flat := viewBasename + ".snap"; fileExists(flat) {
-			entries = append(entries, snapEntry{Path: flat, Stamp: ""})
+			entries = append(entries, Entry{Path: flat, Stamp: ""})
 		}
 		return entries
 	}
@@ -124,25 +95,25 @@ func fileExists(path string) bool {
 	return err == nil && !info.IsDir()
 }
 
-// captureMatchCounts is one capture's per-component matched-node counts plus its
+// MatchCounts is one capture's per-component matched-node counts plus its
 // stamp within a view's set. Counts is keyed by component name.
 // LeafCounts holds leaf-part-only match counts for components that got 0 full
 // matches in this capture — used to distinguish broken selectors (leaf matches but
 // full scoped selector doesn't) from genuinely-absent components.
-type captureMatchCounts struct {
+type MatchCounts struct {
 	Stamp      string
 	Counts     map[string]int
 	LeafCounts map[string]int // nil when no dead-component probe was performed
 }
 
-// componentPresence summarizes how often a view component matched across the
+// ComponentPresence summarizes how often a view component matched across the
 // UNION of a view's snapshot set. A component is "alive" if
 // MatchedIn > 0 and "dead" only when MatchedIn == 0 across the whole set, so a
 // component absent from a single reduced load is no longer flagged.
 // LeafMatchAny is set (only meaningful when MatchedIn==0) when at least one
 // capture had nodes matching the component's leaf selector part — indicating a
 // broken scoped selector rather than a legitimately-absent component.
-type componentPresence struct {
+type ComponentPresence struct {
 	Name             string // component name
 	MatchedIn        int    // captures in which it matched >=1 node
 	Captures         int    // size of the set (N)
@@ -151,21 +122,21 @@ type componentPresence struct {
 	LeafMatchAny     bool   // any capture had leaf-part matches (only set when MatchedIn==0)
 }
 
-// unionPresence aggregates per-capture match counts across a state's set into
+// UnionPresence aggregates per-capture match counts across a state's set into
 // per-component presence. components is the view's declared component inventory;
 // every listed component appears in the result (MatchedIn == 0 when union-dead)
 // so callers can report dead components, while counts for names outside the
 // inventory (e.g. globals) are ignored. Result is sorted by component name.
 // Stamps are compared lexically, which equals chronological order for
-// snapStampLayout.
-func unionPresence(components []string, caps []captureMatchCounts) []componentPresence {
+// StampLayout.
+func UnionPresence(components []string, caps []MatchCounts) []ComponentPresence {
 	ordered := make([]string, 0, len(components))
-	byName := make(map[string]*componentPresence, len(components))
+	byName := make(map[string]*ComponentPresence, len(components))
 	for _, name := range components {
 		if name == "" || byName[name] != nil {
 			continue
 		}
-		p := &componentPresence{Name: name, Captures: len(caps)}
+		p := &ComponentPresence{Name: name, Captures: len(caps)}
 		byName[name] = p
 		ordered = append(ordered, name)
 	}
@@ -191,42 +162,42 @@ func unionPresence(components []string, caps []captureMatchCounts) []componentPr
 		}
 	}
 	sort.Strings(ordered)
-	out := make([]componentPresence, 0, len(ordered))
+	out := make([]ComponentPresence, 0, len(ordered))
 	for _, name := range ordered {
 		out = append(out, *byName[name])
 	}
 	return out
 }
 
-// captureSlots is the corpus-relative structural fingerprint of one capture used
+// Slots is the corpus-relative structural fingerprint of one capture used
 // by snapshot novelty: the component TYPES it matched and the
 // uncovered-interactive SLOTS it left orphaned. Both are computed by re-matching
 // the capture against the CURRENT corpus, so a capture's novelty is re-evaluated
 // as the corpus matures (which is what lets redundant captures be pruned later).
-type captureSlots struct {
+type Slots struct {
 	Stamp   string
 	Matched map[string]bool // component names matched (>=1 node)
 	Orphans map[string]int  // orphan slot key (orphanSlotKey) -> count
 }
 
-// noveltyResult is what a candidate capture adds vs the UNION of the existing set
+// Novelty is what a candidate capture adds vs the UNION of the existing set
 // (the other captures of its (view, state)). A capture is worth keeping iff it is
 // novel — i.e. it expands the union with a new component type or a new orphan slot.
-type noveltyResult struct {
+type Novelty struct {
 	ComparedTo      int            // number of existing captures unioned against
 	NovelComponents []string       // component types matched here, in no existing capture (sorted)
 	NovelOrphans    map[string]int // orphan slot key -> count in candidate, new vs the union
 }
 
 // IsNovel reports whether the candidate expands the union at all.
-func (r noveltyResult) IsNovel() bool {
+func (r Novelty) IsNovel() bool {
 	return len(r.NovelComponents) > 0 || len(r.NovelOrphans) > 0
 }
 
-// computeNovelty diffs a candidate capture's slots against the union of the other
+// ComputeNovelty diffs a candidate capture's slots against the union of the other
 // captures in its set. Additive-only: it reports what the candidate ADDS, never
 // what it lacks (lost-component detection is a separate, deferred problem).
-func computeNovelty(cand captureSlots, others []captureSlots) noveltyResult {
+func ComputeNovelty(cand Slots, others []Slots) Novelty {
 	unionMatched := map[string]bool{}
 	unionOrphan := map[string]bool{}
 	for _, o := range others {
@@ -237,7 +208,7 @@ func computeNovelty(cand captureSlots, others []captureSlots) noveltyResult {
 			unionOrphan[k] = true
 		}
 	}
-	res := noveltyResult{ComparedTo: len(others), NovelOrphans: map[string]int{}}
+	res := Novelty{ComparedTo: len(others), NovelOrphans: map[string]int{}}
 	for c := range cand.Matched {
 		if !unionMatched[c] {
 			res.NovelComponents = append(res.NovelComponents, c)
@@ -252,15 +223,15 @@ func computeNovelty(cand captureSlots, others []captureSlots) noveltyResult {
 	return res
 }
 
-// planPrune returns the indices (into caps) of captures that are SUBSUMED and can
+// PlanPrune returns the indices (into caps) of captures that are SUBSUMED and can
 // be dropped without shrinking the view's union. A capture is
 // subsumed when it adds no new component type or orphan slot vs the OTHERS — i.e.
-// computeNovelty(c, others) is not novel. Pruning is iterative and conservative:
+// ComputeNovelty(c, others) is not novel. Pruning is iterative and conservative:
 // each pass drops the first subsumed capture (scanning in the given order, so
 // pass oldest-first to retire stale duplicates), then recomputes, so two
 // identical captures collapse to one rather than both vanishing. The surviving
 // set's union equals the original's.
-func planPrune(caps []captureSlots) []int {
+func PlanPrune(caps []Slots) []int {
 	alive := make([]int, len(caps))
 	for i := range alive {
 		alive[i] = i
@@ -272,13 +243,13 @@ func planPrune(caps []captureSlots) []int {
 			if len(alive) <= 1 {
 				break // never prune the last capture
 			}
-			others := make([]captureSlots, 0, len(alive)-1)
+			others := make([]Slots, 0, len(alive)-1)
 			for p2, idx2 := range alive {
 				if p2 != pos {
 					others = append(others, caps[idx2])
 				}
 			}
-			if !computeNovelty(caps[alive[pos]], others).IsNovel() {
+			if !ComputeNovelty(caps[alive[pos]], others).IsNovel() {
 				victim = pos
 				break
 			}
@@ -292,16 +263,16 @@ func planPrune(caps []captureSlots) []int {
 	return pruned
 }
 
-// groupSnapshotsByView groups snapshot file paths into per-view sets, each ordered
+// GroupByView groups snapshot file paths into per-view sets, each ordered
 // oldest→newest by capture stamp (untimestamped legacy captures, stamp "", sort
 // first). Non-snapshot paths are skipped. Accepts either .snap or .snap.tree.json
 // paths; the .snap path is canonical, so a .snap and its .tree.json sibling
 // collapse to one entry.
-func groupSnapshotsByView(files []string) map[string][]snapEntry {
-	sets := make(map[string][]snapEntry)
+func GroupByView(files []string) map[string][]Entry {
+	sets := make(map[string][]Entry)
 	seen := make(map[string]bool)
 	for _, f := range files {
-		view, stamp, ok := parseSnapshotPath(f)
+		view, stamp, ok := ParsePath(f)
 		if !ok {
 			continue
 		}
@@ -311,7 +282,7 @@ func groupSnapshotsByView(files []string) map[string][]snapEntry {
 			continue
 		}
 		seen[snapPath] = true
-		sets[view] = append(sets[view], snapEntry{Path: snapPath, Stamp: stamp})
+		sets[view] = append(sets[view], Entry{Path: snapPath, Stamp: stamp})
 	}
 	for view, entries := range sets {
 		sort.Slice(entries, func(i, j int) bool {

--- a/go/viewset/sets_test.go
+++ b/go/viewset/sets_test.go
@@ -1,8 +1,6 @@
-package main
+package viewset
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 )
@@ -11,12 +9,12 @@ func TestSnapshotStamp(t *testing.T) {
 	// A fixed instant in a non-UTC zone must render as UTC basic ISO-8601.
 	loc := time.FixedZone("UTC-5", -5*3600)
 	at := time.Date(2026, 6, 7, 14, 30, 0, 0, loc) // 19:30:00 UTC
-	if got, want := snapshotStamp(at), "20260607T193000Z"; got != want {
-		t.Fatalf("snapshotStamp = %q, want %q", got, want)
+	if got, want := Stamp(at), "20260607T193000Z"; got != want {
+		t.Fatalf("Stamp = %q, want %q", got, want)
 	}
 	// Lexical order must equal chronological order.
-	earlier := snapshotStamp(time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC))
-	later := snapshotStamp(time.Date(2026, 6, 7, 19, 30, 0, 0, time.UTC))
+	earlier := Stamp(time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC))
+	later := Stamp(time.Date(2026, 6, 7, 19, 30, 0, 0, time.UTC))
 	if !(earlier < later) {
 		t.Fatalf("stamp lexical order broken: %q !< %q", earlier, later)
 	}
@@ -24,10 +22,10 @@ func TestSnapshotStamp(t *testing.T) {
 
 func TestViewSnapshotPath(t *testing.T) {
 	at := time.Date(2026, 6, 7, 19, 30, 0, 0, time.UTC)
-	got := viewSnapshotPath(".sightmap", "home", at)
+	got := CapturePath(".sightmap", "home", at)
 	want := ".sightmap/snapshots/home/20260607T193000Z.snap"
 	if got != want {
-		t.Fatalf("viewSnapshotPath = %q, want %q", got, want)
+		t.Fatalf("CapturePath = %q, want %q", got, want)
 	}
 }
 
@@ -44,7 +42,7 @@ func TestGroupSnapshotsByView(t *testing.T) {
 		// Noise that must be skipped.
 		"notes.txt",
 	}
-	sets := groupSnapshotsByView(files)
+	sets := GroupByView(files)
 
 	home := sets["home"]
 	if len(home) != 3 {
@@ -69,16 +67,16 @@ func TestUnionPresence(t *testing.T) {
 	// A 2-capture set where each load omits a different section (the HD-home
 	// non-determinism case): Endcap renders only in the older snap, Recs only in
 	// the newer one, Header in both, and Footer in neither.
-	caps := []captureMatchCounts{
+	caps := []MatchCounts{
 		{Stamp: "20260607T090000Z", Counts: map[string]int{"Header": 1, "Endcap": 4, "GlobalNav": 7}},
 		{Stamp: "20260607T193000Z", Counts: map[string]int{"Header": 1, "Recs": 6}},
 	}
 	inventory := []string{"Header", "Endcap", "Recs", "Footer"}
 
-	pres := unionPresence(inventory, caps)
+	pres := UnionPresence(inventory, caps)
 
 	// Sorted by name: Endcap, Footer, Header, Recs.
-	by := map[string]componentPresence{}
+	by := map[string]ComponentPresence{}
 	for _, p := range pres {
 		by[p.Name] = p
 	}
@@ -110,11 +108,11 @@ func TestUnionPresence(t *testing.T) {
 func TestUnionPresenceSingleUntimestamped(t *testing.T) {
 	// A single legacy (untimestamped) capture behaves like the old per-snap check:
 	// present components are alive (no recency stamp), absent ones are dead.
-	caps := []captureMatchCounts{
+	caps := []MatchCounts{
 		{Stamp: "", Counts: map[string]int{"Header": 2}},
 	}
-	pres := unionPresence([]string{"Header", "Footer"}, caps)
-	by := map[string]componentPresence{}
+	pres := UnionPresence([]string{"Header", "Footer"}, caps)
+	by := map[string]ComponentPresence{}
 	for _, p := range pres {
 		by[p.Name] = p
 	}
@@ -126,38 +124,8 @@ func TestUnionPresenceSingleUntimestamped(t *testing.T) {
 	}
 }
 
-func TestLatestViewSnapshot(t *testing.T) {
-	dir := t.TempDir()
-	write := func(rel string) string {
-		p := filepath.Join(dir, rel)
-		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		return p
-	}
-
-	// Newest stamp under the view dir wins; the .tree.json sibling is ignored.
-	write("snapshots/home/20260607T090000Z.snap")
-	write("snapshots/home/20260607T090000Z.snap.tree.json")
-	newest := write("snapshots/home/20260607T193000Z.snap")
-	write("snapshots/home/20260607T193000Z.snap.tree.json")
-
-	got, ok := latestViewSnapshot(dir, "home")
-	if !ok || got != newest {
-		t.Errorf("view set: got (%q, %v), want (%q, true)", got, ok, newest)
-	}
-
-	// Missing view.
-	if got, ok := latestViewSnapshot(dir, "search"); ok {
-		t.Errorf("missing: got (%q, %v), want ok=false", got, ok)
-	}
-}
-
 func TestComputeNovelty(t *testing.T) {
-	slots := func(matched []string, orphans map[string]int) captureSlots {
+	slots := func(matched []string, orphans map[string]int) Slots {
 		m := map[string]bool{}
 		for _, c := range matched {
 			m[c] = true
@@ -165,7 +133,7 @@ func TestComputeNovelty(t *testing.T) {
 		if orphans == nil {
 			orphans = map[string]int{}
 		}
-		return captureSlots{Matched: m, Orphans: orphans}
+		return Slots{Matched: m, Orphans: orphans}
 	}
 
 	// Candidate uniquely renders DigitalEndcap (a new component type) and has a
@@ -174,12 +142,12 @@ func TestComputeNovelty(t *testing.T) {
 		[]string{"Header", "DigitalEndcap", "ProductPod"},
 		map[string]int{`button @ div[data-testid="endcap"]`: 3, `link @ (no stable ancestor)`: 1},
 	)
-	others := []captureSlots{
+	others := []Slots{
 		slots([]string{"Header", "ProductPod"}, map[string]int{`link @ (no stable ancestor)`: 1}),
 		slots([]string{"Header"}, nil),
 	}
 
-	res := computeNovelty(cand, others)
+	res := ComputeNovelty(cand, others)
 	if !res.IsNovel() {
 		t.Fatalf("expected novel, got %+v", res)
 	}
@@ -198,37 +166,37 @@ func TestComputeNovelty(t *testing.T) {
 
 	// A redundant re-capture (subset of the union) is not novel.
 	dup := slots([]string{"Header", "ProductPod"}, map[string]int{`link @ (no stable ancestor)`: 5})
-	if r := computeNovelty(dup, others); r.IsNovel() {
+	if r := ComputeNovelty(dup, others); r.IsNovel() {
 		t.Errorf("redundant capture flagged novel: %+v", r)
 	}
 
 	// First capture (no others): everything is novel vs the empty union, and
 	// ComparedTo==0 lets the caller treat it as the keep-by-default first capture.
-	if r := computeNovelty(cand, nil); r.ComparedTo != 0 || len(r.NovelComponents) != 3 || len(r.NovelOrphans) != 2 {
+	if r := ComputeNovelty(cand, nil); r.ComparedTo != 0 || len(r.NovelComponents) != 3 || len(r.NovelOrphans) != 2 {
 		t.Errorf("first capture: got %+v, want ComparedTo=0 with all slots novel", r)
 	}
 }
 
 func TestPlanPrune(t *testing.T) {
-	slots := func(matched ...string) captureSlots {
+	slots := func(matched ...string) Slots {
 		m := map[string]bool{}
 		for _, c := range matched {
 			m[c] = true
 		}
-		return captureSlots{Matched: m, Orphans: map[string]int{}}
+		return Slots{Matched: m, Orphans: map[string]int{}}
 	}
 
 	// [0] reduced (subset of [1]), [1] full, [2] duplicate of [1].
 	// Expect: [0] subsumed by [1]; one of the [1]/[2] duplicates dropped; the
 	// union (Header, Hero, Endcap) preserved by the survivor.
-	caps := []captureSlots{
+	caps := []Slots{
 		slots("Header", "Hero"),
 		slots("Header", "Hero", "Endcap"),
 		slots("Header", "Hero", "Endcap"),
 	}
-	prune := planPrune(caps)
+	prune := PlanPrune(caps)
 	if len(prune) != 2 {
-		t.Fatalf("planPrune dropped %d, want 2 (reduced + one duplicate): %v", len(prune), prune)
+		t.Fatalf("PlanPrune dropped %d, want 2 (reduced + one duplicate): %v", len(prune), prune)
 	}
 	// The survivor must still cover the full union.
 	kept := map[int]bool{0: true, 1: true, 2: true}
@@ -245,25 +213,25 @@ func TestPlanPrune(t *testing.T) {
 	}
 
 	// Two captures each contributing a unique component — nothing prunable.
-	distinct := []captureSlots{slots("A", "B"), slots("A", "C")}
-	if p := planPrune(distinct); len(p) != 0 {
-		t.Errorf("planPrune pruned %v from a non-redundant set, want none", p)
+	distinct := []Slots{slots("A", "B"), slots("A", "C")}
+	if p := PlanPrune(distinct); len(p) != 0 {
+		t.Errorf("PlanPrune pruned %v from a non-redundant set, want none", p)
 	}
 
 	// A single capture is never pruned.
-	if p := planPrune([]captureSlots{slots("A")}); len(p) != 0 {
-		t.Errorf("planPrune dropped the sole capture: %v", p)
+	if p := PlanPrune([]Slots{slots("A")}); len(p) != 0 {
+		t.Errorf("PlanPrune dropped the sole capture: %v", p)
 	}
 }
 
 func TestFormatStampDisplay(t *testing.T) {
-	if got := formatStampDisplay(""); got != "" {
+	if got := FormatStamp(""); got != "" {
 		t.Errorf("empty stamp = %q, want \"\"", got)
 	}
-	if got, want := formatStampDisplay("20260607T193000Z"), "2026-06-07 19:30Z"; got != want {
-		t.Errorf("formatStampDisplay = %q, want %q", got, want)
+	if got, want := FormatStamp("20260607T193000Z"), "2026-06-07 19:30Z"; got != want {
+		t.Errorf("FormatStamp = %q, want %q", got, want)
 	}
-	if got, want := formatStampDisplay("not-a-stamp"), "not-a-stamp"; got != want {
+	if got, want := FormatStamp("not-a-stamp"), "not-a-stamp"; got != want {
 		t.Errorf("unparseable stamp = %q, want passthrough %q", got, want)
 	}
 }

--- a/go/viewset/snapfile.go
+++ b/go/viewset/snapfile.go
@@ -1,0 +1,42 @@
+package viewset
+
+import (
+	"os"
+	"strings"
+)
+
+// A saved capture's .snap file carries a small text header — a "[View: NAME]"
+// line and a "route: /path" line — that the offline readers parse to recover the
+// view identity and the route to re-match against without loading the tree JSON.
+
+// ViewNameOf reads the first lines of a .snap file and returns the view name
+// from its "[View: NAME]" header, or "" if not found.
+func ViewNameOf(snapFile string) string {
+	data, err := os.ReadFile(snapFile)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.SplitN(string(data), "\n", 10) {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "[View: ") && strings.HasSuffix(line, "]") {
+			return strings.TrimSuffix(strings.TrimPrefix(line, "[View: "), "]")
+		}
+	}
+	return ""
+}
+
+// RouteOf reads the "route: /path" line from a .snap file header, or "" if not
+// found.
+func RouteOf(snapFile string) string {
+	data, err := os.ReadFile(snapFile)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.SplitN(string(data), "\n", 10) {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "route: ") {
+			return strings.TrimPrefix(line, "route: ")
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## What

Move the on-disk capture-set machinery out of `cmd/` into a reusable **`viewset`** package (built on `coverage`).

| File | Contents |
|---|---|
| `paths.go` | `TreePath`, `ParsePath` — the `snapshots/<view>/<stamp>.snap` layout |
| `sets.go` | `Entry`, `Stamp`/`StampLayout`, `CapturePath`, `Set`, `GroupByView`, `FormatStamp`; presence aggregation (`MatchCounts`, `ComponentPresence`, `UnionPresence`); novelty/prune core (`Slots`, `Novelty`, `ComputeNovelty`, `PlanPrune`) |
| `discovery.go` | `Find` |
| `snapfile.go` | `RouteOf`, `ViewNameOf` — the `.snap` header parsers, previously stranded as `parseSnapRoute`/`parseViewName` in `cmd_coverage.go` |
| `novelty.go` | `SlotsFromMatch`, `SlotsForCapture`, `ViewSlots`, `Gate` — the corpus-relative novelty gate, over `sightmap.Corpus` + `coverage` |

The commands (`capture`, `capture-novelty`, `capture-prune`, `coverage`, `multi-coverage`, `report`) become adapters over `viewset`; their printers (`printNovelty`, `pruneView`, the `emit*` reporters) stay in `cmd`.

## Cleanup

- Two dead functions (`snapshotPath`, `latestViewSnapshot`) and their tests removed.
- Tests move with the code; the report/multi-coverage *reader* tests stay in `cmd` (they test cmd aggregation, not viewset).

## Verified

- `go build`, `go vet`, `gofmt -l`, `go test ./...` all clean; new `viewset` package tests pass.
- Behavior-preserving against the burrito example: `capture` (novelty gate), `capture-novelty`, `capture-prune`, `coverage` (incl. the `[Annotation gaps]` section), and `report` all match the pre-refactor output.
