### PR TITLE
validate: error on missing required fields and unresolved $ref

### DIFF
--- a/.changeset/validate-required.md
+++ b/.changeset/validate-required.md
@@ -1,0 +1,10 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`validate` now surfaces two classes of invalid corpus the loader previously dropped silently (so they shipped with a green check):
+
+- **Missing required fields** — a component with no `selector` (or no `name`), and a view with no `name`, are now errors (`missing-selector` / `missing-name` / `missing-route`) instead of being quietly discarded during load.
+- **Unresolved `$ref`** — a `$ref` naming a component that no file defines is now a `ref-unresolved` error (matching the spec's MUST), instead of the reference being silently skipped.
+
+Both exit non-zero. The spec's diagnostic-code table documents the new error codes alongside the corpus-conflict warnings.

--- a/docs/cli/corpus.mdx
+++ b/docs/cli/corpus.mdx
@@ -14,7 +14,7 @@ description: "Use validate, lint, search, and discover to check corpus structure
 
 ### `sightmap validate`
 
-Loads the YAML and checks the resulting corpus. It verifies component selectors, view routes, `stability:` and `access:` values, and duplicate name-plus-selector pairs within a scope. It reports two kinds of finding: **errors**, which fail validation (exit 1), and **warnings**, which are advisory and do not (exit 0). Run it after YAML edits and in CI.
+Loads the YAML and checks the resulting corpus. It verifies required fields (a view's `name` and `route`, a component's `name` and `selector`), that every `$ref` resolves, component selector syntax, `stability:` and `access:` values, and duplicate name-plus-selector pairs within a scope. It reports two kinds of finding: **errors**, which fail validation (exit 1) — including a missing required field or an unresolved `$ref`, both of which the loader previously dropped silently — and **warnings**, which are advisory and do not (exit 0). Run it after YAML edits and in CI.
 
 Warnings flag *corpus conflicts* — two definitions that collide on identity where only one can win and a fallback rule (declaration order) silently resolves it: duplicate view `name` (`merge-collision-view`), two views sharing a `route` (`route-conflict`), and duplicate root-level global component names with different selectors (`merge-collision-component`). The corpus still loads; the warning tells you which definition is shadowing another.
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -49,7 +49,7 @@ What counts as failure for the check-style commands:
 
 | Command | Exits `1` when |
 |---------|----------------|
-| `validate` | the corpus has structural **errors** (empty route, circular `$ref`, …). Corpus-conflict **warnings** (duplicate view name, shared route, duplicate global component name) print but do **not** fail validation. |
+| `validate` | the corpus has structural **errors** (missing required field, unresolved or circular `$ref`, …). Corpus-conflict **warnings** (duplicate view name, shared route, duplicate global component name) print but do **not** fail validation. |
 | `lint` | any warning exists (`--warn-only` prevents warnings from causing exit `1`) |
 | `snapshot` | the corpus is present but fails to parse, or the observed page has **0 interactive nodes** (blank or still loading). A *missing* corpus is not an error — the tree still renders. |
 | `coverage` | any capture has orphaned (T3) nodes, has **0 interactive nodes** (a blank/unrendered page is never a pass), or a snap file cannot be loaded (dead components print warnings but do not fail) |

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -282,22 +282,27 @@ func globalNameCollisions(globals []rawComponent) []ValidationError {
 // and any structural diagnostics discovered along the way (currently circular
 // $ref chains, which are expanded away and so invisible downstream).
 type flattenCtx struct {
-	reg          map[string]rawComponent
-	diagnostics  []ValidationError
-	seenCircular map[string]bool // dedupe key → already-reported
+	reg         map[string]rawComponent
+	diagnostics []ValidationError
+	seen        map[string]bool // dedupe key (code + identity) → already-reported
+}
+
+// addDiag appends a diagnostic once per distinct key, so a component reused via
+// $ref at several sites does not report the same problem repeatedly.
+func (ctx *flattenCtx) addDiag(key string, ve ValidationError) {
+	if ctx.seen == nil {
+		ctx.seen = map[string]bool{}
+	}
+	if ctx.seen[key] {
+		return
+	}
+	ctx.seen[key] = true
+	ctx.diagnostics = append(ctx.diagnostics, ve)
 }
 
 // recordCircular records a $ref cycle diagnostic once per distinct chain.
 func (ctx *flattenCtx) recordCircular(chain []string) {
-	key := strings.Join(chain, "\x00")
-	if ctx.seenCircular == nil {
-		ctx.seenCircular = map[string]bool{}
-	}
-	if ctx.seenCircular[key] {
-		return
-	}
-	ctx.seenCircular[key] = true
-	ctx.diagnostics = append(ctx.diagnostics, ValidationError{
+	ctx.addDiag("ref-circular\x00"+strings.Join(chain, "\x00"), ValidationError{
 		Component: chain[len(chain)-1],
 		Code:      "ref-circular",
 		Severity:  SeverityError,
@@ -335,14 +340,40 @@ func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentCha
 		}
 		global, ok := ctx.reg[rc.Ref]
 		if !ok {
-			return nil // unknown ref — reported separately by strict validation
+			// Unresolved $ref: the referenced global does not exist. The spec
+			// requires this to be a hard error, so surface it instead of
+			// silently dropping the reference.
+			ctx.addDiag("ref-unresolved\x00"+rc.Ref, ValidationError{
+				Component: rc.Ref,
+				Code:      "ref-unresolved",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("$ref %q does not resolve to any global component", rc.Ref),
+			})
+			return nil
 		}
 		refStack = append(refStack, rc.Ref)
 		rc = global
 	}
 
-	// Skip components that lack a name or a selector.
-	if rc.Name == "" || string(rc.Selector) == "" {
+	// A real (non-$ref) component that lacks a required field would otherwise be
+	// dropped silently, so it never reaches Validate. Surface it as an error
+	// (schema requires both name and selector).
+	if rc.Name == "" {
+		ctx.addDiag("missing-name\x00"+string(rc.Selector), ValidationError{
+			Selector: string(rc.Selector),
+			Code:     "missing-name",
+			Severity: SeverityError,
+			Message:  "component is missing a name",
+		})
+		return nil
+	}
+	if string(rc.Selector) == "" {
+		ctx.addDiag("missing-selector\x00"+rc.Name, ValidationError{
+			Component: rc.Name,
+			Code:      "missing-selector",
+			Severity:  SeverityError,
+			Message:   "component is missing a selector",
+		})
 		return nil
 	}
 

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -67,9 +67,18 @@ func Validate(c *Corpus) []ValidationError {
 
 	// Check views.
 	for _, view := range c.Views {
+		if view.Name == "" {
+			errs = append(errs, ValidationError{
+				Code:     "missing-name",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("view with route %q is missing a name", view.Route),
+			})
+		}
 		if view.Route == "" {
 			errs = append(errs, ValidationError{
 				Component: view.Name,
+				Code:      "missing-route",
+				Severity:  SeverityError,
 				Message:   "view has empty route",
 			})
 		}

--- a/go/sightmap/validate_required_test.go
+++ b/go/sightmap/validate_required_test.go
@@ -1,0 +1,98 @@
+package sightmap_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// hasErrorCode reports whether any finding is an error with the given code.
+func hasErrorCode(fs []sightmap.ValidationError, code string) bool {
+	for _, f := range fs {
+		if f.Code == code && f.IsError() {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRequired_MissingSelector_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "components.yaml"), `
+version: 1
+components:
+  - name: NoSelector
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !hasErrorCode(sightmap.Validate(c), "missing-selector") {
+		t.Errorf("expected a missing-selector error, got %v", sightmap.Validate(c))
+	}
+}
+
+func TestRequired_MissingComponentName_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "components.yaml"), `
+version: 1
+components:
+  - selector: ".orphan"
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !hasErrorCode(sightmap.Validate(c), "missing-name") {
+		t.Errorf("expected a missing-name error, got %v", sightmap.Validate(c))
+	}
+}
+
+func TestRequired_UnresolvedRef_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "views.yaml"), `
+version: 1
+views:
+  - name: Home
+    route: /
+    components:
+      - $ref: DoesNotExist
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !hasErrorCode(sightmap.Validate(c), "ref-unresolved") {
+		t.Errorf("expected a ref-unresolved error, got %v", sightmap.Validate(c))
+	}
+}
+
+func TestRequired_ResolvedRef_NoError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "corpus.yaml"), `
+version: 1
+components:
+  - name: Header
+    selector: "#header"
+views:
+  - name: Home
+    route: /
+    components:
+      - $ref: Header
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if hasErrorCode(sightmap.Validate(c), "ref-unresolved") {
+		t.Errorf("a resolvable $ref must not error, got %v", sightmap.Validate(c))
+	}
+}
+
+func TestRequired_ViewMissingName_Errors(t *testing.T) {
+	c := corpusFrom(nil, []sightmap.View{{Name: "", Route: "/x"}})
+	if !hasErrorCode(sightmap.Validate(c), "missing-name") {
+		t.Errorf("expected a missing-name error for a nameless view, got %v", sightmap.Validate(c))
+	}
+}

--- a/spec/v1/canonical-format.md
+++ b/spec/v1/canonical-format.md
@@ -103,14 +103,18 @@ These are authoring-side diagnostic codes. Each has a stable `code` string, a `s
 
 ### Corpus
 
-Conflicts where two definitions collide on identity and only one can win. These are **warnings**: the corpus still loads and a fallback rule resolves the winner (declaration order), but the author should know one definition is shadowing another. A circular `$ref` is an **error** because it has no defined resolution.
+Structural problems in a `.sightmap/` corpus. **Errors** are inputs with no valid interpretation — a missing required field, or a `$ref` that cannot be resolved. **Warnings** are conflicts where two definitions collide on identity and only one can win: the corpus still loads and a fallback rule resolves the winner (declaration order), but the author should know one definition is shadowing another.
 
 | Code | Severity | Meaning |
 |---|---|---|
+| `missing-name` | error | A view or component is missing its required `name`. |
+| `missing-route` | error | A view is missing its required `route`. |
+| `missing-selector` | error | A component is missing its required `selector`. |
+| `ref-unresolved` | error | A `$ref` names a component that no file's root `components:` defines. |
+| `ref-circular` | error | A `$ref` chain is circular (e.g. `A → B → A`, or a component referencing itself). |
 | `merge-collision-view` | warning | Two or more views share a `name`. Names should be unique; lookups by name and the snapshot header become ambiguous. |
 | `merge-collision-component` | warning | Two or more root-level global components share a `name` with different selectors. Both match every view; resolution falls back to declaration order. |
 | `route-conflict` | warning | Two or more views share the same (normalized) `route`. Only the first-declared view applies to that URL. |
-| `ref-circular` | error | A `$ref` chain is circular (e.g. `A → B → A`, or a component referencing itself). |
 
 ## `.sightmap/config.yaml`
 


### PR DESCRIPTION
The eval's C8: `validate` "accepts a component with no selector with zero complaint," and the exit-code table promises `ref-unresolved` errors that never fired. Both are because the **loader silently drops** these before `Validate` sees them:

- `flattenOne` discards a component with an empty `name` or `selector` (`return nil`).
- `flattenOne` skips a `$ref` whose target isn't in the registry (`return nil`).

So broken corpora shipped with a green check. This PR surfaces them (part 1 of strict `validate`):

### Missing required fields → errors
A component with no `selector` (`missing-selector`), a component with no `name` (`missing-name`), and a view with no `name` (`missing-name`; route was already checked) are now errors instead of being quietly dropped. The component checks record from the loader (before the drop), deduped so a `$ref`-reused component reports once.

### Unresolved `$ref` → error
A `$ref` naming a component no file defines is now `ref-unresolved` (error) — matching the spec MUST and **conformance fixture 011** exactly (`{code: "ref-unresolved", severity: "error"}`).

### Not in this PR
Unknown-field **warnings** are deferred: `properties`/`extract`/`transform`/`url` are unknown to the schema today but the skill requires them and we intend to bless them (properties SEP + `url:` decision), so warning now would fire on fields we're about to legitimize.

### Docs / spec
`spec/v1/canonical-format.md` diagnostic-code table gains `missing-name`/`missing-route`/`missing-selector`/`ref-unresolved`; `cli/corpus` and the `cli/overview` exit-code row updated.

### Validation
Unit tests for each error path + a resolvable-`$ref` regression (must not error); CLI confirmed exit 1 with `component is missing a selector` / `$ref "Ghost" does not resolve…`.

Refs sightmap/sightmap#38 (unknown-field warnings — part 2 — stay open)
