### PR TITLE
Add component/selector screenshot clipping

### DIFF
--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -251,13 +251,25 @@ func ClearStorageForOrigin(ctx context.Context, conn *CDPConn, origin string) er
 	return nil
 }
 
+// ScreenshotClip is the region to capture, in viewport-relative CSS pixels —
+// the same coordinate space as Element.getBoundingClientRect and the
+// `browser bounds` command. ScreenshotWithOptions converts it to the
+// document-relative clip CDP expects by adding the current scroll offset.
+type ScreenshotClip struct {
+	X      float64
+	Y      float64
+	Width  float64
+	Height float64
+}
+
 // ScreenshotOptions controls how Page.captureScreenshot is issued.
 type ScreenshotOptions struct {
-	Format           string // "png" (default) or "jpeg"
-	Quality          int    // JPEG quality 0-100 (ignored for PNG); 0 → 80
-	OptimizeForSpeed bool   // CDP optimizeForSpeed flag — faster at cost of quality
-	PauseAnimations  bool   // send Animation.setPlaybackRate(0) before capture
-	StopLoading      bool   // call Page.stopLoading() before capture to halt ad/iframe repaints
+	Format           string          // "png" (default) or "jpeg"
+	Quality          int             // JPEG quality 0-100 (ignored for PNG); 0 → 80
+	OptimizeForSpeed bool            // CDP optimizeForSpeed flag — faster at cost of quality
+	PauseAnimations  bool            // send Animation.setPlaybackRate(0) before capture
+	StopLoading      bool            // call Page.stopLoading() before capture to halt ad/iframe repaints
+	Clip             *ScreenshotClip // nil = full viewport; otherwise clip to this (viewport-relative) box
 }
 
 // Screenshot captures the viewport as PNG, returns raw bytes.
@@ -302,6 +314,31 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 				params["fromSurface"] = true
 			}
 		}
+	}
+
+	// A clip captures a specific region addressed in document coordinates, so it
+	// needs the beyond-viewport surface and the scroll offset added to the
+	// (viewport-relative) box. This overrides the captureBeyondViewport:false set
+	// above for HTTP(S) pages.
+	if opts.Clip != nil {
+		sx, sy := 0.0, 0.0
+		if raw, err := EvalJSON(ctx, conn, `({x: window.scrollX, y: window.scrollY})`); err == nil {
+			var s struct {
+				X float64 `json:"x"`
+				Y float64 `json:"y"`
+			}
+			if json.Unmarshal(raw, &s) == nil {
+				sx, sy = s.X, s.Y
+			}
+		}
+		params["clip"] = map[string]interface{}{
+			"x":      opts.Clip.X + sx,
+			"y":      opts.Clip.Y + sy,
+			"width":  opts.Clip.Width,
+			"height": opts.Clip.Height,
+			"scale":  1,
+		}
+		params["captureBeyondViewport"] = true
 	}
 
 	if opts.StopLoading {

--- a/go/browser/actions_test.go
+++ b/go/browser/actions_test.go
@@ -778,6 +778,61 @@ func TestScreenshotWithOptions_OptimizeForSpeed(t *testing.T) {
 	}
 }
 
+func TestScreenshotWithOptions_Clip(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("fake"))
+
+	var mu sync.Mutex
+	var capturedParams json.RawMessage
+
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		if method == "Page.captureScreenshot" {
+			mu.Lock()
+			capturedParams = params
+			mu.Unlock()
+			return json.RawMessage(`{"data":"` + encoded + `"}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+
+	_, err := ScreenshotWithOptions(context.Background(), conn, ScreenshotOptions{
+		Clip: &ScreenshotClip{X: 10, Y: 20, Width: 100, Height: 50},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	p := capturedParams
+	mu.Unlock()
+
+	var fields struct {
+		CaptureBeyondViewport bool `json:"captureBeyondViewport"`
+		Clip                  *struct {
+			X      float64 `json:"x"`
+			Y      float64 `json:"y"`
+			Width  float64 `json:"width"`
+			Height float64 `json:"height"`
+			Scale  float64 `json:"scale"`
+		} `json:"clip"`
+	}
+	if err := json.Unmarshal(p, &fields); err != nil {
+		t.Fatalf("unmarshal captureScreenshot params: %v", err)
+	}
+	if fields.Clip == nil {
+		t.Fatal("captureScreenshot: expected a clip in params")
+	}
+	// Scroll offset is 0 in the fake harness, so the box passes through unchanged.
+	if fields.Clip.X != 10 || fields.Clip.Y != 20 || fields.Clip.Width != 100 || fields.Clip.Height != 50 {
+		t.Errorf("clip box = %+v, want {10 20 100 50}", *fields.Clip)
+	}
+	if fields.Clip.Scale != 1 {
+		t.Errorf("clip scale = %v, want 1", fields.Clip.Scale)
+	}
+	if !fields.CaptureBeyondViewport {
+		t.Error("captureScreenshot: expected captureBeyondViewport:true when clipping")
+	}
+}
+
 func TestScreenshotWithOptions_PauseAnimations(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte("fake"))
 

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -91,7 +91,7 @@ Interaction (IDs from sightmap snapshot output):
   drag        COMPONENT-ID --delta-x N --delta-y N
   wait-for    --url PATTERN | --selector SEL | --load  [--timeout-ms N]
   dialog      accept|dismiss [--text INPUT]
-  screenshot  [--out FILE] [--stdout]
+  screenshot  [--out FILE] [--stdout] [--component NAME | --selector SEL] [--expand-pct N]
   bounds      QUERY... | --selector SEL | --all   viewport-% bounding boxes (JSON)
 
 Session utilities:

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -288,6 +288,71 @@ func boundsBySelector(
 	return results, nil
 }
 
+// resolveScreenshotClip resolves --component or --selector to a single clip box:
+// the union of the in-viewport bounding boxes of the matches, grown outward on
+// all sides by expandPct percent of its own size. Returns an error when nothing
+// in-viewport matches. The box is viewport-relative px, matching
+// browser.ScreenshotClip's coordinate space.
+func resolveScreenshotClip(
+	ctx context.Context,
+	conn *browser.CDPConn,
+	sightmapDir, component, selector string,
+	expandPct float64,
+) (*browser.ScreenshotClip, error) {
+	vw, vh, err := viewportSize(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	var results []boundsResult
+	if selector != "" {
+		results, err = boundsBySelector(ctx, conn, selector, vw, vh)
+	} else {
+		results, err = boundsByComponent(ctx, conn, sightmapDir, []string{component}, false, false, vw, vh)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Union the in-viewport match boxes.
+	var x0, y0, x1, y1 float64
+	have := false
+	for _, r := range results {
+		if !r.InViewport {
+			continue
+		}
+		rx0, ry0 := float64(r.Px.X), float64(r.Px.Y)
+		rx1, ry1 := rx0+float64(r.Px.Width), ry0+float64(r.Px.Height)
+		if !have {
+			x0, y0, x1, y1 = rx0, ry0, rx1, ry1
+			have = true
+			continue
+		}
+		x0, y0 = math.Min(x0, rx0), math.Min(y0, ry0)
+		x1, y1 = math.Max(x1, rx1), math.Max(y1, ry1)
+	}
+	if !have {
+		target := component
+		if selector != "" {
+			target = selector
+		}
+		return nil, fmt.Errorf("screenshot: no in-viewport match to clip to for %q", target)
+	}
+
+	// Grow outward on all sides by expandPct% of the box size.
+	if expandPct > 0 {
+		w, h := x1-x0, y1-y0
+		dx, dy := w*expandPct/100, h*expandPct/100
+		x0, y0, x1, y1 = x0-dx, y0-dy, x1+dx, y1+dy
+	}
+	if x0 < 0 {
+		x0 = 0
+	}
+	if y0 < 0 {
+		y0 = 0
+	}
+	return &browser.ScreenshotClip{X: x0, Y: y0, Width: x1 - x0, Height: y1 - y0}, nil
+}
+
 // makeBoundsResult converts viewport-relative px bounds into viewport-% and
 // determines whether the box intersects the viewport at all.
 func makeBoundsResult(comp, label, id string, b *comps.Bounds, vw, vh int) boundsResult {

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -344,8 +344,19 @@ func runScreenshot(args []string) error {
 	jpegFlag := fs.Bool("jpeg", false, "Force JPEG output (skips PNG attempt; implies optimizeForSpeed)")
 	qualityFlag := fs.Int("quality", 80, "JPEG quality 0-100 (default: 80, ignored for PNG)")
 	noRetryFlag := fs.Bool("no-retry", false, "Disable automatic JPEG fallback on timeout")
+	componentFlag := fs.String("component", "", "Clip to the bounding box of this sightmap component (by name)")
+	selectorFlag := fs.String("selector", "", "Clip to the bounding box of elements matching this CSS selector")
+	expandPctFlag := fs.Float64("expand-pct", 0, "Grow the clip outward on all sides by this percent of its size (only with --component/--selector)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for --component)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
+	}
+
+	if *componentFlag != "" && *selectorFlag != "" {
+		return fmt.Errorf("screenshot: pass only one of --component or --selector")
+	}
+	if *expandPctFlag != 0 && *componentFlag == "" && *selectorFlag == "" {
+		return fmt.Errorf("screenshot: --expand-pct requires --component or --selector")
 	}
 
 	conn, err := browser.Connect(*addrFlag, *tabFlag)
@@ -353,6 +364,16 @@ func runScreenshot(args []string) error {
 		return err
 	}
 	defer conn.Close()
+
+	// Resolve an optional clip box (union of in-viewport matches) once, up front,
+	// so every capture attempt below clips identically.
+	var clip *browser.ScreenshotClip
+	if *componentFlag != "" || *selectorFlag != "" {
+		clip, err = resolveScreenshotClip(context.Background(), conn, *sightmapDirFlag, *componentFlag, *selectorFlag, *expandPctFlag)
+		if err != nil {
+			return err
+		}
+	}
 
 	timeout := time.Duration(*timeoutMsFlag) * time.Millisecond
 	outPath := *outFlag
@@ -369,6 +390,7 @@ func runScreenshot(args []string) error {
 			OptimizeForSpeed: true,
 			PauseAnimations:  true,
 			StopLoading:      true,
+			Clip:             clip,
 		})
 		if err != nil {
 			return fmt.Errorf("screenshot: %w", err)
@@ -387,6 +409,7 @@ func runScreenshot(args []string) error {
 			Format:          "png",
 			PauseAnimations: true,
 			StopLoading:     true,
+			Clip:            clip,
 		})
 		if err != nil {
 			if !*noRetryFlag && errors.Is(err, context.DeadlineExceeded) {
@@ -404,6 +427,7 @@ func runScreenshot(args []string) error {
 					OptimizeForSpeed: true,
 					PauseAnimations:  true,
 					StopLoading:      true,
+					Clip:             clip,
 				})
 				if err != nil {
 					return fmt.Errorf("screenshot (JPEG fallback): %w", err)


### PR DESCRIPTION
## What

The final `.10` slice: `browser screenshot` can now clip to a single element's bounding box instead of always capturing the full viewport.

New flags:
- `--component NAME` — clip to the box of a matched sightmap component
- `--selector SEL` — clip to the box of elements matching a raw CSS selector
- `--expand-pct N` — grow the clip outward on all sides by N% of its size (context padding)

This **harmonizes with subtext-live's `live-view-screenshot`** (`component_id` + `expand_pct`), adapted to sightmap's addressing model: we clip by component **name** or CSS **selector** (how sightmap names elements from the CLI) rather than a tree UID, since the sightmap CLI doesn't hand out per-node UIDs the way an MCP tree does.

## How

- `browser.ScreenshotOptions` grows a `Clip *ScreenshotClip` field, documented as **viewport-relative CSS px** — the same coordinate space as `getBoundingClientRect` and the `bounds` command. `ScreenshotWithOptions` adds the live scroll offset and issues a document-coordinate CDP `clip` with `captureBeyondViewport`.
- The CLI resolver (`resolveScreenshotClip`) **reuses the existing bounds resolution** (`boundsByComponent` / `boundsBySelector`), unions the in-viewport matches into one box, and grows it by `--expand-pct` per side (clamped at the viewport top/left edges).
- The clip threads through all three capture attempts (PNG, forced-JPEG, JPEG fallback).

## Validation

`go build`, `go vet`, `gofmt -l .`, `go test ./...` clean (added `TestScreenshotWithOptions_Clip`). Verified live against the burrito Menu tab — clip dimensions match `bounds` exactly:
- `--component CartNavButton` → box `82×36` → PNG `164×72` (DPR 2) ✓
- `--component CartNavButton --expand-pct 50` → `328×132` (full-width expand; height correctly clamped at the top edge) ✓
- `--selector .burrito-nav__logo` → box `132×27` → PNG `264×54` ✓
- off-page selector correctly errors with "no in-viewport match to clip to"

## Follow-up

The `sightmap-browser` skill's screenshot docs will pick up these flags in the docs/skills resync (next slice).