### PR TITLE
Add changeset for the CLI teardown

### DIFF
--- a/.changeset/tools-refactor.md
+++ b/.changeset/tools-refactor.md
@@ -1,0 +1,10 @@
+---
+"@sightmap/sightmap": minor
+---
+
+CLI teardown: reorganize the tooling around reusable library subsystems and add browser devtools.
+
+- Separate `snapshot` (observe: annotated tree + coverage) from `capture` (persist into a view's set); extract the `observe`, `coverage`, `viewset`, and `authoring` packages and merge the internal `Session` into `Corpus`.
+- Make the `browser start` daemon the single session owner: retire `--launch` and the `browser launch` subcommand (live commands attach to a started session).
+- Add `console` and `network` devtools commands, backed by a session-lifetime collector in the daemon that buffers console messages (with uncaught exceptions folded in) and network requests, with lazy response bodies.
+- Add screenshot clipping to `browser screenshot` (`--component` / `--selector` / `--expand-pct`).


### PR DESCRIPTION
A single catch-up changeset covering the tools-refactoring herd (#12–#27), which all landed without individual changesets. `minor` bump for `@sightmap/sightmap` (0.14.0 → 0.15.0).

Once merged, the `changesets` workflow opens the **Version Packages** PR (bumps `go/npm/package.json`, writes the changelog, syncs plugin-manifest versions). Merging that and pushing the `v0.15.0` tag cuts the release (goreleaser + npm publish).