### PR TITLE
Retire --launch and browser launch: one daemon-owned session

### DIFF
--- a/go/browser/connect.go
+++ b/go/browser/connect.go
@@ -7,32 +7,6 @@ import (
 	"strings"
 )
 
-// ConnectOrLaunch attaches to a running Chrome session, or launches a fresh
-// headed one when launch is true and no session is reachable. It returns the
-// connection and a cleanup func the caller must defer: Close for an attached
-// session, or full process teardown for a launched one. When launch is false and
-// nothing is reachable, the connect error is returned unwrapped so callers can
-// present their own guidance. This is the single connection primitive every
-// page-affecting command (and external callers that own the browser lifecycle)
-// should build on.
-func ConnectOrLaunch(ctx context.Context, addr, tabID string, launch bool) (*CDPConn, func(), error) {
-	conn, err := Connect(addr, tabID)
-	if err == nil {
-		return conn, func() { conn.Close() }, nil
-	}
-	if !launch {
-		return nil, nil, err
-	}
-	lconn, cleanup, lerr := Launch(ctx, LaunchOptions{})
-	if lerr != nil {
-		return nil, nil, fmt.Errorf("cannot launch Chrome: %w", lerr)
-	}
-	if cleanup == nil {
-		cleanup = func() {}
-	}
-	return lconn, cleanup, nil
-}
-
 // Connect attaches to a running Chrome session for a page-affecting command.
 // With an explicit tabID it connects to that tab. Without one it auto-selects
 // the single open CONTENT tab, but errors (listing the tabs) when there are zero

--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -1,18 +1,15 @@
 package browser
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // DefaultCDPPort is the Chrome remote-debugging (CDP) port sightmap starts
@@ -106,111 +103,6 @@ func WriteSessionInfo(info SessionInfo) error {
 	return os.WriteFile(sessionFilePath(), data, 0o600)
 }
 
-// LaunchOptions controls how a Chrome subprocess is started.
-type LaunchOptions struct {
-	Headless       bool     // false by default — headed is bot-friendlier
-	Port           int      // 0 = pick a free port automatically
-	UserDataDir    string   // "" = create a temp dir (removed on cleanup)
-	StartURL       string   // navigate here after launch; "" = about:blank
-	HideAutomation bool     // add --disable-blink-features=AutomationControlled
-	ExtraArgs      []string // passed verbatim to Chrome
-}
-
-// Launch starts a Chrome subprocess and returns a connected CDPConn.
-// cleanup kills the process and removes any auto-created UserDataDir.
-func Launch(ctx context.Context, opts LaunchOptions) (*CDPConn, func(), error) {
-	binary, err := FindChrome()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	port := opts.Port
-	if port == 0 {
-		ln, listenErr := net.Listen("tcp", "127.0.0.1:0")
-		if listenErr != nil {
-			return nil, nil, fmt.Errorf("launch: find free port: %w", listenErr)
-		}
-		port = ln.Addr().(*net.TCPAddr).Port
-		ln.Close()
-	}
-
-	userDataDir := opts.UserDataDir
-	var tmpDir string
-	if userDataDir == "" {
-		d, mkErr := os.MkdirTemp("", "sightmap-chrome-*")
-		if mkErr != nil {
-			return nil, nil, fmt.Errorf("launch: create user data dir: %w", mkErr)
-		}
-		tmpDir = d
-		userDataDir = tmpDir
-	}
-
-	args := []string{
-		fmt.Sprintf("--remote-debugging-port=%d", port),
-		fmt.Sprintf("--user-data-dir=%s", userDataDir),
-		"--no-first-run",
-		"--no-default-browser-check",
-	}
-	if opts.HideAutomation {
-		args = append(args, "--disable-blink-features=AutomationControlled")
-	}
-	if opts.Headless {
-		args = append(args, "--headless=new")
-	}
-	if opts.StartURL != "" {
-		args = append(args, opts.StartURL)
-	}
-	args = append(args, opts.ExtraArgs...)
-
-	cmd := exec.CommandContext(ctx, binary, args...)
-	if startErr := cmd.Start(); startErr != nil {
-		if tmpDir != "" {
-			os.RemoveAll(tmpDir)
-		}
-		return nil, nil, fmt.Errorf("launch: start chrome: %w", startErr)
-	}
-
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	if pollErr := pollCDPReady(ctx, addr); pollErr != nil {
-		cmd.Process.Kill()
-		cmd.Wait()
-		if tmpDir != "" {
-			os.RemoveAll(tmpDir)
-		}
-		return nil, nil, fmt.Errorf("launch: %w", pollErr)
-	}
-
-	// Write session file so CLI tools can find the running instance.
-	pid := 0
-	if cmd.Process != nil {
-		pid = cmd.Process.Pid
-	}
-	_ = WriteSessionInfo(SessionInfo{
-		Port:    port,
-		PID:     pid,
-		Profile: userDataDir,
-	})
-
-	cleanup := func() {
-		if cmd.Process != nil {
-			cmd.Process.Kill()
-		}
-		cmd.Wait()
-		if tmpDir != "" {
-			os.RemoveAll(tmpDir)
-		}
-		os.Remove(sessionFilePath())
-	}
-
-	conn, dialErr := DialCDP(ctx, addr)
-	if dialErr != nil {
-		cleanup()
-		return nil, nil, fmt.Errorf("launch: dial cdp: %w", dialErr)
-	}
-
-	return conn, cleanup, nil
-}
-
 // FindChrome returns the path to the Chrome binary on the current platform,
 // or an error if none is found.
 func FindChrome() (string, error) {
@@ -295,33 +187,4 @@ func sessionFilePath() string {
 		return filepath.Join(".sightmap", ".session")
 	}
 	return filepath.Join(os.TempDir(), "sightmap-session")
-}
-
-// pollCDPReady polls http://ADDR/json/version every 100 ms until Chrome
-// responds or the context deadline (10 s when the ctx has none) is exceeded.
-func pollCDPReady(ctx context.Context, addr string) error {
-	// Honor the caller's deadline so a caller that budgets more startup time (a
-	// cold, loaded CI runner can need well over 10s to bind the debug port) gets
-	// it. Fall back to 10s only when the context is deadline-less.
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		deadline = time.Now().Add(10 * time.Second)
-	}
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		reqCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		req, _ := http.NewRequestWithContext(reqCtx, "GET", "http://"+addr+"/json/version", nil)
-		resp, err := http.DefaultClient.Do(req)
-		cancel()
-		if err == nil {
-			resp.Body.Close()
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("chrome did not become ready at %s: %w", addr, err)
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
 }

--- a/go/browser/launcher_test.go
+++ b/go/browser/launcher_test.go
@@ -1,10 +1,8 @@
 package browser
 
 import (
-	"context"
 	"net"
 	"testing"
-	"time"
 )
 
 // TestFindFreePortExcluding_SkipsExcluded guards against the port
@@ -45,33 +43,5 @@ func TestFindFreePortExcluding_SkipsExcluded(t *testing.T) {
 	}
 	if cdpPort == busy {
 		t.Fatalf("FindFreePortExcluding returned the busy port %d", busy)
-	}
-}
-
-func TestLaunch(t *testing.T) {
-	if _, err := FindChrome(); err != nil {
-		t.Skip("Chrome not found:", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	// Force headless with CI-safe flags. The default launch is headed, which
-	// can't start on a display-less CI runner: Chrome exits immediately and
-	// never binds the debug port, surfacing as "connection refused". The extra
-	// flags keep headless Chrome happy in constrained CI sandboxes/containers.
-	conn, cleanup, err := Launch(ctx, LaunchOptions{
-		StartURL:  "about:blank",
-		Headless:  true,
-		ExtraArgs: []string{"--no-sandbox", "--disable-dev-shm-usage"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
-	url, err := GetURL(ctx, conn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if url != "about:blank" {
-		t.Errorf("got URL %q, want about:blank", url)
 	}
 }

--- a/go/cmd/sightmap/cli.go
+++ b/go/cmd/sightmap/cli.go
@@ -24,7 +24,6 @@ import (
 // flags alongside it.
 type liveFlags struct {
 	addr        *string
-	launch      *bool
 	url         *string
 	wait        *float64
 	tab         *string
@@ -38,7 +37,6 @@ type liveFlags struct {
 func addLiveFlags(fs *flag.FlagSet, cmd string) *liveFlags {
 	return &liveFlags{
 		addr:        fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)"),
-		launch:      fs.Bool("launch", false, "Auto-launch Chrome if unreachable"),
 		url:         fs.String("url", "", "Navigate to this URL before acting"),
 		wait:        fs.Float64("wait", 0, "Extra seconds to wait after DOM stability is detected (default 0; raise for unusually slow pages)"),
 		tab:         fs.String("tab", "", "Target tab ID (from 'browser start' output)"),
@@ -47,15 +45,15 @@ func addLiveFlags(fs *flag.FlagSet, cmd string) *liveFlags {
 	}
 }
 
-// connect attaches to the session (launching Chrome first when --launch is set
-// and nothing is reachable). The returned cleanup must be deferred by the
-// caller.
+// connect attaches to the running browser session's tab. The returned cleanup
+// must be deferred by the caller. There is no auto-launch: start a session with
+// 'sightmap browser start' first (Connect's error says so).
 func (lf *liveFlags) connect(ctx context.Context) (*browser.CDPConn, func(), error) {
-	conn, cleanup, err := browser.ConnectOrLaunch(ctx, *lf.addr, *lf.tab, *lf.launch)
+	conn, err := browser.Connect(*lf.addr, *lf.tab)
 	if err != nil {
 		return nil, nil, err
 	}
-	return conn, cleanup, nil
+	return conn, func() { conn.Close() }, nil
 }
 
 // navOpts tunes how navigate waits for the page to settle.

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -3,12 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
@@ -27,8 +24,6 @@ func runBrowser(args []string) error {
 		return runBrowserInstall(args[1:])
 	case "start":
 		return runBrowserStart(args[1:])
-	case "launch":
-		return runLaunch(args[1:])
 	case "stop":
 		return runStop(args[1:])
 	case "status":
@@ -76,7 +71,6 @@ Setup:
 
 Session:
   start [--port N] [--extensions PATH] [--url URL] [--profile DIR]  launch Chrome + sightmap server
-  launch [--headless] [--port N] [--profile DIR] [--extensions PATH[,PATH]] [--url URL] [--wait N]
   stop
   status
   navigate <url>
@@ -106,156 +100,6 @@ Tabs:
 `)
 }
 
-// ── launch ────────────────────────────────────────────────────────────────────
-
-func runLaunch(args []string) error {
-	fs := flag.NewFlagSet("launch", flag.ContinueOnError)
-	headless := fs.Bool("headless", false, "Run headless")
-	port := fs.Int("port", browser.DefaultCDPPort, "CDP port (0 = pick a free one)")
-	profile := fs.String("profile", "", "User data dir (default: ~/.sightmap/profiles/default)")
-	url := fs.String("url", "", "Navigate here after launch")
-	extensions := fs.String("extensions", "", "Comma-separated extension directory paths to load (--load-extension)")
-	wait := fs.Float64("wait", 0, "Seconds to wait after navigation")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-
-	// Check for a live existing session.
-	if info, err := browser.ReadSessionInfo(); err == nil && info.Port > 0 {
-		if isPortAlive(info.Port) {
-			return fmt.Errorf("a session is already running on port %d\n"+
-				"Run 'browser stop' first, or 'browser status' to inspect it.", info.Port)
-		}
-		// Stale session file — clean it up silently.
-		os.Remove(sessionFilePath())
-	}
-
-	chromePath, err := browser.FindChrome()
-	if err != nil {
-		return err
-	}
-
-	resolvedPort := *port
-	if resolvedPort == 0 {
-		p, err := freePort()
-		if err != nil {
-			return fmt.Errorf("find free port: %w", err)
-		}
-		resolvedPort = p
-	}
-
-	resolvedProfile := *profile
-	if resolvedProfile == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("home dir: %w", err)
-		}
-		resolvedProfile = filepath.Join(home, ".sightmap", "profiles", "default")
-	}
-	if err := os.MkdirAll(resolvedProfile, 0o700); err != nil {
-		return fmt.Errorf("create profile dir: %w", err)
-	}
-
-	chromeArgs := []string{
-		fmt.Sprintf("--remote-debugging-port=%d", resolvedPort),
-		fmt.Sprintf("--user-data-dir=%s", resolvedProfile),
-		"--no-first-run",
-		"--no-default-browser-check",
-		"--disable-blink-features=AutomationControlled", // always for authoring
-	}
-	if *headless {
-		chromeArgs = append(chromeArgs, "--headless=new")
-	}
-	if *extensions != "" {
-		absExt, absErr := filepath.Abs(*extensions)
-		if absErr != nil {
-			absExt = *extensions
-		}
-		chromeArgs = append(chromeArgs,
-			"--load-extension="+absExt,
-			"--disable-extensions-except="+absExt,
-		)
-	}
-	if fs.NArg() > 0 {
-		chromeArgs = append(chromeArgs, fs.Args()...)
-	}
-
-	// Use plain exec.Command — NOT exec.CommandContext — so Chrome keeps
-	// running after this process exits.
-	cmd := exec.Command(chromePath, chromeArgs...)
-
-	// Detach: new process group so Chrome isn't killed by terminal signals
-	// sent to our process.
-	setSysProcAttr(cmd)
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start chrome: %w", err)
-	}
-
-	addr := fmt.Sprintf("127.0.0.1:%d", resolvedPort)
-	if err := pollCDPReady(addr); err != nil {
-		// Chrome may have exited or reused an existing process. If the port
-		// is responding anyway (macOS process reuse), treat as success.
-		if !isPortAlive(resolvedPort) {
-			cmd.Process.Kill()
-			cmd.Wait()
-			return fmt.Errorf("chrome did not become ready: %w", err)
-		}
-	}
-
-	// Record the PID — may be 0 if the process already exited due to macOS
-	// reusing an existing Chrome instance.
-	pid := 0
-	if proc := cmd.Process; proc != nil {
-		pid = proc.Pid
-	}
-
-	if err := browser.WriteSessionInfo(browser.SessionInfo{
-		Port:    resolvedPort,
-		PID:     pid,
-		Profile: resolvedProfile,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not write session file: %v\n", err)
-	}
-
-	ctx := context.Background()
-
-	if *url != "" {
-		// Retry DialCDP + NavigateAndWait up to 3 times with 300ms gaps.
-		// On macOS, Chrome may reuse an existing process: the port responds to
-		// /json/version immediately but the initial tab isn't registered in
-		// /json/list for ~200ms, causing DialCDP to get a malformed response.
-		var navErr error
-		for attempt := range 3 {
-			if attempt > 0 {
-				time.Sleep(300 * time.Millisecond)
-			}
-			conn, dialErr := browser.DialCDP(ctx, addr)
-			if dialErr != nil {
-				navErr = dialErr
-				continue
-			}
-			navErr = browser.NavigateAndWait(ctx, conn, *url)
-			conn.Close()
-			if navErr == nil {
-				break
-			}
-		}
-		if navErr != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not navigate to %s: %v\n", *url, navErr)
-		}
-		if *wait > 0 {
-			time.Sleep(time.Duration(*wait * float64(time.Second)))
-		}
-	}
-
-	// Print port to stdout (scripts can capture it).
-	fmt.Println(resolvedPort)
-	fmt.Fprintf(os.Stderr, "Chrome launched on port %d  (pid %d)\n", resolvedPort, pid)
-	fmt.Fprintf(os.Stderr, "Profile: %s\n", resolvedProfile)
-	return nil
-}
-
 // sessionFilePath delegates to the browser package's internal logic by
 // re-reading what WriteSessionInfo would write. We use a local copy of the
 // path-finding logic here for the stale-file cleanup case.
@@ -264,16 +108,6 @@ func sessionFilePath() string {
 		return filepath.Join(".sightmap", ".session")
 	}
 	return filepath.Join(os.TempDir(), "sightmap-session")
-}
-
-func freePort() (int, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
-	return port, nil
 }
 
 // cdpVersionAlive reports whether a genuine Chrome DevTools endpoint is
@@ -512,8 +346,8 @@ func dial(addr string) (*browser.CDPConn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to Chrome at %s\n"+
 			"Start a session first:\n"+
-			"  browser launch\n"+
-			"  browser launch --url https://...\n", addr)
+			"  sightmap browser start\n"+
+			"  sightmap browser start --url https://...\n", addr)
 	}
 	return conn, nil
 }

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -248,7 +248,8 @@ func runBrowserStart(args []string) error {
 			initialTabID = tabs[0].TargetID
 		}
 		if *urlFlag != "" {
-			// Retry navigation (same fix as browser launch).
+			// Retry navigation (Chrome may reuse an existing process and lag on
+			// registering the initial tab).
 			var navErr error
 			for attempt := range 3 {
 				if attempt > 0 {

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -92,7 +92,6 @@ type compAnnotation struct {
 func runSelProbe(args []string) error {
 	fs := flag.NewFlagSet("sel-probe", flag.ContinueOnError)
 	addr := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
-	doLaunch := fs.Bool("launch", false, "Launch a new Chrome instance if --addr is unreachable")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ directory for component annotation")
 	maxN := fs.Int("max", 10, "Max matches to show")
@@ -128,11 +127,11 @@ func runSelProbe(args []string) error {
 	ctx := context.Background()
 
 	// Step 1: connect to Chrome.
-	conn, cleanup, err := browser.ConnectOrLaunch(ctx, *addr, *tabFlag, *doLaunch)
+	conn, err := browser.Connect(*addr, *tabFlag)
 	if err != nil {
 		return err
 	}
-	defer cleanup()
+	defer conn.Close()
 
 	// Step 2: run the query script.
 	results, err := queryElements(ctx, conn, selector, *maxN, *full)

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -89,7 +89,7 @@ func usage() {
 	fmt.Fprint(os.Stderr, `sightmap — sightmap authoring toolkit
 
 Commands:
-  browser launch [--headless] [--port N] [--url URL]  start Chrome session
+  browser start [--headless] [--port N] [--url URL]   start Chrome session + sightmap server
   browser stop / status / navigate / eval             session management
   browser click / fill / hover / keypress / scroll     interact with page elements
   browser drag / wait-for / dialog                     more interactions


### PR DESCRIPTION
## What

Prerequisite for the devtools collector (next PR): make the `browser start` daemon the **sole owner** of the Chrome session and all its tabs. Every page-affecting command connects to that one session; there is no more self-/externally-launched Chrome.

This removes the class of "only works if you launched it a certain way" edge cases — important once a session-lifetime CDP collector (console/network buffering) lives in the daemon, since a command that spun up its own ephemeral Chrome would have no collector behind it.

## Changes

- Drop the `--launch` auto-launch flag from the shared `liveFlags` scaffold and from `sel-probe`. `connect()` now just calls `browser.Connect`, whose error already says `Start a session first: sightmap browser start`.
- Remove `browser.ConnectOrLaunch` (added two PRs ago), `browser.Launch`, and `LaunchOptions`. `browser start` launches Chrome via `exec.Command` directly and is unaffected. This also removes the **flaky real-Chrome `TestLaunch`** integration test.
- Remove the `browser launch` subcommand (`runLaunch`) and its now-dead `freePort` helper; update usage/guidance text to `browser start`.

Kept: session file I/O, `FindFreePort(Excluding)`, `FindChrome`, `DefaultAddr` (already resolves the session's port from the session file), and the port-liveness helpers.

**Net -361 lines.**

## Validation

`go build`, `go vet`, `gofmt -l .`, `go test ./...` clean. Smoke-tested against the burrito session: `browser launch` → `unknown subcommand`; `snapshot --launch` → `flag provided but not defined`; `snapshot`/`sel-probe` still connect to the running session (Menu `22 · T1 100% · 0 T2 · 0 T3 ✓`, sel-probe `button` → 7 matches).