### PR TITLE
Extract the observe package (live acquisition + annotated render)

### DIFF
--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sightmap/sightmap/go/compquery"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -91,7 +92,7 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	for _, c := range components {
 		compByName[c.Name] = c
 	}
-	props := extractProperties(ctx, conn, relevant, compByName)
+	props := observe.ExtractProperties(ctx, conn, relevant, compByName)
 
 	return compquery.Resolve(root, matches, props, q)
 }

--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -21,9 +21,8 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
 	"github.com/sightmap/sightmap/go/viewset"
 )
@@ -109,21 +108,7 @@ func runCapture(args []string) error {
 		time.Sleep(time.Duration(*waitFlag * float64(time.Second)))
 	}
 
-	// ── Extract ───────────────────────────────────────────────────────────────
-	pageURL, err := browser.GetURL(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("get URL: %v", err)
-	}
-	page, err := conn.DefaultPage()
-	if err != nil {
-		return fmt.Errorf("default page: %v", err)
-	}
-	root, err := browser.ExtractComponents(ctx, page)
-	if err != nil {
-		return fmt.Errorf("extract components: %v", err)
-	}
-
-	// ── Load sightmap and require a matching view ─────────────────────────────
+	// ── Observe (require a matching view) ─────────────────────────────────────
 	if _, statErr := os.Stat(*sightmapDirFlag); statErr != nil {
 		return fmt.Errorf("capture: no %s directory — capture appends to a corpus view set", *sightmapDirFlag)
 	}
@@ -131,43 +116,36 @@ func runCapture(args []string) error {
 	if cErr != nil {
 		return fmt.Errorf("capture: load corpus: %v", cErr)
 	}
-	snapshotMatches := corpus.MatchTree(root, pageURL)
-	view := corpus.ViewForURL(pageURL)
-	if view == nil {
+	res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible})
+	if err != nil {
+		return fmt.Errorf("capture: observe: %v", err)
+	}
+	if res.View == nil {
 		return fmt.Errorf("capture: no view matches %q — capture appends to a view's set; "+
-			"use `snapshot` to observe an unmapped page, or add a view with a matching route", pageURL)
+			"use `snapshot` to observe an unmapped page, or add a view with a matching route", res.URL)
 	}
-	viewComponents := corpus.Components(pageURL)
-	globalNames := corpus.GlobalComponentNames()
-
-	opts := printOpts{
-		trace:          *traceFlag,
-		visibleOnly:    visible,
-		selectors:      *selectorsFlag,
-		viewComponents: viewComponents,
-		globalNames:    globalNames,
-	}
+	fmtOpts := observe.FormatOpts{Trace: *traceFlag, Selectors: *selectorsFlag}
 
 	// ── Novelty gate ──────────────────────────────────────────────────────────
-	viewBasename := view.SnapBasename()
-	cov := coverage.Score(root, snapshotMatches, coverage.Options{VisibleOnly: visible})
+	viewBasename := res.View.SnapBasename()
+	cov := res.Coverage
 	if !*forceFlag {
-		cand := viewset.SlotsFromMatch(snapshotMatches, cov.Orphans, cov.ParentMap)
-		if res, write := viewset.Gate(corpus, *sightmapDirFlag, viewBasename, cand, false); !write {
+		cand := viewset.SlotsFromMatch(res.Matches, cov.Orphans, cov.ParentMap)
+		if gres, write := viewset.Gate(corpus, *sightmapDirFlag, viewBasename, cand, false); !write {
 			fmt.Fprintf(os.Stderr, "capture: nothing new vs %d capture(s) in %s — not saved (use --force to keep)\n",
-				res.ComparedTo, viewBasename)
+				gres.ComparedTo, viewBasename)
 			return nil
 		}
 	}
 
 	// ── Write the capture into the view's set ─────────────────────────────────
 	snapPath := viewset.CapturePath(*sightmapDirFlag, viewBasename, time.Now())
-	if err := writeCapture(snapPath, root, view, snapshotMatches, opts); err != nil {
+	if err := writeCapture(snapPath, res, fmtOpts); err != nil {
 		return err
 	}
 	if *jsonOutFlag {
 		jsonPath := strings.TrimSuffix(snapPath, ".snap") + ".snap.annotated.json"
-		if err := writeAnnotatedJSON(root, jsonPath, view, snapshotMatches, nil); err != nil {
+		if err := writeAnnotatedJSON(res.Root, jsonPath, res.View, res.Matches, res.Props); err != nil {
 			fmt.Fprintf(os.Stderr, "capture: json: %v\n", err)
 		}
 	}
@@ -231,49 +209,31 @@ func runCaptureAll(
 			time.Sleep(time.Duration(wait * float64(time.Second)))
 		}
 
-		pageURL, _ := browser.GetURL(ctx, conn)
-		page, err := conn.DefaultPage()
+		res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible})
 		if err != nil {
 			results = append(results, result{name: label, err: err})
 			continue
 		}
-		root, err := browser.ExtractComponents(ctx, page)
-		if err != nil {
-			results = append(results, result{name: label, err: err})
-			continue
-		}
-
-		snapshotMatches := corpus.MatchTree(root, pageURL)
-		view := corpus.ViewForURL(pageURL)
-		viewComponents := corpus.Components(pageURL)
-		globalNames := corpus.GlobalComponentNames()
-
-		opts := printOpts{
-			visibleOnly:    visible,
-			selectors:      selectors,
-			viewComponents: viewComponents,
-			globalNames:    globalNames,
-		}
-
-		cov := coverage.Score(root, snapshotMatches, coverage.Options{VisibleOnly: visible})
+		fmtOpts := observe.FormatOpts{Selectors: selectors}
+		cov := res.Coverage
 
 		// Novelty gate: don't append a redundant capture to the view set.
 		if !force {
-			cand := viewset.SlotsFromMatch(snapshotMatches, cov.Orphans, cov.ParentMap)
-			if res, write := viewset.Gate(corpus, sightmapDir, v.ViewDir, cand, false); !write {
-				results = append(results, result{name: label, skipped: true, skippedVs: res.ComparedTo})
+			cand := viewset.SlotsFromMatch(res.Matches, cov.Orphans, cov.ParentMap)
+			if gres, write := viewset.Gate(corpus, sightmapDir, v.ViewDir, cand, false); !write {
+				results = append(results, result{name: label, skipped: true, skippedVs: gres.ComparedTo})
 				continue
 			}
 		}
 
 		snapPath := viewset.CapturePath(sightmapDir, v.ViewDir, time.Now())
-		if err := writeCapture(snapPath, root, view, snapshotMatches, opts); err != nil {
+		if err := writeCapture(snapPath, res, fmtOpts); err != nil {
 			results = append(results, result{name: label, err: err})
 			continue
 		}
 		if jsonOut {
 			jsonPath := strings.TrimSuffix(snapPath, ".snap") + ".snap.annotated.json"
-			writeAnnotatedJSON(root, jsonPath, view, snapshotMatches, nil) // no propValues in --all mode
+			writeAnnotatedJSON(res.Root, jsonPath, res.View, res.Matches, nil) // no propValues in --all mode
 		}
 
 		results = append(results, result{name: label, t1: cov.T1, t2: cov.T2, t3: cov.T3, total: cov.Total})
@@ -306,13 +266,7 @@ func runCaptureAll(
 // writeCapture renders a capture to snapPath (atomically) plus its .tree.json
 // sibling, creating parent directories as needed. This is the persistence
 // primitive shared by the single-view and --all capture paths.
-func writeCapture(
-	snapPath string,
-	root *comps.ComponentNode,
-	view *sightmap.View,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	opts printOpts,
-) error {
+func writeCapture(snapPath string, res *observe.Result, opts observe.FormatOpts) error {
 	if dir := filepath.Dir(snapPath); dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("create capture directory: %v", err)
@@ -324,7 +278,7 @@ func writeCapture(
 	if ferr != nil {
 		return fmt.Errorf("create capture file: %v", ferr)
 	}
-	writeOutput(f, root, view, matches, opts)
+	observe.Format(f, res, opts)
 	if cerr := f.Close(); cerr != nil {
 		os.Remove(tmpPath)
 		return fmt.Errorf("close capture file: %v", cerr)
@@ -334,7 +288,7 @@ func writeCapture(
 		return fmt.Errorf("rename capture file: %v", rerr)
 	}
 
-	if err := writeTreeJSON(root, viewset.TreePath(snapPath)); err != nil {
+	if err := writeTreeJSON(res.Root, viewset.TreePath(snapPath)); err != nil {
 		fmt.Fprintf(os.Stderr, "capture: tree-out: %v\n", err)
 	}
 	return nil

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -4,15 +4,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
 	"github.com/sightmap/sightmap/go/viewset"
@@ -189,11 +188,11 @@ func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool)
 	if trace {
 		if len(t3nodes) > 0 {
 			fmt.Fprintln(os.Stdout)
-			writeTrace(os.Stdout, t3nodes, parentMap)
+			observe.WriteTrace(os.Stdout, t3nodes, parentMap)
 		}
 		if len(t2clusters) > 0 {
 			fmt.Fprintln(os.Stdout)
-			writeT2Trace(os.Stdout, t2clusters, t2children, matches, view)
+			observe.WriteT2Trace(os.Stdout, t2clusters, t2children, matches, view)
 		}
 		fmt.Println()
 	}
@@ -232,44 +231,10 @@ func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool)
 		for _, gc := range corpus.GlobalComponents {
 			globalNames[gc.Name] = true
 		}
-		checkRootComponents(os.Stdout, view.Components, globalNames, counts, view.Name)
+		observe.CheckRootComponents(os.Stdout, view.Components, globalNames, counts, view.Name)
 	}
 
 	return counts, leafCounts, viewset.ViewNameOf(snapPath), t3, gaps, true
-}
-
-// checkRootComponents writes a [Snapshot check] warning to w when every
-// view-specific top-level component (empty ParentChain, not in globalNames)
-// matched 0 nodes. This is a strong signal that the snapshot captured the
-// wrong page — e.g. a direct URL load silently fell back to a different
-// route (the topwork wizard returning the Dashboard). globalNames excludes
-// shared components (Header, TopworkApp, etc.) that match any page and would
-// suppress the warning spuriously. Pass nil to skip the exclusion.
-func checkRootComponents(w io.Writer, viewComponents []match.SightmapComponent, globalNames map[string]bool, counts map[string]int, viewName string) {
-	var topNames []string
-	for _, comp := range viewComponents {
-		if comp.Name == "" || len(comp.Selectors) == 0 || len(comp.ParentChain) > 0 {
-			continue
-		}
-		if globalNames[comp.Name] {
-			continue // skip globals — they match on any page
-		}
-		topNames = append(topNames, comp.Name)
-	}
-	if len(topNames) == 0 {
-		return // no view-specific top-level components to check
-	}
-	for _, name := range topNames {
-		if counts[name] > 0 {
-			return // at least one view-specific root matched — page is plausibly correct
-		}
-	}
-	label := ""
-	if viewName != "" {
-		label = viewName + ": "
-	}
-	fmt.Fprintf(w, "\n[Snapshot check] %sview root components all unmatched — wrong page captured? (expected: %s)\n\n",
-		label, strings.Join(topNames, ", "))
 }
 
 // countLeafMatches returns the number of tree nodes that satisfy the leaf

--- a/go/cmd/sightmap/cmd_coverage_annotation.go
+++ b/go/cmd/sightmap/cmd_coverage_annotation.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/sightmap/sightmap/go/coverage"
 )
@@ -29,4 +31,18 @@ func emitContentGaps(viewName string, pres []coverage.ContentGapPresence) {
 		}
 	}
 	fmt.Println()
+}
+
+// displayName truncates s to 60 Unicode code points and wraps it in double
+// quotes. Only backslash and double-quote are escaped; all other Unicode is
+// preserved as-is so the output stays human-readable.
+func displayName(s string) string {
+	const maxRunes = 60
+	if utf8.RuneCountInString(s) > maxRunes {
+		runes := []rune(s)
+		s = string(runes[:maxRunes]) + "…"
+	}
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
 }

--- a/go/cmd/sightmap/cmd_report.go
+++ b/go/cmd/sightmap/cmd_report.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/render"
 	"github.com/sightmap/sightmap/go/sightmap"
 	"github.com/sightmap/sightmap/go/viewset"
 )
@@ -343,7 +344,7 @@ func routeDisplay(route, url string) string {
 // truncate shortens s to at most n runes, appending "…" if truncated.
 // (Uses truncateStr from cmd_snapshot.go for consistency.)
 func truncate(s string, n int) string {
-	return truncateStr(s, n)
+	return render.TruncateRunes(s, n)
 }
 
 // lastPathComponent returns the last path segment of s.

--- a/go/cmd/sightmap/cmd_snapshot.go
+++ b/go/cmd/sightmap/cmd_snapshot.go
@@ -8,35 +8,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/match"
-	"github.com/sightmap/sightmap/go/render"
+	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
-
-// printOpts carries the display-filter flags through the tree-printing functions.
-type printOpts struct {
-	interactive    bool
-	compact        bool // kept for compat; now a no-op (render is always compact)
-	maxDepth       int
-	trace          bool
-	coverageOnly   bool // suppress the tree + guide; print View/Coverage/traces only
-	visibleOnly    bool
-	propValues     map[string]map[string]string // nodeID → {propName → value}; nil in offline mode
-	selectors      bool                         // show tag #id [data-testid] selector hints
-	viewComponents []match.SightmapComponent    // for zero-match warnings
-	globalNames    map[string]bool              // corpus-level global component names; used by page-check
-}
 
 // snapshot is a PURE OBSERVE command: it connects, navigates, extracts, matches
 // the corpus, and renders the annotated tree + [Coverage] to stdout (or --out
@@ -52,7 +32,6 @@ func runSnapshot(args []string) error {
 	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
 	interactiveFlag := fs.Bool("interactive", false, "Show interactive nodes only")
 	depthFlag := fs.Int("depth", 0, "Max tree depth (0 = unlimited)")
-	compactFlag := fs.Bool("compact", false, "Omit hidden/ignored nodes from output")
 	traceFlag := fs.Bool("trace", false, "Include selector hints for unlabeled interactive clusters")
 	coverageOnlyFlag := fs.Bool("coverage", false, "Print [View] + [Coverage] + cluster traces only, suppressing the component tree")
 	visibleFlag := fs.Bool("visible", true, "Count only visible nodes (default: true; use --include-hidden to disable)")
@@ -130,57 +109,26 @@ func runSnapshot(args []string) error {
 		time.Sleep(time.Duration(*waitFlag * float64(time.Second)))
 	}
 
-	// ── Extract ───────────────────────────────────────────────────────────────
-	pageURL, err := browser.GetURL(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("get URL: %v", err)
-	}
-
-	page, err := conn.DefaultPage()
-	if err != nil {
-		return fmt.Errorf("default page: %v", err)
-	}
-	root, err := browser.ExtractComponents(ctx, page)
-	if err != nil {
-		return fmt.Errorf("extract components: %v", err)
-	}
-
-	// ── Load sightmap (optional) ──────────────────────────────────────────────
-	var snapshotMatches map[*comps.ComponentNode]*match.SightmapMatch
-	var view *sightmap.View
-	var propValues map[string]map[string]string
-	var viewComponents []match.SightmapComponent
-	var globalNames map[string]bool
+	// ── Observe (extract + match + coverage + properties) ──────────────────────
+	var corpus *sightmap.Corpus
 	if _, statErr := os.Stat(*sightmapDirFlag); statErr == nil {
-		if corpus, cErr := sightmap.Load(*sightmapDirFlag); cErr != nil {
+		if c, cErr := sightmap.Load(*sightmapDirFlag); cErr != nil {
 			fmt.Fprintf(os.Stderr, "snapshot: load corpus: %v\n", cErr)
 		} else {
-			snapshotMatches = corpus.MatchTree(root, pageURL)
-			view = corpus.ViewForURL(pageURL)
-			viewComponents = corpus.Components(pageURL)
-			globalNames = corpus.GlobalComponentNames()
-		}
-		// Extract property values from the live DOM (skipped in offline mode).
-		if conn != nil && len(snapshotMatches) > 0 && len(viewComponents) > 0 {
-			compByName := make(map[string]match.SightmapComponent, len(viewComponents))
-			for _, c := range viewComponents {
-				compByName[c.Name] = c
-			}
-			propValues = extractProperties(ctx, conn, snapshotMatches, compByName)
+			corpus = c
 		}
 	}
+	res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible, ExtractProps: true})
+	if err != nil {
+		return fmt.Errorf("snapshot: observe: %v", err)
+	}
 
-	opts := printOpts{
-		interactive:    *interactiveFlag,
-		compact:        *compactFlag,
-		maxDepth:       *depthFlag,
-		trace:          *traceFlag,
-		coverageOnly:   *coverageOnlyFlag,
-		visibleOnly:    visible,
-		propValues:     propValues,
-		selectors:      *selectorsFlag,
-		viewComponents: viewComponents,
-		globalNames:    globalNames,
+	fmtOpts := observe.FormatOpts{
+		Interactive:  *interactiveFlag,
+		MaxDepth:     *depthFlag,
+		Trace:        *traceFlag,
+		CoverageOnly: *coverageOnlyFlag,
+		Selectors:    *selectorsFlag,
 	}
 
 	// ── Screenshot (alongside the tree, same page state) ───────────────────────
@@ -195,19 +143,19 @@ func runSnapshot(args []string) error {
 		}
 	}
 
-	// ── Write component tree JSON (for offline coverage tools) ──────────────
+	// ── Side JSON artifacts (for offline coverage tools) ───────────────────────
 	if *treeOutFlag != "" {
-		if err := writeTreeJSON(root, *treeOutFlag); err != nil {
+		if err := writeTreeJSON(res.Root, *treeOutFlag); err != nil {
 			fmt.Fprintf(os.Stderr, "snapshot: tree-out: %v\n", err)
 		}
 	}
 	if *jsonOutFlag != "" {
-		if err := writeAnnotatedJSON(root, *jsonOutFlag, view, snapshotMatches, propValues); err != nil {
+		if err := writeAnnotatedJSON(res.Root, *jsonOutFlag, res.View, res.Matches, res.Props); err != nil {
 			fmt.Fprintf(os.Stderr, "snapshot: json-out: %v\n", err)
 		}
 	}
 
-	// ── Write output ───────────────────────────────────────────────────────
+	// ── Write output ───────────────────────────────────────────────────────────
 	// snapshot only ever writes the rendered output to stdout or an explicit
 	// --out FILE. It never appends to the corpus capture set (that is `capture`).
 	if *outFlag != "" {
@@ -216,13 +164,12 @@ func runSnapshot(args []string) error {
 				return fmt.Errorf("create output directory: %v", mkdirErr)
 			}
 		}
-
 		tmpPath := *outFlag + ".tmp"
 		f, ferr := os.Create(tmpPath)
 		if ferr != nil {
 			return fmt.Errorf("create output file: %v", ferr)
 		}
-		writeOutput(f, root, view, snapshotMatches, opts)
+		observe.Format(f, res, fmtOpts)
 		if cerr := f.Close(); cerr != nil {
 			os.Remove(tmpPath)
 			return fmt.Errorf("close output file: %v", cerr)
@@ -232,515 +179,16 @@ func runSnapshot(args []string) error {
 			return fmt.Errorf("rename output file: %v", rerr)
 		}
 	} else {
-		writeOutput(os.Stdout, root, view, snapshotMatches, opts)
+		observe.Format(os.Stdout, res, fmtOpts)
 	}
 	return nil
 }
 
 // ── Output sections ───────────────────────────────────────────────────────────
 
-// writeOutput writes all sections in order to w.
-func writeOutput(
-	w io.Writer,
-	root *comps.ComponentNode,
-	view *sightmap.View,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	opts printOpts,
-) {
-	// ── [View: ...] ──────────────────────────────────────────────────────────
-	if view != nil {
-		fmt.Fprintf(w, "[View: %s]\n", view.Name)
-		fmt.Fprintf(w, "route: %s\n", view.Route)
-		if len(view.Memory) > 0 {
-			fmt.Fprintf(w, "memory:\n")
-			for _, m := range view.Memory {
-				fmt.Fprintf(w, "  - %s\n", m)
-			}
-		}
-		fmt.Fprintln(w)
-	}
-
-	// ── [Guide] ───────────────────────────────────────────────────────────────
-	// Skipped in coverage-only mode, which is meant to be a terse feedback view.
-	if !opts.coverageOnly && len(matches) > 0 {
-		writeGuide(w, matches)
-		fmt.Fprintln(w)
-	}
-
-	// ── component tree ────────────────────────────────────────────────────────
-	// Coverage-only mode suppresses the (potentially huge) tree entirely.
-	if !opts.coverageOnly {
-		fmt.Fprintf(w, "--- component tree ---\n\n")
-		if root != nil {
-			comp := render.Filter(root, matches)
-			if comp != nil {
-				comp.Format(w, "", render.FormatOpts{
-					Selectors:   opts.selectors,
-					MaxDepth:    opts.maxDepth,
-					Interactive: opts.interactive,
-					PropValues:  opts.propValues,
-				})
-			}
-		}
-	}
-
-	// ── [Warnings] ────────────────────────────────────────────────────────────
-	if len(opts.viewComponents) > 0 && matches != nil {
-		writeZeroMatchWarnings(w, opts.viewComponents, matches, view, opts.globalNames)
-	}
-
-	// ── [Coverage] ────────────────────────────────────────────────────────────
-	if matches != nil {
-		fmt.Fprintln(w)
-		cov := coverage.Score(root, matches, coverage.Options{VisibleOnly: opts.visibleOnly})
-		writeCoverage(w, cov)
-
-		// ── Unlabeled clusters (--trace) ─────────────────────────────────────
-		// Coverage-only mode always shows the cluster traces — they are the point
-		// of the terse view (which orphans/ambiguous clusters still need work).
-		if opts.trace || opts.coverageOnly {
-			if len(cov.Orphans) > 0 {
-				fmt.Fprintln(w)
-				writeTrace(w, cov.Orphans, cov.ParentMap)
-			}
-			if len(cov.Scopes) > 0 {
-				fmt.Fprintln(w)
-				writeT2Trace(w, cov.Scopes, cov.ScopeChildren, matches, view)
-			}
-		}
-	}
-}
-
-// writeGuide prints the [Guide] section: component names and match counts,
-// sorted by count descending then name ascending.
-func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.SightmapMatch) {
-	counts := make(map[string]int)
-	for _, m := range matches {
-		if m != nil {
-			counts[m.Name]++
-		}
-	}
-
-	type nc struct {
-		name  string
-		count int
-	}
-	guide := make([]nc, 0, len(counts))
-	for name, cnt := range counts {
-		guide = append(guide, nc{name, cnt})
-	}
-	sort.Slice(guide, func(i, j int) bool {
-		if guide[i].count != guide[j].count {
-			return guide[i].count > guide[j].count
-		}
-		return guide[i].name < guide[j].name
-	})
-	if len(guide) == 0 {
-		return
-	}
-
-	maxNameLen := 0
-	for _, g := range guide {
-		if len(g.name) > maxNameLen {
-			maxNameLen = len(g.name)
-		}
-	}
-	countWidth := len(fmt.Sprintf("%d", guide[0].count))
-	nameWidth := maxNameLen + 2 // minimum two-space gap before count column
-
-	fmt.Fprintf(w, "[Guide]\n")
-	for _, g := range guide {
-		fmt.Fprintf(w, "%-*s%*d\n", nameWidth, g.name, countWidth, g.count)
-	}
-}
-
-// writeZeroMatchWarnings emits a [Warnings] section listing view components
-// that matched 0 nodes in the extracted tree, and a [Snapshot check] line
-// when every top-level component missed \u2014 a strong signal for wrong-page capture.
-// globalNames is the set of corpus-level global component names; these are
-// excluded from the page-check since they match on any page.
-func writeZeroMatchWarnings(
-	w io.Writer,
-	viewComponents []match.SightmapComponent,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	view *sightmap.View,
-	globalNames map[string]bool,
-) {
-	// Count matches per component name.
-	counts := make(map[string]int)
-	for _, m := range matches {
-		if m != nil {
-			counts[m.Name]++
-		}
-	}
-
-	viewName := ""
-	if view != nil {
-		viewName = view.Name
-	}
-
-	// Page-check: if all top-level view-specific components (excluding globals)
-	// matched 0 nodes, the snapshot likely captured the wrong page.
-	if view != nil {
-		checkRootComponents(w, view.Components, globalNames, counts, viewName)
-	}
-
-	var warnings []string
-	for _, comp := range viewComponents {
-		if comp.Name == "" || len(comp.Selectors) == 0 {
-			continue // skip anonymous/empty
-		}
-		if counts[comp.Name] == 0 {
-			if viewName != "" {
-				warnings = append(warnings, fmt.Sprintf("%s: %s \u2014 0 matches", viewName, comp.Name))
-			} else {
-				warnings = append(warnings, fmt.Sprintf("%s \u2014 0 matches", comp.Name))
-			}
-		}
-	}
-
-	if len(warnings) == 0 {
-		return
-	}
-	fmt.Fprintln(w, "[Warnings]")
-	for _, w2 := range warnings {
-		fmt.Fprintln(w, w2)
-	}
-	fmt.Fprintln(w)
-}
-
-// writeCoverage prints the [Coverage] section.
-func writeCoverage(w io.Writer, cov coverage.Result) {
-	check := "✗"
-	if cov.T3 == 0 {
-		check = "✓"
-	}
-	if cov.VisibleOnly {
-		fmt.Fprintf(w, "[Coverage] (visible only)\n")
-	} else {
-		fmt.Fprintf(w, "[Coverage]\n")
-	}
-	fmt.Fprintf(w, "%d interactive · %d direct T1 (%d%%) · %d scoped T2 (%d%%) · %d orphaned T3 %s\n",
-		cov.Total, cov.T1, coverage.Pct(cov.T1, cov.Total), cov.T2, coverage.Pct(cov.T2, cov.Total), cov.T3, check)
-}
-
-// writeTrace prints the "Unlabeled clusters" section for T3 (orphaned) nodes.
-// Clusters are grouped by (role, name, nearest-data-attr-ancestor selector)
-// and sorted by count descending.
-func writeTrace(
-	w io.Writer,
-	t3nodes []*comps.ComponentNode,
-	parentMap map[*comps.ComponentNode]*comps.ComponentNode,
-) {
-	type clusterKey struct {
-		role   string
-		name   string // "(no text)" when empty
-		inside string // selector of nearest data-attr ancestor, or ""
-	}
-	type cluster struct {
-		count int
-		rep   *comps.ComponentNode
-	}
-
-	var order []clusterKey
-	clusters := make(map[clusterKey]*cluster)
-
-	for _, n := range t3nodes {
-		anc := coverage.NearestDataAttrAncestor(n, parentMap)
-		inside := ""
-		if anc != nil {
-			inside = coverage.DataAttrSelector(anc)
-		}
-
-		nameStr := n.Name
-		if nameStr == "" {
-			nameStr = "(no text)"
-		} else {
-			nameStr = truncateStr(nameStr, 40)
-		}
-
-		role := n.Role
-		if role == "" {
-			role = "?"
-		}
-
-		key := clusterKey{role: role, name: nameStr, inside: inside}
-		if c, ok := clusters[key]; ok {
-			c.count++
-		} else {
-			clusters[key] = &cluster{count: 1, rep: n}
-			order = append(order, key)
-		}
-	}
-
-	sort.Slice(order, func(i, j int) bool {
-		ci, cj := clusters[order[i]], clusters[order[j]]
-		if ci.count != cj.count {
-			return ci.count > cj.count
-		}
-		if order[i].role != order[j].role {
-			return order[i].role < order[j].role
-		}
-		return order[i].name < order[j].name
-	})
-
-	fmt.Fprintf(w, "Unlabeled clusters:\n")
-	for _, key := range order {
-		c := clusters[key]
-		nameDisp := key.name
-		if key.name != "(no text)" {
-			nameDisp = `"` + key.name + `"`
-		}
-		fmt.Fprintf(w, "  %d\u00d7 %s %s\n", c.count, key.role, nameDisp)
-		if key.inside != "" {
-			fmt.Fprintf(w, "       inside: %s\n", key.inside)
-			if hint := coverage.ArrowHint(c.rep, parentMap); hint != "" {
-				fmt.Fprintf(w, "       \u2192 %s\n", hint)
-			}
-		}
-	}
-}
-
-// writeT2Trace prints T2 scopes (interactive children without direct matches).
-// Enumerates each child node (role + name) with suppression rules:
-//   - Single-child T2 scopes are omitted (simple wrapper, acceptable)
-//   - Components with memory notes show suppressed summary
-//   - Large lists truncate at 8 items with "… (N more)"
-func writeT2Trace(
-	w io.Writer,
-	t2clusters map[*comps.ComponentNode]int,
-	t2children map[*comps.ComponentNode][]*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	view *sightmap.View,
-) {
-	const minT2Count = 2 // ≥2 children required (single-child = simple wrapper)
-	const truncateAt = 8 // show first 8, then "… (N more)"
-
-	type entry struct {
-		name      string
-		count     int
-		children  []*comps.ComponentNode
-		hasMemory bool
-	}
-	var entries []entry
-	for node, count := range t2clusters {
-		if count < minT2Count {
-			continue
-		}
-		m := matches[node]
-		if m == nil || m.Name == "" {
-			continue
-		}
-		// Check if component has memory note
-		hasMemory := false
-		if view != nil {
-			for _, c := range view.Components {
-				if c.Name == m.Name && len(c.Memory) > 0 {
-					hasMemory = true
-					break
-				}
-			}
-		}
-		entries = append(entries, entry{
-			name:      m.Name,
-			count:     count,
-			children:  t2children[node],
-			hasMemory: hasMemory,
-		})
-	}
-	if len(entries) == 0 {
-		return
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].count != entries[j].count {
-			return entries[i].count > entries[j].count
-		}
-		return entries[i].name < entries[j].name
-	})
-	if len(entries) > 10 {
-		entries = entries[:10]
-	}
-
-	fmt.Fprintf(w, "T2 scopes (interactive children without direct component matches):\n")
-	for _, e := range entries {
-		fmt.Fprintf(w, "  [%s] (%d)", e.name, e.count)
-		if e.hasMemory {
-			fmt.Fprintf(w, " — exhausted, see component memory note\n")
-			continue
-		}
-		fmt.Fprintln(w)
-		// Enumerate children
-		shown := e.count
-		if shown > truncateAt {
-			shown = truncateAt
-		}
-		for i := 0; i < shown && i < len(e.children); i++ {
-			child := e.children[i]
-			fmt.Fprintf(w, "    %s %q\n", child.Role, child.Name)
-		}
-		if e.count > truncateAt {
-			fmt.Fprintf(w, "    … (%d more)\n", e.count-truncateAt)
-		}
-	}
-}
-
 // ── Property extraction ──────────────────────────────────────────────────────
 
-// extractProperties runs a single batched JS evaluation against the live DOM
-// to extract property values for all matched nodes that have property
-// definitions. Returns a map from nodeID to {propName → value}.
-// At most 200 nodes are evaluated to avoid JS timeout.
-func extractProperties(
-	ctx context.Context,
-	conn *browser.CDPConn,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	compByName map[string]match.SightmapComponent,
-) map[string]map[string]string {
-	type specProp struct {
-		Name      string `json:"name"`
-		Extract   string `json:"extract"`
-		Transform string `json:"transform"`
-	}
-	type spec struct {
-		ID       string     `json:"id"`
-		Selector string     `json:"selector"`
-		Props    []specProp `json:"props"`
-	}
-
-	var specs []spec
-	const maxNodes = 200
-	for node, m := range matches {
-		if len(specs) >= maxNodes {
-			break
-		}
-		comp, ok := compByName[m.Name]
-		if !ok || len(comp.Properties) == 0 || len(comp.Selectors) == 0 {
-			continue
-		}
-		sp := spec{
-			ID:       node.Id,
-			Selector: comp.Selectors[0],
-			Props:    make([]specProp, len(comp.Properties)),
-		}
-		for i, p := range comp.Properties {
-			sp.Props[i] = specProp{Name: p.Name, Extract: p.Extract, Transform: p.Transform}
-		}
-		specs = append(specs, sp)
-	}
-	if len(specs) == 0 {
-		return nil
-	}
-
-	specsJSON, err := json.Marshal(specs)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "snapshot: marshal property specs: %v\n", err)
-		return nil
-	}
-
-	const jsTemplate = `(function(specs) {
-  // Canonical extractor — mirrored in cmd/sightmap/extension/{content,resolver}.js
-  // and (transforms only) sightmap/property.go. Returns the RAW value; the caller
-  // normalizes whitespace, applies the transform, and caps length uniformly.
-  function extractValue(el, extract) {
-    if (!extract) return null;
-    if (extract === 'text') return el.textContent;
-    if (extract === 'inner_text') return el.innerText;
-    if (extract === 'text_only') {
-      const clone = el.cloneNode(true);
-      clone.querySelectorAll('img,svg,[alt]').forEach(e => e.remove());
-      return clone.textContent;
-    }
-    if (extract === 'inner_html') return el.innerHTML;
-    if (extract.startsWith('attr=')) return el.getAttribute(extract.slice(5));
-    if (extract.startsWith('exists:')) {
-      return el.querySelector(extract.slice(7)) ? 'true' : null;
-    }
-    const sub = el.querySelector(extract);
-    return sub ? (sub.innerText != null ? sub.innerText : sub.textContent) : null;
-  }
-  function applyTransform(val, transform) {
-    if (!transform || !val) return val;
-    if (transform.indexOf('match:') === 0) {
-      try {
-        const m = val.match(new RegExp(transform.slice(6)));
-        if (!m) return val;
-        return m[1] != null ? m[1] : m[0];
-      } catch (e) { return val; }
-    }
-    const words = val.trim().split(/\s+/);
-    switch(transform) {
-      case 'first_word': return words[0] || val;
-      case 'last_word':  return words[words.length-1] || val;
-      case 'first_number': { const m = val.match(/\d[\d,.]*/); return m ? m[0] : val; }
-      case 'first_dollar': { const m = val.match(/\$[\d,.]+/); return m ? m[0] : val; }
-      case 'number':     return val.replace(/[^\d.]/g, '');
-      case 'slug':       return val.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-      default: return val;
-    }
-  }
-  const results = {};
-  for (const {id, selector, props} of specs) {
-    // Anchor to the exact matched element via its sightmap ID attribute (set by
-    // probe.js as data-sightmap-id). This ensures child components like
-    // BreadcrumbLink get their own text, not the first match on the page.
-    const el = (id ? document.querySelector('[data-sightmap-id="' + id + '"]') : null)
-               || document.querySelector(selector);
-    if (!el) continue;
-    const vals = {};
-    for (const {name, extract, transform} of props) {
-      let val = extractValue(el, extract);
-      if (val == null) continue;
-      val = String(val).trim().replace(/\s+/g, ' ');
-      if (val === '') continue;
-      val = applyTransform(val, transform);
-      if (val) vals[name] = String(val).slice(0, 120);
-    }
-    if (Object.keys(vals).length > 0) results[id] = vals;
-  }
-  return results;
-})(SPECS_JSON)`
-
-	script := strings.Replace(jsTemplate, "SPECS_JSON", string(specsJSON), 1)
-
-	resultJSON, evalErr := browser.EvalJSON(ctx, conn, script)
-	if evalErr != nil {
-		fmt.Fprintf(os.Stderr, "snapshot: property extraction: %v\n", evalErr)
-		return nil
-	}
-
-	var propValues map[string]map[string]string
-	if err := json.Unmarshal(resultJSON, &propValues); err != nil {
-		fmt.Fprintf(os.Stderr, "snapshot: property extraction unmarshal: %v\n", err)
-		return nil
-	}
-	return propValues
-}
-
 // ── Formatting helpers ────────────────────────────────────────────────────────
-
-// displayName truncates s to 60 Unicode code points and wraps it in double
-// quotes. Only backslash and double-quote are escaped; all other Unicode is
-// preserved as-is so the output stays human-readable.
-func displayName(s string) string {
-	const maxRunes = 60
-	if utf8.RuneCountInString(s) > maxRunes {
-		runes := []rune(s)
-		s = string(runes[:maxRunes]) + "…"
-	}
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
-}
-
-// truncateStr truncates s to at most maxRunes Unicode code points,
-// appending "…" when truncation occurs.
-func truncateStr(s string, maxRunes int) string {
-	if utf8.RuneCountInString(s) <= maxRunes {
-		return s
-	}
-	runes := []rune(s)
-	return string(runes[:maxRunes]) + "…"
-}
 
 // writeTreeJSON serialises root as JSON to path atomically.
 func writeTreeJSON(root *comps.ComponentNode, path string) error {

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -1,0 +1,77 @@
+package observe
+
+import (
+	"context"
+
+	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// Result is one observation of a live page: the extracted component tree, the
+// corpus matches applied to it, the view it resolved to, and the coverage score.
+// Props holds live-extracted property values (nodeID → propName → value) and is
+// nil unless Options.ExtractProps was set. Matches/View/Coverage are zero when no
+// corpus was supplied.
+type Result struct {
+	Root        *comps.ComponentNode
+	URL         string
+	Matches     map[*comps.ComponentNode]*match.SightmapMatch
+	View        *sightmap.View
+	Components  []match.SightmapComponent
+	GlobalNames map[string]bool
+	Props       map[string]map[string]string
+	Coverage    coverage.Result
+}
+
+// Options controls how a page is observed.
+type Options struct {
+	// VisibleOnly scores coverage over visible interactive nodes only (the CLI
+	// default); false counts hidden/off-screen nodes too.
+	VisibleOnly bool
+	// ExtractProps runs a live DOM pass to pull component property values. Skip
+	// it when only the tree/coverage are needed (e.g. bulk capture).
+	ExtractProps bool
+}
+
+// Page observes the page currently loaded in conn: it extracts the component
+// tree, applies corpus (when non-nil) to produce matches, the view, the merged
+// component list, and coverage, and optionally extracts property values.
+// Navigation and the browser lifecycle are the caller's responsibility — Page
+// only reads the current page state.
+func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, opts Options) (*Result, error) {
+	page, err := conn.DefaultPage()
+	if err != nil {
+		return nil, err
+	}
+	root, err := browser.ExtractComponents(ctx, page)
+	if err != nil {
+		return nil, err
+	}
+	url, err := browser.GetURL(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &Result{Root: root, URL: url}
+	if corpus == nil {
+		return res, nil
+	}
+
+	res.Matches = corpus.MatchTree(root, url)
+	res.View = corpus.ViewForURL(url)
+	res.Components = corpus.Components(url)
+	res.GlobalNames = corpus.GlobalComponentNames()
+	res.Coverage = coverage.Score(root, res.Matches, coverage.Options{VisibleOnly: opts.VisibleOnly})
+
+	if opts.ExtractProps && len(res.Matches) > 0 && len(res.Components) > 0 {
+		compByName := make(map[string]match.SightmapComponent, len(res.Components))
+		for _, c := range res.Components {
+			compByName[c.Name] = c
+		}
+		res.Props = ExtractProperties(ctx, conn, res.Matches, compByName)
+	}
+	return res, nil
+}

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -1,0 +1,143 @@
+package observe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/match"
+)
+
+// ExtractProperties runs a single batched JS evaluation against the live DOM
+// to extract property values for all matched nodes that have property
+// definitions. Returns a map from nodeID to {propName → value}.
+// At most 200 nodes are evaluated to avoid JS timeout.
+func ExtractProperties(
+	ctx context.Context,
+	conn *browser.CDPConn,
+	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	compByName map[string]match.SightmapComponent,
+) map[string]map[string]string {
+	type specProp struct {
+		Name      string `json:"name"`
+		Extract   string `json:"extract"`
+		Transform string `json:"transform"`
+	}
+	type spec struct {
+		ID       string     `json:"id"`
+		Selector string     `json:"selector"`
+		Props    []specProp `json:"props"`
+	}
+
+	var specs []spec
+	const maxNodes = 200
+	for node, m := range matches {
+		if len(specs) >= maxNodes {
+			break
+		}
+		comp, ok := compByName[m.Name]
+		if !ok || len(comp.Properties) == 0 || len(comp.Selectors) == 0 {
+			continue
+		}
+		sp := spec{
+			ID:       node.Id,
+			Selector: comp.Selectors[0],
+			Props:    make([]specProp, len(comp.Properties)),
+		}
+		for i, p := range comp.Properties {
+			sp.Props[i] = specProp{Name: p.Name, Extract: p.Extract, Transform: p.Transform}
+		}
+		specs = append(specs, sp)
+	}
+	if len(specs) == 0 {
+		return nil
+	}
+
+	specsJSON, err := json.Marshal(specs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "observe: marshal property specs: %v\n", err)
+		return nil
+	}
+
+	const jsTemplate = `(function(specs) {
+  // Canonical extractor — mirrored in cmd/sightmap/extension/{content,resolver}.js
+  // and (transforms only) sightmap/property.go. Returns the RAW value; the caller
+  // normalizes whitespace, applies the transform, and caps length uniformly.
+  function extractValue(el, extract) {
+    if (!extract) return null;
+    if (extract === 'text') return el.textContent;
+    if (extract === 'inner_text') return el.innerText;
+    if (extract === 'text_only') {
+      const clone = el.cloneNode(true);
+      clone.querySelectorAll('img,svg,[alt]').forEach(e => e.remove());
+      return clone.textContent;
+    }
+    if (extract === 'inner_html') return el.innerHTML;
+    if (extract.startsWith('attr=')) return el.getAttribute(extract.slice(5));
+    if (extract.startsWith('exists:')) {
+      return el.querySelector(extract.slice(7)) ? 'true' : null;
+    }
+    const sub = el.querySelector(extract);
+    return sub ? (sub.innerText != null ? sub.innerText : sub.textContent) : null;
+  }
+  function applyTransform(val, transform) {
+    if (!transform || !val) return val;
+    if (transform.indexOf('match:') === 0) {
+      try {
+        const m = val.match(new RegExp(transform.slice(6)));
+        if (!m) return val;
+        return m[1] != null ? m[1] : m[0];
+      } catch (e) { return val; }
+    }
+    const words = val.trim().split(/\s+/);
+    switch(transform) {
+      case 'first_word': return words[0] || val;
+      case 'last_word':  return words[words.length-1] || val;
+      case 'first_number': { const m = val.match(/\d[\d,.]*/); return m ? m[0] : val; }
+      case 'first_dollar': { const m = val.match(/\$[\d,.]+/); return m ? m[0] : val; }
+      case 'number':     return val.replace(/[^\d.]/g, '');
+      case 'slug':       return val.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      default: return val;
+    }
+  }
+  const results = {};
+  for (const {id, selector, props} of specs) {
+    // Anchor to the exact matched element via its sightmap ID attribute (set by
+    // probe.js as data-sightmap-id). This ensures child components like
+    // BreadcrumbLink get their own text, not the first match on the page.
+    const el = (id ? document.querySelector('[data-sightmap-id="' + id + '"]') : null)
+               || document.querySelector(selector);
+    if (!el) continue;
+    const vals = {};
+    for (const {name, extract, transform} of props) {
+      let val = extractValue(el, extract);
+      if (val == null) continue;
+      val = String(val).trim().replace(/\s+/g, ' ');
+      if (val === '') continue;
+      val = applyTransform(val, transform);
+      if (val) vals[name] = String(val).slice(0, 120);
+    }
+    if (Object.keys(vals).length > 0) results[id] = vals;
+  }
+  return results;
+})(SPECS_JSON)`
+
+	script := strings.Replace(jsTemplate, "SPECS_JSON", string(specsJSON), 1)
+
+	resultJSON, evalErr := browser.EvalJSON(ctx, conn, script)
+	if evalErr != nil {
+		fmt.Fprintf(os.Stderr, "observe: property extraction: %v\n", evalErr)
+		return nil
+	}
+
+	var propValues map[string]map[string]string
+	if err := json.Unmarshal(resultJSON, &propValues); err != nil {
+		fmt.Fprintf(os.Stderr, "observe: property extraction unmarshal: %v\n", err)
+		return nil
+	}
+	return propValues
+}

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -1,0 +1,404 @@
+// Package observe acquires and renders an annotated snapshot of a live page: it
+// runs the component-extraction pipeline, applies a corpus, extracts property
+// values, and scores coverage (observe.Page), then formats the result as the
+// annotated tree + section output (observe.Format). It is the shared read path
+// behind the snapshot and capture commands, and the entrypoint external callers
+// use to observe a page against a corpus.
+package observe
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/render"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// FormatOpts carries the display toggles for Format.
+type FormatOpts struct {
+	Interactive  bool // show interactive nodes only
+	MaxDepth     int  // max tree depth (0 = unlimited)
+	Trace        bool // include unlabeled-cluster / T2-scope traces
+	CoverageOnly bool // suppress the guide + tree; show View/Coverage/traces only
+	Selectors    bool // show tag #id [data-testid] selector hints
+}
+
+// Format writes the annotated snapshot sections (View, Guide, tree, Warnings,
+// Coverage) for a Result to w. FormatOpts carries only display toggles; all data
+// comes from the Result.
+func Format(w io.Writer, r *Result, opts FormatOpts) {
+	// ── [View: ...] ──────────────────────────────────────────────────────────
+	if r.View != nil {
+		fmt.Fprintf(w, "[View: %s]\n", r.View.Name)
+		fmt.Fprintf(w, "route: %s\n", r.View.Route)
+		if len(r.View.Memory) > 0 {
+			fmt.Fprintf(w, "memory:\n")
+			for _, m := range r.View.Memory {
+				fmt.Fprintf(w, "  - %s\n", m)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// ── [Guide] ───────────────────────────────────────────────────────────────
+	// Skipped in coverage-only mode, which is meant to be a terse feedback r.View.
+	if !opts.CoverageOnly && len(r.Matches) > 0 {
+		writeGuide(w, r.Matches)
+		fmt.Fprintln(w)
+	}
+
+	// ── component tree ────────────────────────────────────────────────────────
+	// Coverage-only mode suppresses the (potentially huge) tree entirely.
+	if !opts.CoverageOnly {
+		fmt.Fprintf(w, "--- component tree ---\n\n")
+		if r.Root != nil {
+			comp := render.Filter(r.Root, r.Matches)
+			if comp != nil {
+				comp.Format(w, "", render.FormatOpts{
+					Selectors:   opts.Selectors,
+					MaxDepth:    opts.MaxDepth,
+					Interactive: opts.Interactive,
+					PropValues:  r.Props,
+				})
+			}
+		}
+	}
+
+	// ── [Warnings] ────────────────────────────────────────────────────────────
+	if len(r.Components) > 0 && r.Matches != nil {
+		writeZeroMatchWarnings(w, r.Components, r.Matches, r.View, r.GlobalNames)
+	}
+
+	// ── [Coverage] ────────────────────────────────────────────────────────────
+	if r.Matches != nil {
+		fmt.Fprintln(w)
+		cov := r.Coverage
+		writeCoverage(w, cov)
+
+		// ── Unlabeled clusters (--trace) ─────────────────────────────────────
+		// Coverage-only mode always shows the cluster traces — they are the point
+		// of the terse r.View (which orphans/ambiguous clusters still need work).
+		if opts.Trace || opts.CoverageOnly {
+			if len(cov.Orphans) > 0 {
+				fmt.Fprintln(w)
+				WriteTrace(w, cov.Orphans, cov.ParentMap)
+			}
+			if len(cov.Scopes) > 0 {
+				fmt.Fprintln(w)
+				WriteT2Trace(w, cov.Scopes, cov.ScopeChildren, r.Matches, r.View)
+			}
+		}
+	}
+}
+
+// writeGuide prints the [Guide] section: component names and match counts,
+// sorted by count descending then name ascending.
+func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.SightmapMatch) {
+	counts := make(map[string]int)
+	for _, m := range matches {
+		if m != nil {
+			counts[m.Name]++
+		}
+	}
+
+	type nc struct {
+		name  string
+		count int
+	}
+	guide := make([]nc, 0, len(counts))
+	for name, cnt := range counts {
+		guide = append(guide, nc{name, cnt})
+	}
+	sort.Slice(guide, func(i, j int) bool {
+		if guide[i].count != guide[j].count {
+			return guide[i].count > guide[j].count
+		}
+		return guide[i].name < guide[j].name
+	})
+	if len(guide) == 0 {
+		return
+	}
+
+	maxNameLen := 0
+	for _, g := range guide {
+		if len(g.name) > maxNameLen {
+			maxNameLen = len(g.name)
+		}
+	}
+	countWidth := len(fmt.Sprintf("%d", guide[0].count))
+	nameWidth := maxNameLen + 2 // minimum two-space gap before count column
+
+	fmt.Fprintf(w, "[Guide]\n")
+	for _, g := range guide {
+		fmt.Fprintf(w, "%-*s%*d\n", nameWidth, g.name, countWidth, g.count)
+	}
+}
+
+// writeZeroMatchWarnings emits a [Warnings] section listing view components
+// that matched 0 nodes in the extracted tree, and a [Snapshot check] line
+// when every top-level component missed \u2014 a strong signal for wrong-page capture.
+// globalNames is the set of corpus-level global component names; these are
+// excluded from the page-check since they match on any page.
+func writeZeroMatchWarnings(
+	w io.Writer,
+	viewComponents []match.SightmapComponent,
+	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	view *sightmap.View,
+	globalNames map[string]bool,
+) {
+	// Count matches per component name.
+	counts := make(map[string]int)
+	for _, m := range matches {
+		if m != nil {
+			counts[m.Name]++
+		}
+	}
+
+	viewName := ""
+	if view != nil {
+		viewName = view.Name
+	}
+
+	// Page-check: if all top-level view-specific components (excluding globals)
+	// matched 0 nodes, the snapshot likely captured the wrong page.
+	if view != nil {
+		CheckRootComponents(w, view.Components, globalNames, counts, viewName)
+	}
+
+	var warnings []string
+	for _, comp := range viewComponents {
+		if comp.Name == "" || len(comp.Selectors) == 0 {
+			continue // skip anonymous/empty
+		}
+		if counts[comp.Name] == 0 {
+			if viewName != "" {
+				warnings = append(warnings, fmt.Sprintf("%s: %s \u2014 0 matches", viewName, comp.Name))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("%s \u2014 0 matches", comp.Name))
+			}
+		}
+	}
+
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "[Warnings]")
+	for _, w2 := range warnings {
+		fmt.Fprintln(w, w2)
+	}
+	fmt.Fprintln(w)
+}
+
+// writeCoverage prints the [Coverage] section.
+func writeCoverage(w io.Writer, cov coverage.Result) {
+	check := "✗"
+	if cov.T3 == 0 {
+		check = "✓"
+	}
+	if cov.VisibleOnly {
+		fmt.Fprintf(w, "[Coverage] (visible only)\n")
+	} else {
+		fmt.Fprintf(w, "[Coverage]\n")
+	}
+	fmt.Fprintf(w, "%d interactive · %d direct T1 (%d%%) · %d scoped T2 (%d%%) · %d orphaned T3 %s\n",
+		cov.Total, cov.T1, coverage.Pct(cov.T1, cov.Total), cov.T2, coverage.Pct(cov.T2, cov.Total), cov.T3, check)
+}
+
+// WriteTrace prints the "Unlabeled clusters" section for T3 (orphaned) nodes.
+// Clusters are grouped by (role, name, nearest-data-attr-ancestor selector)
+// and sorted by count descending.
+func WriteTrace(
+	w io.Writer,
+	t3nodes []*comps.ComponentNode,
+	parentMap map[*comps.ComponentNode]*comps.ComponentNode,
+) {
+	type clusterKey struct {
+		role   string
+		name   string // "(no text)" when empty
+		inside string // selector of nearest data-attr ancestor, or ""
+	}
+	type cluster struct {
+		count int
+		rep   *comps.ComponentNode
+	}
+
+	var order []clusterKey
+	clusters := make(map[clusterKey]*cluster)
+
+	for _, n := range t3nodes {
+		anc := coverage.NearestDataAttrAncestor(n, parentMap)
+		inside := ""
+		if anc != nil {
+			inside = coverage.DataAttrSelector(anc)
+		}
+
+		nameStr := n.Name
+		if nameStr == "" {
+			nameStr = "(no text)"
+		} else {
+			nameStr = render.TruncateRunes(nameStr, 40)
+		}
+
+		role := n.Role
+		if role == "" {
+			role = "?"
+		}
+
+		key := clusterKey{role: role, name: nameStr, inside: inside}
+		if c, ok := clusters[key]; ok {
+			c.count++
+		} else {
+			clusters[key] = &cluster{count: 1, rep: n}
+			order = append(order, key)
+		}
+	}
+
+	sort.Slice(order, func(i, j int) bool {
+		ci, cj := clusters[order[i]], clusters[order[j]]
+		if ci.count != cj.count {
+			return ci.count > cj.count
+		}
+		if order[i].role != order[j].role {
+			return order[i].role < order[j].role
+		}
+		return order[i].name < order[j].name
+	})
+
+	fmt.Fprintf(w, "Unlabeled clusters:\n")
+	for _, key := range order {
+		c := clusters[key]
+		nameDisp := key.name
+		if key.name != "(no text)" {
+			nameDisp = `"` + key.name + `"`
+		}
+		fmt.Fprintf(w, "  %d\u00d7 %s %s\n", c.count, key.role, nameDisp)
+		if key.inside != "" {
+			fmt.Fprintf(w, "       inside: %s\n", key.inside)
+			if hint := coverage.ArrowHint(c.rep, parentMap); hint != "" {
+				fmt.Fprintf(w, "       \u2192 %s\n", hint)
+			}
+		}
+	}
+}
+
+// WriteT2Trace prints T2 scopes (interactive children without direct matches).
+// Enumerates each child node (role + name) with suppression rules:
+//   - Single-child T2 scopes are omitted (simple wrapper, acceptable)
+//   - Components with memory notes show suppressed summary
+//   - Large lists truncate at 8 items with "… (N more)"
+func WriteT2Trace(
+	w io.Writer,
+	t2clusters map[*comps.ComponentNode]int,
+	t2children map[*comps.ComponentNode][]*comps.ComponentNode,
+	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	view *sightmap.View,
+) {
+	const minT2Count = 2 // ≥2 children required (single-child = simple wrapper)
+	const truncateAt = 8 // show first 8, then "… (N more)"
+
+	type entry struct {
+		name      string
+		count     int
+		children  []*comps.ComponentNode
+		hasMemory bool
+	}
+	var entries []entry
+	for node, count := range t2clusters {
+		if count < minT2Count {
+			continue
+		}
+		m := matches[node]
+		if m == nil || m.Name == "" {
+			continue
+		}
+		// Check if component has memory note
+		hasMemory := false
+		if view != nil {
+			for _, c := range view.Components {
+				if c.Name == m.Name && len(c.Memory) > 0 {
+					hasMemory = true
+					break
+				}
+			}
+		}
+		entries = append(entries, entry{
+			name:      m.Name,
+			count:     count,
+			children:  t2children[node],
+			hasMemory: hasMemory,
+		})
+	}
+	if len(entries) == 0 {
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count != entries[j].count {
+			return entries[i].count > entries[j].count
+		}
+		return entries[i].name < entries[j].name
+	})
+	if len(entries) > 10 {
+		entries = entries[:10]
+	}
+
+	fmt.Fprintf(w, "T2 scopes (interactive children without direct component matches):\n")
+	for _, e := range entries {
+		fmt.Fprintf(w, "  [%s] (%d)", e.name, e.count)
+		if e.hasMemory {
+			fmt.Fprintf(w, " — exhausted, see component memory note\n")
+			continue
+		}
+		fmt.Fprintln(w)
+		// Enumerate children
+		shown := e.count
+		if shown > truncateAt {
+			shown = truncateAt
+		}
+		for i := 0; i < shown && i < len(e.children); i++ {
+			child := e.children[i]
+			fmt.Fprintf(w, "    %s %q\n", child.Role, child.Name)
+		}
+		if e.count > truncateAt {
+			fmt.Fprintf(w, "    … (%d more)\n", e.count-truncateAt)
+		}
+	}
+}
+
+// CheckRootComponents writes a [Snapshot check] warning to w when every
+// view-specific top-level component (empty ParentChain, not in globalNames)
+// matched 0 nodes. This is a strong signal that the snapshot captured the
+// wrong page — e.g. a direct URL load silently fell back to a different
+// route (the topwork wizard returning the Dashboard). globalNames excludes
+// shared components (Header, TopworkApp, etc.) that match any page and would
+// suppress the warning spuriously. Pass nil to skip the exclusion.
+func CheckRootComponents(w io.Writer, viewComponents []match.SightmapComponent, globalNames map[string]bool, counts map[string]int, viewName string) {
+	var topNames []string
+	for _, comp := range viewComponents {
+		if comp.Name == "" || len(comp.Selectors) == 0 || len(comp.ParentChain) > 0 {
+			continue
+		}
+		if globalNames[comp.Name] {
+			continue // skip globals — they match on any page
+		}
+		topNames = append(topNames, comp.Name)
+	}
+	if len(topNames) == 0 {
+		return // no view-specific top-level components to check
+	}
+	for _, name := range topNames {
+		if counts[name] > 0 {
+			return // at least one view-specific root matched — page is plausibly correct
+		}
+	}
+	label := ""
+	if viewName != "" {
+		label = viewName + ": "
+	}
+	fmt.Fprintf(w, "\n[Snapshot check] %sview root components all unmatched — wrong page captured? (expected: %s)\n\n",
+		label, strings.Join(topNames, ", "))
+}

--- a/go/observe/t2trace_test.go
+++ b/go/observe/t2trace_test.go
@@ -1,4 +1,4 @@
-package main
+package observe
 
 import (
 	"bytes"
@@ -39,7 +39,7 @@ func TestWriteT2Trace_Basic(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeT2Trace(&buf, t2clusters, t2children, matches, view)
+	WriteT2Trace(&buf, t2clusters, t2children, matches, view)
 
 	output := buf.String()
 	if output == "" {
@@ -86,7 +86,7 @@ func TestWriteT2Trace_SingleChildSuppressed(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeT2Trace(&buf, t2clusters, t2children, matches, view)
+	WriteT2Trace(&buf, t2clusters, t2children, matches, view)
 
 	output := buf.String()
 	// Single-child T2 should be suppressed (minT2Count = 2)
@@ -126,7 +126,7 @@ func TestWriteT2Trace_MemoryNoteSuppressed(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeT2Trace(&buf, t2clusters, t2children, matches, view)
+	WriteT2Trace(&buf, t2clusters, t2children, matches, view)
 
 	output := buf.String()
 
@@ -177,7 +177,7 @@ func TestWriteT2Trace_Truncation(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	writeT2Trace(&buf, t2clusters, t2children, matches, view)
+	WriteT2Trace(&buf, t2clusters, t2children, matches, view)
 
 	output := buf.String()
 

--- a/go/render/text.go
+++ b/go/render/text.go
@@ -1,0 +1,13 @@
+package render
+
+import "unicode/utf8"
+
+// TruncateRunes truncates s to at most maxRunes Unicode code points,
+// appending "…" when truncation occurs.
+func TruncateRunes(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxRunes]) + "…"
+}


### PR DESCRIPTION
## What

The last big subsystem extraction. `observe` is the shared read path behind `snapshot` and `capture`, and the Tier-B entrypoint external callers (Subtext) use to observe a page against a corpus.

- **`observe.Page(ctx, conn, corpus, opts) -> *Result`** — extract the component tree, apply the corpus (matches, view, components, global names), score coverage, and optionally extract live property values. Navigation and the browser lifecycle stay with the caller; `Page` only reads the current page state.
- **`observe.Format(w, *Result, FormatOpts)`** — the annotated section output (View, Guide, tree, Warnings, Coverage), previously `writeOutput`; the section writers move with it.
- `WriteTrace` / `WriteT2Trace` / `CheckRootComponents` / `ExtractProperties` are exported because the offline `coverage` command and the `browser` component-query resolver genuinely share them.

## Impact

`cmd_snapshot.go` drops from **970 lines** (pre-coverage-extraction) to **204**: `runSnapshot` and `capture` are now thin adapters that navigate, call `observe.Page`, and hand the `Result` to `observe.Format`.

Two shared helpers relocate: `truncateStr` → `render.TruncateRunes` (used by observe's trace + report); `displayName` moves next to the annotation-gaps printer (its only caller). The no-op `--compact` flag is dropped (docs sync is a later step).

## Verified

- `go build`, `go vet`, `gofmt -l .`, `go test ./...` all clean; new `observe` package tests pass (the T2-trace test moved with the code).
- Behavior-preserving against the burrito example: `snapshot` (full tree + guide + coverage), `snapshot --coverage`, `snapshot --json` (properties), `capture`, `browser click` by component query (property resolution), and `coverage --trace` all match the pre-refactor output.
