### PR TITLE
snapshot: surface no-view-matched and always print coverage with a corpus

### DIFF
--- a/.changeset/snapshot-corpus-state.md
+++ b/.changeset/snapshot-corpus-state.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Make `snapshot` loud about corpus-match state instead of silently omitting it. When a corpus is loaded but no view's route matches the URL (e.g. an auth redirect to a login page), the output now shows a `[No view matched] <url>` notice instead of a headerless tree that looks identical to a normal snapshot — so an agent knows the page is off the map. And the `[Coverage]` summary is now printed whenever a corpus is applied, including for a matched view that has no components yet (every interactive node reads as an orphan); previously that case printed only the view header, leaving the documented `snapshot --coverage` bootstrap with nothing to iterate on.

--- a/docs/cli/capture.mdx
+++ b/docs/cli/capture.mdx
@@ -16,7 +16,7 @@ All three commands need a running browser session. Start one with `sightmap brow
 
 Connects to Chrome, extracts the component tree, applies the corpus, and emits an annotated ARIA tree with coverage statistics **to stdout** (or to `--out FILE`). `snapshot` is a pure observe command: it never writes into the corpus's capture set and never applies the novelty gate. Persisting a capture is `capture`'s job.
 
-The output contains a `[View: ...]` header when the URL matches a view, a `[Guide]` with match counts by component, the component tree, and a `[Coverage]` summary. `[Warnings]` lists declared components that matched no nodes.
+The output contains a `[View: ...]` header when the URL matches a view, a `[Guide]` with match counts by component, the component tree, and a `[Coverage]` summary. `[Warnings]` lists declared components that matched no nodes. When a corpus is loaded but **no** view's route matches the URL (for example after an auth redirect), the header is replaced by a `[No view matched] <url>` notice so you know the page is off the map. The `[Coverage]` summary is printed whenever a corpus is applied — even for a matched view with no components yet, where every interactive node reads as an orphan — so the `snapshot --coverage` bootstrap always has something to iterate on.
 
 Each tree line starts with a numeric probe ID, then the node content:
 

--- a/go/observe/format_test.go
+++ b/go/observe/format_test.go
@@ -1,0 +1,73 @@
+package observe
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func renderResult(r *Result) string {
+	var b bytes.Buffer
+	Format(&b, r, FormatOpts{CoverageOnly: true})
+	return b.String()
+}
+
+// TestFormat_NoViewMatched: a corpus is loaded but no view matched the URL — the
+// renderer must say so, not silently omit the header.
+func TestFormat_NoViewMatched(t *testing.T) {
+	r := &Result{
+		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		URL:           "https://app.example.com/login",
+		CorpusApplied: true,
+		View:          nil,
+		Coverage:      coverage.Result{Total: 2, T3: 2},
+	}
+	out := renderResult(r)
+	if !strings.Contains(out, "[No view matched] https://app.example.com/login") {
+		t.Errorf("expected a no-view-matched notice, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[Coverage]") {
+		t.Errorf("expected a [Coverage] line even with no view, got:\n%s", out)
+	}
+}
+
+// TestFormat_CoverageWithZeroMatches: a view matched but zero components did — the
+// [Coverage] line must still print (all orphans), not vanish.
+func TestFormat_CoverageWithZeroMatches(t *testing.T) {
+	r := &Result{
+		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		URL:           "https://app.example.com/x",
+		CorpusApplied: true,
+		View:          &sightmap.View{Name: "Stub", Route: "/x"},
+		Matches:       nil, // zero components matched
+		Coverage:      coverage.Result{Total: 5, T3: 5},
+	}
+	out := renderResult(r)
+	if !strings.Contains(out, "[View: Stub]") {
+		t.Errorf("expected the view header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[Coverage]") || !strings.Contains(out, "5 interactive") {
+		t.Errorf("expected a [Coverage] line with 5 interactive, got:\n%s", out)
+	}
+}
+
+// TestFormat_NoCorpus: no corpus at all — neither the no-view notice nor a
+// [Coverage] line should appear (the raw tree stands on its own).
+func TestFormat_NoCorpus(t *testing.T) {
+	r := &Result{
+		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		URL:           "https://app.example.com/x",
+		CorpusApplied: false,
+	}
+	out := renderResult(r)
+	if strings.Contains(out, "[No view matched]") {
+		t.Errorf("did not expect a no-view-matched notice without a corpus, got:\n%s", out)
+	}
+	if strings.Contains(out, "[Coverage]") {
+		t.Errorf("did not expect a [Coverage] line without a corpus, got:\n%s", out)
+	}
+}

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -24,6 +24,12 @@ type Result struct {
 	GlobalNames map[string]bool
 	Props       map[string]map[string]string
 	Coverage    coverage.Result
+
+	// CorpusApplied is true when a corpus was supplied and matched against the
+	// tree, even if no view matched the URL or no component matched a node. It
+	// lets the renderer tell "no corpus" apart from "corpus loaded but nothing
+	// matched" — the latter must not be silent.
+	CorpusApplied bool
 }
 
 // Options controls how a page is observed.
@@ -59,6 +65,7 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 	if corpus == nil {
 		return res, nil
 	}
+	res.CorpusApplied = true
 
 	res.Matches = corpus.MatchTree(root, url)
 	res.View = corpus.ViewForURL(url)

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -43,6 +43,11 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 			}
 		}
 		fmt.Fprintln(w)
+	} else if r.CorpusApplied {
+		// A corpus is loaded but no view's route matched this URL. Say so, so the
+		// caller knows the page is off the map rather than trusting an unmapped
+		// tree (e.g. an auth redirect to a login page).
+		fmt.Fprintf(w, "[No view matched] %s\n\n", r.URL)
 	}
 
 	// ── [Guide] ───────────────────────────────────────────────────────────────
@@ -75,7 +80,11 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 	}
 
 	// ── [Coverage] ────────────────────────────────────────────────────────────
-	if r.Matches != nil {
+	// Gated on CorpusApplied, not on Matches: a matched view with zero components
+	// (or a page where no component matched) still has a coverage story to tell
+	// (every interactive node is an orphan), and hiding it left the documented
+	// "make a view, run snapshot --coverage" bootstrap with nothing to show.
+	if r.CorpusApplied {
 		fmt.Fprintln(w)
 		cov := r.Coverage
 		writeCoverage(w, cov)


### PR DESCRIPTION
Two corpus-match states were silent in the rendered snapshot — the class of failure the recent Plane eval flagged as "corpus-semantics failures are silent."

### No indication when no view matches
With a corpus loaded but no view's `route:` matching the URL (e.g. an auth redirect to `/login`, or any unmapped page), `snapshot` rendered a headerless tree indistinguishable from a normal snapshot — an agent had no cue it had fallen off the map. It now prints:

```
[No view matched] https://app.example.com/login
```

(A *missing* corpus is still reported separately, as before.)

### No `[Coverage]` line for a matched view with zero components
`[Coverage]` was gated on a non-nil match map, so a view that matched the URL but had no components yet (or a page where nothing matched) printed only the view header and **no coverage line** — leaving the documented `make a view → snapshot --coverage` bootstrap with nothing to iterate on. Coverage is now gated on whether a corpus was applied, so an all-orphans line always shows.

### How
- `observe.Result.CorpusApplied` distinguishes "no corpus" from "corpus loaded, nothing matched"; `Format` keys both behaviors off it.
- Unit tests for all three cases (no-view/coverage, zero-components/coverage, no-corpus/neither).
- Validated live against burrito with throwaway corpora: a route-mismatch corpus prints `[No view matched]` + coverage; a matched-view/zero-components corpus prints the header + coverage.

Closes sightmap/sightmap#66
