### PR TITLE
Honor the context deadline in pollCDPReady (de-flake TestLaunch)

### DIFF
--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -298,9 +298,15 @@ func sessionFilePath() string {
 }
 
 // pollCDPReady polls http://ADDR/json/version every 100 ms until Chrome
-// responds or the deadline (10 s) / ctx is exceeded.
+// responds or the context deadline (10 s when the ctx has none) is exceeded.
 func pollCDPReady(ctx context.Context, addr string) error {
-	deadline := time.Now().Add(10 * time.Second)
+	// Honor the caller's deadline so a caller that budgets more startup time (a
+	// cold, loaded CI runner can need well over 10s to bind the debug port) gets
+	// it. Fall back to 10s only when the context is deadline-less.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(10 * time.Second)
+	}
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -314,7 +320,7 @@ func pollCDPReady(ctx context.Context, addr string) error {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("chrome did not become ready within 10s at %s: %w", addr, err)
+			return fmt.Errorf("chrome did not become ready at %s: %w", addr, err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/go/browser/launcher_test.go
+++ b/go/browser/launcher_test.go
@@ -52,7 +52,7 @@ func TestLaunch(t *testing.T) {
 	if _, err := FindChrome(); err != nil {
 		t.Skip("Chrome not found:", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	// Force headless with CI-safe flags. The default launch is headed, which
 	// can't start on a display-less CI runner: Chrome exits immediately and


### PR DESCRIPTION
TestLaunch is a real-Chrome launch test that has flaked on recent `main` pushes (#17, #19) and is now blocking PR checks. Root cause: `pollCDPReady` hard-caps the debug-port wait at 10s regardless of the caller's context deadline, so a cold/loaded CI runner can't bind Chrome's port in time ("connection refused").

Fix: honor the ctx deadline when present (fall back to 10s only for a deadline-less ctx), and give the test a 30s budget. CLI callers pass `context.Background()` (no deadline), so their 10s behavior is unchanged.

Verified: `go build`, `gofmt -l .`, and `TestLaunch` pass locally.