### PR TITLE
spec: accept SEP-0003, add properties: to the schema

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -92,6 +92,7 @@ A named DOM subtree, identified by one or more CSS selectors.
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this component. See [Dependencies](#dependencies). |
 | `description` | string | no | Free-text. Not surfaced at runtime. |
 | `memory` | string[] | no | Component-level memory entries. |
+| `properties` | [Property](#component-properties)[] | no | Named DOM-value extractions surfaced in enriched snapshots (e.g. `[Card price="$10"]`). Extracted from the live DOM at snapshot time; unavailable to offline tools. See [Component properties](#component-properties). |
 | `children` | (Component \| [ComponentRef](#component-references))[] | no | Nested components. Child selectors are scoped to the parent's subtree. Entries may be either inline definitions or `$ref` reference objects. |
 
 ### Component references
@@ -120,6 +121,42 @@ See [SEP-0002](https://github.com/sightmap/sightmap/blob/main/spec/seps/0002-com
 - A list of strings is tried in order; the first selector that matches wins.
 - Selectors in `children` are evaluated **within** their parent's matched subtree, not globally. This scoping is how Sightmap avoids naming collisions between, say, two different card components that both contain a `button.primary`.
 - Selectors are not required to be unique at their level. If a selector matches multiple elements, all matches are named.
+
+
+### Component properties
+
+A component may declare `properties: Property[]` — named values extracted from its matched DOM element and surfaced alongside the component name in enriched snapshots, e.g. `[DateFilterButton label="This Weekend"]`. Extraction operates on the exact element the selector matched (not an ancestor, not the AX node). Properties are read from the **live DOM at snapshot time**; SDKs operating on saved component-tree data MUST omit the values rather than approximate them (the declarations are not an error offline). When a component's selector matches multiple elements, extraction runs independently on each. See [SEP-0003](https://github.com/sightmap/sightmap/blob/main/spec/seps/0003-component-properties.md).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Key used in the annotation (`name="value"`). Must match `^[a-z][a-z0-9_]*$`. The name `value` is reserved: it may be declared to override the AX built-in, and SDKs MUST prefer a declared `value` over the AX tree's own value. |
+| `extract` | string | yes | Extraction directive (see below). |
+| `transform` | string | no | Optional post-processing applied to the extracted string (see below). |
+
+**Extract modes.** The `extract` value is interpreted in this order (named modes match by exact, case-sensitive equality before the `attr=`/`exists:` prefixes):
+
+| Value | Source |
+|---|---|
+| `text` | `element.textContent.trim()`, internal whitespace collapsed to single spaces |
+| `inner_text` | `element.innerText.trim()` — layout-aware; use when `text` runs adjacent inline elements together |
+| `text_only` | `textContent` after removing `img`, `svg`, and `[alt]` descendants — use when icon alt-text bleeds into the label |
+| `inner_html` | `element.innerHTML` |
+| `attr=NAME` | `element.getAttribute(NAME)` |
+| `exists:SEL` | `"true"` if `element.querySelector(SEL)` matches; the property is **omitted** when it does not (boolean state flag) |
+| *any other string* | Treated as a CSS sub-selector: `element.querySelector(VALUE)?.textContent.trim()`; omitted when it matches nothing |
+
+**Transforms.** When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1).
+
+| Value | Effect |
+|---|---|
+| `first_word` | First whitespace-delimited token |
+| `last_word` | Last whitespace-delimited token |
+| `first_number` | First substring matching `\d[\d,.]*` |
+| `first_dollar` | First substring matching `\$[\d,.]+` |
+| `number` | Strip all non-digit, non-decimal characters |
+| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
+
+**Value omission is silent** — a property that extracts to an empty string (or whose `exists:`/sub-selector finds nothing) is simply dropped from the annotation; consumers MUST NOT treat omission as an error.
 
 ## Dependencies
 

--- a/docs/spec/components.mdx
+++ b/docs/spec/components.mdx
@@ -17,7 +17,7 @@ A component is a named DOM subtree, identified by one or more CSS selectors. Nam
       selector: '[role="gridcell"]'
 ```
 
-`name` and `selector` are required. See [Schema reference](/reference/schema#component) for the full field list, including `description`, `source`, and `memory`.
+`name` and `selector` are required. See [Schema reference](/reference/schema#component) for the full field list, including `description`, `source`, `memory`, and `properties`.
 
 ## Selectors
 
@@ -128,6 +128,29 @@ The conformance rules:
 - When a view-scoped `$ref` and a file-root global share a name, the view-scoped expansion **subsumes** the global for that view — implementations MUST NOT produce two matches.
 
 See the [schema reference](/reference/schema#component-references) for the full statement.
+
+
+## Properties
+
+A component can declare `properties:` — named values pulled from its matched element and shown alongside the name in enriched snapshots, so an agent sees not just *what* matched but *what state it is in*:
+
+```yaml
+- name: DateFilterButton
+  selector: '[data-testid="date-filter-button"]'
+  properties:
+    - name: label
+      extract: text          # → [DateFilterButton label="This Weekend"]
+- name: ProductCard
+  selector: '[data-testid="product-pod"]'
+  properties:
+    - name: price
+      extract: '[data-testid="price"]'   # a CSS sub-selector, read from the child
+      transform: first_dollar
+    - name: sold_out
+      extract: 'exists:[aria-label="Sold Out"]'   # boolean flag; omitted when absent
+```
+
+Each property has a `name` (the annotation key), an `extract` directive (`text`, `inner_text`, `text_only`, `inner_html`, `attr=NAME`, `exists:SEL`, or a CSS sub-selector), and an optional `transform` (`first_word`, `last_word`, `first_number`, `first_dollar`, `number`, `slug`). Extraction runs on the exact matched element, from the live DOM at snapshot time — offline tools omit the values. A value that comes back empty (or an `exists:`/sub-selector that finds nothing) is dropped silently. See the [schema reference](/reference/schema#component-properties) and [SEP-0003](https://github.com/sightmap/sightmap/blob/main/spec/seps/0003-component-properties.md).
 
 ## Dependencies
 

--- a/spec/conformance/014-component-properties.fixture/expected.json
+++ b/spec/conformance/014-component-properties.fixture/expected.json
@@ -1,0 +1,9 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": { "ok": true, "diagnostics": [] }
+    }
+  ]
+}

--- a/spec/conformance/014-component-properties.fixture/sightmap/app.yaml
+++ b/spec/conformance/014-component-properties.fixture/sightmap/app.yaml
@@ -1,0 +1,15 @@
+version: 1
+views:
+  - name: Results
+    route: /search
+    components:
+      - name: ProductCard
+        selector: '[data-testid="product-pod"]'
+        properties:
+          - name: price
+            extract: '[data-testid="price"]'
+            transform: first_dollar
+          - name: sold_out
+            extract: 'exists:[aria-label="Sold Out"]'
+          - name: label
+            extract: text

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -50,6 +50,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 011 | `component-ref-unresolved` | `$ref` to an unknown component → `ref-unresolved` error |
 | 012 | `component-ref-circular` | Self-referential `$ref` chain → `ref-circular` error |
 | 013 | `route-trailing-slash` | Trailing slashes on the URL path are normalized away before matching |
+| 014 | `component-properties` | `properties:` (`name`/`extract`/`transform`) validates ([SEP-0003](../seps/0003-component-properties.md)) |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 

--- a/spec/seps/0003-component-properties.md
+++ b/spec/seps/0003-component-properties.md
@@ -2,11 +2,11 @@
 sep: 0003
 title: Component property extraction via `properties[]`
 author: Joel Webber (@joelgwebber)
-status: Draft
+status: Accepted
 created: 2026-05-27
-updated: 2026-05-27
+updated: 2026-07-27
 spec-version-target: 1
-related-issues: []
+related-issues: [52]
 related-discussions: []
 ---
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -84,6 +84,7 @@ A named DOM subtree, identified by one or more CSS selectors.
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this component. See [Dependencies](#dependencies). |
 | `description` | string | no | Free-text. Not surfaced at runtime. |
 | `memory` | string[] | no | Component-level memory entries. |
+| `properties` | [Property](#component-properties)[] | no | Named DOM-value extractions surfaced in enriched snapshots (e.g. `[Card price="$10"]`). Extracted from the live DOM at snapshot time; unavailable to offline tools. See [Component properties](#component-properties). |
 | `children` | (Component \| [ComponentRef](#component-references))[] | no | Nested components. Child selectors are scoped to the parent's subtree. Entries may be either inline definitions or `$ref` reference objects. |
 
 ### Component references
@@ -112,6 +113,42 @@ See [SEP-0002](../seps/0002-component-ref.md) for the full proposal and rational
 - A list of strings is tried in order; the first selector that matches wins.
 - Selectors in `children` are evaluated **within** their parent's matched subtree, not globally. This scoping is how Sightmap avoids naming collisions between, say, two different card components that both contain a `button.primary`.
 - Selectors are not required to be unique at their level. If a selector matches multiple elements, all matches are named.
+
+
+### Component properties
+
+A component may declare `properties: Property[]` — named values extracted from its matched DOM element and surfaced alongside the component name in enriched snapshots, e.g. `[DateFilterButton label="This Weekend"]`. Extraction operates on the exact element the selector matched (not an ancestor, not the AX node). Properties are read from the **live DOM at snapshot time**; SDKs operating on saved component-tree data MUST omit the values rather than approximate them (the declarations are not an error offline). When a component's selector matches multiple elements, extraction runs independently on each. See [SEP-0003](../seps/0003-component-properties.md).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Key used in the annotation (`name="value"`). Must match `^[a-z][a-z0-9_]*$`. The name `value` is reserved: it may be declared to override the AX built-in, and SDKs MUST prefer a declared `value` over the AX tree's own value. |
+| `extract` | string | yes | Extraction directive (see below). |
+| `transform` | string | no | Optional post-processing applied to the extracted string (see below). |
+
+**Extract modes.** The `extract` value is interpreted in this order (named modes match by exact, case-sensitive equality before the `attr=`/`exists:` prefixes):
+
+| Value | Source |
+|---|---|
+| `text` | `element.textContent.trim()`, internal whitespace collapsed to single spaces |
+| `inner_text` | `element.innerText.trim()` — layout-aware; use when `text` runs adjacent inline elements together |
+| `text_only` | `textContent` after removing `img`, `svg`, and `[alt]` descendants — use when icon alt-text bleeds into the label |
+| `inner_html` | `element.innerHTML` |
+| `attr=NAME` | `element.getAttribute(NAME)` |
+| `exists:SEL` | `"true"` if `element.querySelector(SEL)` matches; the property is **omitted** when it does not (boolean state flag) |
+| *any other string* | Treated as a CSS sub-selector: `element.querySelector(VALUE)?.textContent.trim()`; omitted when it matches nothing |
+
+**Transforms.** When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1).
+
+| Value | Effect |
+|---|---|
+| `first_word` | First whitespace-delimited token |
+| `last_word` | Last whitespace-delimited token |
+| `first_number` | First substring matching `\d[\d,.]*` |
+| `first_dollar` | First substring matching `\$[\d,.]+` |
+| `number` | Strip all non-digit, non-decimal characters |
+| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
+
+**Value omission is silent** — a property that extracts to an empty string (or whose `exists:`/sub-selector finds nothing) is simply dropped from the annotation; consumers MUST NOT treat omission as an error.
 
 ## Dependencies
 

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -115,10 +115,38 @@
         },
         "description": { "type": "string" },
         "memory": { "$ref": "#/$defs/memory" },
+        "properties": {
+          "type": "array",
+          "description": "Ordered list of DOM-value extractions surfaced in enriched snapshot output. See SEP-0003.",
+          "items": { "$ref": "#/$defs/componentProperty" }
+        },
         "children": {
           "type": "array",
           "description": "Nested components. Selectors are scoped to the parent's matched subtree. Entries may be either inline definitions or {\"$ref\": ComponentName} reference objects (see SEP-0002).",
           "items": { "$ref": "#/$defs/componentOrRef" }
+        }
+      }
+    },
+    "componentProperty": {
+      "type": "object",
+      "description": "A named DOM-value extraction from a matched element. See SEP-0003.",
+      "required": ["name", "extract"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Key used in the snapshot annotation (name=\"value\"). The name 'value' is reserved: it may be declared to override the AX built-in, but SDKs treat 'value' as the AX-value fallback even without a declaration."
+        },
+        "extract": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Extraction directive: text | inner_text | text_only | inner_html | attr=NAME | exists:SEL | a CSS sub-selector. See SEP-0003 Extract modes."
+        },
+        "transform": {
+          "type": "string",
+          "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
+          "description": "Optional post-processing applied to the extracted string."
         }
       }
     },


### PR DESCRIPTION
The component `properties:` field (`name`/`extract`/`transform`) is required by the authoring skill and the component-query DSL, and the extraction is **already implemented** in the CLI — but the published JSON Schema forbade it (`additionalProperties: false`), so a corpus authored exactly per the skill failed schema validation. The Plane eval called this the single most damaging finding for "open spec" credibility.

This reconciles the spec with the shipped tooling. **No Go code** — the extractor already exists; this is purely the spec/schema/docs catching up.

- **`sightmap.schema.json`** — add `properties` to `$defs.component` and a new `$defs.componentProperty` (`name` required + `^[a-z][a-z0-9_]*$`, `extract` required `minLength 1`, `transform` enum), matching SEP-0003's own JSON Schema diff verbatim.
- **`schema.md`** — document the field, the extract modes (`text`/`inner_text`/`text_only`/`inner_html`/`attr=`/`exists:`/CSS sub-selector) and transforms.
- **conformance `014-component-properties`** — a `properties` corpus validates cleanly.
- **SEP-0003** — status `Draft → Accepted` (you pre-approved unilateral acceptance pre-launch).
- Regenerated `docs/reference/schema.md`; added a Properties section to `docs/spec/components.mdx`.

Verified with the spec schema validators: `validate:conformance` and `validate:examples` both pass (fixture 014 accepted, nothing else regressed).

No changeset: the published `@sightmap/sightmap` package ships only `bin/`/`README`/`skills/` and doesn't vendor the schema, so this changes only `spec/` + `docs/`.

Closes sightmap/sightmap#52
