### PR TITLE
Resync docs + skills to the current CLI surface

### DIFF
--- a/docs/cli/browser.mdx
+++ b/docs/cli/browser.mdx
@@ -38,6 +38,8 @@ The final line is the binary path on stdout, so scripts can capture it; progress
 
 `start` launches Chrome, starts the Sightmap HTTP server, and loads the overlay extension. The extension is embedded in the binary and extracted to `~/.sightmap/extension/` when needed. The server recompiles the corpus after YAML changes under `.sightmap/`. `start` runs in the foreground until you press Ctrl-C, which stops Chrome and the server.
 
+The `start` daemon owns the session: it is the only way to launch Chrome for sightmap, and every live command attaches to it. It also runs the console/network **collector** that buffers browser activity for the [`console` and `network`](/cli/devtools) commands, so those need a running `start` session.
+
 Run it from the site directory (the one containing `.sightmap/`), typically in a second terminal or as a background job.
 
 | Flag | Default | Description |
@@ -75,33 +77,6 @@ If Chrome is already running for this site, `start` opens a new tab in the exist
 
 Pass that ID as `--tab` on every subsequent page command.
 </Note>
-
----
-
-### `browser launch`
-
-`launch` starts Chrome with its DevTools endpoint, without the Sightmap server. It loads an extension only when you pass `--extensions`. Unlike `start`, it returns immediately and leaves Chrome running. The command prints the CDP port to stdout so scripts can capture it.
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--headless` | off | Run headless |
-| `--port` | `7892` | CDP port (`0` = pick a free one) |
-| `--profile` | `~/.sightmap/profiles/default` | User data dir |
-| `--extensions` | none | Comma-separated extension directory paths to load |
-| `--url` | none | Navigate here after launch |
-| `--wait` | `0` | Seconds to wait after navigation |
-
-```bash
-sightmap browser launch --headless --url 'https://shop.example.com'
-```
-
-```text
-7892
-Chrome launched on port 7892  (pid 84210)
-Profile: /Users/you/.sightmap/profiles/default
-```
-
-If a session is already running, `launch` returns `a session is already running on port 7892`. Run `browser stop` first, or use `browser status` to inspect it.
 
 ---
 
@@ -166,7 +141,7 @@ navigated to https://shop.example.com/deals
 ```
 
 <Warning>
-`browser navigate` takes a positional URL. It has no `--url` flag; that flag belongs to `browser start` and `browser launch`. `sightmap browser navigate --url 'https://...'` treats `--url` as the URL and fails.
+`browser navigate` takes a positional URL. It has no `--url` flag; that flag belongs to `browser start`. `sightmap browser navigate --url 'https://...'` treats `--url` as the URL and fails.
 </Warning>
 
 ---

--- a/docs/cli/capture.mdx
+++ b/docs/cli/capture.mdx
@@ -30,13 +30,11 @@ The probe ID is a handle for the [interaction commands](/cli/interaction). Compo
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--addr` | `localhost:7892` | CDP address (host:port). |
-| `--compact` | `false` | Compatibility flag; snapshot output is always compact. |
 | `--coverage` | `false` | Print `[View]` + `[Coverage]` + cluster traces only, suppressing the component tree. |
 | `--depth` | `0` | Max tree depth (0 = unlimited). |
 | `--include-hidden` | `false` | Include hidden/off-screen nodes in analysis. |
 | `--interactive` | `false` | Show interactive nodes only. |
 | `--json` | — | Write annotated tree JSON to this file. It adds component names, memory, and extracted properties to the raw tree. |
-| `--launch` | `false` | Auto-launch Chrome if unreachable. |
 | `--out` | — | Write the annotated output to this file instead of stdout. No view set, no novelty gate. |
 | `--screenshot` | — | Save a PNG screenshot to this file alongside the tree, from the same page state. |
 | `--selectors` | `false` | Show `tag #id [data-testid]` selector hints (no CSS classes). |
@@ -127,7 +125,6 @@ A view is a *set* of captures, not a single file — real pages are non-determin
 | `--force` | `false` | Write the capture even if it adds no new component or slot vs the view set (skip the novelty gate). |
 | `--include-hidden` | `false` | Include hidden/off-screen nodes in analysis. |
 | `--json` | `false` | Also write an annotated JSON sibling next to each capture. |
-| `--launch` | `false` | Auto-launch Chrome if unreachable. |
 | `--selectors` | `false` | Show `tag #id [data-testid]` selector hints in the saved capture. |
 | `--sightmap-dir` | `.sightmap` | Path to the `.sightmap/` dir. |
 | `--tab` | — | Target tab ID (from `browser start` output). |
@@ -184,7 +181,6 @@ Each line shows the probe ID, a CSS-selector-style display (`tag#id[attr="value"
 | `--classes` | `false` | Show CSS class names in selector display. |
 | `--depth` | `0` | Max tree depth to print (0 = unlimited). |
 | `--interactive` | `false` | Show only interactive nodes and their ancestors. |
-| `--launch` | `false` | Auto-launch Chrome if unreachable. |
 | `--out` | — | Write output to file instead of stdout. |
 | `--selectors` | `false` | Show all attributes, not just key identifying ones. |
 | `--sightmap-dir` | `.sightmap` | Path to the `.sightmap/` dir for ★ annotations. |

--- a/docs/cli/corpus.mdx
+++ b/docs/cli/corpus.mdx
@@ -137,7 +137,6 @@ Run it on pages that link to major sections of the app, then add views for relev
 | --- | --- | --- |
 | `--addr` | `localhost:7892` | CDP address (host:port) |
 | `--all` | off | Include surveyed (`○`) patterns in output |
-| `--launch` | off | Auto-launch Chrome if unreachable |
 | `--sightmap-dir` | `.sightmap` | Path to the `.sightmap/` directory |
 | `--tab` | — | Target tab ID (from `browser start` output) |
 

--- a/docs/cli/devtools.mdx
+++ b/docs/cli/devtools.mdx
@@ -1,0 +1,117 @@
+---
+title: "Sightmap Devtools Commands: Console and Network"
+sidebarTitle: "Devtools"
+description: "Read captured browser console messages and network requests from a running Sightmap session."
+---
+
+`sightmap console` and `sightmap network` read the browser activity captured during a session. The [`browser start`](/cli/browser) daemon runs a **collector**: a session-lifetime CDP client that attaches to every tab and buffers console messages and network requests into bounded ring buffers (the most recent ~1000 of each). These commands query that buffer over the daemon's HTTP server.
+
+<Note>
+Devtools commands require a running `browser start` session — the collector lives in that daemon. With no session they print `no running session — start one with 'sightmap browser start'`. Entries captured before the session started are not available.
+</Note>
+
+Buffers are invisible until they overflow: a long burst of activity (or a client that stays away for a while) drops the oldest entries, which `list` reports as `(N earlier entries dropped — buffer overflowed)`.
+
+---
+
+### `console list`
+
+Lists captured console messages, oldest to newest. Uncaught exceptions are folded in as level `exception`.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--level` | all | Filter by level: `log`, `debug`, `info`, `warn`, `error`, `exception` |
+| `--tab` | all tabs | Filter by tab ID |
+| `--limit` | all | Show only the most recent N messages |
+
+```bash
+sightmap console list --level error --limit 20
+```
+
+```text
+[42] error     Uncaught TypeError: cart.total is not a function
+[57] exception TypeError: undefined is not iterable
+```
+
+Each line is `[index] level text`. When entries span multiple tabs, the tab ID is shown too. The `index` is stable — pass it to `console get`.
+
+---
+
+### `console get`
+
+Prints one console message by index.
+
+```bash
+sightmap console get 42
+```
+
+```text
+[42] error  (tab 8A3F0C7D)
+Uncaught TypeError: cart.total is not a function
+```
+
+---
+
+### `network list`
+
+Lists captured network requests, oldest to newest.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--type` | all | Filter by resource type (`Document`, `XHR`, `Fetch`, `Stylesheet`, `Image`, `Script`, `Font`, …) |
+| `--url` | all | Filter by URL substring (case-insensitive) |
+| `--tab` | all tabs | Filter by tab ID |
+| `--limit` | all | Show only the most recent N requests |
+
+```bash
+sightmap network list --type XHR --url /api/cart
+```
+
+```text
+[128] POST https://shop.example.com/api/cart → 500 Server Error (XHR)
+[131] GET https://shop.example.com/api/cart → 200 OK (XHR)
+```
+
+Each line is `[index] method url → status (resourceType)`. Requests with no response yet show `pending`.
+
+---
+
+### `network get`
+
+Prints one request's metadata by index, then its response body. Bodies are fetched on demand from the collector connection that observed the request.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--response-file` | none | Write the full response body to this file instead of previewing it |
+| `--request-file` | none | Write the request body (POST data) to this file |
+
+```bash
+sightmap network get 128 --response-file /tmp/cart-error.json
+```
+
+```text
+Method: POST
+URL: https://shop.example.com/api/cart
+Resource Type: XHR
+Status: 500 Server Error
+Tab: 8A3F0C7D2B1E4F6A9C8D7E5B3A2F1E0D
+response body saved: /tmp/cart-error.json (842 bytes)
+```
+
+Without `--response-file`, `network get` previews the first few KB of the response body inline.
+
+---
+
+## Typical flow
+
+<Steps>
+  <Step title="Start a session">
+    `sightmap browser start` — the collector begins capturing as soon as Chrome is ready.
+  </Step>
+  <Step title="Reproduce the issue">
+    Drive the page with [interaction commands](/cli/interaction) or in the browser window.
+  </Step>
+  <Step title="Read the evidence">
+    `sightmap console list --level error` and `sightmap network list --type XHR` surface what failed; `network get INDEX` pulls the response body.
+  </Step>
+</Steps>

--- a/docs/cli/interaction.mdx
+++ b/docs/cli/interaction.mdx
@@ -198,7 +198,7 @@ sightmap browser dialog accept --text 'Springfield'
 
 ### `browser screenshot`
 
-Captures the current viewport as a PNG. If the PNG attempt times out, the command retries as JPEG unless you pass `--no-retry`.
+Captures the current viewport as a PNG. If the PNG attempt times out, the command retries as JPEG unless you pass `--no-retry`. Pass `--component` or `--selector` to clip the capture to a single element's bounding box instead of the whole viewport.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -206,6 +206,9 @@ Captures the current viewport as a PNG. If the PNG attempt times out, the comman
 | `--tab` | the lone content tab | Target tab ID |
 | `--out` | `screenshot.png` | Output file path |
 | `--stdout` | off | Write image bytes to stdout (for piping) |
+| `--component` | none | Clip to the bounding box of this Sightmap component (by name) |
+| `--selector` | none | Clip to the bounding box of elements matching this CSS selector |
+| `--expand-pct` | `0` | Grow the clip outward on all sides by this percent of its size (only with `--component`/`--selector`) |
 | `--timeout-ms` | `15000` | Timeout in milliseconds for each attempt |
 | `--jpeg` | off | Capture JPEG without attempting PNG |
 | `--quality` | `80` | JPEG quality from 0 to 100; ignored for PNG |
@@ -218,6 +221,14 @@ sightmap browser screenshot --out cart.png
 ```text
 screenshot saved: cart.png
 ```
+
+Clip to one component, with a little surrounding context:
+
+```bash
+sightmap browser screenshot --component CartSummary --expand-pct 10 --out cart-summary.png
+```
+
+The clip resolves to the union of the component's in-viewport matches (the same boxes `browser bounds` reports); an off-screen target errors with `no in-viewport match to clip to`.
 
 ---
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -29,10 +29,15 @@ Several flags appear in multiple command groups:
 | `--sightmap-dir` | `.sightmap` | Path to the corpus directory |
 | `--addr` | `localhost:7892` | CDP address of the Chrome session (printed by `browser start`) |
 | `--tab` | the lone content tab | Target tab ID; required whenever two or more content tabs are open |
-| `--launch` | off | Auto-launch Chrome when `--addr` is unreachable (live analysis commands: `snapshot`, `capture`, `inspect`, `suggest`, `gap`, `discover`, `sel-probe`) |
 | `--include-hidden` | off | Count hidden and off-screen nodes too |
 
 **Address sessions by port and tab.** `sightmap browser start` launches Chrome with its DevTools endpoint on `localhost:7892` and the Sightmap HTTP server on port `7891`. Live commands use `--addr` to reach the session. When more than one content tab is open, page commands require `--tab` with the tab ID printed by `browser start`. See [Browser sessions](/cli/browser).
+
+**`browser start` is the only launcher.** Live commands attach to a session you started; there is no auto-launch. When none is running they stop with `Start a session first: sightmap browser start`. That single owner also hosts the console/network collector behind the [devtools commands](/cli/devtools).
+
+<Note>
+**Vocabulary.** A sightmap **view** is a route-scoped definition in the corpus; a browser **tab** is a live page in the session. They are different things — the [glossary](/reference/glossary) disambiguates `view`, `tab`, and related terms.
+</Note>
 
 **Visible-only counting is the default.** Coverage and analysis commands count visible interactive nodes only. Pass `--include-hidden` to include hidden and off-screen nodes. These nodes can increase the orphan count, so enable the flag only when you intend to audit them.
 
@@ -73,6 +78,9 @@ What counts as failure for the check-style commands:
   </Card>
   <Card title="Corpus checks" icon="file-lines" href="/cli/corpus">
     Check YAML structure and style, search the corpus, and discover URL patterns.
+  </Card>
+  <Card title="Devtools" icon="bug" href="/cli/devtools">
+    Read captured `console` messages and `network` requests from the running session.
   </Card>
   <Card title="Integration" icon="network-wired" href="/cli/integrate">
     Run the overlay server and install the bundled agent skills.

--- a/docs/cli/selectors.mdx
+++ b/docs/cli/selectors.mdx
@@ -29,7 +29,6 @@ Pass `--exclude-known` to hide candidates already covered by a global component 
 | `--addr` | `localhost:7892` | CDP address (host:port) |
 | `--exclude-known` | off | Exclude elements already matched by a global component |
 | `--group` | off | Group candidates by nearest known ancestor component |
-| `--launch` | off | Auto-launch Chrome if unreachable |
 | `--max` | `20` | Max candidates to show |
 | `--min-count` | `1` | Only show candidates matching at least N elements |
 | `--sightmap-dir` | `.sightmap` | Path to the `.sightmap/` directory |
@@ -78,7 +77,6 @@ With `--scope COMPONENT`, the command reports unmatched interactive nodes (T2) i
 | --- | --- | --- |
 | `--addr` | `localhost:7892` | CDP address (host:port) |
 | `--include-hidden` | off | Include hidden/off-screen nodes in gap analysis |
-| `--launch` | off | Auto-launch Chrome if unreachable |
 | `--scope` | — | Filter gaps to unmatched nodes within the named component's subtree |
 | `--sightmap-dir` | `.sightmap` | Path to the `.sightmap/` directory |
 | `--tab` | — | Target tab ID (from `browser start` output) |
@@ -131,7 +129,6 @@ With `--all`, the command navigates to the corpus's snapshot targets. A view wit
 | `--addr` | `localhost:7892` | CDP address (host:port) |
 | `--all` | off | Probe the selector on every snapshot target declared by the corpus |
 | `--full` | off | Show full text (no truncation to 80 characters) |
-| `--launch` | off | Launch Chrome if `--addr` is unreachable; not used with `--all` |
 | `--max` | `10` | Max matches to query and show |
 | `--sightmap-dir` | `.sightmap` | Path to the `.sightmap/` directory for global component annotation |
 | `--tab` | — | Target tab ID (from `browser start` output) |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,7 +71,8 @@
             "group": "Browser",
             "pages": [
               "cli/browser",
-              "cli/interaction"
+              "cli/interaction",
+              "cli/devtools"
             ]
           },
           {

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -18,6 +18,10 @@ The initial creation of a project's `.sightmap/` directory. An agent or human us
 
 One snapshot of a view. New captures added to a view set are stored at `.sightmap/snapshots/{view}/{stamp}.snap`, with the raw component tree in a sibling `.snap.tree.json` file. See [Snapshots](/cli/snapshots).
 
+### Collector
+
+The session-lifetime CDP client the [`browser start`](/cli/browser) daemon runs to buffer console messages and network requests from every tab. The [`console` and `network`](/cli/devtools) commands read its bounded ring buffers.
+
 ### Component
 
 A named DOM subtree identified by one or more CSS selectors. Components can be global at the file root or scoped inside a view. See [Components](/spec/components).
@@ -70,6 +74,10 @@ A named API endpoint with a route glob and optional method filter, payload field
 
 A CSS selector (or array of alternatives) that locates a component's root element. Child selectors are scoped to the matched parent's subtree. See [Selectors](/concepts/selectors).
 
+### Session
+
+The running Chrome instance owned by a `browser start` daemon, recorded in `.sightmap/.session`. It is the only way to launch Chrome for Sightmap; every live command attaches to it. A session may hold several **tabs**. See [Browser sessions](/cli/browser).
+
 ### Sightmap (the file)
 
 A corpus YAML document under `.sightmap/` that conforms to the stream 1 schema. Depending on context, "a sightmap" can also mean the full directory.
@@ -82,9 +90,13 @@ The `.sightmap/` directory at the project root. Sightmap discovers and merges co
 
 The integer in a sightmap file's `version` field, currently `1`. It selects the spec stream used to interpret the file and changes only for a breaking change to the YAML format. It is independent of project SemVer. See [Versioning policy](/reference/versioning).
 
+### Tab
+
+A live browser page in a **session**, identified by the `--tab` ID printed by `browser start`. Distinct from a sightmap **view**: a tab is a running page; a view is a route-scoped definition in the corpus. When two or more tabs are open, page commands require `--tab` to avoid cross-agent crosstalk.
+
 ### View
 
-A named screen identified by a URL route glob. Sightmap matches the current URL to one active view. See [Views](/spec/views).
+A named screen identified by a URL route glob. Sightmap matches the current URL to one active view. A view is a corpus definition, not a live browser **tab**. See [Views](/spec/views).
 
 ### View set
 

--- a/docs/reference/go-library.mdx
+++ b/docs/reference/go-library.mdx
@@ -24,20 +24,24 @@ All import paths are rooted at `github.com/sightmap/sightmap/go/`.
 
 | Package | Purpose |
 |---|---|
-| `sightmap` | Corpus loading, thread-safe `Session` matching cache, `Validate` and `Lint` |
+| `sightmap` | Corpus loading and matching (the thread-safe `Corpus` handle), plus `Validate`, `Lint`, and `LoadConfig` |
 | `comps` | Component model types (`ComponentNode`, `SelectorPart`, `Bounds`) and tree operations (`Walk`, `Collect`, `Filter`) |
 | `sel` | CSS selector parsing and single-node matching for the sightmap selector subset |
 | `match` | NFA multi-query matcher that applies component definitions in one tree traversal |
-| `extract` | Post-probe pipeline that merges accessibility data with probe output and rebuilds the tree; no browser dependency |
-| `browser` | Minimal `Page` interface plus a direct-CDP client for any Chrome debugging port (no chromedp) |
 | `compquery` | Component-query parser and resolver for queries such as `ProductCard[name^="Weber"]` |
+| `extract` | Post-probe pipeline that merges accessibility data with probe output and rebuilds the tree; no browser dependency |
 | `probe` | Embedded `probe.js` browser-side extractor, exposed as `probe.ProbeJS` |
+| `browser` | Minimal `Page` interface, a direct-CDP client for any Chrome debugging port (no chromedp), and the session `Collector` that buffers console/network |
+| `observe` | The live acquire-and-annotate operation: `observe.Page` connects, extracts, matches the corpus, and computes coverage; `observe.Format` renders it |
+| `coverage` | T1/T2/T3 coverage scoring, parent maps, orphan-slot analysis, and cluster traces |
+| `viewset` | View capture sets: paths, the novelty gate, and pruning |
+| `authoring` | Live DOM scans behind the authoring commands (`suggest` candidates, `discover` link patterns) |
 | `render` | Tree rendering for snapshot- and inspect-style output |
 | `conformance` | Fixture documentation and data used by the component-matching conformance tests |
 
 ## Load a corpus and match a tree
 
-The core flow uses three API calls. `DirLoader` creates a loader for a `.sightmap/` directory, `NewSession` adds a compiled-query cache, and `MatchTree` applies the corpus to a component tree for a page URL.
+The core flow uses two API calls. `sightmap.Load` parses a `.sightmap/` directory into a `Corpus` (a thread-safe handle with a compiled-query cache), and `Corpus.MatchTree` applies it to a component tree for a page URL.
 
 ```go main.go
 package main
@@ -53,8 +57,11 @@ import (
 )
 
 func main() {
-	// Load every YAML file under .sightmap/ (lazily, on first use).
-	sess := sightmap.NewSession(sightmap.DirLoader(".sightmap"))
+	// Load every YAML file under .sightmap/ into a Corpus.
+	corpus, err := sightmap.Load(".sightmap")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Read a component tree saved by `sightmap snapshot --tree-out`.
 	data, err := os.ReadFile("home.snap.tree.json")
@@ -67,10 +74,7 @@ func main() {
 	}
 
 	// Apply the corpus to the tree for this page URL.
-	matches, err := sess.MatchTree(root, "https://example.com/")
-	if err != nil {
-		log.Fatal(err)
-	}
+	matches := corpus.MatchTree(root, "https://example.com/")
 
 	// Walk the tree and print every matched node.
 	comps.Walk(root, func(n *comps.ComponentNode, depth int) bool {
@@ -88,25 +92,28 @@ func main() {
 The stream 1 spec requires the most specific matching view, with declaration order used only to break ties. `ViewForURL` currently uses the first match in corpus order. Avoid overlapping routes when calling the library directly until this implementation gap is closed.
 </Warning>
 
-## Sessions
+## The Corpus handle
 
-`sightmap.Session` is safe for concurrent use. It caches compiled match queries by corpus generation and page URL, so repeated `MatchTree` calls reuse the compiled queries.
+`sightmap.Corpus` is the single operational handle: load one with `Load`, then hold it for the life of a run. It is safe for concurrent use and caches compiled match queries by page URL, so repeated `MatchTree` calls reuse the compiled queries. To pick up on-disk edits in a long-lived process, call `Load` again and swap the handle.
 
 | Method | Purpose |
 |---|---|
-| `Refresh() error` | Reload the corpus and invalidate the cache; call after `.sightmap/` YAML edits |
-| `Components(pageURL string) ([]match.SightmapComponent, error)` | Return the merged component list for a URL without matching a tree |
-| `ViewForURL(pageURL string) (*sightmap.View, error)` | Return the first matching view, or `nil` when no view matches |
-| `GlobalComponentNames() (map[string]bool, error)` | Return the names declared at global scope |
+| `MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.SightmapMatch` | Apply the corpus to a tree for a URL |
+| `Components(pageURL string) []match.SightmapComponent` | Return the merged component list for a URL without matching a tree |
+| `ViewForURL(pageURL string) *sightmap.View` | Return the first matching view, or `nil` when no view matches |
+| `ViewByName(name string) *sightmap.View` | Return the view with the given name, or `nil` |
+| `GlobalComponentNames() map[string]bool` | Return the names declared at global scope |
 
-The package also provides `StaticLoader(c *Corpus) Loader` for an existing corpus. The `LoaderFunc` type, `func() (*Corpus, error)`, implements the `Loader` interface.
+`Load(dir)` is shorthand for `DirLoader(dir).Load()`. For an existing in-memory corpus, `StaticLoader(c *Corpus) Loader` wraps it as a `Loader`; the `LoaderFunc` type, `func() (*Corpus, error)`, also implements `Loader`.
+
+Per-site tooling defaults (`.sightmap/config.yaml`) load separately via `sightmap.LoadConfig(dir) SiteConfig` — this is tooling configuration, not part of the spec.
 
 ## Validate and lint from Go
 
 The `Validate` and `Lint` functions run the same checks as `sightmap validate` and `sightmap lint`:
 
 ```go
-corpus, err := sightmap.DirLoader(".sightmap").Load()
+corpus, err := sightmap.Load(".sightmap")
 if err != nil {
 	log.Fatal(err)
 }
@@ -123,7 +130,7 @@ for _, w := range sightmap.Lint(corpus) {
 ## Where component trees come from
 
 - **Saved captures.** Auto-organized captures under `.sightmap/snapshots/{view}/` include a sibling `.snap.tree.json` file containing the raw `ComponentNode` tree. `sightmap snapshot --tree-out FILE` writes the tree to an explicit path. Unmarshal either form into `*comps.ComponentNode`, as in the example above.
-- **Live pages.** Call `browser.DialCDP` to connect to a Chrome debugging port, then pass a `browser.Page` to `browser.ExtractComponents`.
+- **Live pages.** Call `browser.Connect(addr, tabID)` to attach to a running session's tab, then pass a `browser.Page` to `browser.ExtractComponents` — or use the higher-level `observe.Page`, which connects, extracts, matches the corpus, and computes coverage in one call.
 - **Custom extraction.** Call `extract.BuildTree` with probe, accessibility, and DOM data. Native consumers can create `SelectorPart` values for non-DOM trees.
 
 <Note>

--- a/go/README.md
+++ b/go/README.md
@@ -52,11 +52,11 @@ hot-reloads the corpus whenever you edit YAML.
 
 ### 2. Iterate on a page
 
-`iterate` is the primary edit-verify loop — it navigates, snaps, and prints
-coverage in one step:
+`snapshot --coverage --url` is the primary edit-verify loop — it navigates,
+snaps, and prints coverage in one step:
 
 ```bash
-sightmap iterate 'https://SITE.com/products'
+sightmap snapshot --coverage --url 'https://SITE.com/products'
 ```
 
 ```
@@ -96,14 +96,14 @@ global one), e.g.:
       extract: attr=aria-label
 ```
 
-Re-run `iterate` and repeat until `0 orphaned T3 ✓`.
+Re-run `snapshot --coverage --url` and repeat until `0 orphaned T3 ✓`.
 
 ### 3. Validate, snapshot, and check corpus health
 
 ```bash
 sightmap validate            # structural YAML correctness (exits non-zero on error)
 sightmap lint --warn-only    # advisory style checks
-sightmap snapshot --all      # refresh a saved snap for every view URL
+sightmap capture --all       # refresh a saved capture for every view URL
 sightmap report              # per-view T1/T2/T3 health table
 ```
 

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -14,6 +14,14 @@ component tree and **act on elements by their semantic component identity**
 instead of brittle CSS. To build or maintain the corpus itself, see the
 `sightmap-authoring` skill.
 
+**What to reach for:**
+
+- **`snapshot`** — read page state as an annotated component tree (start here).
+- **interaction** (`click`/`fill`/`scroll`/…) — drive the page by component identity.
+- **`browser screenshot`** — visual evidence; clip to one component with `--component`.
+- **`console` / `network`** — debug what the page logged and requested.
+- **`inspect`** — raw DOM for authoring selectors (see `sightmap-authoring`).
+
 ## Installation
 
 Every command below needs the `sightmap` binary on your PATH. **Check first,
@@ -39,7 +47,7 @@ invocation). Use `npm` in instructions — the published package is identical un
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
 | `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |
-| `sightmap browser screenshot --out FILE.png` | Screenshot of the current page. |
+| `sightmap browser screenshot --out FILE.png` | Screenshot the page. Clip to a component with `--component NAME` (or `--selector CSS`), optionally `--expand-pct N` for context. |
 
 ## Reading the page: annotated snapshots
 
@@ -104,6 +112,25 @@ so nothing goes stale. Prefer queries on dynamic pages.
   property like `FulfillmentTileButton.label` is what makes the element
   addressable (see the `sightmap-authoring` skill).
 - `--sightmap-dir` (default `.sightmap`) controls which corpus resolves a query.
+
+## Debugging: console & network
+
+The `browser start` daemon owns the session and runs a **collector** that buffers
+console messages and network requests from every tab for the life of the session
+(bounded ring buffers, ~1000 of each). Read them with thin query commands — no
+re-attaching to Chrome, and history the transient page commands never saw:
+
+| Command | What it does |
+|---------|-------------|
+| `sightmap console list [--level error] [--tab ID] [--limit N]` | Captured console messages (uncaught exceptions fold in as `level=exception`). |
+| `sightmap console get <index>` | One console message by index. |
+| `sightmap network list [--type XHR] [--url /api] [--tab ID] [--limit N]` | Captured requests: `method url → status (type)`. |
+| `sightmap network get <index> [--response-file F]` | One request + its response body (fetched on demand; save with `--response-file`). |
+
+- These need a running `browser start` session — that's where the collector
+  lives. Entries from before the session started aren't available.
+- Reproduce the issue (navigate/click), then read `console list --level error`
+  and `network list` to see what failed; `network get <index>` pulls the body.
 
 ## Gotchas
 

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -14,6 +14,14 @@ component tree and **act on elements by their semantic component identity**
 instead of brittle CSS. To build or maintain the corpus itself, see the
 `sightmap-authoring` skill.
 
+**What to reach for:**
+
+- **`snapshot`** — read page state as an annotated component tree (start here).
+- **interaction** (`click`/`fill`/`scroll`/…) — drive the page by component identity.
+- **`browser screenshot`** — visual evidence; clip to one component with `--component`.
+- **`console` / `network`** — debug what the page logged and requested.
+- **`inspect`** — raw DOM for authoring selectors (see `sightmap-authoring`).
+
 ## Installation
 
 Every command below needs the `sightmap` binary on your PATH. **Check first,
@@ -39,7 +47,7 @@ invocation). Use `npm` in instructions — the published package is identical un
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
 | `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |
-| `sightmap browser screenshot --out FILE.png` | Screenshot of the current page. |
+| `sightmap browser screenshot --out FILE.png` | Screenshot the page. Clip to a component with `--component NAME` (or `--selector CSS`), optionally `--expand-pct N` for context. |
 
 ## Reading the page: annotated snapshots
 
@@ -104,6 +112,25 @@ so nothing goes stale. Prefer queries on dynamic pages.
   property like `FulfillmentTileButton.label` is what makes the element
   addressable (see the `sightmap-authoring` skill).
 - `--sightmap-dir` (default `.sightmap`) controls which corpus resolves a query.
+
+## Debugging: console & network
+
+The `browser start` daemon owns the session and runs a **collector** that buffers
+console messages and network requests from every tab for the life of the session
+(bounded ring buffers, ~1000 of each). Read them with thin query commands — no
+re-attaching to Chrome, and history the transient page commands never saw:
+
+| Command | What it does |
+|---------|-------------|
+| `sightmap console list [--level error] [--tab ID] [--limit N]` | Captured console messages (uncaught exceptions fold in as `level=exception`). |
+| `sightmap console get <index>` | One console message by index. |
+| `sightmap network list [--type XHR] [--url /api] [--tab ID] [--limit N]` | Captured requests: `method url → status (type)`. |
+| `sightmap network get <index> [--response-file F]` | One request + its response body (fetched on demand; save with `--response-file`). |
+
+- These need a running `browser start` session — that's where the collector
+  lives. Entries from before the session started aren't available.
+- Reproduce the issue (navigate/click), then read `console list --level error`
+  and `network list` to see what failed; `network get <index>` pulls the body.
 
 ## Gotchas
 


### PR DESCRIPTION
## What

The final documentation/skills resync after the CLI teardown. Pure docs + skills — no behavior change.

## Removed (retired surface)

- `--launch` shared-flag row + every per-command occurrence (`capture`, `selectors`, `corpus`, `overview`)
- `--compact` (gone) from `capture`
- the whole `browser launch` section + the navigate note that referenced it

Live commands attach to a `browser start` session; there is no auto-launch (overview now says so).

## Added (new surface)

- **New `cli/devtools` page** — `console` / `network` list+get, the daemon-collector model, buffer-overflow semantics — plus a nav entry, an overview card, and a `browser start` note that it hosts the collector.
- **Screenshot clip** — `--component` / `--selector` / `--expand-pct` in `cli/interaction`.
- **Glossary** — `Tab`, `Session`, `Collector` entries + a tab-vs-view disambiguation (and an overview vocab note).
- **Skill** — `sightmap-browser` gains a console/network debugging section, the screenshot clip, and a "what to reach for" snapshot-first orientation; regen'd the embedded `go/skills` mirror.

## Fixed (materially wrong)

- **`reference/go-library`** taught the **retired** `sightmap.NewSession(DirLoader(...))` / `Session` API — it won't compile. Rewritten to the `Corpus` handle (`sightmap.Load` → `Corpus.MatchTree`, no error return), and the package map now lists `observe`/`coverage`/`viewset`/`authoring` + the browser `Collector`.
- **`go/README`** referenced a non-existent `iterate` command (→ `snapshot --coverage --url`) and `snapshot --all` (→ `capture --all`).

## Scouring

Grepped all of `docs/`, `skills/`, and both READMEs for `--launch`, `browser launch`, `--compact`, `NewSession`/`Session`, `iterate`, `snapshot --all` — no stale references remain outside the intended replacements. `go build`/`vet`/`gofmt`/`test` clean (skills embed compiles; mirror in sync).

Out of scope (tracked separately): the high-level "lead with concrete use cases + screenshots" repositioning, and describing the network tools as sightmap-request-aware (that lands with the request-enrichment work).