### PR TITLE
browser: confirm interactions, friendly errors, note missing corpus

### DIFF
--- a/.changeset/browser-feedback.md
+++ b/.changeset/browser-feedback.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Make browser-use feedback loud: the interaction commands (`click`, `fill`, `hover`, `keypress`, `scroll`, `drag`, `wait-for`, `dialog`, `tabs resize`) now echo a short confirmation on success instead of exiting silently — e.g. `clicked CartNavButton @ (674,30)` — so an agent driving the browser can see what happened. Several raw CDP/Go errors are now rewritten into actionable messages: a `wait-for` timeout reads `timed out after 800ms waiting for selector "..."` (not `context deadline exceeded`), resolving a dialog when none is open says so plainly, and fetching an evicted network response body explains that bodies are only retained briefly. `snapshot` now prints a note when no `.sightmap` corpus is found at the target directory instead of silently rendering an un-annotated tree.

--- a/docs/cli/interaction.mdx
+++ b/docs/cli/interaction.mdx
@@ -44,7 +44,7 @@ Property predicates depend on `properties:` extraction. The Go CLI implements `p
 
 ### `browser click`
 
-Clicks an element. The target is a probe ID, a component query, or raw `--x` and `--y` coordinates. Coordinates depend on the current layout. Prints nothing on success.
+Clicks an element. The target is a probe ID, a component query, or raw `--x` and `--y` coordinates. Coordinates depend on the current layout. On success it echoes a confirmation to stderr, e.g. `clicked CartNavButton @ (674,30)`.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -66,7 +66,7 @@ Off-screen targets can be missed. Scroll the element into view first with `brows
 
 ### `browser fill`
 
-Types a value into an input. Takes two positionals: the target (probe ID or component query) and the value. Prints nothing on success.
+Types a value into an input. Takes two positionals: the target (probe ID or component query) and the value. On success it echoes `filled TARGET = "value"` to stderr.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -91,7 +91,7 @@ sightmap browser eval 'var el = document.querySelector("INPUT_SELECTOR"); Object
 
 ### `browser hover`
 
-Moves the pointer over an element, such as a menu or tooltip trigger. It accepts the same targets as `click`: a probe ID, component query, or `--x` and `--y`. Prints nothing on success.
+Moves the pointer over an element, such as a menu or tooltip trigger. It accepts the same targets as `click`: a probe ID, component query, or `--x` and `--y`. On success it echoes a confirmation to stderr.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -109,7 +109,7 @@ sightmap browser hover 'AccountMenu'
 
 ### `browser keypress`
 
-Sends a key event to the focused element. Click or fill a field first when it needs focus. The key name is a positional argument, such as `Enter`, `Tab`, `Escape`, `Backspace`, `Delete`, `ArrowUp`, `ArrowDown`, or `Space`. Prints nothing on success.
+Sends a key event to the focused element. Click or fill a field first when it needs focus. The key name is a positional argument, such as `Enter`, `Tab`, `Escape`, `Backspace`, `Delete`, `ArrowUp`, `ArrowDown`, or `Space`. On success it echoes `pressed KEY` to stderr.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -125,7 +125,7 @@ sightmap browser keypress Enter
 
 ### `browser scroll`
 
-Scrolls the page by pixel deltas, scrolls a component into view, or does both. When both are set, `--component-id` brings the target into view before applying the deltas. Prints nothing on success.
+Scrolls the page by pixel deltas, scrolls a component into view, or does both. When both are set, `--component-id` brings the target into view before applying the deltas. On success it echoes what it scrolled to stderr.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -145,7 +145,7 @@ sightmap browser scroll --component-id 'FooterLinks'
 
 ### `browser drag`
 
-Drags an element by pixel deltas. The target is a positional probe ID from snapshot output; this command does not accept component queries. Prints nothing on success.
+Drags an element by pixel deltas. The target is a positional probe ID from snapshot output; this command does not accept component queries. On success it echoes `dragged TARGET by (dx,dy)` to stderr.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -162,7 +162,7 @@ sightmap browser drag 214 --delta-x 120 --delta-y 0
 
 ### `browser wait-for`
 
-Waits for exactly one condition: `--url`, `--selector`, or `--load`. It prints nothing on success and exits `1` if the timeout elapses. Use it after an action that triggers navigation or asynchronous rendering.
+Waits for exactly one condition: `--url`, `--selector`, or `--load`. On success it echoes what it matched to stderr; on timeout it exits `1` with a message like `wait-for: timed out after 10000ms waiting for selector "..."`. Use it after an action that triggers navigation or asynchronous rendering.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -182,7 +182,7 @@ sightmap browser wait-for --url '/checkout' --timeout-ms 15000
 
 ### `browser dialog`
 
-Resolves a blocking JavaScript dialog (`alert`, `confirm`, `prompt`). The action is a positional argument: `accept` or `dismiss`. Prints nothing on success.
+Resolves a blocking JavaScript dialog (`alert`, `confirm`, `prompt`). The action is a positional argument: `accept` or `dismiss`. On success it echoes `accepted dialog` / `dismissed dialog` to stderr; when no dialog is open it reports that clearly instead of surfacing a raw CDP error.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/go/cmd/sightmap/cmd_browser_feedback_test.go
+++ b/go/cmd/sightmap/cmd_browser_feedback_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/comps"
+)
+
+func TestActionLabel(t *testing.T) {
+	withBounds := &comps.ComponentNode{
+		Id:     "42",
+		Bounds: &comps.Bounds{X: 100, Y: 40, Width: 80, Height: 20},
+	}
+	if got, want := actionLabel("CartNavButton", withBounds), "CartNavButton @ (140,50)"; got != want {
+		t.Errorf("actionLabel(bounds) = %q, want %q", got, want)
+	}
+
+	noBounds := &comps.ComponentNode{Id: "7"}
+	if got, want := actionLabel("7", noBounds), "7"; got != want {
+		t.Errorf("actionLabel(no bounds) = %q, want %q", got, want)
+	}
+	if got, want := actionLabel("Foo", nil), "Foo"; got != want {
+		t.Errorf("actionLabel(nil) = %q, want %q", got, want)
+	}
+}
+
+func TestFriendlyBodyErr(t *testing.T) {
+	evicted := errors.New("daemon returned 500 Internal Server Error: Network.getResponseBody error -32000: No resource with given identifier found")
+	got := friendlyBodyErr(evicted)
+	if want := "evicted from the network cache"; !contains(got, want) {
+		t.Errorf("friendlyBodyErr(evicted) = %q, want it to mention %q", got, want)
+	}
+
+	other := errors.New("connection refused")
+	if got := friendlyBodyErr(other); !contains(got, "connection refused") {
+		t.Errorf("friendlyBodyErr(other) = %q, want it to include the raw message", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -31,6 +31,19 @@ func resolveNode(ctx context.Context, conn *browser.CDPConn, id string) (*comps.
 	return browser.ResolveBySightmapID(ctx, conn, id)
 }
 
+// actionLabel builds a short human label for a confirmation line: the argument
+// the caller passed (a probe id or component query) plus the element's click
+// point when its bounds are known. Interaction commands echo one of these on
+// success so an agent driving the browser sees what happened.
+func actionLabel(arg string, node *comps.ComponentNode) string {
+	if node != nil && node.Bounds != nil {
+		x := node.Bounds.X + node.Bounds.Width/2
+		y := node.Bounds.Y + node.Bounds.Height/2
+		return fmt.Sprintf("%s @ (%d,%d)", arg, x, y)
+	}
+	return arg
+}
+
 // parseFlagsInterspersed parses fs allowing flags to appear AFTER positional
 // arguments. Go's stdlib flag stops at the first positional, which silently
 // drops flags like `click 'ComponentQuery' --tab X` — a multi-agent footgun where --tab is ignored. We reorder flags
@@ -85,7 +98,11 @@ func runClick(args []string) error {
 	defer conn.Close()
 
 	if *xFlag >= 0 && *yFlag >= 0 {
-		return browser.ClickAt(ctx, conn, *xFlag, *yFlag)
+		if err := browser.ClickAt(ctx, conn, *xFlag, *yFlag); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "clicked @ (%d,%d)\n", *xFlag, *yFlag)
+		return nil
 	}
 	if fs.NArg() == 0 {
 		return fmt.Errorf("usage: browser click (COMPONENT-ID | 'ComponentQuery' | --x N --y N)")
@@ -94,7 +111,11 @@ func runClick(args []string) error {
 	if err != nil {
 		return err
 	}
-	return browser.Click(ctx, conn, node)
+	if err := browser.Click(ctx, conn, node); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "clicked %s\n", actionLabel(fs.Arg(0), node))
+	return nil
 }
 
 // ── fill ──────────────────────────────────────────────────────────────────────
@@ -124,9 +145,14 @@ func runFill(args []string) error {
 		return err
 	}
 	if *clearFlag {
-		return browser.ClearAndFill(ctx, conn, node, fs.Arg(1))
+		if err := browser.ClearAndFill(ctx, conn, node, fs.Arg(1)); err != nil {
+			return err
+		}
+	} else if err := browser.Fill(ctx, conn, node, fs.Arg(1)); err != nil {
+		return err
 	}
-	return browser.Fill(ctx, conn, node, fs.Arg(1))
+	fmt.Fprintf(os.Stderr, "filled %s = %q\n", fs.Arg(0), fs.Arg(1))
+	return nil
 }
 
 // ── hover ─────────────────────────────────────────────────────────────────────
@@ -150,7 +176,11 @@ func runHover(args []string) error {
 	defer conn.Close()
 
 	if *xFlag >= 0 && *yFlag >= 0 {
-		return browser.HoverAt(ctx, conn, *xFlag, *yFlag)
+		if err := browser.HoverAt(ctx, conn, *xFlag, *yFlag); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "hovered @ (%d,%d)\n", *xFlag, *yFlag)
+		return nil
 	}
 	if fs.NArg() == 0 {
 		return fmt.Errorf("usage: browser hover (COMPONENT-ID | 'ComponentQuery' | --x N --y N)")
@@ -159,7 +189,11 @@ func runHover(args []string) error {
 	if err != nil {
 		return err
 	}
-	return browser.Hover(ctx, conn, node)
+	if err := browser.Hover(ctx, conn, node); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "hovered %s\n", actionLabel(fs.Arg(0), node))
+	return nil
 }
 
 // ── keypress ──────────────────────────────────────────────────────────────────
@@ -184,7 +218,11 @@ func runKeyPress(args []string) error {
 	}
 	defer conn.Close()
 
-	return browser.KeyPress(ctx, conn, fs.Arg(0))
+	if err := browser.KeyPress(ctx, conn, fs.Arg(0)); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "pressed %s\n", fs.Arg(0))
+	return nil
 }
 
 // ── scroll ────────────────────────────────────────────────────────────────────
@@ -219,9 +257,13 @@ func runScroll(args []string) error {
 		if err := browser.ScrollIntoView(ctx, conn, node); err != nil {
 			return err
 		}
+		fmt.Fprintf(os.Stderr, "scrolled %s into view\n", *compID)
 	}
 	if *deltaX != 0 || *deltaY != 0 {
-		return browser.ScrollBy(ctx, conn, *deltaX, *deltaY)
+		if err := browser.ScrollBy(ctx, conn, *deltaX, *deltaY); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "scrolled by (%d,%d)\n", *deltaX, *deltaY)
 	}
 	return nil
 }
@@ -253,7 +295,11 @@ func runDrag(args []string) error {
 	if err != nil {
 		return err
 	}
-	return browser.Drag(ctx, conn, node, *deltaX, *deltaY)
+	if err := browser.Drag(ctx, conn, node, *deltaX, *deltaY); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "dragged %s by (%d,%d)\n", fs.Arg(0), *deltaX, *deltaY)
+	return nil
 }
 
 // ── wait-for ──────────────────────────────────────────────────────────────────
@@ -297,14 +343,30 @@ func runWaitFor(args []string) error {
 	}
 	defer conn.Close()
 
+	var waitErr error
+	var what, done string
 	switch {
 	case *urlPattern != "":
-		return browser.WaitForURL(ctx, conn, *urlPattern)
+		what = fmt.Sprintf("url to contain %q", *urlPattern)
+		done = fmt.Sprintf("url now contains %q", *urlPattern)
+		waitErr = browser.WaitForURL(ctx, conn, *urlPattern)
 	case *selector != "":
-		return browser.WaitForSelector(ctx, conn, *selector)
+		what = fmt.Sprintf("selector %q", *selector)
+		done = fmt.Sprintf("matched selector %q", *selector)
+		waitErr = browser.WaitForSelector(ctx, conn, *selector)
 	default:
-		return browser.WaitForLoad(ctx, conn)
+		what = "page load"
+		done = "page load complete"
+		waitErr = browser.WaitForLoad(ctx, conn)
 	}
+	if waitErr != nil {
+		if errors.Is(waitErr, context.DeadlineExceeded) {
+			return fmt.Errorf("wait-for: timed out after %dms waiting for %s", *timeoutMs, what)
+		}
+		return waitErr
+	}
+	fmt.Fprintln(os.Stderr, done)
+	return nil
 }
 
 // ── dialog ────────────────────────────────────────────────────────────────────
@@ -333,7 +395,14 @@ func runDialog(args []string) error {
 	}
 	defer conn.Close()
 
-	return browser.HandleDialog(ctx, conn, action, *text)
+	if err := browser.HandleDialog(ctx, conn, action, *text); err != nil {
+		if strings.Contains(err.Error(), "No dialog is showing") {
+			return fmt.Errorf("dialog: no dialog is currently open (nothing to %s)", action)
+		}
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "%sed dialog\n", action)
+	return nil
 }
 
 // ── screenshot ──────────────────────────────────────────────────────────────────
@@ -624,5 +693,9 @@ func runTabsResize(args []string) error {
 	}
 	defer conn.Close()
 
-	return browser.ResizeViewport(ctx, conn, width, height)
+	if err := browser.ResizeViewport(ctx, conn, width, height); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "resized viewport to %dx%d\n", width, height)
+	return nil
 }

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
@@ -239,7 +240,7 @@ func runNetworkGet(args []string) error {
 	// Fetch the response body (to a file, or inline preview).
 	rbody, err := devtoolsGet(*sightmapDir, "/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {"response"}})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "network get: response body unavailable: %v\n", err)
+		fmt.Fprintf(os.Stderr, "network get: %s\n", friendlyBodyErr(err))
 		return nil
 	}
 	if *respFile != "" {
@@ -253,10 +254,21 @@ func runNetworkGet(args []string) error {
 	return nil
 }
 
+// friendlyBodyErr rewrites the raw daemon/CDP error from a network-body fetch
+// into an actionable message. Response bodies are only retained briefly, so the
+// common failure is the body having been evicted from the network cache.
+func friendlyBodyErr(err error) string {
+	s := err.Error()
+	if strings.Contains(s, "No resource with given identifier") || strings.Contains(s, "No data found") {
+		return "response body no longer available — it was evicted from the network cache (bodies are retained only briefly after the response arrives)"
+	}
+	return "response body unavailable: " + s
+}
+
 func saveBody(sightmapDir string, idx int, kind, path string) error {
 	b, err := devtoolsGet(sightmapDir, "/devtools/network/body", url.Values{"index": {strconv.Itoa(idx)}, "kind": {kind}})
 	if err != nil {
-		return fmt.Errorf("%s body: %w", kind, err)
+		return fmt.Errorf("%s body: %s", kind, friendlyBodyErr(err))
 	}
 	if err := os.WriteFile(path, b, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)

--- a/go/cmd/sightmap/cmd_snapshot.go
+++ b/go/cmd/sightmap/cmd_snapshot.go
@@ -80,6 +80,9 @@ func runSnapshot(args []string) error {
 	if cErr != nil {
 		return fmt.Errorf("snapshot: load corpus: %w", cErr)
 	}
+	if corpus == nil {
+		fmt.Fprintf(os.Stderr, "snapshot: no .sightmap corpus at %q — rendering the raw tree with no component names or coverage (pass --sightmap-dir to point at your corpus)\n", *lf.sightmapDir)
+	}
 	res, err := observe.Page(ctx, conn, corpus, observe.Options{VisibleOnly: visible, ExtractProps: true})
 	if err != nil {
 		return fmt.Errorf("snapshot: observe: %v", err)


### PR DESCRIPTION
The feedback/UX half of the browser-use loudness work — the "silent failures where agents live." (The interaction-*correctness* half — off-screen scroll/verify, fill-didn't-stick, SPA anchor activation — is a separate follow-up.)

### Success confirmations
`click`, `fill`, `hover`, `keypress`, `scroll`, `drag`, `wait-for`, `dialog`, and `tabs resize` all exited `0` with **no output** on success — an agent driving the browser got no confirmation of what happened. Each now echoes a short line to stderr:

```
clicked CartNavButton @ (674,30)
filled EmailInput = "a@b.com"
matched selector "body"
resized viewport to 1024x768
```

### Friendly errors
Raw CDP/Go errors are rewritten into actionable messages:
- `wait-for` timeout → `wait-for: timed out after 800ms waiting for selector "#..."` (was `context deadline exceeded`)
- `dialog accept` with none pending → `dialog: no dialog is currently open (nothing to accept)` (was a raw `-32602` CDP error)
- `network get` on an evicted body → explains the body was evicted from the network cache (bodies are retained only briefly)

### Missing-corpus note
`snapshot` printed nothing and exited 0 when `./.sightmap` was absent — it looked like a failure during testing. It now prints `no .sightmap corpus at "..." — rendering the raw tree ... (pass --sightmap-dir ...)`.

### Tests / validation
Unit tests for the pure helpers (`actionLabel`, `friendlyBodyErr`); interaction docs updated (they claimed these commands "print nothing on success"). Validated live against the burrito app: confirmations on click/hover/keypress/scroll/tabs-resize, wait-for success + timeout, dialog-none-pending, and the missing-corpus note all verified.

Refs sightmap/sightmap#43 (the interaction-correctness half stays open)
