### PR TITLE
Add console + network devtools via a daemon-hosted collector

### DIFF
--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -1,0 +1,501 @@
+package browser
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultMaxEntries is the per-stream ring-buffer cap (console and network are
+// buffered independently). Sized so a normal session never overflows; only a
+// long burst — or a client that stays away for a while — drops the oldest
+// entries, which the query surface then reports as "N earlier entries dropped".
+const DefaultMaxEntries = 1000
+
+// ConsoleEntry is one captured console message (or uncaught exception, folded in
+// as level "exception"). Index is a monotonic per-collector id; it is the stable
+// handle for get-by-index.
+type ConsoleEntry struct {
+	Index int    `json:"index"`
+	Tab   string `json:"tab"`
+	Level string `json:"level"` // log, debug, info, warn, error, exception
+	Text  string `json:"text"`
+	Ts    int64  `json:"ts"` // unix milliseconds
+}
+
+// NetworkEntry is one captured request/response. Bodies are NOT buffered; they
+// are fetched lazily from the collector connection that saw the request (only
+// that connection can, via Network.getResponseBody / getRequestPostData).
+type NetworkEntry struct {
+	Index        int    `json:"index"`
+	Tab          string `json:"tab"`
+	Method       string `json:"method"`
+	URL          string `json:"url"`
+	Status       int    `json:"status"` // 0 until the response is received
+	StatusText   string `json:"statusText"`
+	ResourceType string `json:"resourceType"`
+	Ts           int64  `json:"ts"` // unix milliseconds
+
+	requestID string   // CDP requestId, for lazy body fetch
+	conn      *CDPConn // the collector connection that observed this request
+}
+
+// Collector attaches to every tab of a running Chrome session and buffers
+// console and network activity into bounded ring buffers. It is the session-
+// lifetime component the browser daemon hosts so that per-command CLI queries
+// can read history the transient per-command connections never saw. Safe for
+// concurrent use.
+type Collector struct {
+	addr       string
+	maxEntries int
+
+	mu             sync.Mutex
+	console        []ConsoleEntry
+	network        []NetworkEntry
+	nextConsole    int
+	nextNetwork    int
+	consoleDropped int
+	networkDropped int
+
+	tabsMu sync.Mutex
+	tabs   map[string]*tabColl
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+type tabColl struct {
+	conn   *CDPConn
+	cancel context.CancelFunc
+}
+
+// NewCollector creates a collector for the Chrome session at addr (host:port).
+// Call Start to begin capturing and Stop to tear down.
+func NewCollector(addr string) *Collector {
+	return &Collector{
+		addr:       addr,
+		maxEntries: DefaultMaxEntries,
+		tabs:       make(map[string]*tabColl),
+		stop:       make(chan struct{}),
+	}
+}
+
+// Start begins the tab-attach loop. It returns immediately; capture runs in the
+// background until Stop.
+func (c *Collector) Start() {
+	c.wg.Add(1)
+	go c.attachLoop()
+}
+
+// Stop halts capture and closes every per-tab connection.
+func (c *Collector) Stop() {
+	close(c.stop)
+	c.wg.Wait()
+	c.tabsMu.Lock()
+	for id, tc := range c.tabs {
+		tc.cancel()
+		tc.conn.Close()
+		delete(c.tabs, id)
+	}
+	c.tabsMu.Unlock()
+}
+
+// attachLoop polls the session's tab list, attaching to new tabs and dropping
+// closed ones. Polling (rather than Target auto-attach) keeps the collector on
+// the same per-target CDPConn primitive the rest of the browser package uses.
+func (c *Collector) attachLoop() {
+	defer c.wg.Done()
+	c.syncTabs()
+	t := time.NewTicker(2 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			c.syncTabs()
+		}
+	}
+}
+
+func (c *Collector) syncTabs() {
+	tabs, err := ListTabs(context.Background(), c.addr)
+	if err != nil {
+		return
+	}
+	seen := make(map[string]bool, len(tabs))
+	for _, t := range tabs {
+		seen[t.TargetID] = true
+		c.tabsMu.Lock()
+		_, attached := c.tabs[t.TargetID]
+		c.tabsMu.Unlock()
+		if !attached {
+			c.attachTab(t.TargetID)
+		}
+	}
+	// Detach tabs that have closed.
+	c.tabsMu.Lock()
+	for id, tc := range c.tabs {
+		if !seen[id] {
+			tc.cancel()
+			tc.conn.Close()
+			delete(c.tabs, id)
+		}
+	}
+	c.tabsMu.Unlock()
+}
+
+func (c *Collector) attachTab(tabID string) {
+	conn, err := ConnectTab(context.Background(), c.addr, tabID)
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	consoleCh := conn.Subscribe("Runtime.consoleAPICalled")
+	excCh := conn.Subscribe("Runtime.exceptionThrown")
+	reqCh := conn.Subscribe("Network.requestWillBeSent")
+	respCh := conn.Subscribe("Network.responseReceived")
+
+	// Enable the domains after subscribing so buffered replays aren't missed.
+	if err := conn.EnableDomain(ctx, "Runtime"); err != nil {
+		fmt.Fprintf(os.Stderr, "[collector] tab %s Runtime.enable: %v\n", tabID, err)
+	}
+	if err := conn.EnableDomain(ctx, "Network"); err != nil {
+		fmt.Fprintf(os.Stderr, "[collector] tab %s Network.enable: %v\n", tabID, err)
+	}
+
+	c.tabsMu.Lock()
+	c.tabs[tabID] = &tabColl{conn: conn, cancel: cancel}
+	c.tabsMu.Unlock()
+
+	c.wg.Add(1)
+	go c.drain(ctx, tabID, conn, consoleCh, excCh, reqCh, respCh)
+}
+
+// drain funnels one tab's CDP events into the shared buffers until ctx is
+// cancelled. It does minimal work per event so the cap-8 subscription channels
+// don't drop during bursts.
+func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, consoleCh, excCh, reqCh, respCh <-chan json.RawMessage) {
+	defer c.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case raw := <-consoleCh:
+			if e, ok := parseConsoleAPI(raw); ok {
+				e.Tab = tabID
+				c.addConsole(e)
+			}
+		case raw := <-excCh:
+			if e, ok := parseException(raw); ok {
+				e.Tab = tabID
+				c.addConsole(e)
+			}
+		case raw := <-reqCh:
+			if e, ok := parseRequest(raw); ok {
+				e.Tab = tabID
+				e.conn = conn
+				c.addNetwork(e)
+			}
+		case raw := <-respCh:
+			if reqID, st, stText, rtype, ok := parseResponse(raw); ok {
+				c.applyResponse(reqID, st, stText, rtype)
+			}
+		}
+	}
+}
+
+func (c *Collector) addConsole(e ConsoleEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e.Index = c.nextConsole
+	c.nextConsole++
+	c.console = append(c.console, e)
+	if over := len(c.console) - c.maxEntries; over > 0 {
+		c.console = c.console[over:]
+		c.consoleDropped += over
+	}
+}
+
+func (c *Collector) addNetwork(e NetworkEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e.Index = c.nextNetwork
+	c.nextNetwork++
+	c.network = append(c.network, e)
+	if over := len(c.network) - c.maxEntries; over > 0 {
+		c.network = c.network[over:]
+		c.networkDropped += over
+	}
+}
+
+// applyResponse matches a response back to its pending request (scanning from
+// the tail, where the request almost always is) and fills in status + type.
+func (c *Collector) applyResponse(reqID string, status int, statusText, rtype string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := len(c.network) - 1; i >= 0; i-- {
+		if c.network[i].requestID == reqID {
+			c.network[i].Status = status
+			c.network[i].StatusText = statusText
+			if rtype != "" {
+				c.network[i].ResourceType = rtype
+			}
+			return
+		}
+	}
+}
+
+// ConsoleFilter narrows a Console query.
+type ConsoleFilter struct {
+	Level string // exact level match, or "" for all
+	Tab   string // exact tab match, or "" for all
+	Limit int    // keep only the most recent N (0 = all)
+}
+
+// Console returns the buffered console entries matching f (oldest→newest) plus
+// the number of entries dropped from the front of the ring.
+func (c *Collector) Console(f ConsoleFilter) ([]ConsoleEntry, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]ConsoleEntry, 0, len(c.console))
+	for _, e := range c.console {
+		if f.Level != "" && e.Level != f.Level {
+			continue
+		}
+		if f.Tab != "" && e.Tab != f.Tab {
+			continue
+		}
+		out = append(out, e)
+	}
+	out = tailLimit(out, f.Limit)
+	return out, c.consoleDropped
+}
+
+// NetworkFilter narrows a Network query.
+type NetworkFilter struct {
+	ResourceType string // exact resourceType match (case-insensitive), or "" for all
+	URLSubstr    string // case-insensitive URL substring, or "" for all
+	Tab          string // exact tab match, or "" for all
+	Limit        int    // keep only the most recent N (0 = all)
+}
+
+// Network returns the buffered network entries matching f (oldest→newest) plus
+// the number dropped from the front of the ring.
+func (c *Collector) Network(f NetworkFilter) ([]NetworkEntry, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rt := strings.ToLower(f.ResourceType)
+	sub := strings.ToLower(f.URLSubstr)
+	out := make([]NetworkEntry, 0, len(c.network))
+	for _, e := range c.network {
+		if rt != "" && strings.ToLower(e.ResourceType) != rt {
+			continue
+		}
+		if sub != "" && !strings.Contains(strings.ToLower(e.URL), sub) {
+			continue
+		}
+		if f.Tab != "" && e.Tab != f.Tab {
+			continue
+		}
+		out = append(out, e)
+	}
+	out = tailLimit(out, f.Limit)
+	return out, c.networkDropped
+}
+
+// ResponseBody fetches the response body for the network entry with the given
+// index, from the collector connection that observed it. Returns (body, found,
+// err); found is false when no such entry is buffered.
+func (c *Collector) ResponseBody(ctx context.Context, index int) ([]byte, bool, error) {
+	reqID, conn, ok := c.lookupRequest(index)
+	if !ok {
+		return nil, false, nil
+	}
+	body, err := getResponseBody(ctx, conn, reqID)
+	return body, true, err
+}
+
+// RequestBody fetches the request post-data for the network entry with the given
+// index. Returns (body, found, err).
+func (c *Collector) RequestBody(ctx context.Context, index int) ([]byte, bool, error) {
+	reqID, conn, ok := c.lookupRequest(index)
+	if !ok {
+		return nil, false, nil
+	}
+	body, err := getRequestPostData(ctx, conn, reqID)
+	return body, true, err
+}
+
+func (c *Collector) lookupRequest(index int) (string, *CDPConn, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, e := range c.network {
+		if e.Index == index {
+			return e.requestID, e.conn, true
+		}
+	}
+	return "", nil, false
+}
+
+// tailLimit keeps only the most recent n entries when n > 0.
+func tailLimit[T any](s []T, n int) []T {
+	if n > 0 && len(s) > n {
+		return s[len(s)-n:]
+	}
+	return s
+}
+
+// ── CDP event parsing (pure; unit-tested) ──────────────────────────────────
+
+func parseConsoleAPI(raw json.RawMessage) (ConsoleEntry, bool) {
+	var ev struct {
+		Type      string  `json:"type"`
+		Timestamp float64 `json:"timestamp"`
+		Args      []struct {
+			Type        string          `json:"type"`
+			Value       json.RawMessage `json:"value"`
+			Description string          `json:"description"`
+		} `json:"args"`
+	}
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		return ConsoleEntry{}, false
+	}
+	parts := make([]string, 0, len(ev.Args))
+	for _, a := range ev.Args {
+		parts = append(parts, renderArg(a.Value, a.Description))
+	}
+	return ConsoleEntry{
+		Level: consoleLevel(ev.Type),
+		Text:  strings.Join(parts, " "),
+		Ts:    int64(ev.Timestamp),
+	}, true
+}
+
+func parseException(raw json.RawMessage) (ConsoleEntry, bool) {
+	var ev struct {
+		Timestamp        float64 `json:"timestamp"`
+		ExceptionDetails struct {
+			Text      string `json:"text"`
+			Exception struct {
+				Description string `json:"description"`
+			} `json:"exception"`
+		} `json:"exceptionDetails"`
+	}
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		return ConsoleEntry{}, false
+	}
+	text := ev.ExceptionDetails.Exception.Description
+	if text == "" {
+		text = ev.ExceptionDetails.Text
+	}
+	return ConsoleEntry{Level: "exception", Text: text, Ts: int64(ev.Timestamp)}, true
+}
+
+func parseRequest(raw json.RawMessage) (NetworkEntry, bool) {
+	var ev struct {
+		RequestID string `json:"requestId"`
+		Type      string `json:"type"`
+		Request   struct {
+			URL    string `json:"url"`
+			Method string `json:"method"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
+		return NetworkEntry{}, false
+	}
+	return NetworkEntry{
+		Method:       ev.Request.Method,
+		URL:          ev.Request.URL,
+		ResourceType: ev.Type,
+		Ts:           time.Now().UnixMilli(),
+		requestID:    ev.RequestID,
+	}, true
+}
+
+func parseResponse(raw json.RawMessage) (reqID string, status int, statusText, rtype string, ok bool) {
+	var ev struct {
+		RequestID string `json:"requestId"`
+		Type      string `json:"type"`
+		Response  struct {
+			Status     int    `json:"status"`
+			StatusText string `json:"statusText"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
+		return "", 0, "", "", false
+	}
+	return ev.RequestID, ev.Response.Status, ev.Response.StatusText, ev.Type, true
+}
+
+// renderArg turns one console argument into display text: the JSON value when
+// present (unquoting plain strings), else the remote-object description.
+func renderArg(value json.RawMessage, description string) string {
+	if len(value) > 0 {
+		var s string
+		if json.Unmarshal(value, &s) == nil {
+			return s
+		}
+		return string(value)
+	}
+	return description
+}
+
+func consoleLevel(t string) string {
+	switch t {
+	case "error", "assert":
+		return "error"
+	case "warning":
+		return "warn"
+	case "debug":
+		return "debug"
+	case "info":
+		return "info"
+	case "log":
+		return "log"
+	default:
+		return "info"
+	}
+}
+
+func getResponseBody(ctx context.Context, conn *CDPConn, reqID string) ([]byte, error) {
+	raw, err := conn.call(ctx, "Network.getResponseBody", map[string]interface{}{"requestId": reqID})
+	if err != nil {
+		return nil, err
+	}
+	return decodeBody(raw)
+}
+
+func getRequestPostData(ctx context.Context, conn *CDPConn, reqID string) ([]byte, error) {
+	raw, err := conn.call(ctx, "Network.getRequestPostData", map[string]interface{}{"requestId": reqID})
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		PostData string `json:"postData"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+	return []byte(resp.PostData), nil
+}
+
+func decodeBody(raw json.RawMessage) ([]byte, error) {
+	var resp struct {
+		Body          string `json:"body"`
+		Base64Encoded bool   `json:"base64Encoded"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Base64Encoded {
+		return base64.StdEncoding.DecodeString(resp.Body)
+	}
+	return []byte(resp.Body), nil
+}

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -1,0 +1,120 @@
+package browser
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseConsoleAPI(t *testing.T) {
+	raw := json.RawMessage(`{"type":"warning","timestamp":1785015495306,"args":[{"type":"string","value":"hello"},{"type":"number","value":42}]}`)
+	e, ok := parseConsoleAPI(raw)
+	if !ok {
+		t.Fatal("parseConsoleAPI returned ok=false")
+	}
+	if e.Level != "warn" {
+		t.Errorf("level = %q, want warn", e.Level)
+	}
+	if e.Text != "hello 42" {
+		t.Errorf("text = %q, want \"hello 42\"", e.Text)
+	}
+	if e.Ts != 1785015495306 {
+		t.Errorf("ts = %d, want 1785015495306", e.Ts)
+	}
+}
+
+func TestParseException(t *testing.T) {
+	raw := json.RawMessage(`{"timestamp":1785015495306,"exceptionDetails":{"text":"Uncaught","exception":{"description":"TypeError: x is not a function"}}}`)
+	e, ok := parseException(raw)
+	if !ok {
+		t.Fatal("parseException returned ok=false")
+	}
+	if e.Level != "exception" {
+		t.Errorf("level = %q, want exception", e.Level)
+	}
+	if e.Text != "TypeError: x is not a function" {
+		t.Errorf("text = %q", e.Text)
+	}
+}
+
+func TestParseRequestResponse(t *testing.T) {
+	req := json.RawMessage(`{"requestId":"R1","type":"XHR","request":{"url":"https://x/api","method":"POST"}}`)
+	e, ok := parseRequest(req)
+	if !ok {
+		t.Fatal("parseRequest ok=false")
+	}
+	if e.Method != "POST" || e.URL != "https://x/api" || e.ResourceType != "XHR" || e.requestID != "R1" {
+		t.Errorf("request parse = %+v", e)
+	}
+
+	resp := json.RawMessage(`{"requestId":"R1","type":"XHR","response":{"status":201,"statusText":"Created"}}`)
+	id, st, stText, rtype, ok := parseResponse(resp)
+	if !ok || id != "R1" || st != 201 || stText != "Created" || rtype != "XHR" {
+		t.Errorf("response parse = %s %d %s %s %v", id, st, stText, rtype, ok)
+	}
+}
+
+func TestRingOverflowAndDropped(t *testing.T) {
+	c := NewCollector("localhost:0")
+	c.maxEntries = 3
+	for i := 0; i < 5; i++ {
+		c.addConsole(ConsoleEntry{Level: "log", Text: "m"})
+	}
+	got, dropped := c.Console(ConsoleFilter{})
+	if len(got) != 3 {
+		t.Fatalf("buffered = %d, want 3 (capped)", len(got))
+	}
+	if dropped != 2 {
+		t.Errorf("dropped = %d, want 2", dropped)
+	}
+	// Indexes are monotonic and reflect the retained tail (2,3,4).
+	if got[0].Index != 2 || got[2].Index != 4 {
+		t.Errorf("indexes = %d..%d, want 2..4", got[0].Index, got[2].Index)
+	}
+}
+
+func TestConsoleFilterAndLimit(t *testing.T) {
+	c := NewCollector("localhost:0")
+	c.addConsole(ConsoleEntry{Level: "log", Text: "a", Tab: "T1"})
+	c.addConsole(ConsoleEntry{Level: "error", Text: "b", Tab: "T1"})
+	c.addConsole(ConsoleEntry{Level: "error", Text: "c", Tab: "T2"})
+
+	errs, _ := c.Console(ConsoleFilter{Level: "error"})
+	if len(errs) != 2 {
+		t.Fatalf("level=error → %d, want 2", len(errs))
+	}
+	t2, _ := c.Console(ConsoleFilter{Tab: "T2"})
+	if len(t2) != 1 || t2[0].Text != "c" {
+		t.Errorf("tab=T2 → %+v", t2)
+	}
+	last, _ := c.Console(ConsoleFilter{Limit: 1})
+	if len(last) != 1 || last[0].Text != "c" {
+		t.Errorf("limit=1 → %+v (want most recent)", last)
+	}
+}
+
+func TestNetworkFilterAndResponseMatch(t *testing.T) {
+	c := NewCollector("localhost:0")
+	c.addNetwork(NetworkEntry{Method: "GET", URL: "https://x/style.css", ResourceType: "Stylesheet", requestID: "A"})
+	c.addNetwork(NetworkEntry{Method: "POST", URL: "https://x/api/cart", ResourceType: "XHR", requestID: "B"})
+	c.applyResponse("B", 500, "Server Error", "XHR")
+
+	xhr, _ := c.Network(NetworkFilter{ResourceType: "xhr"})
+	if len(xhr) != 1 || xhr[0].Status != 500 || xhr[0].StatusText != "Server Error" {
+		t.Fatalf("xhr filter/response = %+v", xhr)
+	}
+	byURL, _ := c.Network(NetworkFilter{URLSubstr: "CART"})
+	if len(byURL) != 1 || byURL[0].requestID != "B" {
+		t.Errorf("url substring (case-insensitive) = %+v", byURL)
+	}
+}
+
+func TestDecodeBody(t *testing.T) {
+	plain, err := decodeBody(json.RawMessage(`{"body":"hello","base64Encoded":false}`))
+	if err != nil || string(plain) != "hello" {
+		t.Errorf("plain body = %q, %v", plain, err)
+	}
+	enc, err := decodeBody(json.RawMessage(`{"body":"aGk=","base64Encoded":true}`))
+	if err != nil || string(enc) != "hi" {
+		t.Errorf("base64 body = %q, %v", enc, err)
+	}
+}

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -143,6 +144,11 @@ func runBrowserStart(args []string) error {
 		json.NewEncoder(w).Encode(c)
 	})
 
+	// Devtools query surface. The collector is created after Chrome is ready
+	// (below); the handlers return 503 until then.
+	var collectorPtr atomic.Pointer[browser.Collector]
+	registerDevtoolsHandlers(mux, &collectorPtr)
+
 	srvAddr := fmt.Sprintf(":%d", resolvedServerPort)
 	srv := &http.Server{Addr: srvAddr, Handler: mux}
 	srvReady := make(chan error, 1)
@@ -211,6 +217,13 @@ func runBrowserStart(args []string) error {
 		cmd.Process.Kill()
 		return fmt.Errorf("start: chrome did not become ready: %w", pollErr)
 	}
+
+	// Start the console/network collector against the now-ready session and
+	// publish it to the devtools handlers registered above.
+	collector := browser.NewCollector(cdpAddr)
+	collector.Start()
+	collectorPtr.Store(collector)
+	defer collector.Stop()
 
 	// Write session file.
 	pid := 0

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -1,0 +1,328 @@
+// CLI clients for the daemon's devtools query surface. These are thin HTTP
+// clients: the browser start daemon owns the collector and does all filtering;
+// these commands just render what it returns. They locate the daemon via the
+// session file's ServerPort.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sightmap/sightmap/go/browser"
+)
+
+// devtoolsGet fetches path (with query) from the daemon's HTTP server and
+// returns the raw body. It resolves the daemon via the session file's
+// ServerPort.
+func devtoolsGet(path string, query url.Values) ([]byte, error) {
+	info, err := browser.ReadSessionInfo()
+	if err != nil || info.ServerPort == 0 {
+		return nil, fmt.Errorf("no running session — start one with 'sightmap browser start'")
+	}
+	u := fmt.Sprintf("http://localhost:%d%s", info.ServerPort, path)
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("reach daemon: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("session is still starting (collector not ready) — retry shortly")
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("not found")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("daemon returned %s: %s", resp.Status, string(body))
+	}
+	return body, nil
+}
+
+type consoleResult struct {
+	Entries []browser.ConsoleEntry `json:"entries"`
+	Dropped int                    `json:"dropped"`
+}
+
+type networkResult struct {
+	Entries []browser.NetworkEntry `json:"entries"`
+	Dropped int                    `json:"dropped"`
+}
+
+// ── console ─────────────────────────────────────────────────────────────────
+
+func runConsole(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: sightmap console <list|get> [flags]")
+	}
+	switch args[0] {
+	case "list":
+		return runConsoleList(args[1:])
+	case "get":
+		return runConsoleGet(args[1:])
+	default:
+		return fmt.Errorf("console: unknown subcommand %q (want list|get)", args[0])
+	}
+}
+
+func runConsoleList(args []string) error {
+	fs := flag.NewFlagSet("console list", flag.ContinueOnError)
+	level := fs.String("level", "", "Filter by level: log, debug, info, warn, error, exception")
+	tab := fs.String("tab", "", "Filter by tab ID")
+	limit := fs.Int("limit", 0, "Show only the most recent N messages (0 = all)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	q := url.Values{}
+	setNonEmpty(q, "level", *level)
+	setNonEmpty(q, "tab", *tab)
+	if *limit > 0 {
+		q.Set("limit", strconv.Itoa(*limit))
+	}
+	body, err := devtoolsGet("/devtools/console", q)
+	if err != nil {
+		return err
+	}
+	var res consoleResult
+	if err := json.Unmarshal(body, &res); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if len(res.Entries) == 0 {
+		fmt.Println("No console messages captured.")
+	} else {
+		multiTab := spansMultipleTabs(res.Entries)
+		for _, e := range res.Entries {
+			if multiTab {
+				fmt.Printf("[%d] %-9s [%s] %s\n", e.Index, e.Level, shortTab(e.Tab), e.Text)
+			} else {
+				fmt.Printf("[%d] %-9s %s\n", e.Index, e.Level, e.Text)
+			}
+		}
+	}
+	reportDropped(res.Dropped, "console")
+	return nil
+}
+
+func runConsoleGet(args []string) error {
+	fs := flag.NewFlagSet("console get", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	idx, err := singleIndexArg(fs.Args(), "console get")
+	if err != nil {
+		return err
+	}
+	body, err := devtoolsGet("/devtools/console", nil)
+	if err != nil {
+		return err
+	}
+	var res consoleResult
+	if err := json.Unmarshal(body, &res); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	for _, e := range res.Entries {
+		if e.Index == idx {
+			fmt.Printf("[%d] %s  (tab %s)\n%s\n", e.Index, e.Level, shortTab(e.Tab), e.Text)
+			return nil
+		}
+	}
+	return fmt.Errorf("console message index %d not found", idx)
+}
+
+// ── network ─────────────────────────────────────────────────────────────────
+
+func runNetwork(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: sightmap network <list|get> [flags]")
+	}
+	switch args[0] {
+	case "list":
+		return runNetworkList(args[1:])
+	case "get":
+		return runNetworkGet(args[1:])
+	default:
+		return fmt.Errorf("network: unknown subcommand %q (want list|get)", args[0])
+	}
+}
+
+func runNetworkList(args []string) error {
+	fs := flag.NewFlagSet("network list", flag.ContinueOnError)
+	rtype := fs.String("type", "", "Filter by resource type (Document, XHR, Fetch, Stylesheet, Image, Script, Font, ...)")
+	urlSub := fs.String("url", "", "Filter by URL substring")
+	tab := fs.String("tab", "", "Filter by tab ID")
+	limit := fs.Int("limit", 0, "Show only the most recent N requests (0 = all)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	q := url.Values{}
+	setNonEmpty(q, "type", *rtype)
+	setNonEmpty(q, "url", *urlSub)
+	setNonEmpty(q, "tab", *tab)
+	if *limit > 0 {
+		q.Set("limit", strconv.Itoa(*limit))
+	}
+	body, err := devtoolsGet("/devtools/network", q)
+	if err != nil {
+		return err
+	}
+	var res networkResult
+	if err := json.Unmarshal(body, &res); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if len(res.Entries) == 0 {
+		fmt.Println("No network requests captured.")
+	} else {
+		for _, e := range res.Entries {
+			fmt.Printf("[%d] %s %s → %s (%s)\n", e.Index, e.Method, e.URL, statusStr(e), e.ResourceType)
+		}
+	}
+	reportDropped(res.Dropped, "network")
+	return nil
+}
+
+func runNetworkGet(args []string) error {
+	fs := flag.NewFlagSet("network get", flag.ContinueOnError)
+	respFile := fs.String("response-file", "", "Write the response body to this file")
+	reqFile := fs.String("request-file", "", "Write the request body (POST data) to this file")
+	if err := parseFlagsInterspersed(fs, args); err != nil {
+		return err
+	}
+	idx, err := singleIndexArg(fs.Args(), "network get")
+	if err != nil {
+		return err
+	}
+
+	body, err := devtoolsGet("/devtools/network", nil)
+	if err != nil {
+		return err
+	}
+	var res networkResult
+	if err := json.Unmarshal(body, &res); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	var entry *browser.NetworkEntry
+	for i := range res.Entries {
+		if res.Entries[i].Index == idx {
+			entry = &res.Entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		return fmt.Errorf("network request index %d not found", idx)
+	}
+
+	fmt.Printf("Method: %s\n", entry.Method)
+	fmt.Printf("URL: %s\n", entry.URL)
+	fmt.Printf("Resource Type: %s\n", entry.ResourceType)
+	fmt.Printf("Status: %s\n", statusStr(*entry))
+	fmt.Printf("Tab: %s\n", entry.Tab)
+
+	if *reqFile != "" {
+		if err := saveBody(idx, "request", *reqFile); err != nil {
+			return err
+		}
+	}
+	// Fetch the response body (to a file, or inline preview).
+	rbody, err := devtoolsGet("/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {"response"}})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "network get: response body unavailable: %v\n", err)
+		return nil
+	}
+	if *respFile != "" {
+		if err := os.WriteFile(*respFile, rbody, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", *respFile, err)
+		}
+		fmt.Fprintf(os.Stderr, "response body saved: %s (%d bytes)\n", *respFile, len(rbody))
+		return nil
+	}
+	printBodyPreview(rbody)
+	return nil
+}
+
+func saveBody(idx int, kind, path string) error {
+	b, err := devtoolsGet("/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {kind}})
+	if err != nil {
+		return fmt.Errorf("%s body: %w", kind, err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	fmt.Fprintf(os.Stderr, "%s body saved: %s (%d bytes)\n", kind, path, len(b))
+	return nil
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+const bodyPreviewLimit = 4096
+
+func printBodyPreview(b []byte) {
+	if len(b) == 0 {
+		fmt.Println("Response Body: (empty)")
+		return
+	}
+	if len(b) > bodyPreviewLimit {
+		fmt.Printf("Response Body (first %d of %d bytes; use --response-file for the full body):\n%s\n",
+			bodyPreviewLimit, len(b), string(b[:bodyPreviewLimit]))
+		return
+	}
+	fmt.Printf("Response Body:\n%s\n", string(b))
+}
+
+func statusStr(e browser.NetworkEntry) string {
+	if e.Status == 0 {
+		return "pending"
+	}
+	return fmt.Sprintf("%d %s", e.Status, e.StatusText)
+}
+
+func reportDropped(n int, stream string) {
+	if n > 0 {
+		fmt.Printf("(%d earlier %s entries dropped — buffer overflowed)\n", n, stream)
+	}
+}
+
+func setNonEmpty(q url.Values, key, val string) {
+	if val != "" {
+		q.Set(key, val)
+	}
+}
+
+func singleIndexArg(args []string, cmd string) (int, error) {
+	if len(args) != 1 {
+		return 0, fmt.Errorf("usage: sightmap %s <index>", cmd)
+	}
+	idx, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("%s: index must be a number, got %q", cmd, args[0])
+	}
+	return idx, nil
+}
+
+func spansMultipleTabs(entries []browser.ConsoleEntry) bool {
+	seen := ""
+	for _, e := range entries {
+		if seen == "" {
+			seen = e.Tab
+		} else if e.Tab != seen {
+			return true
+		}
+	}
+	return false
+}
+
+func shortTab(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/go/cmd/sightmap/cmd_devtools_server.go
+++ b/go/cmd/sightmap/cmd_devtools_server.go
@@ -1,0 +1,104 @@
+// Devtools query surface hosted by the `browser start` daemon. These endpoints
+// are the first slice of the daemon protocol: the collector (a session-lifetime
+// CDP client) buffers console/network, and per-command CLI queries read it here
+// rather than re-attaching to Chrome. Filters and pagination run daemon-side; the
+// CLI console/network commands are thin clients.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/sightmap/sightmap/go/browser"
+)
+
+// registerDevtoolsHandlers wires the /devtools/* endpoints onto mux. The
+// collector is supplied via ptr because it is created only after Chrome is
+// ready, whereas handlers must be registered before the server starts serving.
+// Until the collector exists the endpoints return 503.
+func registerDevtoolsHandlers(mux *http.ServeMux, ptr *atomic.Pointer[browser.Collector]) {
+	load := func(w http.ResponseWriter) (*browser.Collector, bool) {
+		if c := ptr.Load(); c != nil {
+			return c, true
+		}
+		http.Error(w, "collector not ready", http.StatusServiceUnavailable)
+		return nil, false
+	}
+
+	mux.HandleFunc("/devtools/console", func(w http.ResponseWriter, r *http.Request) {
+		c, ok := load(w)
+		if !ok {
+			return
+		}
+		q := r.URL.Query()
+		entries, dropped := c.Console(browser.ConsoleFilter{
+			Level: q.Get("level"),
+			Tab:   q.Get("tab"),
+			Limit: atoiDefault(q.Get("limit"), 0),
+		})
+		writeJSON(w, map[string]any{"entries": entries, "dropped": dropped})
+	})
+
+	mux.HandleFunc("/devtools/network", func(w http.ResponseWriter, r *http.Request) {
+		c, ok := load(w)
+		if !ok {
+			return
+		}
+		q := r.URL.Query()
+		entries, dropped := c.Network(browser.NetworkFilter{
+			ResourceType: q.Get("type"),
+			URLSubstr:    q.Get("url"),
+			Tab:          q.Get("tab"),
+			Limit:        atoiDefault(q.Get("limit"), 0),
+		})
+		writeJSON(w, map[string]any{"entries": entries, "dropped": dropped})
+	})
+
+	mux.HandleFunc("/devtools/network/body", func(w http.ResponseWriter, r *http.Request) {
+		c, ok := load(w)
+		if !ok {
+			return
+		}
+		index, err := strconv.Atoi(r.URL.Query().Get("index"))
+		if err != nil {
+			http.Error(w, "index required", http.StatusBadRequest)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+
+		var body []byte
+		var found bool
+		if r.URL.Query().Get("kind") == "request" {
+			body, found, err = c.RequestBody(ctx, index)
+		} else {
+			body, found, err = c.ResponseBody(ctx, index)
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !found {
+			http.Error(w, "no such request index", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(body)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+func atoiDefault(s string, def int) int {
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return def
+}

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -67,6 +67,10 @@ func main() {
 		err = runReport(args)
 	case "sel-check", "sel_check":
 		err = runSelCheck(args)
+	case "console":
+		err = runConsole(args)
+	case "network":
+		err = runNetwork(args)
 	case "skills":
 		err = runSkills(args)
 	case "version", "--version", "-v":
@@ -112,6 +116,11 @@ Commands:
   search   [--field FIELD] PATTERN                           offline YAML content search
   discover [--all]                                           URL pattern discovery
   serve-sightmap [--port N] [--sightmap-dir DIR]             sightmap HTTP server for overlay extension
+
+  console  list [--level L] [--tab T] [--limit N]            captured console messages (needs a running session)
+  console  get INDEX                                         one console message by index
+  network  list [--type T] [--url SUBSTR] [--tab T] [--limit N]  captured network requests
+  network  get INDEX [--response-file F] [--request-file F]  one request + body by index
 
   skills install [--target DIR]                             install sightmap authoring skill to ~/.agents/skills/
   version                                                    print version and exit


### PR DESCRIPTION
## What

Yak .12: `console` and `network` devtools commands, backed by a session-lifetime **collector** in the `browser start` daemon. This is the first slice of the daemon protocol (tracked toward the north-star in a separate yak): per-command CLI queries read buffered history from the daemon over HTTP instead of re-attaching to Chrome.

Design was ratified after a side-quest through lidar's live tools (`fs/services/lidar/.../live`): per-tab console/network ring buffers, exceptions folded into console, response bodies fetched lazily via a retained handle.

## How

- **`browser/collector.go`** — `Collector`: a persistent CDP client that polls the tab list and attaches to every tab, buffering:
  - **console** — `Runtime.consoleAPICalled` + `Runtime.exceptionThrown` (folded in as `level=exception`).
  - **network** — `Network.requestWillBeSent` / `responseReceived`, keyed by requestId.
  - Bounded per-stream **ring buffers** (`DefaultMaxEntries=1000`); overflow is counted and surfaced. Response/request **bodies are fetched lazily** via `Network.getResponseBody` / `getRequestPostData` on the *collecting* connection (only it can). Coexistence of the collector connection with transient per-command connections was verified empirically.
- **Daemon** — `registerDevtoolsHandlers` exposes `GET /devtools/console`, `/devtools/network`, `/devtools/network/body` on the existing HTTP server; **filters + pagination run daemon-side**; 503 until the collector is ready.
- **CLI** — thin clients `console list|get` and `network list|get` (`--level`/`--type`/`--url`/`--tab`/`--limit`; `network get --response-file`/`--request-file`). They locate the daemon via the session file's `ServerPort`.

Devtools requires a `browser start` session (the only browser owner, per the launch-retirement PR).

## Non-goals (unchanged)

No perf/lighthouse/heap/screencast. Routing *all* commands through the daemon is a separate, tracked effort.

## Validation

`go build`, `go vet`, `gofmt -l .`, `go test ./...` clean (collector parsing/ring/filter unit tests added). Verified end-to-end against a live burrito `browser start` session:
- `console list` / `--level` / `get INDEX` — real entries (`[vite] connecting...`, `[sightmap] loaded 43 components`), exceptions captured.
- `network list` / `--type` / `--url` — requests with statuses + resource types.
- `network get 0 --response-file` — fetched the real 377-byte HTML document body via the collector connection.