### PR TITLE
browser: click scrolls+verifies, fill checks the value stuck

### DIFF
--- a/.changeset/click-fill-correctness.md
+++ b/.changeset/click-fill-correctness.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Make `browser click` and `fill` fail loudly instead of silently no-op'ing. `click` now scrolls the target to the center of the viewport and verifies its center is the top-most element there before dispatching — it errors when the target can't be positioned in the viewport (previously an off-screen target below the fold was clicked at a coordinate that hit nothing and still exited 0) or is covered by another element (an open overlay/modal). The success confirmation reports the real post-scroll coordinates. `fill` now reads the value back after typing and errors when a non-empty value was typed but the field is still empty — the signature of a React-controlled input where plain typing doesn't stick — telling you to retry with `--clear`.

--- a/docs/cli/interaction.mdx
+++ b/docs/cli/interaction.mdx
@@ -44,7 +44,7 @@ Property predicates depend on `properties:` extraction. The Go CLI implements `p
 
 ### `browser click`
 
-Clicks an element. The target is a probe ID, a component query, or raw `--x` and `--y` coordinates. Coordinates depend on the current layout. On success it echoes a confirmation to stderr, e.g. `clicked CartNavButton @ (674,30)`.
+Clicks an element. The target is a probe ID, a component query, or raw `--x` and `--y` coordinates. Before dispatching, it scrolls the target to the center of the viewport and verifies that its center is the top-most element there. It **errors** instead of silently doing nothing when the target cannot be positioned in the viewport, or is `covered by another element` (an open overlay or modal). On success it echoes a confirmation with the real post-scroll coordinates, e.g. `clicked CartNavButton @ (674,30)`. (`--x`/`--y` coordinate clicks skip the scroll-and-verify step.)
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -66,7 +66,7 @@ Off-screen targets can be missed. Scroll the element into view first with `brows
 
 ### `browser fill`
 
-Types a value into an input. Takes two positionals: the target (probe ID or component query) and the value. On success it echoes `filled TARGET = "value"` to stderr.
+Types a value into an input. Takes two positionals: the target (probe ID or component query) and the value. After typing it reads the value back and **errors** when a non-empty value was typed but the field is still empty — the signature of a React-controlled input where plain typing doesn't stick; retry with `--clear`, which clears via the native value setter first. On success it echoes `filled TARGET = "value"` to stderr.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -490,20 +490,81 @@ func Drag(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, deltaX,
 	return nil
 }
 
-// Click dispatches a mouse click to the center of node's bounding box.
-// Falls back to JS click() via EvalJSON if node.Bounds is nil.
-func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error {
+// clickTarget is the live geometry of an element after scrolling it to the
+// center of the viewport: whether it is reachable (on-screen and not covered by
+// another element) and the viewport coordinates of its center.
+type clickTarget struct {
+	Found      bool `json:"found"`
+	InViewport bool `json:"inViewport"`
+	Hit        bool `json:"hit"`
+	CX         int  `json:"cx"`
+	CY         int  `json:"cy"`
+}
+
+// locateForClick scrolls the element carrying data-sightmap-id=id to the center
+// of the viewport and reports its resulting geometry, including whether its
+// center is actually the top-most element there (so a target hidden behind an
+// overlay is reported as not-hit rather than clicked through).
+func locateForClick(ctx context.Context, conn *CDPConn, id string) (clickTarget, error) {
+	script := fmt.Sprintf(`(function(){
+  var el=document.querySelector('[data-sightmap-id=%q]');
+  if(!el) return {found:false};
+  el.scrollIntoView({block:"center",inline:"center",behavior:"instant"});
+  var r=el.getBoundingClientRect();
+  var cx=Math.floor(r.left+r.width/2), cy=Math.floor(r.top+r.height/2);
+  var iv = r.width>0 && r.height>0 && cx>=0 && cy>=0 && cx<window.innerWidth && cy<window.innerHeight;
+  var hit=false;
+  if(iv){ var at=document.elementFromPoint(cx,cy); hit=!!at && (at===el||el.contains(at)||at.contains(el)); }
+  return {found:true,inViewport:iv,hit:hit,cx:cx,cy:cy};
+})()`, id)
+	raw, err := EvalJSON(ctx, conn, script)
+	if err != nil {
+		return clickTarget{}, err
+	}
+	var t clickTarget
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return clickTarget{}, err
+	}
+	return t, nil
+}
+
+// Click scrolls node into view, verifies it is reachable, and dispatches a mouse
+// click to its center, returning the viewport coordinates it clicked. It errors
+// loudly when the target cannot be positioned in the viewport or is covered by
+// another element, instead of silently dispatching a click into empty space (the
+// off-screen no-op). A node with no data-sightmap-id and no bounds falls back to
+// a selector-based JS click() and returns (-1, -1).
+func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, int, error) {
+	if node.Id != "" {
+		if t, err := locateForClick(ctx, conn, node.Id); err == nil && t.Found {
+			if !t.InViewport {
+				return -1, -1, fmt.Errorf("click: %q could not be scrolled into the viewport (it may be hidden or have zero size)", node.Id)
+			}
+			if !t.Hit {
+				return -1, -1, fmt.Errorf("click: %q is covered by another element at its center — it may be behind an overlay or modal", node.Id)
+			}
+			if err := ClickAt(ctx, conn, t.CX, t.CY); err != nil {
+				return -1, -1, err
+			}
+			return t.CX, t.CY, nil
+		}
+		// locate failed (no data-sightmap-id on the element, or an eval error);
+		// fall through to the bounds/selector paths below.
+	}
 	if node.Bounds == nil {
 		sel := selectorString(node.Selector)
 		if sel == "" {
-			return fmt.Errorf("Click: node %q has no bounds and no selector", node.Id)
+			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
 		_, err := EvalJSON(ctx, conn, fmt.Sprintf("document.querySelector(%q)?.click()", sel))
-		return err
+		return -1, -1, err
 	}
 	x := node.Bounds.X + node.Bounds.Width/2
 	y := node.Bounds.Y + node.Bounds.Height/2
-	return ClickAt(ctx, conn, x, y)
+	if err := ClickAt(ctx, conn, x, y); err != nil {
+		return -1, -1, err
+	}
+	return x, y, nil
 }
 
 // Hover moves the mouse to the center of node's bounding box.
@@ -522,7 +583,7 @@ func Hover(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error 
 // Fill clears the current value of a form field and types value into it.
 // Clicks the element first, then Ctrl+A to select all, then types each rune.
 func Fill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, value string) error {
-	if err := Click(ctx, conn, node); err != nil {
+	if _, _, err := Click(ctx, conn, node); err != nil {
 		return fmt.Errorf("Fill: click to focus: %w", err)
 	}
 	// Select all: modifiers=10 (Ctrl=2 | Meta/Cmd=8)
@@ -550,7 +611,41 @@ func Fill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, value s
 			return fmt.Errorf("Fill: keyUp %q: %w", ch, err)
 		}
 	}
+	return verifyFilled(ctx, conn, node.Id, value)
+}
+
+// verifyFilled reads the target's value back after typing and reports an error
+// when a non-empty value was typed but the field is still empty — the signature
+// of a React-controlled input where plain Fill's select-all+type does not stick.
+// It is best-effort: an unreadable value (no id, non-input element) is not an
+// error, and a non-empty-but-transformed value (masked inputs) is accepted.
+func verifyFilled(ctx context.Context, conn *CDPConn, id, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	if v, ok := readInputValue(ctx, conn, id); ok && strings.TrimSpace(v) == "" {
+		return fmt.Errorf("fill: typed %q but the field is still empty afterwards — it may be a React-controlled input; retry with --clear", value)
+	}
 	return nil
+}
+
+// readInputValue returns the current .value of the element carrying
+// data-sightmap-id=id. ok is false when the id is empty, the element is gone, or
+// it has no value property.
+func readInputValue(ctx context.Context, conn *CDPConn, id string) (string, bool) {
+	if id == "" {
+		return "", false
+	}
+	raw, err := EvalJSON(ctx, conn, fmt.Sprintf(
+		`(function(){var el=document.querySelector('[data-sightmap-id=%q]');if(!el||el.value==null)return null;return String(el.value)})()`, id))
+	if err != nil || len(raw) == 0 || string(raw) == "null" {
+		return "", false
+	}
+	var v string
+	if json.Unmarshal(raw, &v) != nil {
+		return "", false
+	}
+	return v, true
 }
 
 // ClearAndFill focuses node, clears its current value via the native JS setter
@@ -558,7 +653,7 @@ func Fill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, value s
 // value using keystroke events. Use instead of Fill when a React input accumulates
 // text across multiple fill calls.
 func ClearAndFill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, value string) error {
-	if err := Click(ctx, conn, node); err != nil {
+	if _, _, err := Click(ctx, conn, node); err != nil {
 		return fmt.Errorf("ClearAndFill: click to focus: %w", err)
 	}
 	// Clear the field via JS native setter — works on React-controlled inputs.
@@ -590,7 +685,7 @@ func ClearAndFill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode,
 			return fmt.Errorf("ClearAndFill: keyUp %q: %w", ch, err)
 		}
 	}
-	return nil
+	return verifyFilled(ctx, conn, node.Id, value)
 }
 
 // keyMap maps common key names to their CDP key/code/text representations.

--- a/go/browser/actions_test.go
+++ b/go/browser/actions_test.go
@@ -305,7 +305,7 @@ func TestClick_WithBounds(t *testing.T) {
 		Id:     "test",
 		Bounds: &comps.Bounds{X: 100, Y: 200, Width: 60, Height: 40},
 	}
-	if err := Click(context.Background(), conn, node); err != nil {
+	if _, _, err := Click(context.Background(), conn, node); err != nil {
 		t.Fatal(err)
 	}
 
@@ -345,7 +345,7 @@ func TestClick_NoBounds(t *testing.T) {
 		Id:       "test",
 		Selector: &comps.SelectorPart{Tag: "button", Id: "submit"},
 	}
-	if err := Click(context.Background(), conn, node); err != nil {
+	if _, _, err := Click(context.Background(), conn, node); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/browser/click_verify_test.go
+++ b/go/browser/click_verify_test.go
@@ -1,0 +1,105 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/comps"
+)
+
+// evalResult wraps a JS return value in the CDP Runtime.evaluate envelope the
+// fake server hands back.
+func evalResult(valueJSON string) json.RawMessage {
+	return json.RawMessage(`{"result":{"value":` + valueJSON + `},"exceptionDetails":null}`)
+}
+
+func exprOf(params json.RawMessage) string {
+	var p struct {
+		Expression string `json:"expression"`
+	}
+	_ = json.Unmarshal(params, &p)
+	return p.Expression
+}
+
+func nodeWithID(id string) *comps.ComponentNode {
+	return &comps.ComponentNode{Id: id, Bounds: &comps.Bounds{X: 0, Y: 0, Width: 20, Height: 10}}
+}
+
+func TestClick_OffScreenErrors(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		if method == "Runtime.evaluate" {
+			return evalResult(`{"found":true,"inViewport":false,"hit":false,"cx":0,"cy":0}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	_, _, err := Click(context.Background(), conn, nodeWithID("5"))
+	if err == nil || !strings.Contains(err.Error(), "viewport") {
+		t.Fatalf("expected an off-screen/viewport error, got %v", err)
+	}
+}
+
+func TestClick_CoveredErrors(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		if method == "Runtime.evaluate" {
+			return evalResult(`{"found":true,"inViewport":true,"hit":false,"cx":100,"cy":50}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	_, _, err := Click(context.Background(), conn, nodeWithID("5"))
+	if err == nil || !strings.Contains(err.Error(), "covered") {
+		t.Fatalf("expected a covered/overlay error, got %v", err)
+	}
+}
+
+func TestClick_SuccessReturnsPostScrollCoords(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		if method == "Runtime.evaluate" {
+			return evalResult(`{"found":true,"inViewport":true,"hit":true,"cx":123,"cy":45}`)
+		}
+		return json.RawMessage(`{}`) // Input.dispatchMouseEvent
+	})
+	x, y, err := Click(context.Background(), conn, nodeWithID("5"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if x != 123 || y != 45 {
+		t.Errorf("Click returned (%d,%d), want the post-scroll center (123,45)", x, y)
+	}
+}
+
+func TestFill_DidNotStickErrors(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		if method == "Runtime.evaluate" {
+			switch {
+			case strings.Contains(exprOf(params), "elementFromPoint"):
+				return evalResult(`{"found":true,"inViewport":true,"hit":true,"cx":10,"cy":5}`)
+			case strings.Contains(exprOf(params), "el.value"):
+				return evalResult(`""`) // field still empty → didn't stick
+			}
+		}
+		return json.RawMessage(`{}`)
+	})
+	err := Fill(context.Background(), conn, nodeWithID("3"), "hello")
+	if err == nil || !strings.Contains(err.Error(), "--clear") {
+		t.Fatalf("expected a 'didn't stick / --clear' error, got %v", err)
+	}
+}
+
+func TestFill_StuckSucceeds(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		if method == "Runtime.evaluate" {
+			switch {
+			case strings.Contains(exprOf(params), "elementFromPoint"):
+				return evalResult(`{"found":true,"inViewport":true,"hit":true,"cx":10,"cy":5}`)
+			case strings.Contains(exprOf(params), "el.value"):
+				return evalResult(`"hello"`)
+			}
+		}
+		return json.RawMessage(`{}`)
+	})
+	if err := Fill(context.Background(), conn, nodeWithID("3"), "hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -111,10 +111,15 @@ func runClick(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := browser.Click(ctx, conn, node); err != nil {
+	x, y, err := browser.Click(ctx, conn, node)
+	if err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "clicked %s\n", actionLabel(fs.Arg(0), node))
+	if x >= 0 {
+		fmt.Fprintf(os.Stderr, "clicked %s @ (%d,%d)\n", fs.Arg(0), x, y)
+	} else {
+		fmt.Fprintf(os.Stderr, "clicked %s\n", fs.Arg(0))
+	}
 	return nil
 }
 

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -81,7 +81,7 @@ probe ID from snapshot output **or** a component query (see below):
 |---------|-------------|
 | `sightmap browser click <id>` | Click element by probe ID |
 | `sightmap browser click 'ComponentQuery'` | Click element by sightmap identity (preferred on dynamic pages) |
-| `sightmap browser fill <id-or-query> "text"` | Type into an input. May append on React-controlled inputs — see gotchas. |
+| `sightmap browser fill [--clear] <id-or-query> "text"` | Type into an input. Errors if the value doesn't stick — retry with `--clear` (see gotchas). |
 | `sightmap browser hover <id-or-query>` | Hover over element |
 | `sightmap browser keypress Enter` | Press a key (optionally focused on `<id>`) |
 | `sightmap browser scroll --delta-y 500` | Scroll the page |
@@ -144,11 +144,14 @@ sightmap browser navigate 'https://...'     # ✓ correct
 sightmap browser navigate --url 'https://'  # ✗ wrong — passes literal "--url" as the URL
 ```
 
-**`browser fill` may append on React-controlled inputs.**
-If filling the same field multiple times accumulates text, use `browser eval` with the native value setter:
+**`browser fill` detects when a value doesn't stick.**
+On some React-controlled inputs plain `fill` (select-all + type) leaves the field empty. `fill` now reads the value back and **errors** in that case, telling you to retry with `--clear` (which clears via the native value setter first). If filling the same field repeatedly *accumulates* text, also use `--clear`.
 ```bash
-sightmap browser eval 'var el = document.querySelector("INPUT_SELECTOR"); Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set.call(el, "new value"); el.dispatchEvent(new Event("input", {bubbles: true}))'
+sightmap browser fill --clear 'SearchInput' 'burrito'
 ```
+
+**`browser click` scrolls the target into view and refuses off-screen / covered clicks.**
+`click` scrolls the element to the center of the viewport, then verifies its center is actually the top-most element there before dispatching. It **errors** (rather than silently no-op'ing) when the target can't be positioned in the viewport, or is `covered by another element` — the signal of an open overlay/modal or a target you need to reveal first. The confirmation line reports the real post-scroll coordinates it clicked.
 
 **`browser eval` cannot return DOM elements.**
 Only JSON-serializable values are returned. `document.querySelector(...)` returns an error reference. Extract what you need instead: `document.querySelector("sel")?.textContent`.

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -81,7 +81,7 @@ probe ID from snapshot output **or** a component query (see below):
 |---------|-------------|
 | `sightmap browser click <id>` | Click element by probe ID |
 | `sightmap browser click 'ComponentQuery'` | Click element by sightmap identity (preferred on dynamic pages) |
-| `sightmap browser fill <id-or-query> "text"` | Type into an input. May append on React-controlled inputs — see gotchas. |
+| `sightmap browser fill [--clear] <id-or-query> "text"` | Type into an input. Errors if the value doesn't stick — retry with `--clear` (see gotchas). |
 | `sightmap browser hover <id-or-query>` | Hover over element |
 | `sightmap browser keypress Enter` | Press a key (optionally focused on `<id>`) |
 | `sightmap browser scroll --delta-y 500` | Scroll the page |
@@ -144,11 +144,14 @@ sightmap browser navigate 'https://...'     # ✓ correct
 sightmap browser navigate --url 'https://'  # ✗ wrong — passes literal "--url" as the URL
 ```
 
-**`browser fill` may append on React-controlled inputs.**
-If filling the same field multiple times accumulates text, use `browser eval` with the native value setter:
+**`browser fill` detects when a value doesn't stick.**
+On some React-controlled inputs plain `fill` (select-all + type) leaves the field empty. `fill` now reads the value back and **errors** in that case, telling you to retry with `--clear` (which clears via the native value setter first). If filling the same field repeatedly *accumulates* text, also use `--clear`.
 ```bash
-sightmap browser eval 'var el = document.querySelector("INPUT_SELECTOR"); Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set.call(el, "new value"); el.dispatchEvent(new Event("input", {bubbles: true}))'
+sightmap browser fill --clear 'SearchInput' 'burrito'
 ```
+
+**`browser click` scrolls the target into view and refuses off-screen / covered clicks.**
+`click` scrolls the element to the center of the viewport, then verifies its center is actually the top-most element there before dispatching. It **errors** (rather than silently no-op'ing) when the target can't be positioned in the viewport, or is `covered by another element` — the signal of an open overlay/modal or a target you need to reveal first. The confirmation line reports the real post-scroll coordinates it clicked.
 
 **`browser eval` cannot return DOM elements.**
 Only JSON-serializable values are returned. `document.querySelector(...)` returns an error reference. Extract what you need instead: `document.querySelector("sel")?.textContent`.


### PR DESCRIPTION
The interaction-**correctness** half of the browser-use loudness work — the "silent failures where agents live." (The anchor-activation and client-redirect reporting pieces are a follow-up, validated on a full SPA.)

### `click` was a silent no-op off-screen
`Click` computed a bounds-center and dispatched a mouse event with **no scroll and no viewport check**, so a target below the fold was clicked at a coordinate that hit nothing — and still exited 0. `click` now:
- scrolls the element (resolved by its `data-sightmap-id`, so it works for both probe IDs and component queries) to the center of the viewport,
- verifies its center is actually the top-most element there,
- **errors** when the target can't be positioned in the viewport, or is `covered by another element` (an open overlay/modal),
- returns the real post-scroll coordinates, so the confirmation line is accurate.

### `fill` silently left the field empty
On React-controlled inputs, plain `fill` (select-all + type) could exit 0 with the field still empty. `fill`/`ClearAndFill` now read the value back and **error** (suggesting `--clear`) when a non-empty value was typed but the field is still empty. Non-empty transformed values (masked inputs) are accepted.

### Tests / validation
Fake-CDP unit tests for the off-screen, covered, and success `click` paths and the fill didn't-stick/stuck paths; existing `Click` tests updated for the new return signature. Validated live against burrito: a below-the-fold menu card scrolls in and clicks at post-scroll coords `(242,269)`; clicking an element behind an injected full-screen overlay errors with `covered by another element`. (Fill's live validation is deferred — burrito has no text input — but it's covered by the fake-CDP tests.)

Docs (`cli/interaction`) and the browser skill updated; embedded skills regenerated.

Refs sightmap/sightmap#43 (anchor-activation + client-redirect reporting stay open)
