### PR TITLE
snapshot/coverage/capture: fail loudly on broken corpora and blank pages

### DIFF
--- a/.changeset/fix-empty-page-loudness.md
+++ b/.changeset/fix-empty-page-loudness.md
@@ -1,0 +1,8 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Stop green-lighting broken corpora and blank pages:
+
+- `snapshot` now exits non-zero when the corpus is present but fails to parse (a missing corpus stays non-fatal — the tree still renders), and when the observed page has 0 interactive nodes (blank or still loading). It still renders whatever it observed first. `inspect` and `suggest` now warn on a bad corpus instead of silently ignoring it.
+- Coverage no longer marks a page with 0 interactive nodes as a pass. The coverage line renders a distinct `∅` mark (instead of `✓`), the `coverage` command counts empty captures as failures, and `capture` refuses to persist a blank/loading page as a view's baseline (override with `--force`).

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -49,11 +49,15 @@ What counts as failure for the check-style commands:
 
 | Command | Exits `1` when |
 |---------|----------------|
-| `validate` | the corpus has structural errors |
+| `validate` | the corpus has structural errors (including an unresolved or circular `$ref`) |
 | `lint` | any warning exists (`--warn-only` prevents warnings from causing exit `1`) |
-| `coverage` | any capture has orphaned (T3) nodes, or a snap file cannot be loaded (dead components print warnings but do not fail) |
+| `snapshot` | the corpus is present but fails to parse, or the observed page has **0 interactive nodes** (blank or still loading). A *missing* corpus is not an error — the tree still renders. |
+| `coverage` | any capture has orphaned (T3) nodes, has **0 interactive nodes** (a blank/unrendered page is never a pass), or a snap file cannot be loaded (dead components print warnings but do not fail) |
+| `capture` | the observed page has 0 interactive nodes — `capture` refuses to persist a blank/loading page as a view's baseline (override with `--force`) |
 | `report` | any view has issues (orphans or missing snapshots) |
 | `sel-check` | the selector matches zero nodes |
+
+A page with no interactive nodes renders the `∅` mark (rather than `✓`/`✗`) in the coverage line.
 
 ## Command map
 

--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -90,9 +90,13 @@ func runCapture(args []string) error {
 	}
 	fmtOpts := observe.FormatOpts{Trace: *traceFlag, Selectors: *selectorsFlag}
 
-	// ── Novelty gate ──────────────────────────────────────────────────────────
+	// ── Novelty gate ────────────────────────────────────────────────────
 	viewBasename := res.View.SnapBasename()
 	cov := res.Coverage
+	// Never persist a blank/loading page as a view's baseline.
+	if cov.Empty() && !*forceFlag {
+		return fmt.Errorf("capture: %s has 0 interactive nodes — refusing to save a blank or still-loading page as this view's baseline (wait for it to render, or pass --force)", res.View.Name)
+	}
 	if !*forceFlag {
 		cand := viewset.SlotsFromMatch(res.Matches, cov.Orphans, cov.ParentMap)
 		if gres, write := viewset.Gate(corpus, *lf.sightmapDir, viewBasename, cand, false); !write {
@@ -151,6 +155,7 @@ func runCaptureAll(
 		err               error
 		skipped           bool // novelty gate: nothing new, not written
 		skippedVs         int  // captures compared against when skipped
+		empty             bool // 0 interactive nodes: blank/loading, not written
 	}
 	var results []result
 
@@ -176,6 +181,12 @@ func runCaptureAll(
 		}
 		fmtOpts := observe.FormatOpts{Selectors: selectors}
 		cov := res.Coverage
+
+		// Never persist a blank/loading page as a view's baseline.
+		if cov.Empty() && !force {
+			results = append(results, result{name: label, empty: true})
+			continue
+		}
 
 		// Novelty gate: don't append a redundant capture to the view set.
 		if !force {
@@ -207,6 +218,10 @@ func runCaptureAll(
 		}
 		if r.skipped {
 			fmt.Fprintf(os.Stderr, "%-20s  = nothing new vs %d capture(s) — not saved\n", r.name, r.skippedVs)
+			continue
+		}
+		if r.empty {
+			fmt.Fprintf(os.Stderr, "%-20s  ∅ 0 interactive — blank or still loading, not saved\n", r.name)
 			continue
 		}
 		check := "✓"

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -75,12 +75,14 @@ func runCoverage(args []string) error {
 		var capGaps [][]coverage.ContentGap
 		headerView := ""
 		for _, e := range entries {
-			counts, leafCounts, vName, t3, gaps, ok := coverCapture(e.Path, corpus, visible, *traceFlag)
+			counts, leafCounts, vName, t3, total, gaps, ok := coverCapture(e.Path, corpus, visible, *traceFlag)
 			if !ok {
 				failures++
 				continue
 			}
-			if t3 > 0 {
+			// A capture with orphans (T3) OR no interactive nodes at all fails the
+			// coverage gate — a blank/unrendered page is never a pass.
+			if t3 > 0 || total == 0 {
 				failures++
 			}
 			if vName != "" && headerView == "" {
@@ -147,10 +149,10 @@ func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.Compone
 // genuinely-absent components), the view name from the snap header, the T3
 // count, the annotation-completeness gaps found in the capture,
 // and ok=false if the capture could not be loaded/parsed/matched.
-func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool) (counts map[string]int, leafCounts map[string]int, viewName string, t3 int, gaps []coverage.ContentGap, ok bool) {
+func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool) (counts map[string]int, leafCounts map[string]int, viewName string, t3 int, total int, gaps []coverage.ContentGap, ok bool) {
 	root, matches, route, ok := matchCapture(snapPath, corpus)
 	if !ok {
-		return nil, nil, "", 0, nil, false
+		return nil, nil, "", 0, 0, nil, false
 	}
 
 	// Find view for memory note lookup (T2 trace) and leaf-probe component list.
@@ -165,14 +167,12 @@ func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool)
 	}
 
 	cov := coverage.Score(root, matches, coverage.Options{VisibleOnly: visible})
-	t1, t2, total := cov.T1, cov.T2, cov.Total
+	t1, t2 := cov.T1, cov.T2
+	total = cov.Total
 	t3nodes, t2clusters, t2children := cov.Orphans, cov.Scopes, cov.ScopeChildren
 	parentMap := cov.ParentMap
 	t3 = cov.T3
-	check := "✓"
-	if t3 > 0 {
-		check = "✗"
-	}
+	check := cov.Mark()
 	suffix := ""
 	if visible {
 		suffix = " (visible only)"
@@ -234,7 +234,7 @@ func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool)
 		observe.CheckRootComponents(os.Stdout, view.Components, globalNames, counts, view.Name)
 	}
 
-	return counts, leafCounts, viewset.ViewNameOf(snapPath), t3, gaps, true
+	return counts, leafCounts, viewset.ViewNameOf(snapPath), t3, total, gaps, true
 }
 
 // countLeafMatches returns the number of tree nodes that satisfy the leaf

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
@@ -56,9 +57,11 @@ func runInspect(args []string) error {
 		return fmt.Errorf("extract components: %v", err)
 	}
 
-	// ── Load sightmap (optional, silent on error) ────────────────────────
+	// ── Load sightmap (optional enrichment; warn but don't fail on a bad corpus) ──
 	var inspectMatches map[*comps.ComponentNode]*match.SightmapMatch
-	if corpus, _ := lf.loadCorpus(); corpus != nil {
+	if corpus, cErr := lf.loadCorpus(); cErr != nil {
+		fmt.Fprintf(os.Stderr, "inspect: load corpus: %v (continuing without component names)\n", cErr)
+	} else if corpus != nil {
 		inspectMatches = corpus.MatchTree(root, pageURL)
 	}
 

--- a/go/cmd/sightmap/cmd_snapshot.go
+++ b/go/cmd/sightmap/cmd_snapshot.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -73,9 +74,11 @@ func runSnapshot(args []string) error {
 	}
 
 	// ── Observe (extract + match + coverage + properties) ──────────────────────
+	// A present-but-malformed corpus is fatal (loudness for automation); a missing
+	// corpus is not — loadCorpus returns (nil, nil) for an absent dir.
 	corpus, cErr := lf.loadCorpus()
 	if cErr != nil {
-		fmt.Fprintf(os.Stderr, "snapshot: load corpus: %v\n", cErr)
+		return fmt.Errorf("snapshot: load corpus: %w", cErr)
 	}
 	res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible, ExtractProps: true})
 	if err != nil {
@@ -117,10 +120,20 @@ func runSnapshot(args []string) error {
 	// ── Write output ───────────────────────────────────────────────────────────
 	// snapshot only ever writes the rendered output to stdout or an explicit
 	// --out FILE. It never appends to the corpus capture set (that is `capture`).
-	return writeOut(*outFlag, func(w io.Writer) error {
+	if err := writeOut(*outFlag, func(w io.Writer) error {
 		observe.Format(w, res, fmtOpts)
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// A page with zero interactive nodes is almost always blank or still loading.
+	// Render it (above) but exit non-zero so automation doesn't mistake an
+	// unrendered shell for a real observation.
+	if coverage.CountInteractive(res.Root, visible) == 0 {
+		return fmt.Errorf("snapshot: page has 0 interactive nodes — it may be blank or still loading (try 'browser wait-for --selector ...' or check the URL)")
+	}
+	return nil
 }
 
 // ── Output sections ───────────────────────────────────────────────────────────

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -46,7 +46,9 @@ func runSuggest(args []string) error {
 	// ── Optionally filter out known sightmap components ────────────────────
 	var knownSelectors []string
 	if *excludeKnownFlag {
-		if corpus, _ := lf.loadCorpus(); corpus != nil {
+		if corpus, cErr := lf.loadCorpus(); cErr != nil {
+			fmt.Fprintf(os.Stderr, "suggest: load corpus: %v (continuing without --exclude-known filtering)\n", cErr)
+		} else if corpus != nil {
 			for _, c := range corpus.Components("") {
 				knownSelectors = append(knownSelectors, c.Selectors...)
 			}

--- a/go/coverage/coverage.go
+++ b/go/coverage/coverage.go
@@ -83,6 +83,28 @@ func Score(root *comps.ComponentNode, matches Matches, opts Options) Result {
 	return res
 }
 
+// CountInteractive returns the number of interactive nodes in the tree, applying
+// the same visibility filter Score uses. It is the corpus-independent way to ask
+// "does this page have any actionable content?" — useful for detecting a blank or
+// still-loading page before a corpus is even involved.
+func CountInteractive(root *comps.ComponentNode, visibleOnly bool) int {
+	if root == nil {
+		return 0
+	}
+	n := 0
+	comps.Walk(root, func(node *comps.ComponentNode, _ int) bool {
+		if !node.IsInteractive {
+			return true
+		}
+		if visibleOnly && (!node.IsVisible || node.IsIgnored) {
+			return true
+		}
+		n++
+		return true
+	})
+	return n
+}
+
 // BuildParentMap returns a map from each non-root node to its parent.
 func BuildParentMap(root *comps.ComponentNode) ParentMap {
 	pm := make(ParentMap)
@@ -117,4 +139,28 @@ func Pct(a, b int) int {
 		return 0
 	}
 	return int(math.Round(float64(a) * 100 / float64(b)))
+}
+
+// Empty reports whether no interactive nodes were scored at all. An empty result
+// means the page carried no coverage signal — typically a blank or still-loading
+// page — and must not be treated as a pass.
+func (r Result) Empty() bool { return r.Total == 0 }
+
+// OK reports whether coverage is a clean pass: at least one interactive node was
+// scored and none were orphaned (T3). A page with zero interactive nodes is NOT
+// a pass — there is nothing to green-light.
+func (r Result) OK() bool { return r.Total > 0 && r.T3 == 0 }
+
+// Mark returns the status glyph for a coverage line: "✓" for a clean pass, "✗"
+// when there are orphaned (T3) nodes, and "∅" when there were no interactive
+// nodes at all (a blank or unrendered page, which is never a pass).
+func (r Result) Mark() string {
+	switch {
+	case r.Empty():
+		return "∅"
+	case r.T3 == 0:
+		return "✓"
+	default:
+		return "✗"
+	}
 }

--- a/go/coverage/status_test.go
+++ b/go/coverage/status_test.go
@@ -1,0 +1,57 @@
+package coverage
+
+import (
+	"testing"
+
+	"github.com/sightmap/sightmap/go/comps"
+)
+
+func TestResultStatus(t *testing.T) {
+	cases := []struct {
+		name      string
+		total, t3 int
+		wantOK    bool
+		wantEmpty bool
+		wantMark  string
+	}{
+		{"clean pass", 10, 0, true, false, "✓"},
+		{"orphans", 10, 3, false, false, "✗"},
+		{"blank page", 0, 0, false, true, "∅"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Result{Total: tc.total, T3: tc.t3}
+			if r.OK() != tc.wantOK {
+				t.Errorf("OK() = %v, want %v", r.OK(), tc.wantOK)
+			}
+			if r.Empty() != tc.wantEmpty {
+				t.Errorf("Empty() = %v, want %v", r.Empty(), tc.wantEmpty)
+			}
+			if r.Mark() != tc.wantMark {
+				t.Errorf("Mark() = %q, want %q", r.Mark(), tc.wantMark)
+			}
+		})
+	}
+}
+
+func TestCountInteractive(t *testing.T) {
+	tree := &comps.ComponentNode{
+		Id: "root", Role: "document", IsVisible: true,
+		Children: []*comps.ComponentNode{
+			{Id: "btn", Role: "button", IsInteractive: true, IsVisible: true},
+			{Id: "hidden-btn", Role: "button", IsInteractive: true, IsVisible: false},
+			{Id: "ignored-btn", Role: "button", IsInteractive: true, IsVisible: true, IsIgnored: true},
+			{Id: "text", Role: "StaticText", IsVisible: true},
+		},
+	}
+
+	if got := CountInteractive(tree, true); got != 1 {
+		t.Errorf("CountInteractive(visibleOnly=true) = %d, want 1 (hidden + ignored excluded)", got)
+	}
+	if got := CountInteractive(tree, false); got != 3 {
+		t.Errorf("CountInteractive(visibleOnly=false) = %d, want 3", got)
+	}
+	if got := CountInteractive(nil, true); got != 0 {
+		t.Errorf("CountInteractive(nil) = %d, want 0", got)
+	}
+}

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -196,17 +196,16 @@ func writeZeroMatchWarnings(
 
 // writeCoverage prints the [Coverage] section.
 func writeCoverage(w io.Writer, cov coverage.Result) {
-	check := "✗"
-	if cov.T3 == 0 {
-		check = "✓"
-	}
 	if cov.VisibleOnly {
 		fmt.Fprintf(w, "[Coverage] (visible only)\n")
 	} else {
 		fmt.Fprintf(w, "[Coverage]\n")
 	}
 	fmt.Fprintf(w, "%d interactive · %d direct T1 (%d%%) · %d scoped T2 (%d%%) · %d orphaned T3 %s\n",
-		cov.Total, cov.T1, coverage.Pct(cov.T1, cov.Total), cov.T2, coverage.Pct(cov.T2, cov.Total), cov.T3, check)
+		cov.Total, cov.T1, coverage.Pct(cov.T1, cov.Total), cov.T2, coverage.Pct(cov.T2, cov.Total), cov.T3, cov.Mark())
+	if cov.Empty() {
+		fmt.Fprintf(w, "⚠ no interactive nodes — the page may be blank or still loading (no coverage signal)\n")
+	}
 }
 
 // WriteTrace prints the "Unlabeled clusters" section for T3 (orphaned) nodes.

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -142,13 +142,19 @@ sightmap snapshot --url 'https://www.example.com/page' --out page.snap --tree-ou
 Sites using client-side rendering (React/Next.js canvas, lazy hydration) may
 not have their content ready at `loadEventFired`. Homedepot.com's `snapshot`
 already includes `--wait 1`. For other slow pages add `--wait N` seconds.
+A page with **0 interactive nodes** renders `∅` (not `✓`) and `snapshot` exits
+non-zero — that is the blank/still-loading signal; raise `--wait` or use
+`browser wait-for --selector` and re-snap. `capture` refuses to persist such a
+page as a view's baseline (override with `--force`), and `coverage` counts it as
+a failure.
 
 **A snap is only valid for the page loaded when it was taken.**
 Re-snap after every YAML change. Do not reuse stale snaps.
 
 **0 orphaned is the only acceptable exit condition.**
 T3 > 0 means some interactive nodes have zero semantic context. Do not declare
-a page done until `[Coverage] (visible only) ... 0 orphaned ✓`.
+a page done until `[Coverage] (visible only) ... 0 orphaned ✓`. A `∅` mark (0
+interactive nodes) is never done — the page is blank or still loading.
 
 ---
 

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -68,6 +68,10 @@ tree). Each line starts with a numeric component ID, then the node content:
 Properties are sorted alphabetically. The accessible name is shown last inside
 brackets when not suppressed (an exact match with a property value).
 
+If the page has **0 interactive nodes**, coverage renders `∅` (not `✓`) and
+`snapshot` exits non-zero — the page is blank or still loading. Wait for it with
+`browser wait-for --selector ...` (or `--wait N`) and re-snap before acting.
+
 ## Interaction (by ID or component query)
 
 `click`, `fill`, `hover`, and `scroll --component-id` accept **either** a numeric

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -142,13 +142,19 @@ sightmap snapshot --url 'https://www.example.com/page' --out page.snap --tree-ou
 Sites using client-side rendering (React/Next.js canvas, lazy hydration) may
 not have their content ready at `loadEventFired`. Homedepot.com's `snapshot`
 already includes `--wait 1`. For other slow pages add `--wait N` seconds.
+A page with **0 interactive nodes** renders `∅` (not `✓`) and `snapshot` exits
+non-zero — that is the blank/still-loading signal; raise `--wait` or use
+`browser wait-for --selector` and re-snap. `capture` refuses to persist such a
+page as a view's baseline (override with `--force`), and `coverage` counts it as
+a failure.
 
 **A snap is only valid for the page loaded when it was taken.**
 Re-snap after every YAML change. Do not reuse stale snaps.
 
 **0 orphaned is the only acceptable exit condition.**
 T3 > 0 means some interactive nodes have zero semantic context. Do not declare
-a page done until `[Coverage] (visible only) ... 0 orphaned ✓`.
+a page done until `[Coverage] (visible only) ... 0 orphaned ✓`. A `∅` mark (0
+interactive nodes) is never done — the page is blank or still loading.
 
 ---
 

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -68,6 +68,10 @@ tree). Each line starts with a numeric component ID, then the node content:
 Properties are sorted alphabetically. The accessible name is shown last inside
 brackets when not suppressed (an exact match with a property value).
 
+If the page has **0 interactive nodes**, coverage renders `∅` (not `✓`) and
+`snapshot` exits non-zero — the page is blank or still loading. Wait for it with
+`browser wait-for --selector ...` (or `--wait N`) and re-snap before acting.
+
 ## Interaction (by ID or component query)
 
 `click`, `fill`, `hover`, and `scroll --component-id` accept **either** a numeric


### PR DESCRIPTION
Two silent-degradation classes let automation trust output it should have rejected.

### 1. `snapshot` exited 0 on a corpus parse error
A malformed corpus YAML printed `load corpus: ...` to stderr but `snapshot` still exited 0, rendering an un-annotated tree. `loadCorpus` already distinguishes an *absent* dir `(nil, nil)` from a *parse failure* `(nil, err)`, so `snapshot` now returns that error (exit 1) while a missing corpus stays non-fatal. `inspect` and `suggest` — which use the corpus as optional enrichment — now warn on a bad corpus instead of swallowing the error entirely.

### 2. Blank / still-loading pages were green-lit
An unrendered SPA shell scored `0 interactive · 0 orphaned ✓`, and `capture` happily persisted a 0-interactive loading screen as a view's baseline. Now:
- `coverage.Result` gains `Empty()` / `OK()` / `Mark()`; a page with 0 interactive nodes renders a distinct **`∅`** mark instead of `✓`.
- `snapshot` renders what it observed, then exits non-zero on a 0-interactive page (a new `coverage.CountInteractive` detects this with no corpus involved).
- The `coverage` command counts empty captures as failures.
- `capture` refuses to persist a blank/loading page as a baseline unless `--force`.

### Validation
Unit tests for the coverage status helpers. Verified live against the burrito app:
- normal Menu snapshot unchanged — `22 interactive · 22 T1 (100%) ✓`, exit 0
- blank page (`about:blank`) → `∅` + warning + exit 1
- parse-error corpus → exit 1, nothing rendered
- normal capture/coverage → exit 0
- blank capture → `coverage` reports a failure, exit 1

Docs (`cli/overview` exit-codes table) and both skills updated; embedded skills copy regenerated.

Closes sightmap/sightmap#39
