### PR TITLE
Harden corpus loading against circular $ref and comma-in-selector

### DIFF
--- a/.changeset/fix-loader-robustness.md
+++ b/.changeset/fix-loader-robustness.md
@@ -1,0 +1,8 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Make corpus loading robust against two malformed inputs that previously failed badly:
+
+- A circular `$ref` chain (`A → B → A`, or a component that references itself) sent every corpus-loading command into infinite recursion and hung the process. Loading now detects the cycle, stops expanding, and `validate` reports it as a `ref-circular` error instead of hanging.
+- `splitSelectors` only balanced parentheses, so a comma inside an attribute selector or quoted string (`[data-x="a,b"]`) was wrongly treated as a selector-list separator and split into two dead alternatives. Splitting is now aware of `[]` brackets and quoted strings (with backslash escapes), matching how CSS is actually written.

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -22,6 +22,11 @@ type Corpus struct {
 	// children flattened.
 	Views []View
 
+	// loadDiagnostics holds structural problems detected while loading that are
+	// no longer visible in the flattened data (e.g. a circular $ref chain, which
+	// is expanded away). Validate surfaces these alongside its own checks.
+	loadDiagnostics []ValidationError
+
 	// mu guards the lazily-built compiled-query cache.
 	mu    sync.Mutex
 	cache map[string]*queryCacheEntry

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -165,8 +165,12 @@ func loadDir(path string) (*Corpus, error) {
 		}
 	}
 
+	// One flatten context is shared across the global list and every view so
+	// that $ref cycle detection and diagnostics accumulate in one place.
+	ctx := &flattenCtx{reg: reg}
+
 	// Flatten global components (hierarchy → compound descendant selectors).
-	globalComps := flattenAll(globalRaws, reg)
+	globalComps := flattenAll(globalRaws, ctx)
 
 	// Build views, expanding $refs and flattening each view's component list.
 	var views []View
@@ -195,7 +199,7 @@ func loadDir(path string) (*Corpus, error) {
 				Name:       rv.Name,
 				Route:      rv.Route,
 				Memory:     rv.Memory,
-				Components: flattenAll(rv.Components, reg),
+				Components: flattenAll(rv.Components, ctx),
 				Stability:  rv.Stability,
 				Access:     access,
 				URL:        vf.URL,
@@ -208,6 +212,7 @@ func loadDir(path string) (*Corpus, error) {
 	return &Corpus{
 		GlobalComponents: globalComps,
 		Views:            views,
+		loadDiagnostics:  ctx.diagnostics,
 	}, nil
 }
 
@@ -225,12 +230,37 @@ func rawPropsToMatch(rps []rawProperty) []match.Property {
 	return ps
 }
 
+// flattenCtx carries the shared state for a flattening pass: the $ref registry
+// and any structural diagnostics discovered along the way (currently circular
+// $ref chains, which are expanded away and so invisible downstream).
+type flattenCtx struct {
+	reg          map[string]rawComponent
+	diagnostics  []ValidationError
+	seenCircular map[string]bool // dedupe key → already-reported
+}
+
+// recordCircular records a $ref cycle diagnostic once per distinct chain.
+func (ctx *flattenCtx) recordCircular(chain []string) {
+	key := strings.Join(chain, "\x00")
+	if ctx.seenCircular == nil {
+		ctx.seenCircular = map[string]bool{}
+	}
+	if ctx.seenCircular[key] {
+		return
+	}
+	ctx.seenCircular[key] = true
+	ctx.diagnostics = append(ctx.diagnostics, ValidationError{
+		Component: chain[len(chain)-1],
+		Message:   "ref-circular: circular $ref chain " + strings.Join(chain, " → "),
+	})
+}
+
 // flattenAll flattens a slice of rawComponents into a flat list of
 // SightmapComponents with compound descendant selectors.
-func flattenAll(rcs []rawComponent, reg map[string]rawComponent) []match.SightmapComponent {
+func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.SightmapComponent {
 	var result []match.SightmapComponent
 	for _, rc := range rcs {
-		result = append(result, flattenOne(rc, nil, reg, nil)...)
+		result = append(result, flattenOne(rc, nil, ctx, nil, nil)...)
 	}
 	return result
 }
@@ -241,13 +271,23 @@ func flattenAll(rcs []rawComponent, reg map[string]rawComponent) []match.Sightma
 // selector. parentChain is the slice of ancestor component names (root-first)
 // carried through recursion and stored on each SightmapComponent so the
 // extension can scope child selectors to their parent's DOM subtree.
-func flattenOne(rc rawComponent, parentSels []string, reg map[string]rawComponent, parentChain []string) []match.SightmapComponent {
+// refStack is the chain of $ref names currently being expanded; it guards
+// against circular references, which would otherwise recurse forever.
+func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentChain []string, refStack []string) []match.SightmapComponent {
 	// Expand $ref: replace the placeholder with a deep copy of the named global.
 	if rc.Ref != "" {
-		global, ok := reg[rc.Ref]
-		if !ok {
-			return nil // unknown ref — skip silently
+		for _, prev := range refStack {
+			if prev == rc.Ref {
+				// Cycle: stop expanding rather than recurse forever.
+				ctx.recordCircular(append(append([]string(nil), refStack...), rc.Ref))
+				return nil
+			}
 		}
+		global, ok := ctx.reg[rc.Ref]
+		if !ok {
+			return nil // unknown ref — reported separately by strict validation
+		}
+		refStack = append(refStack, rc.Ref)
 		rc = global
 	}
 
@@ -287,27 +327,42 @@ func flattenOne(rc rawComponent, parentSels []string, reg map[string]rawComponen
 	// Recurse into children: extend the parent chain with this component's name.
 	childChain := append(append([]string(nil), parentChain...), rc.Name)
 	for _, child := range rc.Children {
-		result = append(result, flattenOne(child, mySels, reg, childChain)...)
+		result = append(result, flattenOne(child, mySels, ctx, childChain, refStack)...)
 	}
 
 	return result
 }
 
 // splitSelectors splits a comma-separated selector string and trims whitespace
-// from each alternative, returning only non-empty parts. The split is
-// paren-depth-aware so commas inside :is(), :where(), :not(), etc. are not
-// treated as selector-list separators.
+// from each alternative, returning only non-empty parts. The split ignores
+// commas that are not list separators: those inside a bracket or paren group
+// (`[attr="a,b"]`, `:is()`, `:where()`, `:not()`, `:nth-child()`, …) or inside a
+// quoted string. A backslash escapes the following character.
 func splitSelectors(s string) []string {
 	if s == "" {
 		return nil
 	}
 	var parts []string
 	depth, start := 0, 0
+	var quote byte // 0 outside a quoted string, else the opening quote char
 	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '(':
+		c := s[i]
+		if c == '\\' {
+			i++ // skip the escaped character
+			continue
+		}
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '(', '[':
 			depth++
-		case ')':
+		case ')', ']':
 			if depth > 0 {
 				depth--
 			}

--- a/go/sightmap/loader_ref_test.go
+++ b/go/sightmap/loader_ref_test.go
@@ -1,0 +1,134 @@
+package sightmap_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// TestCircularRefDoesNotHang guards the DoS fix: a mutually-recursive $ref chain
+// must not make Load spin forever, and Validate must report it as ref-circular.
+func TestCircularRefDoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "components.yaml"), `
+version: 1
+components:
+  - name: A
+    selector: ".a"
+    children:
+      - $ref: B
+  - name: B
+    selector: ".b"
+    children:
+      - $ref: A
+`)
+
+	type result struct {
+		c   *sightmap.Corpus
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		c, err := sightmap.DirLoader(dir).Load()
+		done <- result{c, err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("Load returned error: %v", r.err)
+		}
+		errs := sightmap.Validate(r.c)
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e.Message, "ref-circular") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected a ref-circular validation error, got %v", errs)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load hung on a circular $ref chain")
+	}
+}
+
+// TestSelfRefDoesNotHang covers the single-component self reference.
+func TestSelfRefDoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "components.yaml"), `
+version: 1
+components:
+  - name: Loop
+    selector: ".loop"
+    children:
+      - $ref: Loop
+`)
+
+	done := make(chan *sightmap.Corpus, 1)
+	go func() {
+		c, _ := sightmap.DirLoader(dir).Load()
+		done <- c
+	}()
+	select {
+	case c := <-done:
+		errs := sightmap.Validate(c)
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e.Message, "ref-circular") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected ref-circular for self reference, got %v", errs)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load hung on a self-referential $ref")
+	}
+}
+
+// TestSplitSelectorsBracketsAndQuotes verifies that a comma inside an attribute
+// selector or a quoted string is not treated as a selector-list separator.
+func TestSplitSelectorsBracketsAndQuotes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "views.yaml"), `
+version: 1
+views:
+  - name: V
+    route: /v
+    components:
+      - name: AttrComma
+        selector: '[data-x="a,b"]'
+      - name: NthChild
+        selector: 'li:nth-child(2n, 3n)'
+      - name: RealList
+        selector:
+          - '.first'
+          - '.second'
+`)
+
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	v := c.ViewByName("V")
+	if v == nil {
+		t.Fatal("view V not found")
+	}
+	byName := indexByName(v.Components)
+
+	if got := byName["AttrComma"].Selectors; len(got) != 1 || got[0] != `[data-x="a,b"]` {
+		t.Errorf(`AttrComma selectors = %v, want ["[data-x=\"a,b\"]"] (not split at the comma)`, got)
+	}
+	if got := byName["NthChild"].Selectors; len(got) != 1 || got[0] != "li:nth-child(2n, 3n)" {
+		t.Errorf("NthChild selectors = %v, want one un-split selector", got)
+	}
+	// A genuine comma-separated list (authored as a YAML sequence) still yields
+	// two alternatives.
+	if got := byName["RealList"].Selectors; len(got) != 2 {
+		t.Errorf("RealList selectors = %v, want 2 alternatives", got)
+	}
+}

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -38,6 +38,10 @@ func (e ValidationError) Error() string {
 func Validate(c *Corpus) []ValidationError {
 	var errs []ValidationError
 
+	// Structural problems detected at load time (e.g. circular $ref chains that
+	// are expanded away before this point).
+	errs = append(errs, c.loadDiagnostics...)
+
 	// Check global components.
 	globalNames := make(map[string]string)
 	for _, comp := range c.GlobalComponents {


### PR DESCRIPTION
Two malformed-but-plausible corpus inputs failed badly during load; both now fail loudly and correctly.

### 1. Circular `$ref` hung every corpus-loading command (DoS)
A `$ref` chain that loops back on itself (`A → B → A`, or a component whose child `$ref`s itself) drove `flattenOne` into unbounded recursion, hanging `snapshot`, `validate`, `coverage` — anything that loads a corpus — indefinitely, with no output.

`flattenOne` now threads the chain of `$ref` names currently being expanded and stops when it revisits one. The cycle is recorded as a load-time diagnostic on the `Corpus` (refs are expanded away before `Validate` runs, so the check has to happen during flattening), and `Validate` surfaces it as a `ref-circular` error. `sightmap validate` on a circular corpus now exits 1 with `ref-circular: circular $ref chain Loop → Loop` instead of hanging.

### 2. Commas inside selectors were split as list separators
`splitSelectors` only balanced parentheses, so a comma inside an attribute selector or quoted string — `[data-x="a,b"]` — was treated as a selector-list separator and split into two alternatives that each match nothing. Splitting is now aware of `[]` brackets and quote state (with backslash escapes) in addition to `()`, so real-world selectors survive intact while genuine comma-separated lists still split.

### Tests
- `TestCircularRefDoesNotHang` / `TestSelfRefDoesNotHang` run `Load` under a timeout guard and assert a `ref-circular` diagnostic.
- `TestSplitSelectorsBracketsAndQuotes` asserts `[data-x="a,b"]` and `:nth-child(2n, 3n)` stay single selectors while a real YAML-sequence list still yields two.

Closes sightmap/sightmap#34
Closes sightmap/sightmap#35
