### PR TITLE
match: bring offline id/class/svg selector matching to live parity

### DIFF
--- a/.changeset/matcher-parity.md
+++ b/.changeset/matcher-parity.md
@@ -1,0 +1,11 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Offline selector matching now matches the live DOM for `id`, `class`, and SVG. Three gaps are closed so a selector `sel-probe` verifies live behaves the same way `snapshot`/`coverage`/`capture` see it offline:
+
+- **Attribute selectors on `id`** (`[id^="issue_"]`, `[id$=…]`, …) now match. `id` lives in a dedicated node field, so the matcher resolves `id`/`class` attribute selectors to those fields — not only to captured `attrs`.
+- **`placeholder`** is captured, so `input[placeholder="…"]` matches offline.
+- **SVG classes** are captured. On SVG elements `className` is an `SVGAnimatedString`, which broke the old extraction (it threw and dropped the whole selector); `probe.js` now uses `classList`, so `svg.lucide`, `[class*="lucide"]`, and `:has(svg.lucide-x)` match offline.
+
+The authoring skill and docs are corrected accordingly: attribute selectors on `class` and `id` are no longer described as "don't work offline" — they work, for HTML and SVG alike.

--- a/docs/cli/selectors.mdx
+++ b/docs/cli/selectors.mdx
@@ -176,7 +176,7 @@ plp/filtered              sel=[data-testid="product-pod"]  18 matches
 pdp                       sel=[data-testid="product-pod"]  1 match
 ```
 
-Alongside the live `matches:` count, `sel-probe` runs the same selector through the **offline matcher** that `snapshot`, `coverage`, and `capture` use, and prints its count. When the two disagree it emits a `⚠ offline/live divergence` warning with a hint — for example, attribute selectors on `id` (`[id^="…"]`) match live but never offline, because `id` is a dedicated node field. Trust the offline count: that is what the corpus sees. This makes "probe before you write YAML" honest rather than a source of false confidence.
+Alongside the live `matches:` count, `sel-probe` runs the same selector through the **offline matcher** that `snapshot`, `coverage`, and `capture` use, and prints its count. When the two disagree it emits a `⚠ offline/live divergence` warning with a hint — typically the selector targets nodes the offline tree doesn't carry (a subtree hidden at capture time, or content that only appears after an interaction). Trust the offline count: that is what the corpus sees. This makes "probe before you write YAML" honest rather than a source of false confidence.
 
 <Note>
 `sel-probe` exits 0 when the selector matches nothing because `matches: 0` is a valid diagnostic result. Use `sel-check` when automation needs a non-zero exit code for zero matches. Match counts are capped by `--max`, including with `--all`; raise the limit when you need the full count. `sel-probe` also does not create transient UI state. Open a menu or focus an input with a browser interaction before probing elements that only exist in that state.

--- a/go/conformance/fixtures/012-id-class-field-attrs/README.md
+++ b/go/conformance/fixtures/012-id-class-field-attrs/README.md
@@ -1,0 +1,13 @@
+# 012-id-class-field-attrs
+
+Attribute selectors on `id` and `class` must resolve to the dedicated
+`SelectorPart` fields (`Id`, `Classes`), not only to `attrs`. Extraction stores a
+node's id in `selector.id` and its classes in `selector.classes` — including SVG
+elements, whose `className` is an `SVGAnimatedString` rather than a plain string —
+so a matcher that only consulted `attrs` would silently see zero matches for
+these selectors even though the live browser matches them.
+
+`IssueRow` (`[id^="issue_"]`) matches `row1` (id `issue_9f1c`) and not `row2`
+(id `cycle_42`), confirming prefix matching against the `id` field. `LucideIcon`
+(`[class*="lucide"]`) matches the `svg` node `icon1`, whose classes live in
+`selector.classes`, confirming substring matching against the `classes` field.

--- a/go/conformance/fixtures/012-id-class-field-attrs/component-tree.json
+++ b/go/conformance/fixtures/012-id-class-field-attrs/component-tree.json
@@ -1,0 +1,50 @@
+{
+  "id": "root",
+  "role": "generic",
+  "name": "",
+  "value": "",
+  "isVisible": true,
+  "isInteractive": false,
+  "inViewport": true,
+  "isIgnored": false,
+  "nthChild": 1,
+  "selector": {"tag": "div"},
+  "children": [
+    {
+      "id": "row1",
+      "role": "generic",
+      "name": "",
+      "value": "",
+      "isVisible": true,
+      "isInteractive": false,
+      "inViewport": true,
+      "isIgnored": false,
+      "nthChild": 1,
+      "selector": {"tag": "div", "id": "issue_9f1c"}
+    },
+    {
+      "id": "row2",
+      "role": "generic",
+      "name": "",
+      "value": "",
+      "isVisible": true,
+      "isInteractive": false,
+      "inViewport": true,
+      "isIgnored": false,
+      "nthChild": 2,
+      "selector": {"tag": "div", "id": "cycle_42"}
+    },
+    {
+      "id": "icon1",
+      "role": "image",
+      "name": "",
+      "value": "",
+      "isVisible": true,
+      "isInteractive": false,
+      "inViewport": true,
+      "isIgnored": false,
+      "nthChild": 3,
+      "selector": {"tag": "svg", "classes": ["lucide", "lucide-check"]}
+    }
+  ]
+}

--- a/go/conformance/fixtures/012-id-class-field-attrs/expected-matches.json
+++ b/go/conformance/fixtures/012-id-class-field-attrs/expected-matches.json
@@ -1,0 +1,1 @@
+{"IssueRow": ["row1"], "LucideIcon": ["icon1"]}

--- a/go/conformance/fixtures/012-id-class-field-attrs/sightmap.yaml
+++ b/go/conformance/fixtures/012-id-class-field-attrs/sightmap.yaml
@@ -1,0 +1,6 @@
+- name: IssueRow
+  selectors:
+    - '[id^="issue_"]'
+- name: LucideIcon
+  selectors:
+    - '[class*="lucide"]'

--- a/go/probe/probe.js
+++ b/go/probe/probe.js
@@ -265,15 +265,19 @@ function computeCompProps(isLogicalRoot, useScrollOffset) {
                 selector += '#' + CSS.escape(element.id);
             }
 
-            if (element.className) {
-                const classes = element.className.split(/\s+/).filter(c => c);
-                for (const cls of classes) {
+            // Use classList, not className: on SVG elements className is an
+            // SVGAnimatedString (no .split), which would throw and lose the whole
+            // selector. classList is a DOMTokenList on both HTML and SVG.
+            const classList = element.classList;
+            if (classList && classList.length) {
+                for (const cls of classList) {
                     selector += '.' + CSS.escape(cls);
                 }
             }
 
-            // Key attributes that should always be included
-            const keyAttrs = ['type', 'name', 'href', 'role', 'for', 'tabindex', 'title', 'alt'];
+            // Key attributes that should always be included. placeholder is here
+            // so selectors like input[placeholder="..."] match offline too.
+            const keyAttrs = ['type', 'name', 'href', 'role', 'for', 'tabindex', 'title', 'alt', 'placeholder'];
             for (const attr of keyAttrs) {
                 const value = element.getAttribute(attr);
                 if (value) {

--- a/go/sel/match.go
+++ b/go/sel/match.go
@@ -106,7 +106,7 @@ func Matches(node, rule *comps.SelectorPart) bool {
 			}
 		}
 
-		nodeVal, present := node.Attrs[key]
+		nodeVal, present := effectiveAttrValue(node, key)
 		if !present {
 			// Attribute not present on node — only "[]" (presence-only) would
 			// logically not care, but absence means presence check fails too.
@@ -138,6 +138,29 @@ func Matches(node, rule *comps.SelectorPart) bool {
 	}
 
 	return true
+}
+
+// effectiveAttrValue resolves an attribute value on a node's SelectorPart for
+// matching. id and class live in dedicated fields (Id, Classes) — not always in
+// Attrs — so attribute selectors like [id^="issue_"] or [class*="card"] must see
+// them there to match offline the way the browser matches them live. Attrs is
+// consulted first (it wins when populated); id/class then fall back to their
+// dedicated fields. All other attributes come straight from Attrs.
+func effectiveAttrValue(node *comps.SelectorPart, key string) (string, bool) {
+	if v, ok := node.Attrs[key]; ok {
+		return v, true
+	}
+	switch key {
+	case "id":
+		if node.Id != "" {
+			return node.Id, true
+		}
+	case "class":
+		if len(node.Classes) > 0 {
+			return strings.Join(node.Classes, " "), true
+		}
+	}
+	return "", false
 }
 
 // attrMatches returns whether a node attribute value satisfies the operator

--- a/go/sel/match_test.go
+++ b/go/sel/match_test.go
@@ -100,6 +100,68 @@ func TestMatches_AttrPresence(t *testing.T) {
 	}
 }
 
+func TestMatches_AttrOnID_ResolvesToIdField(t *testing.T) {
+	// id lives in the dedicated Id field, not Attrs. Attribute selectors on id
+	// ([id^=...] etc.) must still resolve to it so they match offline like live.
+	node := nodeWith("div", "issue_9f1c-42", nil, nil)
+
+	prefix := &comps.SelectorPart{
+		Attrs:   map[string]string{"id": "issue_"},
+		AttrOps: map[string]string{"id": "^="},
+	}
+	if !sel.Matches(node, prefix) {
+		t.Error(`[id^="issue_"] should match id="issue_9f1c-42"`)
+	}
+
+	exact := &comps.SelectorPart{Attrs: map[string]string{"id": "issue_9f1c-42"}}
+	if !sel.Matches(node, exact) {
+		t.Error(`[id="issue_9f1c-42"] should match`)
+	}
+
+	presence := &comps.SelectorPart{
+		Attrs:   map[string]string{"id": ""},
+		AttrOps: map[string]string{"id": "[]"},
+	}
+	if !sel.Matches(node, presence) {
+		t.Error("[id] presence should match a node with an id")
+	}
+
+	bad := &comps.SelectorPart{
+		Attrs:   map[string]string{"id": "cycle_"},
+		AttrOps: map[string]string{"id": "^="},
+	}
+	if sel.Matches(node, bad) {
+		t.Error(`[id^="cycle_"] should not match id="issue_9f1c-42"`)
+	}
+
+	noID := nodeWith("div", "", nil, nil)
+	if sel.Matches(noID, presence) {
+		t.Error("[id] presence should not match a node with no id")
+	}
+}
+
+func TestMatches_AttrOnClass_ResolvesToClassesField(t *testing.T) {
+	// class stored only in the Classes field (no Attrs["class"]) must still be
+	// reachable by attribute selectors like [class*=...].
+	node := nodeWith("svg", "", []string{"lucide", "lucide-check"}, nil)
+
+	contains := &comps.SelectorPart{
+		Attrs:   map[string]string{"class": "lucide-check"},
+		AttrOps: map[string]string{"class": "*="},
+	}
+	if !sel.Matches(node, contains) {
+		t.Error(`[class*="lucide-check"] should match Classes {lucide, lucide-check}`)
+	}
+
+	word := &comps.SelectorPart{
+		Attrs:   map[string]string{"class": "lucide"},
+		AttrOps: map[string]string{"class": "~="},
+	}
+	if !sel.Matches(node, word) {
+		t.Error(`[class~="lucide"] should match`)
+	}
+}
+
 func TestMatches_AttrPrefix(t *testing.T) {
 	node := nodeWith("a", "", nil, map[string]string{"href": "https://example.com"})
 	rule := &comps.SelectorPart{

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -98,13 +98,13 @@ that `snapshot`/`coverage`/`capture` actually use — it prints both counts and 
 `⚠ offline/live divergence` warning when they disagree. Trust the **offline**
 count: that is what the corpus will see. Wrong match count = corrupt coverage.
 
-**Prefer `.class` over `[class*=…]`, and `#id` over `[id…]`.**
-The Go tree matcher keeps classes in `SelectorPart.Classes` and `id` in a
-dedicated node field. `.classname` and `#id` are the reliable forms. Attribute
-selectors on `class` can behave differently offline depending on how the element
-was captured, and attribute selectors on `id` don't match offline at all — if you
-reach for one, `sel-probe`'s divergence check will flag it. Use `.classname` /
-`#id` when you can.
+**Attribute selectors on `class` and `id` match offline**, the same as live
+(`[class*=…]`, `[class^=…]`, `[class~=…]`, `[id^=…]`, `[id$=…]`, …). `class` and
+`id` are captured for every element (SVG included) and resolve to the same fields
+`.classname` / `#id` use. Prefer `.classname` / `#id` when a full class or id is
+stable — they're the shortest forms — but reach for the attribute forms when only
+a fragment is stable, e.g. `[id^="issue_"]` for dynamic `issue_<uuid>` ids.
+Verify any new selector with `sel-probe` regardless.
 
 **Pseudo-classes: `:not()`, `:is()`, `:where()`, `:has()` are supported**
 (both offline — `validate`/`snapshot`/`coverage`/`sel-check` — and live).
@@ -452,8 +452,6 @@ sightmap lint --warn-only   # deep-nesting warnings are expected; watch for new 
 **Async-rendered pages** (React/Next.js): use `--wait 1` or `--wait 2` for pages
 that render content after `loadEventFired`. Homedepot's `snapshot` includes
 `--wait 1` by default.
-
-**Class-attribute selectors** (`[class*="..."]`): don't work — use `.classname`.
 
 **Page non-determinism — a view needs MULTIPLE snapshots**. Real
 pages render differently load-to-load (lazy carousels, personalization, ad-driven

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -98,13 +98,13 @@ that `snapshot`/`coverage`/`capture` actually use — it prints both counts and 
 `⚠ offline/live divergence` warning when they disagree. Trust the **offline**
 count: that is what the corpus will see. Wrong match count = corrupt coverage.
 
-**Prefer `.class` over `[class*=…]`, and `#id` over `[id…]`.**
-The Go tree matcher keeps classes in `SelectorPart.Classes` and `id` in a
-dedicated node field. `.classname` and `#id` are the reliable forms. Attribute
-selectors on `class` can behave differently offline depending on how the element
-was captured, and attribute selectors on `id` don't match offline at all — if you
-reach for one, `sel-probe`'s divergence check will flag it. Use `.classname` /
-`#id` when you can.
+**Attribute selectors on `class` and `id` match offline**, the same as live
+(`[class*=…]`, `[class^=…]`, `[class~=…]`, `[id^=…]`, `[id$=…]`, …). `class` and
+`id` are captured for every element (SVG included) and resolve to the same fields
+`.classname` / `#id` use. Prefer `.classname` / `#id` when a full class or id is
+stable — they're the shortest forms — but reach for the attribute forms when only
+a fragment is stable, e.g. `[id^="issue_"]` for dynamic `issue_<uuid>` ids.
+Verify any new selector with `sel-probe` regardless.
 
 **Pseudo-classes: `:not()`, `:is()`, `:where()`, `:has()` are supported**
 (both offline — `validate`/`snapshot`/`coverage`/`sel-check` — and live).
@@ -452,8 +452,6 @@ sightmap lint --warn-only   # deep-nesting warnings are expected; watch for new 
 **Async-rendered pages** (React/Next.js): use `--wait 1` or `--wait 2` for pages
 that render content after `loadEventFired`. Homedepot's `snapshot` includes
 `--wait 1` by default.
-
-**Class-attribute selectors** (`[class*="..."]`): don't work — use `.classname`.
 
 **Page non-determinism — a view needs MULTIPLE snapshots**. Real
 pages render differently load-to-load (lazy carousels, personalization, ad-driven


### PR DESCRIPTION
## Problem

A selector you verify with `sel-probe` (live DOM) could still match **nothing** in `snapshot`/`coverage`/`capture`, which use the offline matcher against the extracted tree. Three concrete gaps:

1. **Attribute selectors on `id`** — `[id^="issue_"]`, `[id$=…]`, `[id]`, etc. matched **0 offline**. `id` is stored in a dedicated `SelectorPart` field, and the matcher only looked in `attrs`. This is common for dynamic ids (`issue_<uuid>`) where only a prefix is stable.
2. **`placeholder`** was never captured, so `input[placeholder="…"]` matched **0 offline**.
3. **SVG classes were dropped entirely.** On SVG elements `element.className` is an `SVGAnimatedString` (no `.split`), so the old `generateSelector` threw and fell back to the bare tag — losing id, classes, and attrs for every SVG. So `svg.lucide`, `[class*="lucide"]`, and `:has(svg.lucide-x)` all matched **0 offline**.

## Fix

- **Matcher** (`go/sel/match.go`): resolve `id`/`class` attribute selectors against the dedicated `Id`/`Classes` fields (falling back from `Attrs`). One small `effectiveAttrValue` helper; other attributes are unchanged.
- **probe.js**: use `element.classList` (a `DOMTokenList` on both HTML and SVG) instead of `element.className`, and add `placeholder` to the always-captured key attributes.

## Validation

Live `sel-probe` (live-vs-offline cross-check) on a running app, before vs after:

| selector | offline before | offline after | live |
|---|---|---|---|
| `svg.lucide` | 0 ⚠ divergence | **16** ✓ | 16 |
| `[id^="headlessui-menu"]` | 0 ⚠ divergence | **4** ✓ | 4 |
| `input[placeholder="Search commands..."]` | 0 ⚠ divergence | **1** ✓ | 1 |
| `[class*="lucide"]`, `svg[class*="lucide-"]`, `button[id]` | — | 16 / 16 / 12 ✓ | (parity) |

All divergence warnings gone.

- New conformance fixture `012-id-class-field-attrs` locks in `[id^=…]`-against-`id`-field and `[class*=…]`-against-`classes`-field (SVG) matching.
- Corrected the authoring skill + `docs/cli/selectors.mdx`, which wrongly stated class/id attribute selectors "don't work offline" (they do — for HTML and SVG). Embedded skills mirror regenerated.
- `go build ./... && go vet ./... && gofmt -l . && go test ./...` clean; spec `validate:conformance` clean.

Closes #41
