### PR TITLE
Fix view route matching: trailing slashes, :param, most-specific-wins

### DIFF
--- a/.changeset/fix-route-matching.md
+++ b/.changeset/fix-route-matching.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix view route matching so it behaves as the spec documents. Trailing slashes are now normalized off both the route pattern and the URL path before matching, so a slash-free route like `/*/projects` matches the `/acme/projects/` paths that Django, Rails, and many React-Router apps emit — previously such URLs matched no view at all, silently dropping the `[View:]` header, view memory, and view-scoped components. Express-style `:param` segments in view routes now match a single path segment (and score between a literal and `*` for specificity). And `Corpus.ViewForURL` now returns the *most specific* matching view — using declaration order only to break equal-specificity ties — instead of the first match in corpus order, closing a divergence between the exported library and the spec.

--- a/docs/reference/go-library.mdx
+++ b/docs/reference/go-library.mdx
@@ -86,11 +86,7 @@ func main() {
 }
 ```
 
-`MatchTree` returns `map[*comps.ComponentNode]*match.SightmapMatch`. Each match contains the component `Name` and `Memory` notes. The current library selects the first view in corpus order whose route matches the URL pathname. If no view matches, global components still apply.
-
-<Warning>
-The stream 1 spec requires the most specific matching view, with declaration order used only to break ties. `ViewForURL` currently uses the first match in corpus order. Avoid overlapping routes when calling the library directly until this implementation gap is closed.
-</Warning>
+`MatchTree` returns `map[*comps.ComponentNode]*match.SightmapMatch`. Each match contains the component `Name` and `Memory` notes. The library selects the most specific view whose route matches the URL pathname, using declaration order only to break equal-specificity ties (per the stream 1 spec). Trailing slashes on the URL path are normalized away before matching. If no view matches, global components still apply.
 
 ## The Corpus handle
 
@@ -100,7 +96,7 @@ The stream 1 spec requires the most specific matching view, with declaration ord
 |---|---|
 | `MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.SightmapMatch` | Apply the corpus to a tree for a URL |
 | `Components(pageURL string) []match.SightmapComponent` | Return the merged component list for a URL without matching a tree |
-| `ViewForURL(pageURL string) *sightmap.View` | Return the first matching view, or `nil` when no view matches |
+| `ViewForURL(pageURL string) *sightmap.View` | Return the most specific matching view, or `nil` when no view matches |
 | `ViewByName(name string) *sightmap.View` | Return the view with the given name, or `nil` |
 | `GlobalComponentNames() map[string]bool` | Return the names declared at global scope |
 

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -118,58 +118,123 @@ func (c *Corpus) ComponentsForURL(pageURL string) []match.SightmapComponent {
 	return result
 }
 
-// ViewForURL returns the first View whose route matches pageURL's path,
-// or nil if no view matches. The returned View is a copy.
+// ViewForURL returns the View whose route most specifically matches pageURL's
+// path, or nil if no view matches. Specificity follows the spec's per-segment
+// scoring (literal > :param > * > **); when scores tie, the first-declared view
+// wins. The returned View is a copy.
 func (c *Corpus) ViewForURL(pageURL string) *View {
 	u, err := url.Parse(pageURL)
 	if err != nil {
 		return nil
 	}
-	path := u.Path
-	if path == "" {
-		path = "/"
-	}
+	path := normalizeRoutePath(u.Path)
+
+	best := -1
+	bestScore := -1
 	for i := range c.Views {
-		if MatchRoute(c.Views[i].Route, path) {
-			v := c.Views[i] // copy so caller doesn't share Corpus internals
-			return &v
+		if !MatchRoute(c.Views[i].Route, path) {
+			continue
+		}
+		if s := routeSpecificity(c.Views[i].Route); s > bestScore {
+			bestScore = s
+			best = i
 		}
 	}
-	return nil
+	if best < 0 {
+		return nil
+	}
+	v := c.Views[best] // copy so caller doesn't share Corpus internals
+	return &v
 }
 
-// MatchRoute reports whether the glob-style route pattern matches path.
-// ** matches any sequence of characters including slashes (one or more).
-// *  matches a single path segment (no slashes).
+// MatchRoute reports whether the glob-style route pattern matches path. A single
+// trailing slash is normalized off both sides first (except the root "/"), so
+// "/*/projects" matches "/acme/projects/".
+//   - **      matches any sequence of characters including slashes (one or more)
+//   - *       matches a single path segment (no slashes)
+//   - :param  matches a single path segment (no slashes)
 func MatchRoute(pattern, path string) bool {
-	re := regexp.MustCompile(routeToRegex(pattern))
-	return re.MatchString(path)
+	re := regexp.MustCompile(routeToRegex(normalizeRoutePath(pattern)))
+	return re.MatchString(normalizeRoutePath(path))
 }
 
-// routeToRegex converts a route glob pattern to an anchored regexp string.
+// normalizeRoutePath strips a trailing slash from a URL path or route pattern so
+// that matching is insensitive to it. The root "/" (or an all-slash/empty path)
+// normalizes to "/".
+func normalizeRoutePath(p string) string {
+	trimmed := strings.TrimRight(p, "/")
+	if trimmed == "" {
+		return "/"
+	}
+	return trimmed
+}
+
+// routeToRegex converts a normalized route glob pattern to an anchored regexp
+// string. `*` and `:param` segments each match a single path segment; `**`
+// matches any depth.
 func routeToRegex(pattern string) string {
 	var sb strings.Builder
 	sb.WriteByte('^')
+	atSegStart := true
 	for i := 0; i < len(pattern); {
-		if pattern[i] == '*' {
+		c := pattern[i]
+		if c == '*' {
 			if i+1 < len(pattern) && pattern[i+1] == '*' {
 				sb.WriteString("(.+)")
 				i += 2
-				continue
+			} else {
+				sb.WriteString("([^/]+)")
+				i++
 			}
-			sb.WriteString("([^/]+)")
-			i++
+			atSegStart = false
 			continue
 		}
-		c := pattern[i]
+		// Express-style :param — a whole segment starting with ':' — matches a
+		// single path segment, exactly like `*` but scoring higher (see
+		// routeSpecificity).
+		if c == ':' && atSegStart {
+			j := i + 1
+			for j < len(pattern) && pattern[j] != '/' {
+				j++
+			}
+			sb.WriteString("([^/]+)")
+			i = j
+			atSegStart = false
+			continue
+		}
 		// Escape regex metacharacters that can appear in URL patterns.
 		switch c {
 		case '.', '+', '?', '(', ')', '[', ']', '{', '}', '\\', '|', '^', '$':
 			sb.WriteByte('\\')
 		}
 		sb.WriteByte(c)
+		atSegStart = c == '/'
 		i++
 	}
 	sb.WriteByte('$')
 	return sb.String()
+}
+
+// routeSpecificity scores a route pattern per the spec's most-specific-wins
+// table: literal segments score 3, :param 2, `*` 1, and `**` or empty 0. The
+// score is summed over segments; the root route "/" scores 1.
+func routeSpecificity(pattern string) int {
+	pattern = normalizeRoutePath(pattern)
+	if pattern == "/" {
+		return 1
+	}
+	score := 0
+	for _, seg := range strings.Split(pattern, "/") {
+		switch {
+		case seg == "" || seg == "**":
+			// 0
+		case seg == "*":
+			score++
+		case strings.HasPrefix(seg, ":"):
+			score += 2
+		default:
+			score += 3
+		}
+	}
+	return score
 }

--- a/go/sightmap/route_test.go
+++ b/go/sightmap/route_test.go
@@ -1,0 +1,96 @@
+package sightmap_test
+
+import (
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// ---- Route matching: trailing slashes + :param ------------------------------
+
+func TestMatchRouteTrailingSlash(t *testing.T) {
+	cases := []struct {
+		pattern, path string
+		want          bool
+	}{
+		// Trailing slash on the path (the common real-app case) must not defeat
+		// a slash-free pattern, and vice versa.
+		{"/*/projects", "/acme/projects/", true},
+		{"/*/projects", "/acme/projects", true},
+		{"/*/projects/", "/acme/projects", true},
+		{"/*/projects/", "/acme/projects/", true},
+		{"/settings", "/settings/", true},
+		{"/settings/", "/settings", true},
+		// Root is never stripped to empty.
+		{"/", "/", true},
+		{"/", "", true},
+		// :param matches a single segment, like *.
+		{"/api/users/:id/orders", "/api/users/42/orders", true},
+		{"/api/users/:id/orders", "/api/users/42/orders/", true},
+		{"/api/users/:id", "/api/users/42/extra", false},
+		// Single-segment wildcard still doesn't cross a slash.
+		{"/users/*", "/users/42/edit", false},
+		{"/users/*", "/users/42", true},
+	}
+	for _, tc := range cases {
+		if got := sightmap.MatchRoute(tc.pattern, tc.path); got != tc.want {
+			t.Errorf("MatchRoute(%q, %q) = %v, want %v", tc.pattern, tc.path, got, tc.want)
+		}
+	}
+}
+
+// ---- View resolution: most specific wins ------------------------------------
+
+func TestViewForURLMostSpecificWins(t *testing.T) {
+	// Declaration order deliberately puts the GENERIC route first so a
+	// first-match implementation would pick the wrong view.
+	c := &sightmap.Corpus{
+		Views: []sightmap.View{
+			{Name: "Generic", Route: "/users/*"},
+			{Name: "Specific", Route: "/users/me"},
+			{Name: "Param", Route: "/users/:id/edit"},
+			{Name: "Tree", Route: "/admin/**"},
+			{Name: "Root", Route: "/"},
+		},
+	}
+
+	cases := []struct {
+		url, want string
+	}{
+		{"/users/me", "Specific"},   // literal beats /users/*
+		{"/users/42", "Generic"},    // only /users/* matches
+		{"/users/42/edit", "Param"}, // :param route matches a 3rd segment
+		{"/admin/foo/bar", "Tree"},  // ** depth
+		{"/", "Root"},               // root scores 1, beats nothing else here
+		{"/users/me/", "Specific"},  // trailing slash normalized
+		{"/nope/nowhere", ""},       // no match
+	}
+	for _, tc := range cases {
+		v := c.ViewForURL(tc.url)
+		got := ""
+		if v != nil {
+			got = v.Name
+		}
+		if got != tc.want {
+			t.Errorf("ViewForURL(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+// TestViewForURLTieBreakDeclarationOrder verifies that equally specific routes
+// resolve to the first-declared view.
+func TestViewForURLTieBreakDeclarationOrder(t *testing.T) {
+	c := &sightmap.Corpus{
+		Views: []sightmap.View{
+			{Name: "First", Route: "/a/*"},
+			{Name: "Second", Route: "/*/b"},
+		},
+	}
+	if v := c.ViewForURL("/a/b"); v == nil || v.Name != "First" {
+		got := "<nil>"
+		if v != nil {
+			got = v.Name
+		}
+		t.Errorf("ViewForURL(/a/b) = %q, want First (declaration-order tiebreak)", got)
+	}
+}

--- a/spec/conformance/003-route-precedence.fixture/sightmap/app.yaml
+++ b/spec/conformance/003-route-precedence.fixture/sightmap/app.yaml
@@ -1,8 +1,11 @@
 version: 1
 views:
-  - name: Specific
-    route: /users/me
+  # Generic routes are declared BEFORE the specific ones on purpose: resolution
+  # is most-specific-wins, not first-match, so declaration order must not decide
+  # the winner here.
   - name: Generic
     route: /users/*
   - name: Tree
     route: /admin/**
+  - name: Specific
+    route: /users/me

--- a/spec/conformance/013-route-trailing-slash.fixture/expected.json
+++ b/spec/conformance/013-route-trailing-slash.fixture/expected.json
@@ -1,0 +1,19 @@
+{
+  "cases": [
+    {
+      "command": "match",
+      "args": { "url": "/acme/projects/" },
+      "expected": { "result": { "view": { "name": "Projects" } } }
+    },
+    {
+      "command": "match",
+      "args": { "url": "/acme/projects" },
+      "expected": { "result": { "view": { "name": "Projects" } } }
+    },
+    {
+      "command": "match",
+      "args": { "url": "/acme/projects/42/" },
+      "expected": { "result": { "view": { "name": "WorkItem" } } }
+    }
+  ]
+}

--- a/spec/conformance/013-route-trailing-slash.fixture/sightmap/app.yaml
+++ b/spec/conformance/013-route-trailing-slash.fixture/sightmap/app.yaml
@@ -1,0 +1,8 @@
+version: 1
+views:
+  # Real apps (Django, Rails, many React-Router setups) append a trailing slash
+  # to every URL. A slash-free route pattern must still match such a path.
+  - name: Projects
+    route: /*/projects
+  - name: WorkItem
+    route: /*/projects/:id

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -41,7 +41,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 001 | `minimal` | Smallest valid sightmap; basic `match` |
 | 002 | `multi-file-merge` | Same view name across two files → `merge-collision-view` warning |
 | 003 | `route-precedence` | Most-specific-wins: literal &gt; `:param` &gt; `*` &gt; `**`, declaration order tie-breaks |
-| 004 | `param-normalization` | Express-style `:param` normalizes to `*` |
+| 004 | `param-normalization` | Express-style `:param` normalizes to `*` (requests); `:param` also matches a single view-route segment |
 | 005 | `selector-array` | `selector` accepts array; alternates tried in order |
 | 006 | `view-scoped-vs-global` | Global components match everywhere; scoped only on their view |
 | 007 | `request-method-filter` | `match` filters requests by HTTP method |
@@ -49,6 +49,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 010 | `component-ref` | `$ref` expansion, view attestation, and global+view-scoped dedup ([SEP-0002](../seps/0002-component-ref.md)) |
 | 011 | `component-ref-unresolved` | `$ref` to an unknown component → `ref-unresolved` error |
 | 012 | `component-ref-circular` | Self-referential `$ref` chain → `ref-circular` error |
+| 013 | `route-trailing-slash` | Trailing slashes on the URL path are normalized away before matching |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 


### PR DESCRIPTION
View route matching diverged from the spec in three ways, all of which failed **silently** — no error, just a missing `[View:]` header, no view memory, and no view-scoped components:

1. **Trailing slashes were not normalized.** A slash-free route like `/*/projects` could not match `/acme/projects/` — the shape most real apps (Django, Rails, many React-Router setups) emit — so *zero* views matched. Both the route pattern and the URL path now have a single trailing slash stripped before matching (the root `/` is preserved).
2. **`:param` segments in view routes did not match.** Express-style `:param` now matches a single path segment and scores 2 for specificity (between a literal and `*`), per the spec's scoring table.
3. **`Corpus.ViewForURL` used first-match, not most-specific-wins.** The exported library returned the first route match in corpus order rather than the most specific one, diverging from both the spec and the CLI's own observation path. It now scores each matching route and picks the most specific, using declaration order only to break ties.

### Changes
- `go/sightmap/corpus.go`: trailing-slash normalization, `:param` support in `routeToRegex`, and specificity-scored `ViewForURL`.
- `go/sightmap/route_test.go`: unit tests for all three behaviors, including a declaration-order tie-break and a generic-declared-first specificity case.
- `spec/conformance/003-route-precedence.fixture`: reordered so the generic route is declared *before* the specific one — the fixture now genuinely exercises most-specific-wins instead of accidentally passing under first-match.
- `spec/conformance/013-route-trailing-slash.fixture`: new fixture for trailing-slash normalization.
- `docs/reference/go-library.mdx`: drops the warning documenting the old first-match behavior.

Behavior is now what `spec/v1/schema.md` already documented; no spec-prose changes were needed.

Closes sightmap/sightmap#33
Closes sightmap/sightmap#36
