### PR TITLE
coverage: compute effective visibility in-browser via checkVisibility

### DIFF
--- a/.changeset/visible-only-coverage.md
+++ b/.changeset/visible-only-coverage.md
@@ -1,0 +1,7 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Coverage and the annotated tree now agree on what counts as visible. `probe.js` set each node's `isVisible` from that element's *own* computed style, which misses ancestor-driven hiding: a control inside a closed `opacity:0` overlay (a dismissed dropdown or context menu) has computed `opacity:1` of its own, so it reported visible even though it is painted nowhere. Coverage counted these while the renderer dropped the hidden container's subtree, so on real apps a large share of a page's interactive nodes (all the closed menus) silently inflated the count and tanked the score.
+
+`probe.js` now computes `isVisible` with the browser's own `Element.checkVisibility`, which accounts for ancestors hidden by `display:none`, `visibility:hidden`, `opacity:0`, or `content-visibility` — keeping the layout/rendering judgment in the real browser instead of re-deriving CSS semantics. `snapshot`/`coverage` "(visible only)" now excludes descendants of hidden containers; `--include-hidden` still counts every interactive node. The renderer also drops invisible subtrees regardless of interactivity so it and coverage read one signal.

--- a/go/comps/component.go
+++ b/go/comps/component.go
@@ -88,7 +88,11 @@ type ComponentNode struct {
 	// Bounds is the viewport bounding box. (pre-merge)
 	Bounds *Bounds `json:"bounds,omitempty"`
 
-	// IsVisible reports whether the element is visible (not hidden by CSS). (pre-merge)
+	// IsVisible reports whether the element is EFFECTIVELY visible. probe.js
+	// computes it in-browser via Element.checkVisibility, so it already accounts
+	// for ancestor-driven hiding (display:none, visibility:hidden, opacity:0,
+	// content-visibility): a node inside a hidden container is false too.
+	// Coverage and the tree renderer both read this one signal. (pre-merge)
 	IsVisible bool `json:"isVisible"`
 
 	// IsInteractive reports whether the element is actionable (clickable,

--- a/go/conformance/component-schema.md
+++ b/go/conformance/component-schema.md
@@ -75,7 +75,7 @@ Viewport bounding box in pixels.
 | Properties | map[string]string | `properties` | post-merge | Additional A11Y properties (`aria-*` etc.). |
 | Selector | \*SelectorPart | `selector` | pre-merge | Structured CSS identity. Nil for virtual nodes. |
 | Bounds | \*Bounds | `bounds` | pre-merge | Viewport bounding box. |
-| IsVisible | bool | `isVisible` | pre-merge | Element is not CSS-hidden. |
+| IsVisible | bool | `isVisible` | pre-merge | Effective visibility, computed in-browser via `Element.checkVisibility` — false when the element or any ancestor is hidden (`display:none`, `visibility:hidden`, `opacity:0`, `content-visibility`). |
 | IsInteractive | bool | `isInteractive` | pre-merge | Element is actionable per probe heuristics. |
 | InViewport | bool | `inViewport` | pre-merge | Bounds intersect the viewport. |
 | IsIgnored | bool | `isIgnored` | post-merge | A11Y tree marks this node as ignored. |

--- a/go/probe/probe.js
+++ b/go/probe/probe.js
@@ -81,20 +81,44 @@ function computeCompProps(isLogicalRoot, useScrollOffset) {
     }
 
     /**
-     * Computes visibility properties for an element
+     * Computes EFFECTIVE visibility for an element.
+     *
+     * We defer to the browser's own style engine via Element.checkVisibility(),
+     * which — unlike a per-element getComputedStyle — accounts for ANCESTORS: it
+     * returns false when the element or any ancestor is hidden by display:none,
+     * visibility:hidden/collapse, opacity:0, or content-visibility. That is the
+     * signal coverage and the tree renderer both need: a control inside a closed
+     * opacity:0 overlay (a dismissed dropdown/context menu) has computed
+     * opacity:1 of its own, so a per-element check reports it visible while it is
+     * really painted nowhere. Keeping the layout/rendering judgment in the real
+     * browser avoids re-deriving CSS semantics on the Go side.
      */
     function computeVisibility(element, bounds) {
         try {
-            const styles = window.getComputedStyle(element);
+            // Zero-size boxes never paint.
+            if (bounds.width <= 0 || bounds.height <= 0) return false;
 
-            // Check CSS visibility properties
+            if (typeof element.checkVisibility === 'function') {
+                // Standardized option names (opacityProperty/visibilityProperty/
+                // contentVisibilityAuto) plus their pre-standard aliases
+                // (checkOpacity/checkVisibilityCSS), so older engines that only
+                // know the aliases still honor the opacity/visibility checks.
+                // Unknown dictionary members are ignored per WebIDL.
+                return element.checkVisibility({
+                    opacityProperty: true,
+                    visibilityProperty: true,
+                    contentVisibilityAuto: true,
+                    checkOpacity: true,
+                    checkVisibilityCSS: true,
+                });
+            }
+
+            // Fallback for engines without checkVisibility: per-element checks
+            // only (no ancestor awareness).
+            const styles = window.getComputedStyle(element);
             if (styles.display === 'none') return false;
             if (styles.visibility === 'hidden') return false;
             if (styles.opacity === '0') return false;
-
-            // Check bounds
-            if (bounds.width <= 0 || bounds.height <= 0) return false;
-
             return true;
         } catch (e) {
             return false;

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -39,7 +39,7 @@ type FormatOpts struct {
 // Filter builds a compact, filtered Comp tree from a raw ComponentNode tree.
 // It applies the shouldFilter algorithm:
 //   - style/script/noscript tags are dropped (with their subtrees)
-//   - invisible, non-interactive nodes are dropped
+//   - invisible nodes are dropped (with their subtrees)
 //   - role="none" structural wrappers (without a sightmap match) are made
 //     transparent (removed; their children are promoted)
 //   - AX-ignored nodes (without a sightmap match) are made transparent
@@ -178,8 +178,11 @@ func decide(node *comps.ComponentNode, matched bool) disposition {
 		}
 	}
 
-	// Drop invisible and non-interactive subtrees entirely.
-	if !node.IsVisible && !node.IsInteractive {
+	// Drop invisible subtrees entirely. IsVisible is effective visibility
+	// (probe.js consults the browser's style engine, so ancestor-hidden nodes
+	// like a closed opacity:0 menu's items are already false), so this keeps the
+	// rendered tree in lockstep with coverage, which skips the same nodes.
+	if !node.IsVisible {
 		return dropNode
 	}
 

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -42,6 +42,18 @@ func TestFilter_Drop_Invisible(t *testing.T) {
 	}
 }
 
+// Invisible subtrees are dropped regardless of interactivity, so the rendered
+// tree stays in lockstep with coverage (which skips the same nodes). probe.js
+// reports effective visibility, so an interactive control hidden by an ancestor
+// (e.g. a closed opacity:0 menu's item) arrives here as invisible and must not
+// appear.
+func TestFilter_Drop_InvisibleInteractive(t *testing.T) {
+	root := node("1", "button", "Hidden", false /* visible */, true /* interactive */, false)
+	if comp := Filter(root, nil); comp != nil {
+		t.Errorf("expected nil for invisible interactive node, got role=%q", comp.Role)
+	}
+}
+
 func TestFilter_Drop_Script(t *testing.T) {
 	root := nodeWithTag("1", "none", "", "script", true, false, false)
 	comp := Filter(root, nil)


### PR DESCRIPTION
## Problem

`probe.js` set each node's `isVisible` from that element's **own** computed style + bounds. That misses **ancestor-driven** hiding. Concretely, the app's context menus / dropdowns render as a full-screen `opacity:0` overlay when closed; the menu *items* inside have their own computed `opacity:1` (opacity isn't inherited as a computed value), so probe marked each item `isVisible:true` even though nothing of it is painted.

The two readers of the tree then disagreed:

- the **renderer** drops the invisible container's whole subtree (never shows the items), while
- **coverage** gated per-node on `isVisible` and *counted* them.

On real pages this was most of the interactive nodes — every closed menu — silently inflating the interactive count and tanking the coverage score with phantom orphans.

## Fix

Keep the layout/rendering judgment in the real browser: `probe.js` now computes `isVisible` with **`Element.checkVisibility({ opacityProperty, visibilityProperty, contentVisibilityAuto, ... })`**, which returns false when the element **or any ancestor** is hidden by `display:none`, `visibility:hidden/collapse`, `opacity:0`, or `content-visibility`. This is more correct than re-deriving CSS semantics on the Go side (it also handles a `visibility:visible` override under a hidden ancestor, and `content-visibility`), and `isVisible` now carries one effective-visibility signal that both coverage and the renderer read.

The renderer also drops invisible subtrees **regardless of interactivity**, so it and coverage stay in lockstep. `--include-hidden` still counts every interactive node. A zero-size bounds guard and a per-element fallback (for engines without `checkVisibility`) are retained.

## Validation

Confirmed `checkVisibility` behaves as intended in Chrome-for-Testing (a `<button>` inside an `opacity:0` wrapper has own-opacity `1` but `checkVisibility() === false`), then validated end-to-end against a live app on one authenticated page, same session:

| probe | visible-only interactive |
|---|---|
| before (per-element) | 106 |
| after (`checkVisibility`) | 37 |

The 69 phantom nodes were interactive controls inside closed `opacity:0` overlays (command palette, pre-rendered dropdowns/menus); real content is unchanged and coverage stays `0 orphaned ✓`.

`go build ./... && go vet ./... && gofmt -l . && go test ./...` all clean; unit test added asserting invisible interactive nodes are dropped from the rendered tree. The conformance component-schema doc updates `isVisible` to "effective visibility".

Closes #40
