### PR TITLE
spec+report: make view url: first-class, read per-view

### DIFF
--- a/.changeset/view-url.md
+++ b/.changeset/view-url.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `report` and make the view `url:` field first-class. `url:` is now read **per view** (with a file-level `url:` as a default for views that omit their own), instead of only at the file level. Previously per-view `url:` was silently dropped, so `report` — which needs a representative URL per view — errored with `no views with URLs found` even when every view declared one. `url:` is also now part of the published schema (SEP-accepted alongside `properties`), so a corpus that declares it validates instead of failing `additionalProperties: false`.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -58,6 +58,7 @@ A named screen in the app, identified by a URL route.
 |---|---|---|---|
 | `name` | string | yes | Shown in the snapshot header. Should be unique across the sightmap. |
 | `route` | string | yes | Glob pattern matched against the URL pathname. See [Route matching](#route-matching). |
+| `url` | string | no | Representative URL for this view — a concrete address that resolves to it. Tooling uses it to navigate to the view (e.g. coverage reporting and bulk capture/probe). A file-root `url` supplies a default for every view in the file that omits its own. |
 | `description` | string | no | Free-text. Not surfaced at runtime but useful for PR review and future maintenance. |
 | `source` | string | no | Relative path to the source file. |
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this view. See [Dependencies](#dependencies). |

--- a/docs/spec/views.mdx
+++ b/docs/spec/views.mdx
@@ -23,7 +23,7 @@ views:
         method: POST
 ```
 
-`name` and `route` are required. `description` records the view's purpose, and `source` links it to a source file. See [Schema reference](/reference/schema#view) for every field.
+`name` and `route` are required. `url` gives the view a representative URL — a concrete address that resolves to it — which tooling uses to navigate to the view (coverage reporting, bulk capture, and probing); a file-level `url` supplies a default for views that omit their own. `description` records the view's purpose, and `source` links it to a source file. See [Schema reference](/reference/schema#view) for every field.
 
 ## Route matching
 

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -56,6 +56,7 @@ type rawSnapshot struct {
 type rawView struct {
 	Name        string         `yaml:"name"`
 	Route       string         `yaml:"route"`
+	URL         string         `yaml:"url"`
 	Description string         `yaml:"description"`
 	Memory      []string       `yaml:"memory"`
 	Components  []rawComponent `yaml:"components"`
@@ -201,6 +202,11 @@ func loadDir(path string) (*Corpus, error) {
 			if rv.Access != nil {
 				access = Access{Status: rv.Access.Status, Reason: rv.Access.Reason}
 			}
+			// Per-view url wins; fall back to the file-level url as a default.
+			viewURL := rv.URL
+			if viewURL == "" {
+				viewURL = vf.URL
+			}
 			views = append(views, View{
 				Name:       rv.Name,
 				Route:      rv.Route,
@@ -208,7 +214,7 @@ func loadDir(path string) (*Corpus, error) {
 				Components: flattenAll(rv.Components, ctx),
 				Stability:  rv.Stability,
 				Access:     access,
-				URL:        vf.URL,
+				URL:        viewURL,
 				Snapshots:  snapshots,
 				SourceFile: basename,
 			})

--- a/go/sightmap/view_url_test.go
+++ b/go/sightmap/view_url_test.go
@@ -1,0 +1,42 @@
+package sightmap_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// TestViewURL_PerViewAndFileFallback verifies a per-view url wins and a
+// file-level url is the default for views that omit their own.
+func TestViewURL_PerViewAndFileFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "views.yaml"), `
+version: 1
+url: https://example.com/default
+views:
+  - name: Home
+    route: /
+    url: https://example.com/
+  - name: Search
+    route: /search
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v := c.ViewByName("Home"); v == nil || v.URL != "https://example.com/" {
+		got := "<nil>"
+		if v != nil {
+			got = v.URL
+		}
+		t.Errorf("Home.URL = %q, want the per-view url", got)
+	}
+	if v := c.ViewByName("Search"); v == nil || v.URL != "https://example.com/default" {
+		got := "<nil>"
+		if v != nil {
+			got = v.URL
+		}
+		t.Errorf("Search.URL = %q, want the file-level default", got)
+	}
+}

--- a/spec/conformance/015-view-url.fixture/expected.json
+++ b/spec/conformance/015-view-url.fixture/expected.json
@@ -1,0 +1,9 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": { "ok": true, "diagnostics": [] }
+    }
+  ]
+}

--- a/spec/conformance/015-view-url.fixture/sightmap/app.yaml
+++ b/spec/conformance/015-view-url.fixture/sightmap/app.yaml
@@ -1,0 +1,9 @@
+version: 1
+url: https://example.com
+views:
+  - name: Home
+    route: /
+    url: https://example.com/
+  - name: Search
+    route: /search
+    # no per-view url — inherits the file-level default

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -51,6 +51,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 012 | `component-ref-circular` | Self-referential `$ref` chain → `ref-circular` error |
 | 013 | `route-trailing-slash` | Trailing slashes on the URL path are normalized away before matching |
 | 014 | `component-properties` | `properties:` (`name`/`extract`/`transform`) validates ([SEP-0003](../seps/0003-component-properties.md)) |
+| 015 | `view-url` | `url:` on a view (and a file-level default) validates |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -50,6 +50,7 @@ A named screen in the app, identified by a URL route.
 |---|---|---|---|
 | `name` | string | yes | Shown in the snapshot header. Should be unique across the sightmap. |
 | `route` | string | yes | Glob pattern matched against the URL pathname. See [Route matching](#route-matching). |
+| `url` | string | no | Representative URL for this view — a concrete address that resolves to it. Tooling uses it to navigate to the view (e.g. coverage reporting and bulk capture/probe). A file-root `url` supplies a default for every view in the file that omits its own. |
 | `description` | string | no | Free-text. Not surfaced at runtime but useful for PR review and future maintenance. |
 | `source` | string | no | Relative path to the source file. |
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this view. See [Dependencies](#dependencies). |

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -11,6 +11,10 @@
       "const": 1,
       "description": "Must be 1 for files that conform to this version of the spec."
     },
+    "url": {
+      "type": "string",
+      "description": "File-level default representative URL, applied to every view in this file that does not declare its own. See the per-view `url`."
+    },
     "memory": {
       "$ref": "#/$defs/memory",
       "description": "File-level memory entries — surfaced whenever any definition from this file is active."
@@ -60,6 +64,10 @@
           "type": "string",
           "minLength": 1,
           "description": "Glob pattern matched against the URL pathname. * matches one segment, ** matches any depth."
+        },
+        "url": {
+          "type": "string",
+          "description": "Representative URL for this view: a concrete address that resolves to it, used by tooling to navigate to the view (report, capture --all, sel-probe --all, discover). Falls back to the file-level `url` when omitted."
         },
         "description": { "type": "string" },
         "source": { "type": "string" },


### PR DESCRIPTION
> **Stacked on #75** (SEP-0003/`properties` acceptance) — they share `sightmap.schema.json` / `schema.md`. Merge #75 first; this PR's base is `spec-accept-properties` and will retarget to `main` once #75 lands.

The `url:` field had a three-way mismatch (eval C15 / the broken `report`):
1. the published schema **forbade** it (`additionalProperties: false`),
2. `report` **required** it, per-view, and
3. the loader read it **only at the file level** — so a per-view `url:` was silently dropped and `report` dead-ended with `no views with URLs found` even when every view declared one.

Per your call, `url:` becomes a first-class **spec field on views**:

- **Schema** — `url` added to `$defs.view` and the file root (a file-level `url` is a default for views that omit their own); documented in `schema.md`.
- **Loader** — `rawView` gains `url`; `View.URL` is the per-view value when present, else the file-level default.
- **`report`** — now finds per-view URLs and prints its table (MISSING-capture rows as expected) instead of erroring.
- **conformance `015-view-url`**; regenerated `docs/reference/schema.md`; `url` documented in `docs/spec/views.mdx`.

Validated: loader unit test (per-view wins, file-level fallback), spec schema validators pass (`015` accepted, nothing regressed), and `report` on a per-view-`url` corpus prints the table.

Closes sightmap/sightmap#64
