### PR TITLE
Share the live-session CLI scaffold across commands

### DIFF
--- a/go/browser/connect.go
+++ b/go/browser/connect.go
@@ -7,6 +7,32 @@ import (
 	"strings"
 )
 
+// ConnectOrLaunch attaches to a running Chrome session, or launches a fresh
+// headed one when launch is true and no session is reachable. It returns the
+// connection and a cleanup func the caller must defer: Close for an attached
+// session, or full process teardown for a launched one. When launch is false and
+// nothing is reachable, the connect error is returned unwrapped so callers can
+// present their own guidance. This is the single connection primitive every
+// page-affecting command (and external callers that own the browser lifecycle)
+// should build on.
+func ConnectOrLaunch(ctx context.Context, addr, tabID string, launch bool) (*CDPConn, func(), error) {
+	conn, err := Connect(addr, tabID)
+	if err == nil {
+		return conn, func() { conn.Close() }, nil
+	}
+	if !launch {
+		return nil, nil, err
+	}
+	lconn, cleanup, lerr := Launch(ctx, LaunchOptions{})
+	if lerr != nil {
+		return nil, nil, fmt.Errorf("cannot launch Chrome: %w", lerr)
+	}
+	if cleanup == nil {
+		cleanup = func() {}
+	}
+	return lconn, cleanup, nil
+}
+
 // Connect attaches to a running Chrome session for a page-affecting command.
 // With an explicit tabID it connects to that tab. Without one it auto-selects
 // the single open CONTENT tab, but errors (listing the tabs) when there are zero

--- a/go/cmd/sightmap/cli.go
+++ b/go/cmd/sightmap/cli.go
@@ -1,0 +1,139 @@
+// Shared CLI adapter glue for every command that drives a live Chrome session.
+// This is adapter-tier code (package main, never imported): it declares the
+// common flag set, maps connection/navigation into the browser subsystem, and
+// centralises the atomic --out write. Reusable browser behaviour lives in the
+// browser package; only flag wiring and CLI error prose live here.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// liveFlags is the flag set shared by every command that connects to a live
+// page. Register it on a FlagSet with addLiveFlags, then use its methods to
+// connect, navigate, and load the corpus. Commands declare their own bespoke
+// flags alongside it.
+type liveFlags struct {
+	addr        *string
+	launch      *bool
+	url         *string
+	wait        *float64
+	tab         *string
+	sightmapDir *string
+	cmd         string // command name, for error messages
+}
+
+// addLiveFlags registers the common live-session flags on fs and returns a
+// handle whose methods drive the connection. cmd is the command name used in
+// error messages.
+func addLiveFlags(fs *flag.FlagSet, cmd string) *liveFlags {
+	return &liveFlags{
+		addr:        fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)"),
+		launch:      fs.Bool("launch", false, "Auto-launch Chrome if unreachable"),
+		url:         fs.String("url", "", "Navigate to this URL before acting"),
+		wait:        fs.Float64("wait", 0, "Extra seconds to wait after DOM stability is detected (default 0; raise for unusually slow pages)"),
+		tab:         fs.String("tab", "", "Target tab ID (from 'browser start' output)"),
+		sightmapDir: fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir"),
+		cmd:         cmd,
+	}
+}
+
+// connect attaches to the session (launching Chrome first when --launch is set
+// and nothing is reachable). The returned cleanup must be deferred by the
+// caller.
+func (lf *liveFlags) connect(ctx context.Context) (*browser.CDPConn, func(), error) {
+	conn, cleanup, err := browser.ConnectOrLaunch(ctx, *lf.addr, *lf.tab, *lf.launch)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, cleanup, nil
+}
+
+// navOpts tunes how navigate waits for the page to settle.
+type navOpts struct {
+	idle    bool    // use the SPA-aware idle wait (loadEvent + networkIdle) rather than a plain DOM-ready wait
+	minWait float64 // floor applied to --wait after navigation (0 = none)
+}
+
+// navigate applies --url and --wait per opts. It is a no-op when --url is empty
+// except for an explicit --wait sleep.
+func (lf *liveFlags) navigate(ctx context.Context, conn *browser.CDPConn, opts navOpts) error {
+	if *lf.url != "" {
+		var err error
+		if opts.idle {
+			err = browser.NavigateAndWaitIdle(ctx, conn, *lf.url, 8*time.Second)
+		} else {
+			err = browser.NavigateAndWait(ctx, conn, *lf.url)
+		}
+		if err != nil {
+			return fmt.Errorf("%s: navigate: %v", lf.cmd, err)
+		}
+	}
+	wait := *lf.wait
+	if *lf.url != "" && wait < opts.minWait {
+		wait = opts.minWait
+	}
+	if wait > 0 {
+		time.Sleep(time.Duration(wait * float64(time.Second)))
+	}
+	return nil
+}
+
+// loadCorpus loads the corpus from --sightmap-dir, returning (nil, nil) when the
+// directory is absent. Use this for commands that annotate opportunistically.
+func (lf *liveFlags) loadCorpus() (*sightmap.Corpus, error) {
+	if _, err := os.Stat(*lf.sightmapDir); err != nil {
+		return nil, nil
+	}
+	return sightmap.Load(*lf.sightmapDir)
+}
+
+// requireCorpus loads the corpus, erroring when --sightmap-dir is absent. Use
+// this for commands that cannot operate without a corpus.
+func (lf *liveFlags) requireCorpus() (*sightmap.Corpus, error) {
+	if _, err := os.Stat(*lf.sightmapDir); err != nil {
+		return nil, fmt.Errorf("%s: sightmap dir %q not found — run 'sightmap validate' to check setup", lf.cmd, *lf.sightmapDir)
+	}
+	return sightmap.Load(*lf.sightmapDir)
+}
+
+// writeOut writes to path atomically (temp file + rename), or to stdout when
+// path is "". emit receives the destination writer.
+func writeOut(path string, emit func(w io.Writer) error) error {
+	if path == "" {
+		return emit(os.Stdout)
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create output directory: %v", err)
+		}
+	}
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create output file: %v", err)
+	}
+	if err := emit(f); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("close output file: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename output file: %v", err)
+	}
+	return nil
+}

--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -15,8 +15,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,18 +29,13 @@ import (
 
 func runCapture(args []string) error {
 	fs := flag.NewFlagSet("capture", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	launchFlag := fs.Bool("launch", false, "Auto-launch Chrome if unreachable")
-	urlFlag := fs.String("url", "", "Navigate to this URL before capturing")
-	waitFlag := fs.Float64("wait", 0, "Extra seconds to wait after DOM stability is detected (default 0; use for unusually slow pages)")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
+	lf := addLiveFlags(fs, "capture")
 	allFlag := fs.Bool("all", false, "Capture every view URL declared in views/*.yaml")
 	forceFlag := fs.Bool("force", false, "Write the capture even if it adds no new component/slot vs the view set (skip the novelty gate)")
 	traceFlag := fs.Bool("trace", false, "Include selector hints for unlabeled interactive clusters in the saved capture")
 	selectorsFlag := fs.Bool("selectors", false, "Show tag #id [data-testid] selector hints in the saved capture")
 	includeHiddenFlag := fs.Bool("include-hidden", false, "Include hidden/off-screen nodes in analysis")
 	jsonOutFlag := fs.Bool("json", false, "Also write an annotated JSON sibling next to each capture")
-	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -49,9 +44,9 @@ func runCapture(args []string) error {
 	{
 		explicit := map[string]bool{}
 		fs.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
-		cfg := loadSiteConfig(*sightmapDirFlag)
+		cfg := loadSiteConfig(*lf.sightmapDir)
 		if !explicit["wait"] && cfg.Snapshot.Wait > 0 {
-			*waitFlag = cfg.Snapshot.Wait
+			*lf.wait = cfg.Snapshot.Wait
 		}
 		if !explicit["include-hidden"] && cfg.Snapshot.IncludeHidden {
 			*includeHiddenFlag = true
@@ -64,57 +59,26 @@ func runCapture(args []string) error {
 	visible := !*includeHiddenFlag
 
 	if *allFlag {
-		return runCaptureAll(*sightmapDirFlag, *addrFlag, *tabFlag, *waitFlag,
+		return runCaptureAll(*lf.sightmapDir, *lf.addr, *lf.tab, *lf.wait,
 			visible, *selectorsFlag, *jsonOutFlag, *forceFlag)
 	}
 
 	ctx := context.Background()
 
-	// ── Connect to Chrome ────────────────────────────────────────────────────
-	cleanup := func() {}
-	defer func() { cleanup() }()
+	conn, cleanup, err := lf.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
-	conn, dialErr := browser.Connect(*addrFlag, *tabFlag)
-	if dialErr != nil {
-		if !*launchFlag {
-			return fmt.Errorf(
-				"capture: cannot connect to Chrome at %s\n"+
-					"Start a session first:\n"+
-					"  capture --launch --url https://...    (auto-launch Chrome)\n"+
-					"  /path/to/chrome --remote-debugging-port=7892 --user-data-dir=/tmp/cdp",
-				*addrFlag,
-			)
-		}
-		var launchCleanup func()
-		var launchErr error
-		conn, launchCleanup, launchErr = browser.Launch(ctx, browser.LaunchOptions{})
-		if launchErr != nil {
-			return fmt.Errorf("cannot launch Chrome: %v", launchErr)
-		}
-		if launchCleanup != nil {
-			cleanup = launchCleanup
-		}
-	} else {
-		cleanup = func() { conn.Close() }
+	if err := lf.navigate(ctx, conn, navOpts{idle: true}); err != nil {
+		return err
 	}
 
-	// ── Navigate ─────────────────────────────────────────────────────────────
-	if *urlFlag != "" {
-		if err := browser.NavigateAndWaitIdle(ctx, conn, *urlFlag, 8*time.Second); err != nil {
-			return fmt.Errorf("navigate: %v", err)
-		}
-	}
-	if *waitFlag > 0 {
-		time.Sleep(time.Duration(*waitFlag * float64(time.Second)))
-	}
-
-	// ── Observe (require a matching view) ─────────────────────────────────────
-	if _, statErr := os.Stat(*sightmapDirFlag); statErr != nil {
-		return fmt.Errorf("capture: no %s directory — capture appends to a corpus view set", *sightmapDirFlag)
-	}
-	corpus, cErr := sightmap.Load(*sightmapDirFlag)
+	// ── Observe (require a matching view) ───────────────────────────────
+	corpus, cErr := lf.requireCorpus()
 	if cErr != nil {
-		return fmt.Errorf("capture: load corpus: %v", cErr)
+		return cErr
 	}
 	res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible})
 	if err != nil {
@@ -131,7 +95,7 @@ func runCapture(args []string) error {
 	cov := res.Coverage
 	if !*forceFlag {
 		cand := viewset.SlotsFromMatch(res.Matches, cov.Orphans, cov.ParentMap)
-		if gres, write := viewset.Gate(corpus, *sightmapDirFlag, viewBasename, cand, false); !write {
+		if gres, write := viewset.Gate(corpus, *lf.sightmapDir, viewBasename, cand, false); !write {
 			fmt.Fprintf(os.Stderr, "capture: nothing new vs %d capture(s) in %s — not saved (use --force to keep)\n",
 				gres.ComparedTo, viewBasename)
 			return nil
@@ -139,7 +103,7 @@ func runCapture(args []string) error {
 	}
 
 	// ── Write the capture into the view's set ─────────────────────────────────
-	snapPath := viewset.CapturePath(*sightmapDirFlag, viewBasename, time.Now())
+	snapPath := viewset.CapturePath(*lf.sightmapDir, viewBasename, time.Now())
 	if err := writeCapture(snapPath, res, fmtOpts); err != nil {
 		return err
 	}
@@ -267,27 +231,12 @@ func runCaptureAll(
 // sibling, creating parent directories as needed. This is the persistence
 // primitive shared by the single-view and --all capture paths.
 func writeCapture(snapPath string, res *observe.Result, opts observe.FormatOpts) error {
-	if dir := filepath.Dir(snapPath); dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("create capture directory: %v", err)
-		}
+	if err := writeOut(snapPath, func(w io.Writer) error {
+		observe.Format(w, res, opts)
+		return nil
+	}); err != nil {
+		return err
 	}
-
-	tmpPath := snapPath + ".tmp"
-	f, ferr := os.Create(tmpPath)
-	if ferr != nil {
-		return fmt.Errorf("create capture file: %v", ferr)
-	}
-	observe.Format(f, res, opts)
-	if cerr := f.Close(); cerr != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("close capture file: %v", cerr)
-	}
-	if rerr := os.Rename(tmpPath, snapPath); rerr != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename capture file: %v", rerr)
-	}
-
 	if err := writeTreeJSON(res.Root, viewset.TreePath(snapPath)); err != nil {
 		fmt.Fprintf(os.Stderr, "capture: tree-out: %v\n", err)
 	}

--- a/go/cmd/sightmap/cmd_discover.go
+++ b/go/cmd/sightmap/cmd_discover.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/sightmap/sightmap/go/authoring"
-	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -23,10 +22,7 @@ type surveyPattern struct {
 
 func runDiscover(args []string) error {
 	fs := flag.NewFlagSet("discover", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	launchFlag := fs.Bool("launch", false, "Auto-launch Chrome if unreachable")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
+	lf := addLiveFlags(fs, "discover")
 	allFlag := fs.Bool("all", false, "Include surveyed (○) patterns in output")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -34,29 +30,13 @@ func runDiscover(args []string) error {
 
 	ctx := context.Background()
 
-	// ── Connect to Chrome ────────────────────────────────────────────────────
-	cleanup := func() {}
-	defer func() { cleanup() }()
-
-	conn, dialErr := browser.Connect(*addrFlag, *tabFlag)
-	if dialErr != nil {
-		if !*launchFlag {
-			return dialErr
-		}
-		var launchCleanup func()
-		var launchErr error
-		conn, launchCleanup, launchErr = browser.Launch(ctx, browser.LaunchOptions{})
-		if launchErr != nil {
-			return fmt.Errorf("discover: cannot launch Chrome: %v", launchErr)
-		}
-		if launchCleanup != nil {
-			cleanup = launchCleanup
-		}
-	} else {
-		cleanup = func() { conn.Close() }
+	conn, cleanup, err := lf.connect(ctx)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 
-	// ── Extract internal links from the current page ─────────────────────────
+	// ── Extract internal links from the current page ───────────────────────
 	pathnames, err := authoring.ScanLinks(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("discover: %v", err)
@@ -69,19 +49,15 @@ func runDiscover(args []string) error {
 	}
 
 	// ── Load corpus (optional — absent dir = treat all patterns as unseen) ────
-	var corpus *sightmap.Corpus
-	if _, statErr := os.Stat(*sightmapDirFlag); statErr == nil {
-		loader := sightmap.DirLoader(*sightmapDirFlag)
-		corpus, err = loader.Load()
-		if err != nil {
-			return fmt.Errorf("discover: load corpus: %v", err)
-		}
+	corpus, err := lf.loadCorpus()
+	if err != nil {
+		return fmt.Errorf("discover: load corpus: %v", err)
 	}
 
-	// ── Load survey.yaml (optional) ───────────────────────────────────────────
+	// ── Load survey.yaml (optional) ──────────────────────────────────
 	// surveyPatterns holds ordered (pattern, reason) pairs for glob matching.
 	var surveyPatterns []surveyPattern
-	surveyPath := filepath.Join(*sightmapDirFlag, "survey.yaml")
+	surveyPath := filepath.Join(*lf.sightmapDir, "survey.yaml")
 	if data, readErr := os.ReadFile(surveyPath); readErr == nil {
 		var surveyFile struct {
 			Surveyed []struct {

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -4,22 +4,16 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"sort"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runGap(args []string) error {
 	fs := flag.NewFlagSet("gap", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	launchFlag := fs.Bool("launch", false, "Auto-launch Chrome if unreachable")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
-	urlFlag := fs.String("url", "", "Navigate to this URL before extracting")
+	lf := addLiveFlags(fs, "gap")
 	includeHiddenFlag := fs.Bool("include-hidden", false, "Include hidden/off-screen nodes in gap analysis")
 	scopeFlag := fs.String("scope", "", "Filter gaps to components within named component's subtree")
 	if err := fs.Parse(args); err != nil {
@@ -28,36 +22,17 @@ func runGap(args []string) error {
 
 	ctx := context.Background()
 
-	// ── Connect to Chrome ────────────────────────────────────────────────────
-	cleanup := func() {}
-	defer func() { cleanup() }()
+	conn, cleanup, err := lf.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
-	conn, dialErr := browser.Connect(*addrFlag, *tabFlag)
-	if dialErr != nil {
-		if !*launchFlag {
-			return dialErr
-		}
-		var launchCleanup func()
-		var launchErr error
-		conn, launchCleanup, launchErr = browser.Launch(ctx, browser.LaunchOptions{})
-		if launchErr != nil {
-			return fmt.Errorf("gap: cannot launch Chrome: %v", launchErr)
-		}
-		if launchCleanup != nil {
-			cleanup = launchCleanup
-		}
-	} else {
-		cleanup = func() { conn.Close() }
+	if err := lf.navigate(ctx, conn, navOpts{}); err != nil {
+		return err
 	}
 
-	// ── Optionally navigate ──────────────────────────────────────────────────
-	if *urlFlag != "" {
-		if err := browser.NavigateAndWait(ctx, conn, *urlFlag); err != nil {
-			return fmt.Errorf("gap: navigate: %v", err)
-		}
-	}
-
-	// ── Extract component tree ───────────────────────────────────────────────
+	// ── Extract component tree ────────────────────────────────────────
 	pageURL, err := browser.GetURL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("gap: get URL: %v", err)
@@ -73,14 +48,10 @@ func runGap(args []string) error {
 		return fmt.Errorf("gap: extract components: %v", err)
 	}
 
-	// ── Require .sightmap dir ────────────────────────────────────────────────
-	if _, statErr := os.Stat(*sightmapDirFlag); statErr != nil {
-		return fmt.Errorf("gap: sightmap dir %q not found — run 'sightmap validate' to check setup", *sightmapDirFlag)
-	}
-
-	corpus, loadErr := sightmap.Load(*sightmapDirFlag)
+	// ── Require .sightmap dir ────────────────────────────────────────
+	corpus, loadErr := lf.requireCorpus()
 	if loadErr != nil {
-		return fmt.Errorf("gap: load corpus: %v", loadErr)
+		return loadErr
 	}
 	matches := corpus.MatchTree(root, pageURL)
 

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -7,24 +7,18 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
-	"time"
+	"io"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/render"
-	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runInspect(args []string) error {
 	fs := flag.NewFlagSet("inspect", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	launchFlag := fs.Bool("launch", false, "Auto-launch Chrome if unreachable")
-	urlFlag := fs.String("url", "", "Navigate to this URL before inspecting")
-	waitFlag := fs.Float64("wait", 0, "Seconds to wait after navigation (minimum 0.5 when --url is used)")
+	lf := addLiveFlags(fs, "inspect")
 	outFlag := fs.String("out", "", "Write output to file instead of stdout")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir for ★ annotations")
 	classesFlag := fs.Bool("classes", false, "Show CSS class names in selector display")
 	selectorsFlag := fs.Bool("selectors", false, "Show all attributes, not just key identifying ones")
 	depthFlag := fs.Int("depth", 0, "Max tree depth to print (0 = unlimited)")
@@ -35,50 +29,19 @@ func runInspect(args []string) error {
 
 	ctx := context.Background()
 
-	// ── Connect to Chrome ────────────────────────────────────────────────────
-	cleanup := func() {}
-	defer func() { cleanup() }()
+	conn, cleanup, err := lf.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
-	conn, dialErr := browser.DialCDP(ctx, *addrFlag)
-	if dialErr != nil {
-		if !*launchFlag {
-			return fmt.Errorf(
-				"inspect: cannot connect to Chrome at %s\n"+
-					"Start a session first:\n"+
-					"  inspect --launch --url https://...    (auto-launch Chrome)\n"+
-					"  /path/to/chrome --remote-debugging-port=7892 --user-data-dir=/tmp/cdp",
-				*addrFlag,
-			)
-		}
-		var launchCleanup func()
-		var launchErr error
-		conn, launchCleanup, launchErr = browser.Launch(ctx, browser.LaunchOptions{})
-		if launchErr != nil {
-			return fmt.Errorf("cannot launch Chrome: %v", launchErr)
-		}
-		if launchCleanup != nil {
-			cleanup = launchCleanup
-		}
-	} else {
-		cleanup = func() { conn.Close() }
+	// A minimum 0.5s settle applies when --url is used, so freshly-navigated
+	// content is present before extraction.
+	if err := lf.navigate(ctx, conn, navOpts{minWait: 0.5}); err != nil {
+		return err
 	}
 
-	// ── Navigate ─────────────────────────────────────────────────────────────
-	if *urlFlag != "" {
-		if err := browser.NavigateAndWait(ctx, conn, *urlFlag); err != nil {
-			return fmt.Errorf("navigate: %v", err)
-		}
-		// Minimum 0.5s wait when --url is used; --wait overrides upward only.
-		wait := *waitFlag
-		if wait < 0.5 {
-			wait = 0.5
-		}
-		time.Sleep(time.Duration(wait * float64(time.Second)))
-	} else if *waitFlag > 0 {
-		time.Sleep(time.Duration(*waitFlag * float64(time.Second)))
-	}
-
-	// ── Extract ───────────────────────────────────────────────────────────────
+	// ── Extract ──────────────────────────────────────────────────────────
 	pageURL, err := browser.GetURL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("get URL: %v", err)
@@ -93,12 +56,10 @@ func runInspect(args []string) error {
 		return fmt.Errorf("extract components: %v", err)
 	}
 
-	// ── Load sightmap (optional, silent on error) ─────────────────────────────
+	// ── Load sightmap (optional, silent on error) ────────────────────────
 	var inspectMatches map[*comps.ComponentNode]*match.SightmapMatch
-	if _, statErr := os.Stat(*sightmapDirFlag); statErr == nil {
-		if corpus, cErr := sightmap.Load(*sightmapDirFlag); cErr == nil {
-			inspectMatches = corpus.MatchTree(root, pageURL)
-		}
+	if corpus, _ := lf.loadCorpus(); corpus != nil {
+		inspectMatches = corpus.MatchTree(root, pageURL)
 	}
 
 	// ── Render ────────────────────────────────────────────────────────────────
@@ -110,24 +71,9 @@ func runInspect(args []string) error {
 		Interactive: *interactiveFlag,
 	}
 
-	// ── Write output ─────────────────────────────────────────────────────────
-	if *outFlag != "" {
-		tmpPath := *outFlag + ".tmp"
-		f, ferr := os.Create(tmpPath)
-		if ferr != nil {
-			return fmt.Errorf("create output file: %v", ferr)
-		}
-		render.FormatInspect(f, inRoot, opts)
-		if cerr := f.Close(); cerr != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("close output file: %v", cerr)
-		}
-		if rerr := os.Rename(tmpPath, *outFlag); rerr != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("rename output file: %v", rerr)
-		}
-	} else {
-		render.FormatInspect(os.Stdout, inRoot, opts)
-	}
-	return nil
+	// ── Write output ──────────────────────────────────────────────────────
+	return writeOut(*outFlag, func(w io.Writer) error {
+		render.FormatInspect(w, inRoot, opts)
+		return nil
+	})
 }

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -128,14 +128,11 @@ func runSelProbe(args []string) error {
 	ctx := context.Background()
 
 	// Step 1: connect to Chrome.
-	conn, cleanup, err := selProbeConnect(ctx, *addr, *doLaunch, *tabFlag)
+	conn, cleanup, err := browser.ConnectOrLaunch(ctx, *addr, *tabFlag, *doLaunch)
 	if err != nil {
 		return err
 	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	defer conn.Close()
+	defer cleanup()
 
 	// Step 2: run the query script.
 	results, err := queryElements(ctx, conn, selector, *maxN, *full)
@@ -210,51 +207,6 @@ func runSelProbe(args []string) error {
 		}
 	}
 	return nil
-}
-
-// selProbeConnect dials CDP at addr. If tabID is non-empty, connects directly to
-// that tab. Otherwise, if dial fails and launch is true, starts a new Chrome
-// instance. Returns a cleanup func (non-nil only when Chrome was launched) that
-// should be deferred by the caller.
-func selProbeConnect(ctx context.Context, addr string, launch bool, tabID string) (*browser.CDPConn, func(), error) {
-	if tabID != "" {
-		conn, err := browser.ConnectTab(ctx, addr, tabID)
-		if err != nil {
-			return nil, nil, fmt.Errorf("sel-probe: cannot connect to tab %s at %s\n"+
-				"Run 'sightmap browser tabs list' to see open tabs.", tabID, addr)
-		}
-		return conn, nil, nil
-	}
-
-	// No --tab: auto-select the single content tab, but refuse to guess when
-	// several are open (concurrent agents) so we never probe the wrong tab or the
-	// extension side panel.
-	if tabs, listErr := browser.ListTabs(ctx, addr); listErr == nil {
-		if len(tabs) == 1 {
-			if conn, err := browser.ConnectTab(ctx, addr, tabs[0].TargetID); err == nil {
-				return conn, nil, nil
-			}
-		} else if len(tabs) > 1 {
-			return nil, nil, fmt.Errorf("sel-probe: %w", browser.AmbiguousTabError(tabs))
-		}
-	}
-
-	if !launch {
-		return nil, nil, fmt.Errorf(
-			"sel-probe: cannot connect to Chrome at %s\n"+
-				"Start a session first:\n"+
-				"  sel-probe --launch 'your-selector'    (auto-launch Chrome)\n"+
-				"  sightmap browser launch               (start persistent session)\n"+
-				"  /path/to/chrome --remote-debugging-port=7892 --user-data-dir=/tmp/cdp",
-			addr,
-		)
-	}
-
-	conn, cleanup, launchErr := browser.Launch(ctx, browser.LaunchOptions{})
-	if launchErr != nil {
-		return nil, nil, fmt.Errorf("sel-probe: launch Chrome: %w", launchErr)
-	}
-	return conn, cleanup, nil
 }
 
 // queryElements runs the inline JS and returns the parsed element list.

--- a/go/cmd/sightmap/cmd_snapshot.go
+++ b/go/cmd/sightmap/cmd_snapshot.go
@@ -8,14 +8,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/observe"
-	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // snapshot is a PURE OBSERVE command: it connects, navigates, extracts, matches
@@ -24,12 +22,8 @@ import (
 // persisting a capture is the separate `capture` command's job.
 func runSnapshot(args []string) error {
 	fs := flag.NewFlagSet("snapshot", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	launchFlag := fs.Bool("launch", false, "Auto-launch Chrome if unreachable")
-	urlFlag := fs.String("url", "", "Navigate to this URL before snapping")
-	waitFlag := fs.Float64("wait", 0, "Extra seconds to wait after DOM stability is detected (default 0; use for unusually slow pages)")
+	lf := addLiveFlags(fs, "snapshot")
 	outFlag := fs.String("out", "", "Write the annotated output to this file instead of stdout")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
 	interactiveFlag := fs.Bool("interactive", false, "Show interactive nodes only")
 	depthFlag := fs.Int("depth", 0, "Max tree depth (0 = unlimited)")
 	traceFlag := fs.Bool("trace", false, "Include selector hints for unlabeled interactive clusters")
@@ -40,7 +34,6 @@ func runSnapshot(args []string) error {
 	treeOutFlag := fs.String("tree-out", "", "Write raw ComponentNode tree JSON to this file (enables offline coverage/multi-coverage)")
 	jsonOutFlag := fs.String("json", "", "Write annotated tree JSON to this file (superset of --tree-out: includes component name, memory, extracted props)")
 	screenshotFlag := fs.String("screenshot", "", "Save a PNG screenshot to this file alongside the tree")
-	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -49,9 +42,9 @@ func runSnapshot(args []string) error {
 	{
 		explicit := map[string]bool{}
 		fs.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
-		cfg := loadSiteConfig(*sightmapDirFlag)
+		cfg := loadSiteConfig(*lf.sightmapDir)
 		if !explicit["wait"] && cfg.Snapshot.Wait > 0 {
-			*waitFlag = cfg.Snapshot.Wait
+			*lf.wait = cfg.Snapshot.Wait
 		}
 		if !explicit["include-hidden"] && cfg.Snapshot.IncludeHidden {
 			*includeHiddenFlag = true
@@ -68,55 +61,20 @@ func runSnapshot(args []string) error {
 
 	ctx := context.Background()
 
-	// ── Connect to Chrome ────────────────────────────────────────────────────
-	cleanup := func() {}
-	defer func() { cleanup() }()
-
-	conn, dialErr := browser.Connect(*addrFlag, *tabFlag)
-	if dialErr != nil {
-		if !*launchFlag {
-			return fmt.Errorf(
-				"snapshot: cannot connect to Chrome at %s\n"+
-					"Start a session first:\n"+
-					"  snapshot --launch --url https://...    (auto-launch Chrome)\n"+
-					"  /path/to/chrome --remote-debugging-port=7892 --user-data-dir=/tmp/cdp",
-				*addrFlag,
-			)
-		}
-		var launchCleanup func()
-		var launchErr error
-		conn, launchCleanup, launchErr = browser.Launch(ctx, browser.LaunchOptions{})
-		if launchErr != nil {
-			return fmt.Errorf("cannot launch Chrome: %v", launchErr)
-		}
-		if launchCleanup != nil {
-			cleanup = launchCleanup
-		}
-	} else {
-		cleanup = func() { conn.Close() }
+	conn, cleanup, err := lf.connect(ctx)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 
-	// ── Navigate ─────────────────────────────────────────────────────────────
-	if *urlFlag != "" {
-		// NavigateAndWaitIdle waits for loadEventFired then networkIdle — the
-		// correct signal for React/SPA pages where the a11y tree is populated
-		// only after async data fetches complete.
-		if err := browser.NavigateAndWaitIdle(ctx, conn, *urlFlag, 8*time.Second); err != nil {
-			return fmt.Errorf("navigate: %v", err)
-		}
-	}
-	if *waitFlag > 0 {
-		time.Sleep(time.Duration(*waitFlag * float64(time.Second)))
+	if err := lf.navigate(ctx, conn, navOpts{idle: true}); err != nil {
+		return err
 	}
 
 	// ── Observe (extract + match + coverage + properties) ──────────────────────
-	var corpus *sightmap.Corpus
-	if _, statErr := os.Stat(*sightmapDirFlag); statErr == nil {
-		if c, cErr := sightmap.Load(*sightmapDirFlag); cErr != nil {
-			fmt.Fprintf(os.Stderr, "snapshot: load corpus: %v\n", cErr)
-		} else {
-			corpus = c
-		}
+	corpus, cErr := lf.loadCorpus()
+	if cErr != nil {
+		fmt.Fprintf(os.Stderr, "snapshot: load corpus: %v\n", cErr)
 	}
 	res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible, ExtractProps: true})
 	if err != nil {
@@ -158,30 +116,10 @@ func runSnapshot(args []string) error {
 	// ── Write output ───────────────────────────────────────────────────────────
 	// snapshot only ever writes the rendered output to stdout or an explicit
 	// --out FILE. It never appends to the corpus capture set (that is `capture`).
-	if *outFlag != "" {
-		if dir := filepath.Dir(*outFlag); dir != "." {
-			if mkdirErr := os.MkdirAll(dir, 0o755); mkdirErr != nil {
-				return fmt.Errorf("create output directory: %v", mkdirErr)
-			}
-		}
-		tmpPath := *outFlag + ".tmp"
-		f, ferr := os.Create(tmpPath)
-		if ferr != nil {
-			return fmt.Errorf("create output file: %v", ferr)
-		}
-		observe.Format(f, res, fmtOpts)
-		if cerr := f.Close(); cerr != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("close output file: %v", cerr)
-		}
-		if rerr := os.Rename(tmpPath, *outFlag); rerr != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("rename output file: %v", rerr)
-		}
-	} else {
-		observe.Format(os.Stdout, res, fmtOpts)
-	}
-	return nil
+	return writeOut(*outFlag, func(w io.Writer) error {
+		observe.Format(w, res, fmtOpts)
+		return nil
+	})
 }
 
 // ── Output sections ───────────────────────────────────────────────────────────

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -19,10 +19,7 @@ import (
 
 func runSuggest(args []string) error {
 	fs := flag.NewFlagSet("suggest", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	launchFlag := fs.Bool("launch", false, "Auto-launch Chrome if unreachable")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
+	lf := addLiveFlags(fs, "suggest")
 	maxFlag := fs.Int("max", 20, "Max candidates to show")
 	excludeKnownFlag := fs.Bool("exclude-known", false, "Exclude elements already matched by a known sightmap component")
 	minCountFlag := fs.Int("min-count", 1, "Only show candidates matching >= N elements")
@@ -34,45 +31,26 @@ func runSuggest(args []string) error {
 
 	ctx := context.Background()
 
-	// ── Connect to Chrome ────────────────────────────────────────────────────
-	cleanup := func() {}
-	defer func() { cleanup() }()
-
-	conn, dialErr := browser.Connect(*addrFlag, *tabFlag)
-	if dialErr != nil {
-		if !*launchFlag {
-			return dialErr
-		}
-		var launchCleanup func()
-		var launchErr error
-		conn, launchCleanup, launchErr = browser.Launch(ctx, browser.LaunchOptions{})
-		if launchErr != nil {
-			return fmt.Errorf("suggest: cannot launch Chrome: %v", launchErr)
-		}
-		if launchCleanup != nil {
-			cleanup = launchCleanup
-		}
-	} else {
-		cleanup = func() { conn.Close() }
+	conn, cleanup, err := lf.connect(ctx)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 
-	// ── Scan the live DOM for selector candidates ────────────────────────────
+	// ── Scan the live DOM for selector candidates ───────────────────────
 	candidates, err := authoring.ScanCandidates(ctx, conn, *maxFlag)
 	if err != nil {
 		return fmt.Errorf("suggest: %v", err)
 	}
 
-	// ── Optionally filter out known sightmap components ──────────────────────
+	// ── Optionally filter out known sightmap components ────────────────────
 	var knownSelectors []string
 	if *excludeKnownFlag {
-		if _, statErr := os.Stat(*sightmapDirFlag); statErr == nil {
-			if corpus, loadErr := sightmap.Load(*sightmapDirFlag); loadErr == nil {
-				for _, c := range corpus.Components("") {
-					knownSelectors = append(knownSelectors, c.Selectors...)
-				}
+		if corpus, _ := lf.loadCorpus(); corpus != nil {
+			for _, c := range corpus.Components("") {
+				knownSelectors = append(knownSelectors, c.Selectors...)
 			}
 		}
-		// If dir doesn't exist, skip silently.
 	}
 
 	// ── Apply filters ────────────────────────────────────────────────────────
@@ -105,7 +83,7 @@ func runSuggest(args []string) error {
 	// ── Grouped output ───────────────────────────────────────────────────────
 	if *groupFlag {
 		// Build the sightmapId → matchName map.
-		sightmapMatchMap, mapErr := buildSightmapMatchMapForSuggest(ctx, conn, *snapFlag, *sightmapDirFlag)
+		sightmapMatchMap, mapErr := buildSightmapMatchMapForSuggest(ctx, conn, *snapFlag, *lf.sightmapDir)
 		if mapErr != nil {
 			return fmt.Errorf("suggest: --group: %v", mapErr)
 		}


### PR DESCRIPTION
## What

The first slice of the CLI-thinning work (yak .10a). Every command that drives a live Chrome page re-implemented the same scaffold with subtle drift:

- **connect → launch-fallback → cleanup** (~25 lines) copied into snapshot, capture, inspect, gap, suggest, discover
- `inspect` used `browser.DialCDP` and so **silently ignored `--tab`** (a real bug)
- `sel-probe` hand-rolled a *third* connect variant (`selProbeConnect`) that was a verbatim reimplementation of the connect/launch logic
- `--url`/`--wait` navigate, the config-default block, and the atomic `--out` temp-write-rename were each duplicated

## How

Two layers, matching `ARCHITECTURE.md`:

1. **`browser.ConnectOrLaunch(ctx, addr, tabID, launch)`** — the single connection primitive (library op in the `browser` subsystem; reusable by callers that own the browser lifecycle). Returns conn + cleanup.
2. **`cli.go` `liveFlags`** (package main, adapter-tier, never imported) — `addLiveFlags` registers the common flag set (`--addr/--launch/--url/--wait/--tab/--sightmap-dir`) and exposes `connect`, `navigate(navOpts)`, `loadCorpus`/`requireCorpus`, plus a shared `writeOut` atomic writer.

Each command's adapter now composes these. Net **-125 lines** across the command files.

## Behavior notes

- `inspect` now honors `--tab` (bug fix).
- Stale per-command guidance (`chrome --remote-debugging-port=7892 ...`, `sel-probe --launch 'your-selector'`) is dropped in favor of `Connect`'s canonical "Start a session first: sightmap browser start" message — already what `gap`/`suggest` did.
- `sel-probe` keeps its bespoke flag surface (positional selector + `--` separator); only its connect is routed through the shared primitive.

## Validation

`go build`, `go vet`, `gofmt -l .`, `go test ./...` all clean. Smoke-tested every refactored command against the burrito app: Menu view still `22 interactive · 22 T1 (100%) · 0 T2 · 0 T3 ✓`; capture writes + novelty-gates correctly; inspect/sel-probe/gap/suggest/discover all behave identically.