### PR TITLE
validate: warn on unknown fields (finishes strict validate)

### DIFF
--- a/.changeset/validate-unknown-fields.md
+++ b/.changeset/validate-unknown-fields.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`validate` now warns on unknown fields. The typed loader silently ignored any YAML key it didn't recognize, so a typo like `memroy:` — or a half-baked field — vanished without a trace. `validate` now walks the raw YAML and emits an `unknown-field` **warning** (not an error) for any key the spec doesn't define at its position, at any nesting depth. It warns rather than rejects, so authors can stash experimental fields (e.g. `macros:`) during development; recognized fields — including the reserved tooling fields `access` and `snapshots` — are never flagged, and `.sightmap/config.yaml` is excluded. This completes strict `validate` alongside the earlier required-field and `$ref` checks.

--- a/docs/cli/corpus.mdx
+++ b/docs/cli/corpus.mdx
@@ -18,6 +18,8 @@ Loads the YAML and checks the resulting corpus. It verifies required fields (a v
 
 Warnings flag *corpus conflicts* — two definitions that collide on identity where only one can win and a fallback rule (declaration order) silently resolves it: duplicate view `name` (`merge-collision-view`), two views sharing a `route` (`route-conflict`), and duplicate root-level global component names with different selectors (`merge-collision-component`). The corpus still loads; the warning tells you which definition is shadowing another.
 
+Warnings also flag **unknown fields** (`unknown-field`) — a key the spec doesn't define at its position, such as a typo (`memroy:`) or an experimental field. These warn rather than fail, so you can stash work-in-progress fields during development; recognized fields (including the reserved tooling fields `access` and `snapshots`) are never flagged.
+
 The command also rejects selector syntax outside Sightmap's supported subset. For example, `:nth-child()` produces a parse error; the supported pseudo-classes are `:not()`, `:is()`, `:where()`, and `:has()`.
 
 **Flags:**

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -140,6 +140,7 @@ func loadDir(path string) (*Corpus, error) {
 		path string
 	}
 	var viewFiles []viewFileWithPath
+	var fieldDiags []ValidationError
 
 	for _, p := range yamlPaths {
 		data, err := os.ReadFile(p)
@@ -149,6 +150,11 @@ func loadDir(path string) (*Corpus, error) {
 		var rf rawFile
 		if err := yaml.Unmarshal(data, &rf); err != nil {
 			return nil, fmt.Errorf("sightmap: parse %q: %w", p, err)
+		}
+		// config.yaml is tooling config (its own schema), not a corpus file —
+		// don't run the corpus unknown-field check over it.
+		if base := filepath.Base(p); base != "config.yaml" && base != "config.yml" {
+			fieldDiags = append(fieldDiags, unknownFieldWarnings(data, base)...)
 		}
 		if len(rf.Components) > 0 {
 			globalRaws = append(globalRaws, rf.Components...)
@@ -224,7 +230,7 @@ func loadDir(path string) (*Corpus, error) {
 	return &Corpus{
 		GlobalComponents: globalComps,
 		Views:            views,
-		loadDiagnostics:  ctx.diagnostics,
+		loadDiagnostics:  append(ctx.diagnostics, fieldDiags...),
 	}, nil
 }
 

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -1,0 +1,141 @@
+package sightmap
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Unknown-field detection.
+//
+// The typed loader silently ignores YAML keys it doesn't recognize, so a typo
+// like `memroy:` or a half-baked field like `macros:` disappears without a
+// trace. This walks the raw YAML and warns (not errors) on any key that isn't
+// part of the spec at its position — loud enough to catch typos, lenient enough
+// that authors can stash experimental fields during development.
+//
+// The known-key sets below mirror sightmap.schema.json (the source of truth),
+// NOT the Go structs — the structs are deliberately incomplete (e.g. rawFile
+// doesn't read file-level memory/requests), which would produce false positives.
+// stability/access/snapshots/url/properties are all recognized here.
+
+var (
+	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "snapshots")
+	viewFields      = set("name", "route", "url", "stability", "access", "description", "source", "dependencies", "memory", "components", "requests")
+	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "properties", "children")
+	refFields       = set("$ref")
+	requestFields   = set("name", "route", "method", "description", "source", "request", "response", "headers", "memory")
+	payloadFields   = set("fields")
+	fieldFields     = set("name", "type", "description")
+	propertyFields  = set("name", "extract", "transform")
+	accessFields    = set("status", "reason")
+	snapshotFields  = set("name", "notes", "url")
+)
+
+func set(keys ...string) map[string]bool {
+	m := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		m[k] = true
+	}
+	return m
+}
+
+// unknownFieldWarnings walks the raw YAML in data and returns a warning for each
+// key that is not part of the spec at its location. file labels the warnings.
+func unknownFieldWarnings(data []byte, file string) []ValidationError {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil // parse errors are surfaced elsewhere
+	}
+	if len(doc.Content) == 0 {
+		return nil
+	}
+	var out []ValidationError
+	walkFile(doc.Content[0], file, &out)
+	return out
+}
+
+// checkKeys warns on keys of a mapping node that are not in known, and returns
+// the value node for each present key so callers can recurse.
+func checkKeys(node *yaml.Node, known map[string]bool, file string, out *[]ValidationError) map[string]*yaml.Node {
+	vals := map[string]*yaml.Node{}
+	if node == nil || node.Kind != yaml.MappingNode {
+		return vals
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		vals[key.Value] = node.Content[i+1]
+		if !known[key.Value] {
+			*out = append(*out, ValidationError{
+				File:     file,
+				Code:     "unknown-field",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("unknown field %q (line %d)", key.Value, key.Line),
+			})
+		}
+	}
+	return vals
+}
+
+// forEachItem calls fn on each element of a sequence node (no-op otherwise).
+func forEachItem(seq *yaml.Node, fn func(*yaml.Node)) {
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, item := range seq.Content {
+		fn(item)
+	}
+}
+
+func walkFile(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, fileRootFields, file, out)
+	forEachItem(v["views"], func(n *yaml.Node) { walkView(n, file, out) })
+	forEachItem(v["components"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
+	forEachItem(v["requests"], func(n *yaml.Node) { walkRequest(n, file, out) })
+	forEachItem(v["snapshots"], func(n *yaml.Node) { checkKeys(n, snapshotFields, file, out) })
+}
+
+func walkView(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, viewFields, file, out)
+	if a := v["access"]; a != nil {
+		checkKeys(a, accessFields, file, out)
+	}
+	forEachItem(v["components"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
+	forEachItem(v["requests"], func(n *yaml.Node) { walkRequest(n, file, out) })
+}
+
+// walkComponentOrRef dispatches on whether the entry is a $ref object or an
+// inline component definition.
+func walkComponentOrRef(node *yaml.Node, file string, out *[]ValidationError) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == "$ref" {
+			checkKeys(node, refFields, file, out)
+			return
+		}
+	}
+	walkComponent(node, file, out)
+}
+
+func walkComponent(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, componentFields, file, out)
+	forEachItem(v["properties"], func(n *yaml.Node) { checkKeys(n, propertyFields, file, out) })
+	forEachItem(v["children"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
+}
+
+func walkRequest(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, requestFields, file, out)
+	if p := v["request"]; p != nil {
+		walkPayload(p, file, out)
+	}
+	if p := v["response"]; p != nil {
+		walkPayload(p, file, out)
+	}
+}
+
+func walkPayload(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, payloadFields, file, out)
+	forEachItem(v["fields"], func(n *yaml.Node) { checkKeys(n, fieldFields, file, out) })
+}

--- a/go/sightmap/unknownfields_test.go
+++ b/go/sightmap/unknownfields_test.go
@@ -1,0 +1,118 @@
+package sightmap_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func unknownWarnings(t *testing.T, yaml string) []sightmap.ValidationError {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "app.yaml"), yaml)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	var out []sightmap.ValidationError
+	for _, f := range sightmap.Validate(c) {
+		if f.Code == "unknown-field" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func TestUnknownField_Typo(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+memroy:
+  - oops
+views:
+  - name: Home
+    route: /
+`)
+	if len(w) != 1 {
+		t.Fatalf("expected 1 unknown-field warning for 'memroy', got %v", w)
+	}
+	if w[0].IsError() {
+		t.Errorf("unknown field should be a warning, not an error")
+	}
+}
+
+// TestUnknownField_FutureFieldSurvives: a half-baked field warns but does not
+// fail the corpus (so authors can stash experimental fields mid-development).
+func TestUnknownField_FutureFieldSurvives(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+macros:
+  - name: signIn
+views:
+  - name: Home
+    route: /
+`)
+	if len(w) != 1 || w[0].IsError() {
+		t.Fatalf("expected exactly one non-fatal warning for 'macros', got %v", w)
+	}
+}
+
+func TestUnknownField_NestedTypo(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+components:
+  - name: Btn
+    selector: .btn
+    selecto: .oops
+`)
+	if len(w) != 1 {
+		t.Fatalf("expected 1 nested unknown-field warning for 'selecto', got %v", w)
+	}
+}
+
+// TestUnknownField_NoFalsePositives: every blessed + reserved field must be
+// recognized — including stability/access/snapshots/url/properties and $ref.
+func TestUnknownField_NoFalsePositives(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+url: https://example.com
+memory:
+  - file note
+snapshots:
+  - name: base
+    notes: n
+    url: https://example.com/
+components:
+  - name: Header
+    selector: '#header'
+    stability: uncertain
+requests:
+  - name: List
+    route: /api/list
+    method: GET
+views:
+  - name: Home
+    route: /
+    url: https://example.com/
+    stability: stub
+    access:
+      status: blocked
+      reason: admin only
+    memory:
+      - view note
+    components:
+      - $ref: Header
+      - name: Card
+        selector: .card
+        properties:
+          - name: price
+            extract: text
+            transform: first_dollar
+        children:
+          - name: Inner
+            selector: .inner
+`)
+	if len(w) != 0 {
+		t.Errorf("expected no unknown-field warnings for an all-blessed corpus, got %v", w)
+	}
+}

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -54,7 +54,7 @@ Use `npm` in instructions — it's the universal baseline. `pnpm`/`yarn` work to
 | `sightmap snapshot --url URL` | Observe: full annotated tree + coverage to stdout (add `--out FILE` / `--tree-out FILE` to save). |
 | `sightmap capture --url URL` | Persist a novelty-gated capture into the matched view's set. |
 | `sightmap sel-probe 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. |
-| `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; corpus-conflict **warnings** — duplicate view name, shared route, duplicate global component — print but pass). No prepare step needed. |
+| `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; **warnings** — corpus conflicts + unknown/typo'd fields like `memroy:` — print but pass). No prepare step needed. |
 | `sightmap lint --warn-only` | Style checks (`--warn-only`; exits 0 always). |
 | `sightmap coverage --trace FILE.snap` | Offline T1/T2/T3 re-check on saved snap (requires `.snap.tree.json` companion). |
 | `sightmap multi-coverage` | Cross-page coverage matrix; surfaces global candidates. |

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -54,7 +54,7 @@ Use `npm` in instructions — it's the universal baseline. `pnpm`/`yarn` work to
 | `sightmap snapshot --url URL` | Observe: full annotated tree + coverage to stdout (add `--out FILE` / `--tree-out FILE` to save). |
 | `sightmap capture --url URL` | Persist a novelty-gated capture into the matched view's set. |
 | `sightmap sel-probe 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. |
-| `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; corpus-conflict **warnings** — duplicate view name, shared route, duplicate global component — print but pass). No prepare step needed. |
+| `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; **warnings** — corpus conflicts + unknown/typo'd fields like `memroy:` — print but pass). No prepare step needed. |
 | `sightmap lint --warn-only` | Style checks (`--warn-only`; exits 0 always). |
 | `sightmap coverage --trace FILE.snap` | Offline T1/T2/T3 re-check on saved snap (requires `.snap.tree.json` companion). |
 | `sightmap multi-coverage` | Cross-page coverage matrix; surfaces global candidates. |

--- a/spec/v1/canonical-format.md
+++ b/spec/v1/canonical-format.md
@@ -115,6 +115,7 @@ Structural problems in a `.sightmap/` corpus. **Errors** are inputs with no vali
 | `merge-collision-view` | warning | Two or more views share a `name`. Names should be unique; lookups by name and the snapshot header become ambiguous. |
 | `merge-collision-component` | warning | Two or more root-level global components share a `name` with different selectors. Both match every view; resolution falls back to declaration order. |
 | `route-conflict` | warning | Two or more views share the same (normalized) `route`. Only the first-declared view applies to that URL. |
+| `unknown-field` | warning | A key not defined by the spec at its position (a typo like `memroy:`, or an experimental field). Warned rather than rejected so authors can stash work-in-progress fields; recognized fields — including the reserved tooling fields `access` and `snapshots` — are not flagged. |
 
 ## `.sightmap/config.yaml`
 


### PR DESCRIPTION
The last piece of strict `validate` (eval C8). The typed loader silently ignores any YAML key it doesn't recognize, so a typo like `memroy:` — or a half-baked field — vanished without a trace.

`validate` now walks the raw YAML and emits an **`unknown-field` warning** (not an error) for any key the spec doesn't define at its position, at any nesting depth. Per the `f9b9` policy it *warns rather than rejects*, so an author can stash an experimental field (e.g. `macros:`) mid-development and the corpus still passes.

### Key design decision
The known-key sets mirror **`sightmap.schema.json`**, not the Go structs — the structs are deliberately incomplete (`rawFile` doesn't even read file-level `memory`/`requests`), which would false-positive. So every blessed + reserved field (`stability`/`access`/`snapshots`/`url`/`properties`/`memory`/`requests`/`$ref`) is recognized, and `.sightmap/config.yaml` (tooling config with its own schema) is excluded.

### Validation
Unit tests: typo, nested typo, future-field-survives (warns, doesn't fail), and an all-blessed-fields corpus with **zero** false positives. Verified on the real corpora:
- **burrito** → clean (after excluding `config.yaml`, which was an initial false positive I fixed)
- **top-five** → warns on its experimental `macros:` (its `:has-text()` selector *errors* are pre-existing and unrelated)
- **plane** → clean

Pairs with the `stability`/`access`/`snapshots` schema work in #78 (which makes the JSON-schema surface agree with these Go field sets).

Closes sightmap/sightmap#38
