### PR TITLE
Extract the authoring package (suggest/discover DOM scans)

### DIFF
--- a/go/authoring/scan.go
+++ b/go/authoring/scan.go
@@ -1,0 +1,118 @@
+// Package authoring holds the live-DOM discovery scans used while building a
+// corpus: a selector-candidate scan (behind `suggest`) and an internal-link
+// scan plus URL-pattern normalization (behind `discover`). The bespoke
+// browser-side JavaScript lives here, in one place, rather than inline in each
+// command, so it cannot drift and can be reused by other tooling.
+package authoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sightmap/sightmap/go/browser"
+)
+
+// Candidate is one selector candidate found by ScanCandidates: a stable
+// data-attribute selector, how many elements it matched, and enough context
+// (role/tag/sample text, nearest already-captured ancestor) to rank and group it.
+type Candidate struct {
+	Sel        string `json:"sel"`
+	Count      int    `json:"count"`
+	Role       string `json:"role"`
+	Tag        string `json:"tag"`
+	Sample     string `json:"sample"`
+	AncestorId string `json:"ancestorId"`
+}
+
+// ScanCandidates runs a DOM pass over the live page and returns up to max
+// data-testid / data-component selector candidates, most-frequent first. Each
+// candidate records the nearest [data-sightmap-id] ancestor so callers can group
+// candidates under the component that already covers their region.
+func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Candidate, error) {
+	script := fmt.Sprintf(`(function(max) {
+  const results = {};
+  const selectors = [
+    '[data-testid]',
+    '[data-component]',
+    '[aria-label][role]',
+    '[role="navigation"]',
+    '[role="search"]',
+    '[role="banner"]',
+    '[role="main"]',
+    '[role="complementary"]',
+    '[role="contentinfo"]',
+    '[role="dialog"]',
+    '[role="alertdialog"]',
+    '[role="tablist"]',
+    '[role="tab"]',
+    '[role="tabpanel"]',
+  ];
+  for (const sel of selectors) {
+    const els = document.querySelectorAll(sel);
+    for (const el of els) {
+      let candidate = '';
+      const dt = el.getAttribute('data-testid');
+      const dc = el.getAttribute('data-component');
+      const role = el.getAttribute('role') || el.tagName.toLowerCase();
+      const tag = el.tagName.toLowerCase();
+      const text = el.textContent.trim().replace(/\s+/g, ' ').slice(0, 60);
+      if (dt) {
+        candidate = '[data-testid="' + dt + '"]';
+      } else if (dc) {
+        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, '');
+        candidate = '[data-component^="' + base + '"]';
+      } else {
+        continue;
+      }
+      if (!results[candidate]) {
+        const ancestorEl = el.closest('[data-sightmap-id]');
+        const ancestorId = ancestorEl ? ancestorEl.getAttribute('data-sightmap-id') : '';
+        results[candidate] = {sel: candidate, count: 0, role: role, tag: tag, sample: text, ancestorId: ancestorId};
+      }
+      results[candidate].count++;
+    }
+  }
+  return Object.values(results).sort((a,b) => b.count - a.count).slice(0, max);
+})(%d)`, max)
+
+	raw, err := browser.EvalJSON(ctx, conn, script)
+	if err != nil {
+		return nil, fmt.Errorf("scan candidates: eval: %v", err)
+	}
+	var candidates []Candidate
+	if err := json.Unmarshal(raw, &candidates); err != nil {
+		return nil, fmt.Errorf("scan candidates: parse result: %v", err)
+	}
+	return candidates, nil
+}
+
+// ScanLinks returns the distinct same-host link pathnames on the live page, in
+// document order. Callers normalize these into route patterns with NormalizePath.
+func ScanLinks(ctx context.Context, conn *browser.CDPConn) ([]string, error) {
+	const linkScript = `(function() {
+  const host = location.host;
+  const seen = new Set();
+  const links = [];
+  for (const a of document.querySelectorAll('a[href]')) {
+    try {
+      const u = new URL(a.href);
+      if (u.host === host && !seen.has(u.pathname)) {
+        seen.add(u.pathname);
+        links.push(u.pathname);
+      }
+    } catch(e) {}
+  }
+  return links;
+})()`
+
+	raw, err := browser.EvalJSON(ctx, conn, linkScript)
+	if err != nil {
+		return nil, fmt.Errorf("scan links: eval: %v", err)
+	}
+	var pathnames []string
+	if err := json.Unmarshal(raw, &pathnames); err != nil {
+		return nil, fmt.Errorf("scan links: parse result: %v", err)
+	}
+	return pathnames, nil
+}

--- a/go/authoring/urlpattern.go
+++ b/go/authoring/urlpattern.go
@@ -1,0 +1,38 @@
+package authoring
+
+import (
+	"regexp"
+	"strings"
+)
+
+// NormalizePath collapses a concrete URL path into a route pattern by replacing
+// dynamic segments with "*". A segment is dynamic if it is all digits, a UUID,
+// or a slug-like token (8+ lowercase alphanumeric/dash chars) containing at
+// least one digit. Used by `discover` to fold many concrete links into the
+// handful of route patterns a corpus would declare.
+func NormalizePath(path string) string {
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	for i, seg := range segments {
+		if isDynamicSegment(seg) {
+			segments[i] = "*"
+		}
+	}
+	return "/" + strings.Join(segments, "/")
+}
+
+var (
+	reAllDigits = regexp.MustCompile(`^\d+$`)
+	reSlugDyn   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{7,}$`) // 8+ chars
+	reUUID      = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	reHasDigit  = regexp.MustCompile(`\d`)
+)
+
+func isDynamicSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	lower := strings.ToLower(seg)
+	return reAllDigits.MatchString(seg) ||
+		reUUID.MatchString(lower) ||
+		(reSlugDyn.MatchString(lower) && reHasDigit.MatchString(lower))
+}

--- a/go/authoring/urlpattern_test.go
+++ b/go/authoring/urlpattern_test.go
@@ -1,0 +1,20 @@
+package authoring
+
+import "testing"
+
+func TestNormalizePath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/products/12345", "/products/*"},
+		{"/p/garden-hose-50ft", "/p/*"},                               // slug with digit → dynamic
+		{"/category/outdoor", "/category/outdoor"},                    // pure-word slug → kept
+		{"/orders/550e8400-e29b-41d4-a716-446655440000", "/orders/*"}, // UUID
+		{"/", "/"},
+		{"/about", "/about"},
+		{"/u/42/settings", "/u/*/settings"},
+	}
+	for _, c := range cases {
+		if got := NormalizePath(c.in); got != c.want {
+			t.Errorf("NormalizePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/go/cmd/sightmap/cmd_discover.go
+++ b/go/cmd/sightmap/cmd_discover.go
@@ -2,17 +2,15 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/sightmap/sightmap/go/authoring"
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -59,36 +57,15 @@ func runDiscover(args []string) error {
 	}
 
 	// ── Extract internal links from the current page ─────────────────────────
-	const linkScript = `(function() {
-  const host = location.host;
-  const seen = new Set();
-  const links = [];
-  for (const a of document.querySelectorAll('a[href]')) {
-    try {
-      const u = new URL(a.href);
-      if (u.host === host && !seen.has(u.pathname)) {
-        seen.add(u.pathname);
-        links.push(u.pathname);
-      }
-    } catch(e) {}
-  }
-  return links;
-})()`
-
-	raw, err := browser.EvalJSON(ctx, conn, linkScript)
+	pathnames, err := authoring.ScanLinks(ctx, conn)
 	if err != nil {
-		return fmt.Errorf("discover: eval links: %v", err)
-	}
-
-	var pathnames []string
-	if err := json.Unmarshal(raw, &pathnames); err != nil {
-		return fmt.Errorf("discover: parse links: %v", err)
+		return fmt.Errorf("discover: %v", err)
 	}
 
 	// ── Normalise paths → patterns; count how many raw paths map to each ──────
 	patternCounts := make(map[string]int)
 	for _, p := range pathnames {
-		patternCounts[normalisePath(p)]++
+		patternCounts[authoring.NormalizePath(p)]++
 	}
 
 	// ── Load corpus (optional — absent dir = treat all patterns as unseen) ────
@@ -213,74 +190,13 @@ func runDiscover(args []string) error {
 	return nil
 }
 
-// normalisePath replaces dynamic path segments with "*".
-// A segment is dynamic if it is all digits, a UUID, or a slug-like token
-// (8+ lowercase alphanumeric/dash chars) that contains at least one digit.
-func normalisePath(path string) string {
-	segments := strings.Split(strings.Trim(path, "/"), "/")
-	for i, seg := range segments {
-		if isDynamicSegment(seg) {
-			segments[i] = "*"
-		}
-	}
-	return "/" + strings.Join(segments, "/")
-}
-
-var (
-	reAllDigits = regexp.MustCompile(`^\d+$`)
-	reSlugDyn   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{7,}$`) // 8+ chars
-	reUUID      = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
-	reHasDigit  = regexp.MustCompile(`\d`)
-)
-
-func isDynamicSegment(seg string) bool {
-	if seg == "" {
-		return false
-	}
-	lower := strings.ToLower(seg)
-	return reAllDigits.MatchString(seg) ||
-		reUUID.MatchString(lower) ||
-		(reSlugDyn.MatchString(lower) && reHasDigit.MatchString(lower))
-}
-
 // matchSurvey returns the first survey pattern that glob-matches discoveredPattern,
 // using the same ** / * semantics as sightmap view route matching.
 func matchSurvey(patterns []surveyPattern, discoveredPattern string) (surveyPattern, bool) {
 	for _, sp := range patterns {
-		re := routePatternToRegex(sp.pattern)
-		if compiled, err := regexp.Compile(re); err == nil {
-			if compiled.MatchString(discoveredPattern) {
-				return sp, true
-			}
+		if sightmap.MatchRoute(sp.pattern, discoveredPattern) {
+			return sp, true
 		}
 	}
 	return surveyPattern{}, false
-}
-
-// routePatternToRegex converts a route glob (with ** and *) to an anchored regexp.
-// Mirrors sightmap/corpus.go:routeToRegex but defined locally to avoid importing internals.
-func routePatternToRegex(pattern string) string {
-	var sb strings.Builder
-	sb.WriteByte('^')
-	for i := 0; i < len(pattern); {
-		if pattern[i] == '*' {
-			if i+1 < len(pattern) && pattern[i+1] == '*' {
-				sb.WriteString("(.+)")
-				i += 2
-				continue
-			}
-			sb.WriteString("([^/]+)")
-			i++
-			continue
-		}
-		c := pattern[i]
-		switch c {
-		case '.', '+', '?', '(', ')', '[', ']', '{', '}', '\\', '|', '^', '$':
-			sb.WriteByte('\\')
-		}
-		sb.WriteByte(c)
-		i++
-	}
-	sb.WriteByte('$')
-	return sb.String()
 }

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -11,20 +11,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sightmap/sightmap/go/authoring"
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
-
-// suggestCandidate holds one DOM selector candidate from the JS probe.
-type suggestCandidate struct {
-	Sel        string `json:"sel"`
-	Count      int    `json:"count"`
-	Role       string `json:"role"`
-	Tag        string `json:"tag"`
-	Sample     string `json:"sample"`
-	AncestorId string `json:"ancestorId"`
-}
 
 func runSuggest(args []string) error {
 	fs := flag.NewFlagSet("suggest", flag.ContinueOnError)
@@ -65,61 +56,10 @@ func runSuggest(args []string) error {
 		cleanup = func() { conn.Close() }
 	}
 
-	// ── Build and run the JS probe ───────────────────────────────────────────
-	script := fmt.Sprintf(`(function(max) {
-  const results = {};
-  const selectors = [
-    '[data-testid]',
-    '[data-component]',
-    '[aria-label][role]',
-    '[role="navigation"]',
-    '[role="search"]',
-    '[role="banner"]',
-    '[role="main"]',
-    '[role="complementary"]',
-    '[role="contentinfo"]',
-    '[role="dialog"]',
-    '[role="alertdialog"]',
-    '[role="tablist"]',
-    '[role="tab"]',
-    '[role="tabpanel"]',
-  ];
-  for (const sel of selectors) {
-    const els = document.querySelectorAll(sel);
-    for (const el of els) {
-      let candidate = '';
-      const dt = el.getAttribute('data-testid');
-      const dc = el.getAttribute('data-component');
-      const role = el.getAttribute('role') || el.tagName.toLowerCase();
-      const tag = el.tagName.toLowerCase();
-      const text = el.textContent.trim().replace(/\s+/g, ' ').slice(0, 60);
-      if (dt) {
-        candidate = '[data-testid="' + dt + '"]';
-      } else if (dc) {
-        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, '');
-        candidate = '[data-component^="' + base + '"]';
-      } else {
-        continue;
-      }
-      if (!results[candidate]) {
-        const ancestorEl = el.closest('[data-sightmap-id]');
-        const ancestorId = ancestorEl ? ancestorEl.getAttribute('data-sightmap-id') : '';
-        results[candidate] = {sel: candidate, count: 0, role: role, tag: tag, sample: text, ancestorId: ancestorId};
-      }
-      results[candidate].count++;
-    }
-  }
-  return Object.values(results).sort((a,b) => b.count - a.count).slice(0, max);
-})(%d)`, *maxFlag)
-
-	raw, err := browser.EvalJSON(ctx, conn, script)
+	// ── Scan the live DOM for selector candidates ────────────────────────────
+	candidates, err := authoring.ScanCandidates(ctx, conn, *maxFlag)
 	if err != nil {
-		return fmt.Errorf("suggest: eval: %v", err)
-	}
-
-	var candidates []suggestCandidate
-	if err := json.Unmarshal(raw, &candidates); err != nil {
-		return fmt.Errorf("suggest: parse result: %v", err)
+		return fmt.Errorf("suggest: %v", err)
 	}
 
 	// ── Optionally filter out known sightmap components ──────────────────────
@@ -136,7 +76,7 @@ func runSuggest(args []string) error {
 	}
 
 	// ── Apply filters ────────────────────────────────────────────────────────
-	var filtered []suggestCandidate
+	var filtered []authoring.Candidate
 	for _, c := range candidates {
 		if c.Count < *minCountFlag {
 			continue
@@ -171,7 +111,7 @@ func runSuggest(args []string) error {
 		}
 
 		// Group candidates by match name.
-		groups := make(map[string][]suggestCandidate)
+		groups := make(map[string][]authoring.Candidate)
 		for _, c := range filtered {
 			matchName := sightmapMatchMap[c.AncestorId]
 			groups[matchName] = append(groups[matchName], c)
@@ -187,7 +127,7 @@ func runSuggest(args []string) error {
 		// Build sorted list of named groups (exclude ungrouped for now).
 		type namedGroup struct {
 			name  string
-			cands []suggestCandidate
+			cands []authoring.Candidate
 		}
 		var sortedGroups []namedGroup
 		for name, cands := range groups {
@@ -256,7 +196,7 @@ func runSuggest(args []string) error {
 
 // printSuggestCandidates prints a formatted list of candidates, aligned by
 // selector width. Used by the grouped output path.
-func printSuggestCandidates(cands []suggestCandidate) {
+func printSuggestCandidates(cands []authoring.Candidate) {
 	maxSelLen := 0
 	for _, c := range cands {
 		if len(c.Sel) > maxSelLen {

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -130,7 +130,7 @@ func (c *Corpus) ViewForURL(pageURL string) *View {
 		path = "/"
 	}
 	for i := range c.Views {
-		if matchRoute(c.Views[i].Route, path) {
+		if MatchRoute(c.Views[i].Route, path) {
 			v := c.Views[i] // copy so caller doesn't share Corpus internals
 			return &v
 		}
@@ -138,10 +138,10 @@ func (c *Corpus) ViewForURL(pageURL string) *View {
 	return nil
 }
 
-// matchRoute reports whether the glob-style route pattern matches path.
+// MatchRoute reports whether the glob-style route pattern matches path.
 // ** matches any sequence of characters including slashes (one or more).
 // *  matches a single path segment (no slashes).
-func matchRoute(pattern, path string) bool {
+func MatchRoute(pattern, path string) bool {
 	re := regexp.MustCompile(routeToRegex(pattern))
 	return re.MatchString(path)
 }


### PR DESCRIPTION
## What

Factor the bespoke browser-side JavaScript out of `suggest` and `discover` into a shared **`authoring`** package, so the DOM-scan JS lives in one place and can't drift.

- `ScanCandidates(ctx, conn, max)` — the `data-testid`/`data-component` selector-candidate scan (behind `suggest`), returning ranked `Candidate` values.
- `ScanLinks(ctx, conn)` — the same-host `a[href]` pathname scan (behind `discover`).
- `NormalizePath` — folds a concrete path into a route pattern by replacing dynamic (numeric / UUID / slug) segments with `*`.

The commands keep their flag parsing, corpus loading, filtering, grouping, and printing — only the DOM JS and URL-pattern logic move. `gap` is untouched (it uses no bespoke JS — extract + match + coverage T3).

## Bonus dedup

`discover` carried a hand-rolled `routePatternToRegex` — an admitted copy of `sightmap/corpus.go`'s route matcher. Exported `sightmap.MatchRoute` and used it for `survey.yaml` glob matching, deleting the duplicate.

## Verified

- `go build`, `go vet`, `gofmt -l .`, `go test ./...` all clean; new `NormalizePath` test passes.
- Against the burrito example: `suggest` and `discover` run cleanly. The app has no `data-*` attributes or `<a href>` links (confirmed via `browser eval`), so both correctly report nothing — the scan JS is byte-identical to before and executes without error.
