### PR TITLE
Isolate concurrent browser sessions by corpus

### DIFF
--- a/.changeset/fix-multiagent-crosstalk.md
+++ b/.changeset/fix-multiagent-crosstalk.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Isolate concurrent browser sessions so agents working in different projects no longer cross-talk. The session file is now keyed to `--sightmap-dir` (it lives at `<sightmap-dir>/.session`) instead of a single shared `$TMPDIR` file, so a second `browser start` only ever reuses the Chrome for *its own* corpus rather than piggybacking on another agent's browser. Free-port probing now checks the IPv4 loopback (where Chrome's CDP and the sightmap server bind), and the sightmap server binds `127.0.0.1`, so two daemons started on the default ports slide to non-overlapping ports instead of one daemon's server colliding with another's CDP port. Every session-aware `browser` command (including `console`/`network`, `status`/`stop`, `tabs`, and the low-level interactions) now accepts `--sightmap-dir` to select which session it talks to.

--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -33,10 +33,10 @@ type SessionInfo struct {
 	// TargetID removed — use --tab flag on individual commands instead
 }
 
-// ReadSessionInfo reads and parses the session file. Returns an error if
-// the file is absent or unparseable.
-func ReadSessionInfo() (SessionInfo, error) {
-	data, err := os.ReadFile(sessionFilePath())
+// ReadSessionInfo reads and parses the session file for the corpus at
+// sightmapDir. Returns an error if the file is absent or unparseable.
+func ReadSessionInfo(sightmapDir string) (SessionInfo, error) {
+	data, err := os.ReadFile(SessionFilePath(sightmapDir))
 	if err != nil {
 		return SessionInfo{}, err
 	}
@@ -80,7 +80,12 @@ func FindFreePortExcluding(start int, exclude ...int) (int, error) {
 		if excluded[port] {
 			continue
 		}
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		// Probe on the IPv4 loopback specifically. Chrome's --remote-debugging-port
+		// binds 127.0.0.1, and the sightmap server binds the same, so a loopback
+		// probe detects BOTH. A bare ":port" probe binds the IPv6 wildcard on some
+		// systems and would miss an existing IPv4-loopback listener — letting a
+		// second daemon's server collide with a first daemon's CDP port.
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err == nil {
 			ln.Close()
 			return port, nil
@@ -89,18 +94,18 @@ func FindFreePortExcluding(start int, exclude ...int) (int, error) {
 	return 0, fmt.Errorf("no free port found in range %d–%d", start, start+99)
 }
 
-// RemoveSessionFile deletes the session file, if present.
-func RemoveSessionFile() error {
-	return os.Remove(sessionFilePath())
+// RemoveSessionFile deletes the session file for the corpus at sightmapDir, if present.
+func RemoveSessionFile(sightmapDir string) error {
+	return os.Remove(SessionFilePath(sightmapDir))
 }
 
-// WriteSessionInfo writes info to the session file.
-func WriteSessionInfo(info SessionInfo) error {
+// WriteSessionInfo writes info to the session file for the corpus at sightmapDir.
+func WriteSessionInfo(sightmapDir string, info SessionInfo) error {
 	data, err := json.Marshal(info)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(sessionFilePath(), data, 0o600)
+	return os.WriteFile(SessionFilePath(sightmapDir), data, 0o600)
 }
 
 // FindChrome returns the path to the Chrome binary on the current platform,
@@ -169,22 +174,29 @@ func FindChrome() (string, error) {
 	}
 }
 
-// DefaultAddr reads the session file written by Launch and returns
+// DefaultAddr reads the session file for the corpus at sightmapDir and returns
 // "localhost:PORT". Falls back to the DefaultCDPPort if no file exists.
-func DefaultAddr() string {
-	info, err := ReadSessionInfo()
+func DefaultAddr(sightmapDir string) string {
+	info, err := ReadSessionInfo(sightmapDir)
 	if err != nil || info.Port <= 0 || info.Port > 65535 {
 		return fmt.Sprintf("localhost:%d", DefaultCDPPort)
 	}
 	return fmt.Sprintf("localhost:%d", info.Port)
 }
 
-// sessionFilePath returns the path where Launch writes the port number.
-// Uses .sightmap/.session if a .sightmap/ directory exists in the working
-// directory, otherwise falls back to $TMPDIR/sightmap-session.
-func sessionFilePath() string {
-	if _, err := os.Stat(".sightmap"); err == nil {
-		return filepath.Join(".sightmap", ".session")
+// SessionFilePath returns the path where the session for the corpus at
+// sightmapDir records its ports. The file lives inside the corpus directory
+// (<sightmapDir>/.session) so that concurrent sessions for different corpora
+// never share a rendezvous file — the root cause of cross-agent crosstalk. An
+// empty sightmapDir is treated as the default ".sightmap". Only when the corpus
+// directory does not exist does it fall back to a single shared file under
+// $TMPDIR (best-effort for the genuinely corpus-less case).
+func SessionFilePath(sightmapDir string) string {
+	if sightmapDir == "" {
+		sightmapDir = ".sightmap"
+	}
+	if fi, err := os.Stat(sightmapDir); err == nil && fi.IsDir() {
+		return filepath.Join(sightmapDir, ".session")
 	}
 	return filepath.Join(os.TempDir(), "sightmap-session")
 }

--- a/go/browser/launcher_test.go
+++ b/go/browser/launcher_test.go
@@ -2,17 +2,69 @@ package browser
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+// TestSessionFileIsolationByCorpus is the regression guard for cross-agent
+// crosstalk: the session file must live inside the corpus directory so that
+// concurrent sessions for different corpora never share a rendezvous file (which
+// let a second `browser start` piggyback on the first agent's Chrome).
+func TestSessionFileIsolationByCorpus(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	if got, want := SessionFilePath(dirA), filepath.Join(dirA, ".session"); got != want {
+		t.Fatalf("SessionFilePath(dirA) = %q, want %q", got, want)
+	}
+	if SessionFilePath(dirA) == SessionFilePath(dirB) {
+		t.Fatal("distinct corpora must not share a session file")
+	}
+
+	if err := WriteSessionInfo(dirA, SessionInfo{Port: 1111, ServerPort: 2222}); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteSessionInfo(dirB, SessionInfo{Port: 3333, ServerPort: 4444}); err != nil {
+		t.Fatal(err)
+	}
+	if a, err := ReadSessionInfo(dirA); err != nil || a.Port != 1111 || a.ServerPort != 2222 {
+		t.Fatalf("ReadSessionInfo(dirA) = %+v, %v; want Port 1111 ServerPort 2222", a, err)
+	}
+	if b, err := ReadSessionInfo(dirB); err != nil || b.Port != 3333 {
+		t.Fatalf("ReadSessionInfo(dirB) = %+v, %v; want Port 3333", b, err)
+	}
+	if got := DefaultAddr(dirA); got != "localhost:1111" {
+		t.Fatalf("DefaultAddr(dirA) = %q, want localhost:1111", got)
+	}
+
+	if err := RemoveSessionFile(dirA); err != nil {
+		t.Fatalf("RemoveSessionFile(dirA): %v", err)
+	}
+	if _, err := os.Stat(SessionFilePath(dirA)); !os.IsNotExist(err) {
+		t.Fatalf("session file for dirA should be gone, stat err = %v", err)
+	}
+}
+
+// TestSessionFilePathFallback verifies the corpus-less fallback: when the
+// sightmap dir does not exist, the session file lands under $TMPDIR.
+func TestSessionFilePathFallback(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-corpus")
+	if got, want := SessionFilePath(missing), filepath.Join(os.TempDir(), "sightmap-session"); got != want {
+		t.Fatalf("SessionFilePath(missing) = %q, want %q", got, want)
+	}
+}
 
 // TestFindFreePortExcluding_SkipsExcluded guards against the port
 // collision: two allocations that start from overlapping ranges must not return
 // the same port. FindFreePort only probes (open+close) without holding the port,
 // so without an exclusion the server and CDP allocations could collide.
 func TestFindFreePortExcluding_SkipsExcluded(t *testing.T) {
-	// Bind a port so the default starting point is taken, forcing the first
-	// allocation to slide upward — mimicking a busy server default (7891).
-	ln, err := net.Listen("tcp", ":0")
+	// Bind a port on the IPv4 loopback so the default starting point is taken,
+	// forcing the first allocation to slide upward — mimicking a busy server
+	// default (7891). Loopback matches how the sightmap server and Chrome's CDP
+	// actually bind, and how FindFreePort now probes.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/cmd/sightmap/cli.go
+++ b/go/cmd/sightmap/cli.go
@@ -36,7 +36,7 @@ type liveFlags struct {
 // error messages.
 func addLiveFlags(fs *flag.FlagSet, cmd string) *liveFlags {
 	return &liveFlags{
-		addr:        fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)"),
+		addr:        fs.String("addr", "", "CDP address (host:port; default: the session for --sightmap-dir)"),
 		url:         fs.String("url", "", "Navigate to this URL before acting"),
 		wait:        fs.Float64("wait", 0, "Extra seconds to wait after DOM stability is detected (default 0; raise for unusually slow pages)"),
 		tab:         fs.String("tab", "", "Target tab ID (from 'browser start' output)"),
@@ -49,11 +49,24 @@ func addLiveFlags(fs *flag.FlagSet, cmd string) *liveFlags {
 // must be deferred by the caller. There is no auto-launch: start a session with
 // 'sightmap browser start' first (Connect's error says so).
 func (lf *liveFlags) connect(ctx context.Context) (*browser.CDPConn, func(), error) {
-	conn, err := browser.Connect(*lf.addr, *lf.tab)
+	conn, err := browser.Connect(resolveCDPAddr(*lf.addr, *lf.sightmapDir), *lf.tab)
 	if err != nil {
 		return nil, nil, err
 	}
 	return conn, func() { conn.Close() }, nil
+}
+
+// resolveCDPAddr returns the CDP address to connect to: the explicit --addr when
+// the user set one, otherwise the port recorded in the session file for the
+// corpus at sightmapDir (falling back to the default CDP port). Keying the
+// lookup on --sightmap-dir is what keeps concurrent sessions for different
+// corpora from finding each other's daemon. Commands pass "" for explicitAddr
+// when --addr was left at its empty default.
+func resolveCDPAddr(explicitAddr, sightmapDir string) string {
+	if explicitAddr != "" {
+		return explicitAddr
+	}
+	return browser.DefaultAddr(sightmapDir)
 }
 
 // navOpts tunes how navigate waits for the page to settle.

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -100,16 +100,6 @@ Tabs:
 `)
 }
 
-// sessionFilePath delegates to the browser package's internal logic by
-// re-reading what WriteSessionInfo would write. We use a local copy of the
-// path-finding logic here for the stale-file cleanup case.
-func sessionFilePath() string {
-	if _, err := os.Stat(".sightmap"); err == nil {
-		return filepath.Join(".sightmap", ".session")
-	}
-	return filepath.Join(os.TempDir(), "sightmap-session")
-}
-
 // cdpVersionAlive reports whether a genuine Chrome DevTools endpoint is
 // listening at addr (host:port). It is deliberately stricter than a bare
 // TCP/HTTP probe: the sightmap HTTP server can occupy the same port and answer
@@ -162,11 +152,11 @@ func pollCDPReady(addr string) error {
 
 // ── stop ──────────────────────────────────────────────────────────────────────
 
-// defaultProfileDir reconstructs the Chrome --user-data-dir this site would use,
-// mirroring browser start. Lets stop/status reap a profile's Chrome even when the
-// session file is gone.
-func defaultProfileDir() string {
-	cfg := sightmap.LoadConfig(".sightmap")
+// defaultProfileDir reconstructs the Chrome --user-data-dir the corpus at
+// sightmapDir would use, mirroring browser start. Lets stop/status reap a
+// profile's Chrome even when the session file is gone.
+func defaultProfileDir(sightmapDir string) string {
+	cfg := sightmap.LoadConfig(sightmapDir)
 	name := cfg.Name
 	if name == "" {
 		name = filepath.Base(cwd())
@@ -189,8 +179,9 @@ func portOrProfileAlive(port int, profile string) bool {
 // the profile --user-data-dir (covers a missing session file and PID reuse), and
 // only remove the session file once the port AND profile are actually dead (so we
 // never leave an invisible orphan).
-func runStop(_ []string) error {
-	info, infoErr := browser.ReadSessionInfo()
+func runStop(args []string) error {
+	sightmapDir, _ := resolveSightmapDir(args)
+	info, infoErr := browser.ReadSessionInfo(sightmapDir)
 	hasSession := infoErr == nil && (info.Port > 0 || info.PID > 0 || info.Pgid > 0)
 
 	profile := ""
@@ -198,7 +189,7 @@ func runStop(_ []string) error {
 		profile = info.Profile
 	}
 	if profile == "" {
-		profile = defaultProfileDir()
+		profile = defaultProfileDir(sightmapDir)
 	}
 
 	acted := false
@@ -240,7 +231,7 @@ func runStop(_ []string) error {
 			"  try manually: pkill -f %q", profile)
 	}
 	if hasSession {
-		os.Remove(sessionFilePath())
+		os.Remove(browser.SessionFilePath(sightmapDir))
 	}
 	if !acted {
 		fmt.Fprintln(os.Stderr, "no active session")
@@ -253,13 +244,14 @@ func runStop(_ []string) error {
 // ── status ────────────────────────────────────────────────────────────────────
 
 func runStatus(args []string) error {
+	sightmapDir, args := resolveSightmapDir(args)
 	tabID, _ := resolveTab(args)
 
-	info, err := browser.ReadSessionInfo()
+	info, err := browser.ReadSessionInfo(sightmapDir)
 	if err != nil {
 		// No session file — but an orphan Chrome for this profile may still be alive
 		// (e.g. a prior stop dropped the file without reaping the process).
-		if profile := defaultProfileDir(); profileProcessAlive(profile) {
+		if profile := defaultProfileDir(sightmapDir); profileProcessAlive(profile) {
 			fmt.Printf("⚠ orphan  Chrome is running for this profile but there is no session file\n"+
 				"  profile: %s\n  run 'browser stop' to reap it.\n", profile)
 			return nil
@@ -282,7 +274,7 @@ func runStatus(args []string) error {
 			fmt.Println("  a Chrome process for this profile is still alive — run 'browser stop' to reap it.")
 		}
 		fmt.Println("  run 'browser start' to launch a fresh session.")
-		os.Remove(sessionFilePath())
+		os.Remove(browser.SessionFilePath(sightmapDir))
 		return nil
 	}
 
@@ -318,15 +310,29 @@ func runStatus(args []string) error {
 
 // ── navigate / eval ───────────────────────────────────────────────────────────
 
-// resolveAddr extracts the --addr flag value from args if present,
-// returning the address and the remaining args.
-func resolveAddr(args []string) (addr string, rest []string) {
+// resolveSightmapDir extracts the --sightmap-dir flag value from args if
+// present (defaulting to ".sightmap"), returning it and the remaining args. It
+// keys session-file lookup so concurrent sessions for different corpora stay
+// isolated.
+func resolveSightmapDir(args []string) (dir string, rest []string) {
+	for i, a := range args {
+		if a == "--sightmap-dir" && i+1 < len(args) {
+			return args[i+1], append(args[:i:i], args[i+2:]...)
+		}
+	}
+	return ".sightmap", args
+}
+
+// resolveAddr extracts the --addr flag value from args if present, returning the
+// address and the remaining args. When --addr is absent it falls back to the
+// CDP port recorded in the session file for the corpus at sightmapDir.
+func resolveAddr(args []string, sightmapDir string) (addr string, rest []string) {
 	for i, a := range args {
 		if a == "--addr" && i+1 < len(args) {
 			return args[i+1], append(args[:i:i], args[i+2:]...)
 		}
 	}
-	return browser.DefaultAddr(), args
+	return browser.DefaultAddr(sightmapDir), args
 }
 
 // resolveTab extracts the --tab flag value from args, returning the tabID and
@@ -353,7 +359,8 @@ func dial(addr string) (*browser.CDPConn, error) {
 }
 
 func runNavigate(args []string) error {
-	addr, args := resolveAddr(args)
+	sightmapDir, args := resolveSightmapDir(args)
+	addr, args := resolveAddr(args, sightmapDir)
 	tabID, args := resolveTab(args)
 	if len(args) == 0 {
 		return fmt.Errorf("usage: browser navigate <url>")
@@ -382,7 +389,8 @@ func runNavigate(args []string) error {
 }
 
 func runEval(args []string) error {
-	addr, args := resolveAddr(args)
+	sightmapDir, args := resolveSightmapDir(args)
+	addr, args := resolveAddr(args, sightmapDir)
 	tabID, args := resolveTab(args)
 	if len(args) == 0 {
 		return fmt.Errorf("usage: browser eval <script>")

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -41,7 +41,7 @@ type boundsPx struct {
 
 func runBounds(args []string) error {
 	fs := flag.NewFlagSet("bounds", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
+	addrFlag := fs.String("addr", "", "CDP address (host:port; default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component-name queries)")
 	selectorFlag := fs.String("selector", "", "Query raw DOM elements by CSS selector instead of component name")
@@ -74,7 +74,7 @@ func runBounds(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -68,9 +68,9 @@ func parseFlagsInterspersed(fs *flag.FlagSet, args []string) error {
 
 func runClick(args []string) error {
 	fs := flag.NewFlagSet("click", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries; keys session lookup)")
 	xFlag := fs.Int("x", -1, "Absolute x coordinate (skips node lookup)")
 	yFlag := fs.Int("y", -1, "Absolute y coordinate (skips node lookup)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
@@ -78,7 +78,7 @@ func runClick(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -101,9 +101,9 @@ func runClick(args []string) error {
 
 func runFill(args []string) error {
 	fs := flag.NewFlagSet("fill", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries; keys session lookup)")
 	clearFlag := fs.Bool("clear", false, "Clear the field via JS before typing (use for React-controlled inputs)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
@@ -113,7 +113,7 @@ func runFill(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -133,9 +133,9 @@ func runFill(args []string) error {
 
 func runHover(args []string) error {
 	fs := flag.NewFlagSet("hover", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries; keys session lookup)")
 	xFlag := fs.Int("x", -1, "Absolute x coordinate (skips node lookup)")
 	yFlag := fs.Int("y", -1, "Absolute y coordinate (skips node lookup)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
@@ -143,7 +143,7 @@ func runHover(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -166,8 +166,9 @@ func runHover(args []string) error {
 
 func runKeyPress(args []string) error {
 	fs := flag.NewFlagSet("keypress", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
 	}
@@ -177,7 +178,7 @@ func runKeyPress(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -190,9 +191,9 @@ func runKeyPress(args []string) error {
 
 func runScroll(args []string) error {
 	fs := flag.NewFlagSet("scroll", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
-	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (for component queries; keys session lookup)")
 	compID := fs.String("component-id", "", "Component ID or 'ComponentQuery' to scroll into view first")
 	deltaX := fs.Int("delta-x", 0, "Horizontal scroll delta in pixels")
 	deltaY := fs.Int("delta-y", 0, "Vertical scroll delta in pixels")
@@ -204,7 +205,7 @@ func runScroll(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -229,8 +230,9 @@ func runScroll(args []string) error {
 
 func runDrag(args []string) error {
 	fs := flag.NewFlagSet("drag", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	deltaX := fs.Int("delta-x", 0, "Horizontal drag delta in pixels")
 	deltaY := fs.Int("delta-y", 0, "Vertical drag delta in pixels")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
@@ -241,7 +243,7 @@ func runDrag(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -258,8 +260,9 @@ func runDrag(args []string) error {
 
 func runWaitFor(args []string) error {
 	fs := flag.NewFlagSet("wait-for", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	urlPattern := fs.String("url", "", "Wait until the page URL contains this pattern")
 	selector := fs.String("selector", "", "Wait until a DOM element matching this selector appears")
 	loadFlag := fs.Bool("load", false, "Wait for the page load event")
@@ -288,7 +291,7 @@ func runWaitFor(args []string) error {
 	)
 	defer cancel()
 
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -308,8 +311,9 @@ func runWaitFor(args []string) error {
 
 func runDialog(args []string) error {
 	fs := flag.NewFlagSet("dialog", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	text := fs.String("text", "", "Prompt input text (prompt dialogs only)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
@@ -323,7 +327,7 @@ func runDialog(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -336,7 +340,7 @@ func runDialog(args []string) error {
 
 func runScreenshot(args []string) error {
 	fs := flag.NewFlagSet("screenshot", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	outFlag := fs.String("out", "screenshot.png", "Output file path")
 	stdoutFlag := fs.Bool("stdout", false, "Write image bytes to stdout (for piping)")
@@ -359,7 +363,7 @@ func runScreenshot(args []string) error {
 		return fmt.Errorf("screenshot: --expand-pct requires --component or --selector")
 	}
 
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -459,8 +463,9 @@ func runScreenshot(args []string) error {
 // reset session state (including httpOnly cookies that JS cannot touch).
 func runClearStorage(args []string) error {
 	fs := flag.NewFlagSet("clear-storage", flag.ContinueOnError)
-	addrFlag := fs.String("addr", browser.DefaultAddr(), "CDP address")
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	originFlag := fs.String("origin", "", "Origin to clear (default: current page origin)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
@@ -468,7 +473,7 @@ func runClearStorage(args []string) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	conn, err := browser.Connect(*addrFlag, *tabFlag)
+	conn, err := browser.Connect(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}
@@ -536,17 +541,18 @@ Subcommands:
 `)
 }
 
-func sessionAddr() string {
-	info, err := browser.ReadSessionInfo()
+func sessionAddr(sightmapDir string) string {
+	info, err := browser.ReadSessionInfo(sightmapDir)
 	if err != nil || info.Port <= 0 {
 		return fmt.Sprintf("localhost:%d", browser.DefaultCDPPort)
 	}
 	return fmt.Sprintf("localhost:%d", info.Port)
 }
 
-func runTabsList(_ []string) error {
+func runTabsList(args []string) error {
+	sightmapDir, _ := resolveSightmapDir(args)
 	ctx := context.Background()
-	tabs, err := browser.ListTabs(ctx, sessionAddr())
+	tabs, err := browser.ListTabs(ctx, sessionAddr(sightmapDir))
 	if err != nil {
 		return err
 	}
@@ -561,13 +567,14 @@ func runTabsList(_ []string) error {
 }
 
 func runTabsNew(args []string) error {
+	sightmapDir, args := resolveSightmapDir(args)
 	tabURL := ""
 	if len(args) > 0 {
 		tabURL = args[0]
 	}
 
 	ctx := context.Background()
-	addr := sessionAddr()
+	addr := sessionAddr(sightmapDir)
 
 	targetID, conn, err := browser.CreateTab(ctx, addr, tabURL)
 	if err != nil {
@@ -579,11 +586,12 @@ func runTabsNew(args []string) error {
 }
 
 func runTabsClose(args []string) error {
+	sightmapDir, args := resolveSightmapDir(args)
 	if len(args) == 0 {
 		return fmt.Errorf("usage: browser tabs close <target-id>")
 	}
 	ctx := context.Background()
-	if err := browser.CloseTab(ctx, sessionAddr(), args[0]); err != nil {
+	if err := browser.CloseTab(ctx, sessionAddr(sightmapDir), args[0]); err != nil {
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "closed tab %s\n", args[0])
@@ -593,6 +601,7 @@ func runTabsClose(args []string) error {
 func runTabsResize(args []string) error {
 	fs := flag.NewFlagSet("tabs-resize", flag.ContinueOnError)
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
 	}
@@ -609,7 +618,7 @@ func runTabsResize(args []string) error {
 	}
 
 	ctx := context.Background()
-	conn, err := browser.Connect(sessionAddr(), *tabFlag)
+	conn, err := browser.Connect(sessionAddr(*sightmapDirFlag), *tabFlag)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -59,8 +59,10 @@ func runBrowserStart(args []string) error {
 	}
 	_ = os.MkdirAll(resolvedProfile, 0o700)
 
-	// ── Detect existing Chrome for this site ──────────────────────────────────
-	existingInfo, _ := browser.ReadSessionInfo()
+	// ── Detect existing Chrome for this corpus ────────────────────────────────
+	// The session file is keyed to --sightmap-dir, so this only ever matches a
+	// prior session for THIS corpus — never another agent's browser.
+	existingInfo, _ := browser.ReadSessionInfo(*sightmapDir)
 	if existingInfo.Port > 0 && isPortAlive(existingInfo.Port) {
 		// Chrome is already running — open a new tab and return immediately.
 		cdpAddr := fmt.Sprintf("localhost:%d", existingInfo.Port)
@@ -149,7 +151,11 @@ func runBrowserStart(args []string) error {
 	var collectorPtr atomic.Pointer[browser.Collector]
 	registerDevtoolsHandlers(mux, &collectorPtr)
 
-	srvAddr := fmt.Sprintf(":%d", resolvedServerPort)
+	// Bind the sightmap server on the IPv4 loopback (not the ":port" wildcard) so
+	// it shares an address family with Chrome's CDP and with FindFreePort's probe.
+	// This keeps concurrent daemons from landing one daemon's server on another's
+	// CDP port, and keeps the server local-only.
+	srvAddr := fmt.Sprintf("127.0.0.1:%d", resolvedServerPort)
 	srv := &http.Server{Addr: srvAddr, Handler: mux}
 	srvReady := make(chan error, 1)
 	go func() {
@@ -230,7 +236,7 @@ func runBrowserStart(args []string) error {
 	if cmd.Process != nil {
 		pid = cmd.Process.Pid
 	}
-	_ = browser.WriteSessionInfo(browser.SessionInfo{
+	_ = browser.WriteSessionInfo(*sightmapDir, browser.SessionInfo{
 		Port: resolvedCDPPort, PID: pid, Pgid: pid, Profile: resolvedProfile,
 		ServerPort: resolvedServerPort,
 	})
@@ -304,7 +310,7 @@ func runBrowserStart(args []string) error {
 		// Exit cleanly so the sightmap server releases its port.
 		fmt.Fprintln(os.Stderr, "\nChrome exited — sightmap server stopping")
 		// Chrome is already gone; skip the SIGTERM/kill below.
-		_ = browser.RemoveSessionFile()
+		_ = browser.RemoveSessionFile(*sightmapDir)
 		return nil
 	}
 
@@ -324,7 +330,7 @@ func runBrowserStart(args []string) error {
 	srv.Shutdown(shutCtx)
 
 	// Remove session file.
-	os.Remove(sessionFilePath())
+	os.Remove(browser.SessionFilePath(*sightmapDir))
 
 	return nil
 }

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -21,8 +21,8 @@ import (
 // devtoolsGet fetches path (with query) from the daemon's HTTP server and
 // returns the raw body. It resolves the daemon via the session file's
 // ServerPort.
-func devtoolsGet(path string, query url.Values) ([]byte, error) {
-	info, err := browser.ReadSessionInfo()
+func devtoolsGet(sightmapDir, path string, query url.Values) ([]byte, error) {
+	info, err := browser.ReadSessionInfo(sightmapDir)
 	if err != nil || info.ServerPort == 0 {
 		return nil, fmt.Errorf("no running session — start one with 'sightmap browser start'")
 	}
@@ -80,6 +80,7 @@ func runConsoleList(args []string) error {
 	level := fs.String("level", "", "Filter by level: log, debug, info, warn, error, exception")
 	tab := fs.String("tab", "", "Filter by tab ID")
 	limit := fs.Int("limit", 0, "Show only the most recent N messages (0 = all)")
+	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -89,7 +90,7 @@ func runConsoleList(args []string) error {
 	if *limit > 0 {
 		q.Set("limit", strconv.Itoa(*limit))
 	}
-	body, err := devtoolsGet("/devtools/console", q)
+	body, err := devtoolsGet(*sightmapDir, "/devtools/console", q)
 	if err != nil {
 		return err
 	}
@@ -115,6 +116,7 @@ func runConsoleList(args []string) error {
 
 func runConsoleGet(args []string) error {
 	fs := flag.NewFlagSet("console get", flag.ContinueOnError)
+	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -122,7 +124,7 @@ func runConsoleGet(args []string) error {
 	if err != nil {
 		return err
 	}
-	body, err := devtoolsGet("/devtools/console", nil)
+	body, err := devtoolsGet(*sightmapDir, "/devtools/console", nil)
 	if err != nil {
 		return err
 	}
@@ -161,6 +163,7 @@ func runNetworkList(args []string) error {
 	urlSub := fs.String("url", "", "Filter by URL substring")
 	tab := fs.String("tab", "", "Filter by tab ID")
 	limit := fs.Int("limit", 0, "Show only the most recent N requests (0 = all)")
+	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func runNetworkList(args []string) error {
 	if *limit > 0 {
 		q.Set("limit", strconv.Itoa(*limit))
 	}
-	body, err := devtoolsGet("/devtools/network", q)
+	body, err := devtoolsGet(*sightmapDir, "/devtools/network", q)
 	if err != nil {
 		return err
 	}
@@ -194,6 +197,7 @@ func runNetworkGet(args []string) error {
 	fs := flag.NewFlagSet("network get", flag.ContinueOnError)
 	respFile := fs.String("response-file", "", "Write the response body to this file")
 	reqFile := fs.String("request-file", "", "Write the request body (POST data) to this file")
+	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
 		return err
 	}
@@ -202,7 +206,7 @@ func runNetworkGet(args []string) error {
 		return err
 	}
 
-	body, err := devtoolsGet("/devtools/network", nil)
+	body, err := devtoolsGet(*sightmapDir, "/devtools/network", nil)
 	if err != nil {
 		return err
 	}
@@ -228,12 +232,12 @@ func runNetworkGet(args []string) error {
 	fmt.Printf("Tab: %s\n", entry.Tab)
 
 	if *reqFile != "" {
-		if err := saveBody(idx, "request", *reqFile); err != nil {
+		if err := saveBody(*sightmapDir, idx, "request", *reqFile); err != nil {
 			return err
 		}
 	}
 	// Fetch the response body (to a file, or inline preview).
-	rbody, err := devtoolsGet("/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {"response"}})
+	rbody, err := devtoolsGet(*sightmapDir, "/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {"response"}})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "network get: response body unavailable: %v\n", err)
 		return nil
@@ -249,8 +253,8 @@ func runNetworkGet(args []string) error {
 	return nil
 }
 
-func saveBody(idx int, kind, path string) error {
-	b, err := devtoolsGet("/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {kind}})
+func saveBody(sightmapDir string, idx int, kind, path string) error {
+	b, err := devtoolsGet(sightmapDir, "/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {kind}})
 	if err != nil {
 		return fmt.Errorf("%s body: %w", kind, err)
 	}

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -91,7 +91,7 @@ type compAnnotation struct {
 
 func runSelProbe(args []string) error {
 	fs := flag.NewFlagSet("sel-probe", flag.ContinueOnError)
-	addr := fs.String("addr", browser.DefaultAddr(), "CDP address (host:port)")
+	addr := fs.String("addr", "", "CDP address (host:port; default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ directory for component annotation")
 	maxN := fs.Int("max", 10, "Max matches to show")
@@ -110,9 +110,10 @@ func runSelProbe(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	resolvedAddr := resolveCDPAddr(*addr, *sightmapDir)
 
 	if *allFlag {
-		return runSelProbeAll(fs.Args(), *sightmapDir, *addr, *tabFlag, *maxN, *full, *waitFlag)
+		return runSelProbeAll(fs.Args(), *sightmapDir, resolvedAddr, *tabFlag, *maxN, *full, *waitFlag)
 	}
 
 	remaining := fs.Args()
@@ -127,7 +128,7 @@ func runSelProbe(args []string) error {
 	ctx := context.Background()
 
 	// Step 1: connect to Chrome.
-	conn, err := browser.Connect(*addr, *tabFlag)
+	conn, err := browser.Connect(resolvedAddr, *tabFlag)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/sightmap/cmd_serve.go
+++ b/go/cmd/sightmap/cmd_serve.go
@@ -148,7 +148,7 @@ func runServeSightmap(args []string) error {
 		json.NewEncoder(w).Encode(c)
 	})
 
-	addr := fmt.Sprintf(":%d", *portFlag)
+	addr := fmt.Sprintf("127.0.0.1:%d", *portFlag)
 	fmt.Fprintf(os.Stderr, "[serve-sightmap] listening on http://%s\n", addr)
 
 	srv := &http.Server{Addr: addr, Handler: mux}


### PR DESCRIPTION
Fixes cross-agent crosstalk: two agents driving sightmap in different projects could stomp each other's Chrome.

## Root causes

1. **Shared session file → existing-Chrome reuse.** `sessionFilePath()` returned `.sightmap/.session` only when the *cwd* literally contained `.sightmap/`; otherwise (including whenever `--sightmap-dir` pointed elsewhere) it fell back to a single global `$TMPDIR/sightmap-session`. `browser start` then reuses any live session it finds there, so a second agent silently opened a tab in the first agent's browser — and a `stop`/`pkill` from either killed both.

2. **Cross-daemon port collision.** The sightmap server bound the `:port` IPv6 wildcard while Chrome's CDP bound IPv4 `127.0.0.1:port`. `FindFreePort` probed `:port` (IPv6), so it didn't see Chrome's IPv4 loopback bind — a second daemon's server could grab a first daemon's CDP port (both on 7892, different families), and a client's `localhost` lookup would nondeterministically hit the wrong one.

## Fix

- **Key the session file to `--sightmap-dir`**: it now lives at `<sightmap-dir>/.session`, so the existing-Chrome check only ever matches the caller's *own* corpus. `--sightmap-dir` is threaded through every session-aware command (`status`/`stop`/`tabs`, `navigate`/`eval`, the interactions, `console`/`network`, `sel-probe`, `bounds`), and `--addr` resolves lazily from that corpus's session file (also closing the `console`/`network` `--sightmap-dir` gap).
- **Loopback-consistent ports**: `FindFreePort` probes `127.0.0.1`, and the server binds `127.0.0.1`, matching Chrome's CDP — so concurrent daemons slide to non-overlapping ports.

## Verification

Two daemons for two corpora (`/tmp/smA` menu, `/tmp/smB` cart) on default ports:

- Session files, profiles, and ports all distinct (A 7891/7892, B 7893/7894).
- `snapshot`/`tabs` route correctly (A→Menu, B→Cart); `console` isolated (no cross-leak).
- Re-`start` of A reused A's Chrome (new tab), left B untouched, spawned no duplicate.
- New unit test `TestSessionFileIsolationByCorpus`; `go build`/`vet`/`gofmt`/`test ./...` clean.

Independent of #30 (overlay reload loop); no overlapping hunks.