### PR TITLE
spec: bless stability:, reserve access:/snapshots: as tooling fields

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -59,6 +59,7 @@ A named screen in the app, identified by a URL route.
 | `name` | string | yes | Shown in the snapshot header. Should be unique across the sightmap. |
 | `route` | string | yes | Glob pattern matched against the URL pathname. See [Route matching](#route-matching). |
 | `url` | string | no | Representative URL for this view — a concrete address that resolves to it. Tooling uses it to navigate to the view (e.g. coverage reporting and bulk capture/probe). A file-root `url` supplies a default for every view in the file that omits its own. |
+| `stability` | string | no | Authoring-confidence marker: `stub` or `deferred`. See [Stability](#stability). |
 | `description` | string | no | Free-text. Not surfaced at runtime but useful for PR review and future maintenance. |
 | `source` | string | no | Relative path to the source file. |
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this view. See [Dependencies](#dependencies). |
@@ -93,6 +94,7 @@ A named DOM subtree, identified by one or more CSS selectors.
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this component. See [Dependencies](#dependencies). |
 | `description` | string | no | Free-text. Not surfaced at runtime. |
 | `memory` | string[] | no | Component-level memory entries. |
+| `stability` | string | no | Authoring-confidence marker: `uncertain` or `unstable`. See [Stability](#stability). |
 | `properties` | [Property](#component-properties)[] | no | Named DOM-value extractions surfaced in enriched snapshots (e.g. `[Card price="$10"]`). Extracted from the live DOM at snapshot time; unavailable to offline tools. See [Component properties](#component-properties). |
 | `children` | (Component \| [ComponentRef](#component-references))[] | no | Nested components. Child selectors are scoped to the parent's subtree. Entries may be either inline definitions or `$ref` reference objects. |
 
@@ -327,6 +329,29 @@ views:
       - name: DashboardLayout       # scoped — only on /dashboard
         selector: '[data-component="DashboardLayout"]'
 ```
+
+
+## Stability
+
+Both views and components may carry an optional `stability` marker recording how much the author trusts the definition. It is advisory metadata — it does not change matching — and conforming tools SHOULD surface it (e.g. in enriched output or lint) so agents know which parts of the map are provisional.
+
+| On | Value | Meaning |
+|---|---|---|
+| View | `stub` | A placeholder view, not yet fleshed out. |
+| View | `deferred` | Intentionally left unmapped for now. |
+| Component | `uncertain` | The selector is a best guess and unverified. |
+| Component | `unstable` | Known to break across renders. |
+
+Omit the field for an active view or a stable component.
+
+## Reserved tooling fields
+
+Some fields are consumed by tooling built on Sightmap (the reference CLI's capture and probe workflows) but are **not part of this spec's matching or merge semantics**. They are permitted by the schema so corpora that use them validate, but conforming SDKs MAY ignore them:
+
+- **`access`** (on a view) — reachability of the view for a tool's reference account: `status` (`open` | `blocked` | `needs-data`) and an optional `reason`.
+- **`snapshots`** (file-level) — named page states to capture (`name`, `notes`, `url`), used to enumerate capture/probe targets.
+
+These are reserved rather than standardized: their shape may change, and other tooling need not implement them. Do not rely on them for cross-SDK matching behavior.
 
 ## Conformance
 

--- a/spec/conformance/016-stability-tooling-fields.fixture/expected.json
+++ b/spec/conformance/016-stability-tooling-fields.fixture/expected.json
@@ -1,0 +1,9 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": { "ok": true, "diagnostics": [] }
+    }
+  ]
+}

--- a/spec/conformance/016-stability-tooling-fields.fixture/sightmap/app.yaml
+++ b/spec/conformance/016-stability-tooling-fields.fixture/sightmap/app.yaml
@@ -1,0 +1,20 @@
+version: 1
+snapshots:
+  - name: base
+    notes: default state
+    url: https://example.com/
+components:
+  - name: Flaky
+    selector: '.flaky'
+    stability: unstable
+views:
+  - name: Draft
+    route: /draft
+    stability: stub
+    access:
+      status: blocked
+      reason: requires admin role
+    components:
+      - name: Guess
+        selector: '.guess'
+        stability: uncertain

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -52,6 +52,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 013 | `route-trailing-slash` | Trailing slashes on the URL path are normalized away before matching |
 | 014 | `component-properties` | `properties:` (`name`/`extract`/`transform`) validates ([SEP-0003](../seps/0003-component-properties.md)) |
 | 015 | `view-url` | `url:` on a view (and a file-level default) validates |
+| 016 | `stability-tooling-fields` | `stability:` (view + component) validates; reserved tooling fields `access:`/`snapshots:` are permitted |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -51,6 +51,7 @@ A named screen in the app, identified by a URL route.
 | `name` | string | yes | Shown in the snapshot header. Should be unique across the sightmap. |
 | `route` | string | yes | Glob pattern matched against the URL pathname. See [Route matching](#route-matching). |
 | `url` | string | no | Representative URL for this view — a concrete address that resolves to it. Tooling uses it to navigate to the view (e.g. coverage reporting and bulk capture/probe). A file-root `url` supplies a default for every view in the file that omits its own. |
+| `stability` | string | no | Authoring-confidence marker: `stub` or `deferred`. See [Stability](#stability). |
 | `description` | string | no | Free-text. Not surfaced at runtime but useful for PR review and future maintenance. |
 | `source` | string | no | Relative path to the source file. |
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this view. See [Dependencies](#dependencies). |
@@ -85,6 +86,7 @@ A named DOM subtree, identified by one or more CSS selectors.
 | `dependencies` | string[] | no | Supplementary files (minimatch globs, project-root-anchored, `!` negates) whose changes should trigger re-curation of this component. See [Dependencies](#dependencies). |
 | `description` | string | no | Free-text. Not surfaced at runtime. |
 | `memory` | string[] | no | Component-level memory entries. |
+| `stability` | string | no | Authoring-confidence marker: `uncertain` or `unstable`. See [Stability](#stability). |
 | `properties` | [Property](#component-properties)[] | no | Named DOM-value extractions surfaced in enriched snapshots (e.g. `[Card price="$10"]`). Extracted from the live DOM at snapshot time; unavailable to offline tools. See [Component properties](#component-properties). |
 | `children` | (Component \| [ComponentRef](#component-references))[] | no | Nested components. Child selectors are scoped to the parent's subtree. Entries may be either inline definitions or `$ref` reference objects. |
 
@@ -319,6 +321,29 @@ views:
       - name: DashboardLayout       # scoped — only on /dashboard
         selector: '[data-component="DashboardLayout"]'
 ```
+
+
+## Stability
+
+Both views and components may carry an optional `stability` marker recording how much the author trusts the definition. It is advisory metadata — it does not change matching — and conforming tools SHOULD surface it (e.g. in enriched output or lint) so agents know which parts of the map are provisional.
+
+| On | Value | Meaning |
+|---|---|---|
+| View | `stub` | A placeholder view, not yet fleshed out. |
+| View | `deferred` | Intentionally left unmapped for now. |
+| Component | `uncertain` | The selector is a best guess and unverified. |
+| Component | `unstable` | Known to break across renders. |
+
+Omit the field for an active view or a stable component.
+
+## Reserved tooling fields
+
+Some fields are consumed by tooling built on Sightmap (the reference CLI's capture and probe workflows) but are **not part of this spec's matching or merge semantics**. They are permitted by the schema so corpora that use them validate, but conforming SDKs MAY ignore them:
+
+- **`access`** (on a view) — reachability of the view for a tool's reference account: `status` (`open` | `blocked` | `needs-data`) and an optional `reason`.
+- **`snapshots`** (file-level) — named page states to capture (`name`, `notes`, `url`), used to enumerate capture/probe targets.
+
+These are reserved rather than standardized: their shape may change, and other tooling need not implement them. Do not rely on them for cross-SDK matching behavior.
 
 ## Conformance
 

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -32,6 +32,12 @@
       "type": "array",
       "description": "Global requests — matched against every view.",
       "items": { "$ref": "#/$defs/request" }
+    },
+    "snapshots": {
+      "$comment": "Reserved tooling field. Not part of the spec's matching or merge semantics; conforming SDKs MAY ignore it. Consumed by the reference CLI's capture/probe workflow.",
+      "type": "array",
+      "description": "Non-normative tooling field: named page states to capture for the views in this file (used by capture/probe tooling).",
+      "items": { "$ref": "#/$defs/snapshot" }
     }
   },
   "$defs": {
@@ -68,6 +74,21 @@
         "url": {
           "type": "string",
           "description": "Representative URL for this view: a concrete address that resolves to it, used by tooling to navigate to the view (report, capture --all, sel-probe --all, discover). Falls back to the file-level `url` when omitted."
+        },
+        "stability": {
+          "type": "string",
+          "enum": ["stub", "deferred"],
+          "description": "Authoring-confidence marker. 'stub': a placeholder not yet fleshed out. 'deferred': intentionally left unmapped for now. Omit for an active view."
+        },
+        "access": {
+          "$comment": "Reserved tooling field. Not part of the spec's matching or merge semantics; conforming SDKs MAY ignore it.",
+          "type": "object",
+          "description": "Non-normative tooling field: reachability of this view for the reference capture account.",
+          "additionalProperties": false,
+          "properties": {
+            "status": { "type": "string", "enum": ["open", "blocked", "needs-data"] },
+            "reason": { "type": "string" }
+          }
         },
         "description": { "type": "string" },
         "source": { "type": "string" },
@@ -122,6 +143,11 @@
           "description": "Optional list of supplementary files (minimatch globs, '!' negation, project-root-anchored) whose changes should trigger re-curation of this component. See spec/v1/schema.md#dependencies for semantics."
         },
         "description": { "type": "string" },
+        "stability": {
+          "type": "string",
+          "enum": ["uncertain", "unstable"],
+          "description": "Authoring-confidence marker. 'uncertain': the selector is a best guess. 'unstable': known to break across renders. Omit for a stable component."
+        },
         "memory": { "$ref": "#/$defs/memory" },
         "properties": {
           "type": "array",
@@ -202,6 +228,16 @@
         "name": { "type": "string", "minLength": 1 },
         "type": { "type": "string" },
         "description": { "type": "string" }
+      }
+    },
+    "snapshot": {
+      "$comment": "Reserved tooling field. Not part of the spec's matching or merge semantics.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "notes": { "type": "string" },
+        "url": { "type": "string" }
       }
     }
   }


### PR DESCRIPTION
Closes the remaining schema-vs-loader schism (companion to `properties` #75 and `url` #77). The loader reads three field areas the schema forbade:

- **`stability:`** (view `stub`/`deferred`; component `uncertain`/`unstable`) — useful authoring-confidence metadata that `validate` already enum-checks. Now a **first-class spec field** (schema enums + a Stability section in `schema.md`).
- **`access:`** (view reachability) and **`snapshots:`** (file-level capture states) — tool-oriented, consumed only by the reference CLI (`access` is enum-validated but has *no functional consumer* — `IsOpen()` is never called; `snapshots` drives `ProbeTargets` for `capture --all`/`sel-probe --all`). Added as **reserved, non-normative tooling fields**: permitted so corpora validate and the upcoming unknown-field check won't flag them, but explicitly *not* part of matching/merge and documented as MAY-ignore — rather than standardized spec fields.

Spec-only, no Go (the loader already reads these; `validate` already checks the enums). conformance `016-stability-tooling-fields`; regenerated docs schema page. Schema validators pass (016 accepted, examples + all fixtures clean). No changeset (package doesn't vendor the schema).

This unblocks the unknown-field-warnings half of strict `validate` (`c5ad`), since every field the loader knows is now recognized by the schema.
