### PR TITLE
sel-probe: cross-check the offline matcher and warn on divergence

### DIFF
--- a/.changeset/selprobe-offline-check.md
+++ b/.changeset/selprobe-offline-check.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`sel-probe` now cross-checks the offline matcher. It queries the live DOM as before, but also runs the same selector through the offline matcher that `snapshot`/`coverage`/`capture` use, prints that count, and emits a `⚠ offline/live divergence` warning (with a hint) when the two disagree. This closes the false-confidence trap where a selector "verified" against the live DOM is silently dead in the corpus — e.g. attribute selectors on `id` (`[id^="…"]`) match live but never offline, because `id` is a dedicated node field rather than a matchable attribute.

--- a/docs/cli/selectors.mdx
+++ b/docs/cli/selectors.mdx
@@ -141,6 +141,7 @@ sightmap sel-probe -- '[data-testid="product-pod"] button[data-testid="atc"]'
 ```text
 selector: [data-testid="product-pod"] button[data-testid="atc"]
 matches: 2
+offline matcher: 2 matches (snapshot/coverage/capture use this)
 nearest component: ★ ProductCard  (div[data-testid="product-pod"])
 
 [1] button.atc-btn
@@ -174,6 +175,8 @@ plp                       sel=[data-testid="product-pod"]  24 matches
 plp/filtered              sel=[data-testid="product-pod"]  18 matches
 pdp                       sel=[data-testid="product-pod"]  1 match
 ```
+
+Alongside the live `matches:` count, `sel-probe` runs the same selector through the **offline matcher** that `snapshot`, `coverage`, and `capture` use, and prints its count. When the two disagree it emits a `⚠ offline/live divergence` warning with a hint — for example, attribute selectors on `id` (`[id^="…"]`) match live but never offline, because `id` is a dedicated node field. Trust the offline count: that is what the corpus sees. This makes "probe before you write YAML" honest rather than a source of false confidence.
 
 <Note>
 `sel-probe` exits 0 when the selector matches nothing because `matches: 0` is a valid diagnostic result. Use `sel-check` when automation needs a non-zero exit code for zero matches. Match counts are capped by `--max`, including with `--all`; raise the limit when you need the full count. `sel-probe` also does not create transient UI state. Open a menu or focus an input with a browser interaction before probing elements that only exist in that state.

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -143,6 +144,13 @@ func runSelProbe(args []string) error {
 	fmt.Printf("selector: %s\n", selector)
 	fmt.Printf("matches: %d\n", len(results))
 
+	// Cross-check against the OFFLINE matcher. sel-probe queries the live DOM,
+	// but snapshot/coverage/capture match the extracted component tree with the
+	// Go matcher, which supports a subset of CSS and a reduced node model. When
+	// the two disagree, a "verified" selector can be silently dead downstream, so
+	// surface the divergence loudly. Best-effort: never fail sel-probe on it.
+	printOfflineCheck(ctx, conn, selector, len(results))
+
 	if len(results) == 0 {
 		return nil
 	}
@@ -207,6 +215,99 @@ func runSelProbe(args []string) error {
 		}
 	}
 	return nil
+}
+
+// printOfflineCheck compares the live querySelectorAll count against the offline
+// matcher's count for the same selector and warns when they diverge. The offline
+// matcher is what snapshot/coverage/capture use, so a divergence means the
+// selector will behave differently there than sel-probe's live query suggests.
+// liveShown is the (possibly --max-capped) number of results already printed; the
+// true live total is re-counted here for an honest comparison.
+func printOfflineCheck(ctx context.Context, conn *browser.CDPConn, selector string, liveShown int) {
+	liveN, lErr := liveSelectorCount(ctx, conn, selector)
+	if lErr != nil {
+		liveN = liveShown // fall back to what we showed
+	}
+	offN, oErr := offlineSelectorCount(ctx, conn, selector)
+	if oErr != nil {
+		return // extraction/match unavailable — skip the cross-check silently
+	}
+
+	fmt.Printf("offline matcher: %d match%s (snapshot/coverage/capture use this)\n", offN, pluralS(offN))
+	if offN == liveN {
+		return
+	}
+	fmt.Printf("⚠ offline/live divergence: live DOM matches %d, but the offline matcher sees %d.\n"+
+		"  snapshot/coverage/capture will see %d — don't trust a live-only match here.\n", liveN, offN, offN)
+	for _, h := range offlineDivergenceHints(selector) {
+		fmt.Printf("  - %s\n", h)
+	}
+}
+
+// liveSelectorCount returns the true (uncapped) number of DOM elements matching
+// selector in the live page.
+func liveSelectorCount(ctx context.Context, conn *browser.CDPConn, selector string) (int, error) {
+	selJSON, _ := json.Marshal(selector)
+	raw, err := browser.EvalJSON(ctx, conn, fmt.Sprintf(
+		`(function(s){try{return document.querySelectorAll(s).length}catch(e){return -1}})(%s)`, string(selJSON)))
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	if json.Unmarshal(raw, &n) != nil || n < 0 {
+		return 0, fmt.Errorf("live count eval failed")
+	}
+	return n, nil
+}
+
+// offlineSelectorCount extracts the component tree from the live page and counts
+// how many nodes the offline matcher assigns to selector — exactly what
+// snapshot/coverage/capture would see.
+func offlineSelectorCount(ctx context.Context, conn *browser.CDPConn, selector string) (int, error) {
+	page, err := conn.DefaultPage()
+	if err != nil {
+		return 0, err
+	}
+	root, err := browser.ExtractComponents(ctx, page)
+	if err != nil {
+		return 0, err
+	}
+	defs := []match.SightmapComponent{{Name: "__probe__", Selectors: []string{selector}}}
+	return len(match.ApplySightmap(root, defs)), nil
+}
+
+// offlineDivergenceHints returns human-readable reasons a selector might match
+// live but not offline, derived from the parsed selector. It recognizes the two
+// best-known traps — attribute selectors on `id` and on `class` — and otherwise
+// gives a general nudge about the reduced offline node model.
+func offlineDivergenceHints(selector string) []string {
+	ps, err := sel.ParseSightmapSelector(selector)
+	if err != nil {
+		return []string{"the offline selector parser could not parse this selector, so it matches nothing offline"}
+	}
+	var hints []string
+	seen := map[string]bool{}
+	add := func(h string) {
+		if !seen[h] {
+			seen[h] = true
+			hints = append(hints, h)
+		}
+	}
+	for _, part := range ps.Parts {
+		if part == nil {
+			continue
+		}
+		if _, ok := part.Attrs["id"]; ok {
+			add("attribute selectors on `id` (e.g. [id^=\"…\"]) don't match offline — `id` is a dedicated node field; use `#id` instead")
+		}
+		if _, ok := part.Attrs["class"]; ok {
+			add("attribute selectors on `class` (e.g. [class*=\"…\"]) never match offline — use a `.class` selector instead")
+		}
+	}
+	if len(hints) == 0 {
+		add("the offline node model may not capture the attribute(s) or structure this selector relies on (e.g. non-standard form attributes like `placeholder`, or `class` on SVG elements)")
+	}
+	return hints
 }
 
 // queryElements runs the inline JS and returns the parsed element list.

--- a/go/cmd/sightmap/cmd_sel_probe_hints_test.go
+++ b/go/cmd/sightmap/cmd_sel_probe_hints_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOfflineDivergenceHints(t *testing.T) {
+	cases := []struct {
+		name     string
+		selector string
+		wantSub  string
+	}{
+		{"id attribute selector", `[id^="context-menu"]`, "`id` is a dedicated node field"},
+		{"class attribute selector", `[class*="lucide"]`, "use a `.class` selector"},
+		{"unparseable", `[[[not valid`, "could not parse"},
+		{"generic fallback", `input[placeholder="Search"]`, "offline node model may not capture"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hints := offlineDivergenceHints(tc.selector)
+			if len(hints) == 0 {
+				t.Fatalf("expected at least one hint for %q", tc.selector)
+			}
+			joined := strings.Join(hints, "\n")
+			if !strings.Contains(joined, tc.wantSub) {
+				t.Errorf("hints for %q = %v, want one mentioning %q", tc.selector, hints, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestOfflineDivergenceHintsDedup verifies a selector referencing the same trap
+// twice yields a single hint.
+func TestOfflineDivergenceHintsDedup(t *testing.T) {
+	hints := offlineDivergenceHints(`[id^="a"] [id$="b"]`)
+	n := 0
+	for _, h := range hints {
+		if strings.Contains(h, "`id` is a dedicated node field") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected the id hint exactly once, got %d (%v)", n, hints)
+	}
+}

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -92,17 +92,19 @@ component still needs a disambiguating property.
 ## Hard rules
 
 **NEVER write YAML without first verifying selectors.**
-Run `sightmap sel-probe 'selector'` on every new selector before committing
-it to YAML. Wrong match count = corrupt coverage.
+Run `sightmap sel-probe 'selector'` on every new selector before committing it to
+YAML. sel-probe queries the live DOM **and** cross-checks the offline matcher
+that `snapshot`/`coverage`/`capture` actually use — it prints both counts and a
+`⚠ offline/live divergence` warning when they disagree. Trust the **offline**
+count: that is what the corpus will see. Wrong match count = corrupt coverage.
 
-**Selector type matters for the Go matcher.**
-The Go tree matcher stores classes in `SelectorPart.Classes`, NOT in
-`Attrs["class"]`. This means:
-- ✓ `.QSIFeedBackLink` — class selector, works
-- ✗ `[class*="QSIFeedBackLink"]` — attribute selector on `class`, always matches 0
-
-Use `.classname` syntax for class-based selectors. `lint` will warn
-about `[class*=...]` patterns once implemented.
+**Prefer `.class` over `[class*=…]`, and `#id` over `[id…]`.**
+The Go tree matcher keeps classes in `SelectorPart.Classes` and `id` in a
+dedicated node field. `.classname` and `#id` are the reliable forms. Attribute
+selectors on `class` can behave differently offline depending on how the element
+was captured, and attribute selectors on `id` don't match offline at all — if you
+reach for one, `sel-probe`'s divergence check will flag it. Use `.classname` /
+`#id` when you can.
 
 **Pseudo-classes: `:not()`, `:is()`, `:where()`, `:has()` are supported**
 (both offline — `validate`/`snapshot`/`coverage`/`sel-check` — and live).

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -92,17 +92,19 @@ component still needs a disambiguating property.
 ## Hard rules
 
 **NEVER write YAML without first verifying selectors.**
-Run `sightmap sel-probe 'selector'` on every new selector before committing
-it to YAML. Wrong match count = corrupt coverage.
+Run `sightmap sel-probe 'selector'` on every new selector before committing it to
+YAML. sel-probe queries the live DOM **and** cross-checks the offline matcher
+that `snapshot`/`coverage`/`capture` actually use — it prints both counts and a
+`⚠ offline/live divergence` warning when they disagree. Trust the **offline**
+count: that is what the corpus will see. Wrong match count = corrupt coverage.
 
-**Selector type matters for the Go matcher.**
-The Go tree matcher stores classes in `SelectorPart.Classes`, NOT in
-`Attrs["class"]`. This means:
-- ✓ `.QSIFeedBackLink` — class selector, works
-- ✗ `[class*="QSIFeedBackLink"]` — attribute selector on `class`, always matches 0
-
-Use `.classname` syntax for class-based selectors. `lint` will warn
-about `[class*=...]` patterns once implemented.
+**Prefer `.class` over `[class*=…]`, and `#id` over `[id…]`.**
+The Go tree matcher keeps classes in `SelectorPart.Classes` and `id` in a
+dedicated node field. `.classname` and `#id` are the reliable forms. Attribute
+selectors on `class` can behave differently offline depending on how the element
+was captured, and attribute selectors on `id` don't match offline at all — if you
+reach for one, `sel-probe`'s divergence check will flag it. Use `.classname` /
+`#id` when you can.
 
 **Pseudo-classes: `:not()`, `:is()`, `:where()`, `:has()` are supported**
 (both offline — `validate`/`snapshot`/`coverage`/`sel-check` — and live).


### PR DESCRIPTION
`sel-probe` matches against the **live DOM**, but `snapshot`/`coverage`/`capture` match the extracted component tree with the **offline Go matcher** — which supports a subset of CSS and a reduced node model. When they disagree, a selector "verified" with `sel-probe` is silently dead in the corpus, so the skill's mandated "sel-probe before writing YAML" discipline created *false confidence*.

`sel-probe` now runs the selector through the offline matcher too, prints that count, and warns when it diverges from the live count:

```
selector: [id^="context-menu"]
matches: 3
offline matcher: 0 matches (snapshot/coverage/capture use this)
⚠ offline/live divergence: live DOM matches 3, but the offline matcher sees 0.
  snapshot/coverage/capture will see 0 — don't trust a live-only match here.
  - attribute selectors on `id` (e.g. [id^="…"]) don't match offline — `id` is a dedicated node field; use `#id` instead
```

Because it compares **counts**, it catches unknown divergences too, not just the known `id` / `placeholder` / svg-`class` cases; those recognized traps get a specific hint, everything else a general nudge about the reduced offline model. Best-effort — it never fails `sel-probe` itself.

### Notes
- Live testing surfaced that the offline matcher *does* support `[class*=…]` when `class` is captured (burrito: `[class*="menu-card"]` → 35 offline), contradicting the skill's old "`[class*=]` always matches 0" absolute — softened here; the precise model reconciliation and the deeper parity fixes (make `id`/`placeholder` matchable, fix svg `className`) are a tracked follow-up.

### Tests / validation
Unit tests for the hint helper (including dedup). Validated live against burrito: `[id]` → id-node-field hint; `[style]`/`[data-sightmap-id]` → generic hint; `.menu-card` / `[class*=]` / `[class~=]` agree with **no false warning**. Skill regenerated into the embedded copy; docs updated.

Refs sightmap/sightmap#41 (offline-matcher parity half stays open)
