### PR TITLE
validate: severity model + warn on silent corpus conflicts

### DIFF
--- a/.changeset/corpus-conflict-warnings.md
+++ b/.changeset/corpus-conflict-warnings.md
@@ -1,0 +1,11 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`validate` now distinguishes **errors** (which fail validation, exit 1) from **warnings** (advisory, exit 0), and warns on silent corpus conflicts that a fallback rule was resolving without telling you:
+
+- **`merge-collision-view`** — two or more views share a `name`.
+- **`route-conflict`** — two or more views share the same (normalized) `route`; only the first-declared applies to that URL (this is the "same-route hijack" that can silently drop a view's components).
+- **`merge-collision-component`** — two or more root-level global components share a `name` with different selectors.
+
+Findings now carry a stable `code` and `severity`. Scoped component name reuse (the same child under multiple parents) is correctly *not* flagged, since that is intentional. The spec's diagnostic-code table documents the new corpus codes.

--- a/docs/cli/corpus.mdx
+++ b/docs/cli/corpus.mdx
@@ -14,7 +14,9 @@ description: "Use validate, lint, search, and discover to check corpus structure
 
 ### `sightmap validate`
 
-Loads the YAML and checks the resulting corpus. It verifies component selectors, view routes, `stability:` and `access:` values, and duplicate name-plus-selector pairs within a scope. It exits 1 on any load or validation error. Run it after YAML edits and in CI.
+Loads the YAML and checks the resulting corpus. It verifies component selectors, view routes, `stability:` and `access:` values, and duplicate name-plus-selector pairs within a scope. It reports two kinds of finding: **errors**, which fail validation (exit 1), and **warnings**, which are advisory and do not (exit 0). Run it after YAML edits and in CI.
+
+Warnings flag *corpus conflicts* — two definitions that collide on identity where only one can win and a fallback rule (declaration order) silently resolves it: duplicate view `name` (`merge-collision-view`), two views sharing a `route` (`route-conflict`), and duplicate root-level global component names with different selectors (`merge-collision-component`). The corpus still loads; the warning tells you which definition is shadowing another.
 
 The command also rejects selector syntax outside Sightmap's supported subset. For example, `:nth-child()` produces a parse error; the supported pseudo-classes are `:not()`, `:is()`, `:where()`, and `:has()`.
 
@@ -32,13 +34,15 @@ sightmap validate
 ✓ no validation errors
 ```
 
-On a broken corpus, each problem prints as one `error:` line and the command exits 1:
+On a broken corpus, each error prints as one `error:` line and the command exits 1; warnings print as `warning:` lines and do not affect the exit code:
 
 ```text
-error: ProductPod: duplicate component name and selector
 error: BrowsePage: view has empty route
-sightmap validate: 2 validation error(s)
+warning: route "/products" is claimed by 2 views (ProductList, Browse); only the first (ProductList) applies to that URL
+sightmap validate: 1 validation error(s), 1 warning(s)
 ```
+
+When only warnings are present the command prints `✓ no errors (N warning(s))` and exits 0.
 
 ---
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -49,7 +49,7 @@ What counts as failure for the check-style commands:
 
 | Command | Exits `1` when |
 |---------|----------------|
-| `validate` | the corpus has structural errors (including an unresolved or circular `$ref`) |
+| `validate` | the corpus has structural **errors** (empty route, circular `$ref`, …). Corpus-conflict **warnings** (duplicate view name, shared route, duplicate global component name) print but do **not** fail validation. |
 | `lint` | any warning exists (`--warn-only` prevents warnings from causing exit `1`) |
 | `snapshot` | the corpus is present but fails to parse, or the observed page has **0 interactive nodes** (blank or still loading). A *missing* corpus is not an error — the tree still renders. |
 | `coverage` | any capture has orphaned (T3) nodes, has **0 interactive nodes** (a blank/unrendered page is never a pass), or a snap file cannot be loaded (dead components print warnings but do not fail) |

--- a/go/cmd/sightmap/cmd_validate.go
+++ b/go/cmd/sightmap/cmd_validate.go
@@ -20,13 +20,31 @@ func runValidate(args []string) error {
 		return fmt.Errorf("load corpus: %w", err)
 	}
 
-	errs := sightmap.Validate(corpus)
-	if len(errs) == 0 {
-		fmt.Fprintf(os.Stderr, "✓ no validation errors\n")
+	findings := sightmap.Validate(corpus)
+
+	// Print errors first, then warnings. Warnings are advisory (corpus conflicts
+	// resolved by a fallback rule) and do NOT fail validation; only errors do.
+	var errCount, warnCount int
+	for _, f := range findings {
+		if f.IsError() {
+			errCount++
+			fmt.Fprintf(os.Stderr, "error: %s\n", f.Error())
+		}
+	}
+	for _, f := range findings {
+		if !f.IsError() {
+			warnCount++
+			fmt.Fprintf(os.Stderr, "warning: %s\n", f.Error())
+		}
+	}
+
+	if errCount > 0 {
+		return fmt.Errorf("%d validation error(s), %d warning(s)", errCount, warnCount)
+	}
+	if warnCount > 0 {
+		fmt.Fprintf(os.Stderr, "✓ no errors (%d warning(s))\n", warnCount)
 		return nil
 	}
-	for _, e := range errs {
-		fmt.Fprintf(os.Stderr, "error: %s\n", e.Error())
-	}
-	return fmt.Errorf("%d validation error(s)", len(errs))
+	fmt.Fprintf(os.Stderr, "✓ no validation errors\n")
+	return nil
 }

--- a/go/sightmap/conflict_test.go
+++ b/go/sightmap/conflict_test.go
@@ -1,0 +1,113 @@
+package sightmap_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// findByCode returns the first finding with the given code, or a zero value.
+func findByCode(fs []sightmap.ValidationError, code string) (sightmap.ValidationError, bool) {
+	for _, f := range fs {
+		if f.Code == code {
+			return f, true
+		}
+	}
+	return sightmap.ValidationError{}, false
+}
+
+func TestConflict_DuplicateViewName_Warns(t *testing.T) {
+	c := corpusFrom(nil, []sightmap.View{
+		{Name: "Dashboard", Route: "/a"},
+		{Name: "Dashboard", Route: "/b"},
+	})
+	f, ok := findByCode(sightmap.Validate(c), "merge-collision-view")
+	if !ok {
+		t.Fatalf("expected a merge-collision-view finding, got %v", sightmap.Validate(c))
+	}
+	if f.IsError() {
+		t.Errorf("duplicate view name should be a warning, not an error")
+	}
+}
+
+func TestConflict_DuplicateRoute_Warns(t *testing.T) {
+	c := corpusFrom(nil, []sightmap.View{
+		{Name: "First", Route: "/x"},
+		{Name: "Second", Route: "/x/"}, // normalizes to the same route
+	})
+	f, ok := findByCode(sightmap.Validate(c), "route-conflict")
+	if !ok {
+		t.Fatalf("expected a route-conflict finding, got %v", sightmap.Validate(c))
+	}
+	if f.IsError() {
+		t.Errorf("route conflict should be a warning, not an error")
+	}
+}
+
+func TestConflict_NoFalsePositive_DistinctViews(t *testing.T) {
+	c := corpusFrom(nil, []sightmap.View{
+		{Name: "A", Route: "/a"},
+		{Name: "B", Route: "/b"},
+	})
+	for _, f := range sightmap.Validate(c) {
+		if f.Code == "merge-collision-view" || f.Code == "route-conflict" {
+			t.Errorf("unexpected conflict finding for distinct views: %v", f)
+		}
+	}
+}
+
+func TestConflict_DuplicateGlobalComponentName_Warns(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.yaml"), `
+version: 1
+components:
+  - name: Header
+    selector: "#header"
+`)
+	writeFile(t, filepath.Join(dir, "b.yaml"), `
+version: 1
+components:
+  - name: Header
+    selector: ".site-header"
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	f, ok := findByCode(sightmap.Validate(c), "merge-collision-component")
+	if !ok {
+		t.Fatalf("expected a merge-collision-component finding, got %v", sightmap.Validate(c))
+	}
+	if f.IsError() {
+		t.Errorf("global component name collision should be a warning, not an error")
+	}
+}
+
+// TestConflict_ChildReuse_NoGlobalCollision guards the false positive: a child
+// component reused under two parents flattens to same-name entries with
+// different compound selectors, which must NOT be reported as a global collision.
+func TestConflict_ChildReuse_NoGlobalCollision(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "components.yaml"), `
+version: 1
+components:
+  - name: CarouselA
+    selector: ".carousel-a"
+    children:
+      - name: ScrollButton
+        selector: "button.scroll"
+  - name: CarouselB
+    selector: ".carousel-b"
+    children:
+      - name: ScrollButton
+        selector: "button.scroll"
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if f, ok := findByCode(sightmap.Validate(c), "merge-collision-component"); ok {
+		t.Errorf("child reuse must not be flagged as a global collision, got: %v", f)
+	}
+}

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -169,6 +169,12 @@ func loadDir(path string) (*Corpus, error) {
 	// that $ref cycle detection and diagnostics accumulate in one place.
 	ctx := &flattenCtx{reg: reg}
 
+	// Warn on duplicate top-level global component names. This must run on the
+	// RAW globals, not the flattened list: flattening a child component reused
+	// under several parents yields multiple same-name entries, which would
+	// otherwise look like a collision.
+	ctx.diagnostics = append(ctx.diagnostics, globalNameCollisions(globalRaws)...)
+
 	// Flatten global components (hierarchy → compound descendant selectors).
 	globalComps := flattenAll(globalRaws, ctx)
 
@@ -230,6 +236,48 @@ func rawPropsToMatch(rps []rawProperty) []match.Property {
 	return ps
 }
 
+// globalNameCollisions warns when two or more top-level global components share a
+// name with different selectors. A duplicated global name is ambiguous — both
+// match every view and resolution falls back to declaration order. (Same
+// name + same selector is a true duplicate, reported as an error elsewhere, so
+// it is skipped here.)
+func globalNameCollisions(globals []rawComponent) []ValidationError {
+	type acc struct {
+		count int
+		sels  map[string]bool
+	}
+	byName := map[string]*acc{}
+	var order []string
+	for _, g := range globals {
+		if g.Name == "" {
+			continue
+		}
+		a := byName[g.Name]
+		if a == nil {
+			a = &acc{sels: map[string]bool{}}
+			byName[g.Name] = a
+			order = append(order, g.Name)
+		}
+		a.count++
+		a.sels[string(g.Selector)] = true
+	}
+	var out []ValidationError
+	for _, name := range order {
+		a := byName[name]
+		if a.count < 2 || len(a.sels) < 2 {
+			continue
+		}
+		out = append(out, ValidationError{
+			Component: name,
+			Code:      "merge-collision-component",
+			Severity:  SeverityWarning,
+			Message: fmt.Sprintf("global component name %q is defined %d times with different selectors; only the first applies to a given node",
+				name, a.count),
+		})
+	}
+	return out
+}
+
 // flattenCtx carries the shared state for a flattening pass: the $ref registry
 // and any structural diagnostics discovered along the way (currently circular
 // $ref chains, which are expanded away and so invisible downstream).
@@ -251,7 +299,9 @@ func (ctx *flattenCtx) recordCircular(chain []string) {
 	ctx.seenCircular[key] = true
 	ctx.diagnostics = append(ctx.diagnostics, ValidationError{
 		Component: chain[len(chain)-1],
-		Message:   "ref-circular: circular $ref chain " + strings.Join(chain, " → "),
+		Code:      "ref-circular",
+		Severity:  SeverityError,
+		Message:   "circular $ref chain " + strings.Join(chain, " → "),
 	})
 }
 

--- a/go/sightmap/loader_ref_test.go
+++ b/go/sightmap/loader_ref_test.go
@@ -2,7 +2,6 @@ package sightmap_test
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -44,7 +43,7 @@ components:
 		errs := sightmap.Validate(r.c)
 		found := false
 		for _, e := range errs {
-			if strings.Contains(e.Message, "ref-circular") {
+			if e.Code == "ref-circular" {
 				found = true
 			}
 		}
@@ -78,7 +77,7 @@ components:
 		errs := sightmap.Validate(c)
 		found := false
 		for _, e := range errs {
-			if strings.Contains(e.Message, "ref-circular") {
+			if e.Code == "ref-circular" {
 				found = true
 			}
 		}

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -9,14 +9,31 @@ import (
 	"github.com/sightmap/sightmap/go/sel"
 )
 
-// ValidationError describes a structural problem in the corpus that would
-// cause incorrect or undefined runtime behaviour.
+// Severity classifies a validation finding. Errors fail validation (nonzero
+// exit); warnings are advisory and do not (see runValidate).
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// ValidationError describes a structural problem in the corpus. Despite the
+// name it carries a Severity: an error is a hard problem that fails validation,
+// a warning is an advisory finding (e.g. a corpus conflict resolved by a
+// fallback rule) that the author should see but that does not fail the corpus.
 type ValidationError struct {
-	File      string // source YAML file path (empty for in-memory corpus)
-	Component string // component name (empty if file-level error)
-	Selector  string // offending selector string (empty if not selector-specific)
-	Message   string
+	File      string   // source YAML file path (empty for in-memory corpus)
+	Component string   // component name (empty if file-level error)
+	Selector  string   // offending selector string (empty if not selector-specific)
+	Message   string   //
+	Code      string   // stable diagnostic code, e.g. "ref-circular", "merge-collision-view"
+	Severity  Severity // empty is treated as SeverityError
 }
+
+// IsError reports whether this finding fails validation. The zero-value
+// Severity ("") is treated as an error, so existing checks stay errors.
+func (e ValidationError) IsError() bool { return e.Severity != SeverityWarning }
 
 func (e ValidationError) Error() string {
 	parts := []string{}
@@ -85,7 +102,101 @@ func Validate(c *Corpus) []ValidationError {
 		}
 	}
 
+	// Corpus-conflict warnings: definitions that collide on identity and are
+	// resolved silently by a fallback rule. These are advisory (warnings), not
+	// errors — the corpus still loads, but the author should know one definition
+	// is shadowing another.
+	// Duplicate GLOBAL component names are detected at load time (loader.go),
+	// not here: flattening a child component reused under several parents
+	// produces multiple same-name entries in GlobalComponents, so the collision
+	// is only distinguishable from the raw top-level definitions.
+	errs = append(errs, checkViewNameCollisions(c.Views)...)
+	errs = append(errs, checkRouteCollisions(c.Views)...)
+
 	return errs
+}
+
+// checkViewNameCollisions warns when two or more views share a name. View names
+// should be unique across the corpus; when they collide, lookups by name and the
+// snapshot header become ambiguous. (Merging same-named views is a future SEP,
+// not v0 behaviour.)
+func checkViewNameCollisions(views []View) []ValidationError {
+	byName := map[string][]View{}
+	var order []string
+	for _, v := range views {
+		if v.Name == "" {
+			continue
+		}
+		if _, seen := byName[v.Name]; !seen {
+			order = append(order, v.Name)
+		}
+		byName[v.Name] = append(byName[v.Name], v)
+	}
+	var out []ValidationError
+	for _, name := range order {
+		vs := byName[name]
+		if len(vs) < 2 {
+			continue
+		}
+		out = append(out, ValidationError{
+			Component: name,
+			Code:      "merge-collision-view",
+			Severity:  SeverityWarning,
+			Message: fmt.Sprintf("view name %q is defined %d times (%s); view names should be unique",
+				name, len(vs), viewLocList(vs)),
+		})
+	}
+	return out
+}
+
+// checkRouteCollisions warns when two or more views share the same (normalized)
+// route. Only one view can win for a given URL — resolution falls back to
+// declaration order — so the later views' components silently stop applying.
+func checkRouteCollisions(views []View) []ValidationError {
+	byRoute := map[string][]View{}
+	var order []string
+	for _, v := range views {
+		if v.Route == "" {
+			continue
+		}
+		r := normalizeRoutePath(v.Route)
+		if _, seen := byRoute[r]; !seen {
+			order = append(order, r)
+		}
+		byRoute[r] = append(byRoute[r], v)
+	}
+	var out []ValidationError
+	for _, r := range order {
+		vs := byRoute[r]
+		if len(vs) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(vs))
+		for _, v := range vs {
+			names = append(names, v.Name)
+		}
+		out = append(out, ValidationError{
+			Code:     "route-conflict",
+			Severity: SeverityWarning,
+			Message: fmt.Sprintf("route %q is claimed by %d views (%s); only the first (%s) applies to that URL",
+				r, len(vs), strings.Join(names, ", "), vs[0].Name),
+		})
+	}
+	return out
+}
+
+// viewLocList formats a set of views as "file:route" entries for a collision
+// message.
+func viewLocList(vs []View) string {
+	parts := make([]string, 0, len(vs))
+	for _, v := range vs {
+		f := v.SourceFile
+		if f == "" {
+			f = "?"
+		}
+		parts = append(parts, fmt.Sprintf("%s:%s", f, v.Route))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // validateComponent validates a single component against the shared seen map.

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -54,7 +54,7 @@ Use `npm` in instructions — it's the universal baseline. `pnpm`/`yarn` work to
 | `sightmap snapshot --url URL` | Observe: full annotated tree + coverage to stdout (add `--out FILE` / `--tree-out FILE` to save). |
 | `sightmap capture --url URL` | Persist a novelty-gated capture into the matched view's set. |
 | `sightmap sel-probe 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. |
-| `sightmap validate` | Spec-validate `.sightmap/` YAML. No prepare step needed. |
+| `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; corpus-conflict **warnings** — duplicate view name, shared route, duplicate global component — print but pass). No prepare step needed. |
 | `sightmap lint --warn-only` | Style checks (`--warn-only`; exits 0 always). |
 | `sightmap coverage --trace FILE.snap` | Offline T1/T2/T3 re-check on saved snap (requires `.snap.tree.json` companion). |
 | `sightmap multi-coverage` | Cross-page coverage matrix; surfaces global candidates. |

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -54,7 +54,7 @@ Use `npm` in instructions — it's the universal baseline. `pnpm`/`yarn` work to
 | `sightmap snapshot --url URL` | Observe: full annotated tree + coverage to stdout (add `--out FILE` / `--tree-out FILE` to save). |
 | `sightmap capture --url URL` | Persist a novelty-gated capture into the matched view's set. |
 | `sightmap sel-probe 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. |
-| `sightmap validate` | Spec-validate `.sightmap/` YAML. No prepare step needed. |
+| `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; corpus-conflict **warnings** — duplicate view name, shared route, duplicate global component — print but pass). No prepare step needed. |
 | `sightmap lint --warn-only` | Style checks (`--warn-only`; exits 0 always). |
 | `sightmap coverage --trace FILE.snap` | Offline T1/T2/T3 re-check on saved snap (requires `.snap.tree.json` companion). |
 | `sightmap multi-coverage` | Cross-page coverage matrix; surfaces global candidates. |

--- a/spec/v1/canonical-format.md
+++ b/spec/v1/canonical-format.md
@@ -101,6 +101,17 @@ These are authoring-side diagnostic codes. Each has a stable `code` string, a `s
 |---|---|---|
 | `config.invalid-version` | error | `.sightmap/config.yaml` `version` field missing, malformed, or unsupported. |
 
+### Corpus
+
+Conflicts where two definitions collide on identity and only one can win. These are **warnings**: the corpus still loads and a fallback rule resolves the winner (declaration order), but the author should know one definition is shadowing another. A circular `$ref` is an **error** because it has no defined resolution.
+
+| Code | Severity | Meaning |
+|---|---|---|
+| `merge-collision-view` | warning | Two or more views share a `name`. Names should be unique; lookups by name and the snapshot header become ambiguous. |
+| `merge-collision-component` | warning | Two or more root-level global components share a `name` with different selectors. Both match every view; resolution falls back to declaration order. |
+| `route-conflict` | warning | Two or more views share the same (normalized) `route`. Only the first-declared view applies to that URL. |
+| `ref-circular` | error | A `$ref` chain is circular (e.g. `A → B → A`, or a component referencing itself). |
+
 ## `.sightmap/config.yaml`
 
 Optional in any project; pins the spec version. Schema: [`config.schema.json`](./config.schema.json). A missing, malformed, or unsupported `version` field surfaces `config.invalid-version` (see above).


### PR DESCRIPTION
The Plane eval's "corpus-semantics failures are silent" class — definitions that collide on identity and get resolved by a fallback rule with no warning. The nastiest was two views on the same route, where the alphabetically-earlier file silently hijacks the route and the other view's components stop applying (coverage drops with no indication why).

Per the `f9b9` ruling, these are **warnings**, not errors (the spec *defines* the tiebreak, so the corpus is valid but ambiguous). So this PR first gives `validate` a severity model, then adds the warnings.

### Severity model
Validation findings now carry a `Severity` (`error`|`warning`, default error) and a stable `Code`. `validate` prints errors then warnings; **errors fail (exit 1), warnings print and exit 0**. `ref-circular` is moved onto the new model (code + error severity).

### New corpus-conflict warnings
- **`merge-collision-view`** — two+ views share a `name`.
- **`route-conflict`** — two+ views share the same normalized `route`; only the first-declared applies to that URL.
- **`merge-collision-component`** — two+ root-level global components share a `name` with different selectors.

### The one subtlety
The global-component check runs in the **loader on the raw top-level names**, not the flattened `GlobalComponents` — flattening a child component reused under several parents produces same-name entries with *different compound selectors*, which would otherwise look like a collision. Guarded by `TestConflict_ChildReuse_NoGlobalCollision`.

### Docs / spec
- `spec/v1/canonical-format.md` gains a **Corpus** diagnostic-code table (`merge-collision-view`, `merge-collision-component`, `route-conflict`, `ref-circular`) — aligning the spec's code registry with what's emitted (the codes were already referenced piecemeal in `schema.md` / conformance 002).
- `cli/corpus`, `cli/overview` exit-code table, and the authoring skill updated.

### Validation
Unit tests for each warning + the child-reuse non-collision; CLI confirmed offline — a conflict corpus prints `warning:` and exits 0, a real error still exits 1, a clean corpus prints `✓`.

This establishes the diagnostics/severity model that `c5ad` (strict validate: missing-required, unresolved-`$ref`, unknown-field warnings) and the observe-side runtime conflict warnings will build on.

Closes sightmap/sightmap#65
