### PR TITLE
browser: report client-side redirects; add wait-for --view/--component

### DIFF
--- a/.changeset/report-spa-navigation.md
+++ b/.changeset/report-spa-navigation.md
@@ -1,0 +1,10 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Better handling of asynchronous SPA navigation, without baking implicit waits into `click`.
+
+- **`navigate` now reports client-side redirects.** It previously only saw server-side (HTTP) redirects, which are reflected by the load event; a client-side redirect that fires during hydration (an auth guard bouncing `/login → /`, or `/ → /workspace`) went unreported, so the caller was told it was somewhere it wasn't. `navigate` now waits briefly after load for a follow-up navigation and prints `(redirected to FINAL)` for those too.
+- **`wait-for` gains `--view` and `--component`.** These are the explicit, corpus-aware step boundaries to use after an action that should navigate (the act-then-wait split Playwright and Selenium use): `--view <Name>` waits until the current URL resolves to a named sightmap view, and `--component '<Query>'` waits until a component query — including property filters like `WorkItemRow[key="FALCON-7"]` — matches a node. Both auto-retry until they hold or time out loudly. `--url`, `--selector`, and `--load` remain the raw equivalents.
+
+`click` deliberately does **not** wait for or guess about resulting navigation — it acts, reports, and keeps its loud covered/off-screen refusals. Adds `browser.AwaitNavigation` (waits for `Page.frameNavigated` / `Page.navigatedWithinDocument`, settling chained redirects) behind `navigate`.

--- a/docs/cli/browser.mdx
+++ b/docs/cli/browser.mdx
@@ -124,7 +124,7 @@ With no session it prints `○ no session`. If a Chrome process for the site's p
 
 ### `browser navigate`
 
-Navigates the session to a URL and waits for the page to load. The URL is a positional argument. After a server-side redirect, `navigate` prints the requested and final URLs.
+Navigates the session to a URL and waits for the page to load. The URL is a positional argument. After a redirect — server-side or client-side (an SPA auth guard bouncing `/login → /`, or `/ → /workspace`) — `navigate` prints the requested and final URLs, so you know where you actually landed.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/cli/interaction.mdx
+++ b/docs/cli/interaction.mdx
@@ -44,7 +44,7 @@ Property predicates depend on `properties:` extraction. The Go CLI implements `p
 
 ### `browser click`
 
-Clicks an element. The target is a probe ID, a component query, or raw `--x` and `--y` coordinates. Before dispatching, it scrolls the target to the center of the viewport and verifies that its center is the top-most element there. It **errors** instead of silently doing nothing when the target cannot be positioned in the viewport, or is `covered by another element` (an open overlay or modal). On success it echoes a confirmation with the real post-scroll coordinates, e.g. `clicked CartNavButton @ (674,30)`. (`--x`/`--y` coordinate clicks skip the scroll-and-verify step.)
+Clicks an element. The target is a probe ID, a component query, or raw `--x` and `--y` coordinates. Before dispatching, it scrolls the target to the center of the viewport and verifies that its center is the top-most element there. It **errors** instead of silently doing nothing when the target cannot be positioned in the viewport, or is `covered by another element` (an open overlay or modal). On success it echoes a confirmation with the real post-scroll coordinates, e.g. `clicked CartNavButton @ (674,30)`. A click may trigger navigation that settles **after** the command returns (client-side SPA routing is asynchronous); `click` does not wait for it. Follow an action that should navigate with an explicit [`wait-for`](#browser-wait-for) on the destination — the same act-then-wait split Playwright and Selenium use. (`--x`/`--y` coordinate clicks skip the scroll-and-verify step.)
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -162,20 +162,25 @@ sightmap browser drag 214 --delta-x 120 --delta-y 0
 
 ### `browser wait-for`
 
-Waits for exactly one condition: `--url`, `--selector`, or `--load`. On success it echoes what it matched to stderr; on timeout it exits `1` with a message like `wait-for: timed out after 10000ms waiting for selector "..."`. Use it after an action that triggers navigation or asynchronous rendering.
+Waits for exactly one condition. It is the explicit step boundary after an action that triggers navigation or asynchronous rendering: act, then `wait-for` the postcondition. On success it echoes what it matched to stderr; on timeout it exits `1` with a message like `wait-for: timed out after 10000ms waiting for selector "..."`.
+
+The semantic conditions are corpus-aware and auto-retry until they hold: `--view` waits until the current URL resolves to a named sightmap view, and `--component` waits until a component query (name plus optional property filters, e.g. `WorkItemRow[key="FALCON-7"]`) matches at least one node on the live page. `--url` (a plain URL substring, not a glob or regex), `--selector`, and `--load` are the raw DOM/URL escape hatches — prefer `--view`/`--component` when the destination is in the corpus, since they absorb dynamic path segments and wait for real rendered content rather than a URL proxy.
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--addr` | `localhost:7892` | CDP address |
+| `--component` | none | Wait until this component query matches a node (e.g. `WorkItemDetail`) |
 | `--load` | off | Wait for the page load event |
-| `--selector` | none | Wait until a DOM element matching this selector appears |
+| `--selector` | none | Wait until a DOM element matching this CSS selector appears |
 | `--tab` | the lone content tab | Target tab ID |
 | `--timeout-ms` | `10000` | Timeout in milliseconds |
-| `--url` | none | Wait until the page URL contains this pattern |
+| `--url` | none | Wait until the page URL contains this **substring** (a plain substring, not a glob or regex) |
+| `--view` | none | Wait until the page URL resolves to this sightmap view |
 
 ```bash
 sightmap browser click 'CheckoutButton'
-sightmap browser wait-for --url '/checkout' --timeout-ms 15000
+sightmap browser wait-for --view Checkout            # URL resolves to the Checkout view
+sightmap browser wait-for --component 'OrderSummary' # or wait until a component appears
 ```
 
 ---

--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -59,6 +59,72 @@ func NavigateAndWait(ctx context.Context, conn *CDPConn, url string) error {
 	}
 }
 
+// AwaitNavigation waits up to maxWait for the page to navigate — either a full
+// document navigation (Page.frameNavigated) or a same-document SPA navigation
+// via history.pushState/replaceState (Page.navigatedWithinDocument). It returns
+// the settled final URL and true once a navigation is observed, or ("", false)
+// if none happens within maxWait. After the first navigation it waits a short
+// grace for chained redirects (e.g. /login → / → /workspace) to settle, so the
+// returned URL is the final destination rather than an intermediate hop.
+//
+// This surfaces async navigation that a click or a client-side redirect triggers
+// AFTER the initial load event has already fired — the signal an agent needs to
+// know an action actually moved the page. Callers should compare the result
+// against the pre-action URL and only report a move when it actually changed.
+func AwaitNavigation(ctx context.Context, conn *CDPConn, maxWait time.Duration) (string, bool) {
+	if err := conn.EnableDomain(ctx, "Page"); err != nil {
+		return "", false
+	}
+	frameCh := conn.Subscribe("Page.frameNavigated")
+	defer conn.Unsubscribe("Page.frameNavigated", frameCh)
+	docCh := conn.Subscribe("Page.navigatedWithinDocument")
+	defer conn.Unsubscribe("Page.navigatedWithinDocument", docCh)
+
+	const grace = 400 * time.Millisecond
+	overall := time.NewTimer(maxWait)
+	defer overall.Stop()
+	var graceTimer *time.Timer
+	var graceCh <-chan time.Time // nil until the first navigation; a nil channel never selects
+	navigated := false
+
+	for {
+		select {
+		case <-frameCh:
+			navigated = true
+		case <-docCh:
+			navigated = true
+		case <-graceCh:
+			url, _ := GetURL(ctx, conn)
+			return url, true
+		case <-overall.C:
+			if navigated {
+				url, _ := GetURL(ctx, conn)
+				return url, true
+			}
+			return "", false
+		case <-ctx.Done():
+			return "", false
+		case <-conn.done:
+			return "", false
+		}
+		// A navigation was seen; (re)arm the grace timer to absorb chained
+		// redirects, and return once navigations go quiet for `grace`.
+		if graceTimer == nil {
+			graceTimer = time.NewTimer(grace)
+			defer graceTimer.Stop()
+		} else {
+			if !graceTimer.Stop() {
+				select {
+				case <-graceTimer.C:
+				default:
+				}
+			}
+			graceTimer.Reset(grace)
+		}
+		graceCh = graceTimer.C
+	}
+}
+
 // GetURL returns the current page URL.
 // Uses Target.getTargetInfo — the result has a targetInfo.url field.
 func GetURL(ctx context.Context, conn *CDPConn) (string, error) {
@@ -533,6 +599,7 @@ func locateForClick(ctx context.Context, conn *CDPConn, id string) (clickTarget,
 // loudly when the target cannot be positioned in the viewport or is covered by
 // another element, instead of silently dispatching a click into empty space (the
 // off-screen no-op). A node with no data-sightmap-id and no bounds falls back to
+// A node with no data-sightmap-id and no bounds falls back to
 // a selector-based JS click() and returns (-1, -1).
 func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, int, error) {
 	if node.Id != "" {

--- a/go/browser/actions_test.go
+++ b/go/browser/actions_test.go
@@ -80,13 +80,17 @@ func newFakeCDP(t *testing.T, handler func(method string, params json.RawMessage
 					"result": result,
 				})
 
-				// Fire a loadEventFired event 50 ms after any navigate.
+				// Fire loadEventFired then frameNavigated 50 ms after any navigate.
 				if req.Method == "Page.navigate" {
 					go func() {
 						time.Sleep(50 * time.Millisecond)
 						writeMsg(map[string]interface{}{
 							"method": "Page.loadEventFired",
 							"params": map[string]interface{}{"timestamp": 1.0},
+						})
+						writeMsg(map[string]interface{}{
+							"method": "Page.frameNavigated",
+							"params": map[string]interface{}{"frame": map[string]interface{}{"url": "about:blank"}},
 						})
 					}()
 				}

--- a/go/browser/await_navigation_test.go
+++ b/go/browser/await_navigation_test.go
@@ -1,0 +1,45 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// AwaitNavigation returns (url, true) when a navigation event fires within the
+// window. The fake CDP emits Page.frameNavigated shortly after Page.navigate, so
+// triggering a navigate after AwaitNavigation has subscribed exercises the path.
+func TestAwaitNavigation_DetectsNavigation(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		return json.RawMessage(`{}`)
+	})
+	ctx := context.Background()
+
+	// Kick a navigate slightly after AwaitNavigation subscribes; the fake fires
+	// Page.frameNavigated 50 ms after that.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = Navigate(ctx, conn, "about:blank")
+	}()
+
+	_, moved := AwaitNavigation(ctx, conn, 2*time.Second)
+	if !moved {
+		t.Fatal("expected AwaitNavigation to report a navigation")
+	}
+}
+
+// With no navigation, AwaitNavigation returns ("", false) once maxWait elapses.
+func TestAwaitNavigation_TimesOutWhenStill(t *testing.T) {
+	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
+		return json.RawMessage(`{}`)
+	})
+	start := time.Now()
+	url, moved := AwaitNavigation(context.Background(), conn, 200*time.Millisecond)
+	if moved || url != "" {
+		t.Fatalf("expected no navigation, got url=%q moved=%v", url, moved)
+	}
+	if elapsed := time.Since(start); elapsed < 150*time.Millisecond {
+		t.Errorf("returned too early (%v); should wait out maxWait", elapsed)
+	}
+}

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -373,14 +373,21 @@ func runNavigate(args []string) error {
 	}
 	defer conn.Close()
 
-	if err := browser.NavigateAndWait(context.Background(), conn, url); err != nil {
+	ctx := context.Background()
+	if err := browser.NavigateAndWait(ctx, conn, url); err != nil {
 		return err
 	}
-	// Print the FINAL url after any server-side redirects, not the one we asked
-	// for — e.g. HD silently redirects some category URLs to a different
-	// category, and a caller needs to know where it actually landed.
-	finalURL, urlErr := browser.GetURL(context.Background(), conn)
-	if urlErr == nil && finalURL != "" && finalURL != url {
+	// The URL right after load reflects server-side (HTTP) redirects — e.g. HD
+	// silently redirects some category URLs, and a caller needs to know where it
+	// actually landed.
+	finalURL, _ := browser.GetURL(ctx, conn)
+	// A client-side (SPA) redirect fires AFTER the load event (an auth guard
+	// bouncing /login → /, or / → /last-workspace). GetURL alone misses it; wait
+	// briefly for a follow-up navigation so we report the real destination.
+	if clientURL, moved := browser.AwaitNavigation(ctx, conn, 2*time.Second); moved && clientURL != "" {
+		finalURL = clientURL
+	}
+	if finalURL != "" && finalURL != url {
 		fmt.Fprintf(os.Stderr, "navigated to %s\n  (redirected to %s)\n", url, finalURL)
 	} else {
 		fmt.Fprintf(os.Stderr, "navigated to %s\n", url)

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -14,7 +14,9 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/compquery"
 	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // ── Component ID resolution ───────────────────────────────────────────────────
@@ -120,6 +122,10 @@ func runClick(args []string) error {
 	} else {
 		fmt.Fprintf(os.Stderr, "clicked %s\n", fs.Arg(0))
 	}
+	// A click may trigger async (SPA) navigation that only settles after this
+	// returns. We deliberately do NOT wait here — waiting is the caller's explicit
+	// step: follow an action that should navigate with `wait-for --view/--component`
+	// (or --url), matching how Playwright/Selenium separate the act from the wait.
 	return nil
 }
 
@@ -314,8 +320,10 @@ func runWaitFor(args []string) error {
 	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
 	tabFlag := fs.String("tab", "", "Target tab ID (from 'browser start' output)")
 	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
-	urlPattern := fs.String("url", "", "Wait until the page URL contains this pattern")
-	selector := fs.String("selector", "", "Wait until a DOM element matching this selector appears")
+	urlPattern := fs.String("url", "", "Wait until the page URL contains this substring (not a glob/regex; prefer --view)")
+	selector := fs.String("selector", "", "Wait until a DOM element matching this CSS selector appears")
+	viewName := fs.String("view", "", "Wait until the page URL resolves to this sightmap view")
+	component := fs.String("component", "", "Wait until this component query matches a node (e.g. 'WorkItemDetail')")
 	loadFlag := fs.Bool("load", false, "Wait for the page load event")
 	timeoutMs := fs.Int("timeout-ms", 10000, "Timeout in milliseconds (default 10 000)")
 	if err := parseFlagsInterspersed(fs, args); err != nil {
@@ -323,17 +331,13 @@ func runWaitFor(args []string) error {
 	}
 
 	n := 0
-	if *urlPattern != "" {
-		n++
-	}
-	if *selector != "" {
-		n++
-	}
-	if *loadFlag {
-		n++
+	for _, set := range []bool{*urlPattern != "", *selector != "", *viewName != "", *component != "", *loadFlag} {
+		if set {
+			n++
+		}
 	}
 	if n != 1 {
-		return fmt.Errorf("usage: browser wait-for (--url PATTERN | --selector SEL | --load)")
+		return fmt.Errorf("usage: browser wait-for (--url PATTERN | --selector SEL | --view NAME | --component QUERY | --load)")
 	}
 
 	ctx, cancel := context.WithTimeout(
@@ -359,6 +363,14 @@ func runWaitFor(args []string) error {
 		what = fmt.Sprintf("selector %q", *selector)
 		done = fmt.Sprintf("matched selector %q", *selector)
 		waitErr = browser.WaitForSelector(ctx, conn, *selector)
+	case *viewName != "":
+		what = fmt.Sprintf("view %q", *viewName)
+		done = fmt.Sprintf("view %q now matches the page URL", *viewName)
+		waitErr = waitForView(ctx, conn, *sightmapDirFlag, *viewName)
+	case *component != "":
+		what = fmt.Sprintf("component query %q", *component)
+		done = fmt.Sprintf("component query %q now matches", *component)
+		waitErr = waitForComponent(ctx, conn, *sightmapDirFlag, *component)
 	default:
 		what = "page load"
 		done = "page load complete"
@@ -372,6 +384,50 @@ func runWaitFor(args []string) error {
 	}
 	fmt.Fprintln(os.Stderr, done)
 	return nil
+}
+
+// waitForView polls until the current page URL resolves to the view named
+// viewName in the corpus at sightmapDir, or ctx expires. The corpus is loaded
+// once up front (view routes don't change mid-wait); only the URL is re-read.
+func waitForView(ctx context.Context, conn *browser.CDPConn, sightmapDir, viewName string) error {
+	corpus, err := sightmap.Load(sightmapDir)
+	if err != nil {
+		return fmt.Errorf("wait-for --view: load corpus: %w", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		url, _ := browser.GetURL(ctx, conn)
+		if v := corpus.ViewForURL(url); v != nil && v.Name == viewName {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// waitForComponent polls until the component query matches at least one node on
+// the live page, or ctx expires. The query syntax is validated up front so a
+// typo fails immediately instead of silently timing out. Each poll re-extracts
+// the live tree (so property-filtered queries like `Row[state="Done"]` are
+// honored), which is the same resolve path a `click 'Query'` uses.
+func waitForComponent(ctx context.Context, conn *browser.CDPConn, sightmapDir, query string) error {
+	if _, err := compquery.ParseQuery(query); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if node, err := resolveComponentQuery(ctx, conn, sightmapDir, query); err == nil && node != nil {
+			return nil
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
 }
 
 // ── dialog ────────────────────────────────────────────────────────────────────

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -87,7 +87,9 @@ probe ID from snapshot output **or** a component query (see below):
 | `sightmap browser scroll --delta-y 500` | Scroll the page |
 | `sightmap browser scroll --component-id <id-or-query>` | Scroll a component into view |
 | `sightmap browser click --x N --y N` | Click raw coordinates (escape hatch; layout-fragile) |
-| `sightmap browser wait-for --selector "[data-loaded]"` | Wait for element |
+| `sightmap browser wait-for --view <Name>` | Wait until the URL resolves to a sightmap view (the step boundary after a navigating action) |
+| `sightmap browser wait-for --component '<Query>'` | Wait until a component query matches a node |
+| `sightmap browser wait-for --selector "[data-loaded]"` | Wait until a CSS selector matches (also `--url SUBSTRING` (plain substring, not glob), `--load`) |
 | `sightmap browser tabs list` | List open tabs |
 
 ### Component queries (CSS-shaped, over sightmap components + extracted properties)
@@ -153,6 +155,14 @@ sightmap browser fill --clear 'SearchInput' 'burrito'
 **`browser click` scrolls the target into view and refuses off-screen / covered clicks.**
 `click` scrolls the element to the center of the viewport, then verifies its center is actually the top-most element there before dispatching. It **errors** (rather than silently no-op'ing) when the target can't be positioned in the viewport, or is `covered by another element` — the signal of an open overlay/modal or a target you need to reveal first. The confirmation line reports the real post-scroll coordinates it clicked.
 
+**After an action that should navigate, wait for the destination — don't snapshot immediately.**
+SPA (client-side) navigation lands *after* `click` returns, so a snapshot taken right away shows the old page. `click` deliberately does not guess or wait; make the wait an explicit step, the way Playwright/Selenium do:
+```
+sightmap browser click 'WorkItemRow[key="FALCON-7"]'
+sightmap browser wait-for --view WorkItemDetail      # or --component 'WorkItemDetail', or --url '/browse/'
+```
+`wait-for` auto-retries until the postcondition holds or it times out (loudly). Record per-app async quirks (which actions navigate, slow routes) in the relevant view/component `memory` so the next agent knows to wait.
+
 **`browser eval` cannot return DOM elements.**
 Only JSON-serializable values are returned. `document.querySelector(...)` returns an error reference. Extract what you need instead: `document.querySelector("sel")?.textContent`.
 
@@ -163,4 +173,4 @@ Only JSON-serializable values are returned. `document.querySelector(...)` return
 Page commands auto-pick the lone content tab but error (listing tabs) when zero or several are open. `browser start` prints your tab ID; thread it through as `--tab <ID>`.
 
 **`browser navigate` prints the final URL.**
-After a server-side redirect, `navigate` prints `(redirected to FINAL)` so you know where you actually landed.
+After a redirect — server-side *or* client-side (an SPA auth guard bouncing `/login → /`, or `/ → /workspace`) — `navigate` prints `(redirected to FINAL)` so you know where you actually landed, not just the URL you asked for.

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -87,7 +87,9 @@ probe ID from snapshot output **or** a component query (see below):
 | `sightmap browser scroll --delta-y 500` | Scroll the page |
 | `sightmap browser scroll --component-id <id-or-query>` | Scroll a component into view |
 | `sightmap browser click --x N --y N` | Click raw coordinates (escape hatch; layout-fragile) |
-| `sightmap browser wait-for --selector "[data-loaded]"` | Wait for element |
+| `sightmap browser wait-for --view <Name>` | Wait until the URL resolves to a sightmap view (the step boundary after a navigating action) |
+| `sightmap browser wait-for --component '<Query>'` | Wait until a component query matches a node |
+| `sightmap browser wait-for --selector "[data-loaded]"` | Wait until a CSS selector matches (also `--url SUBSTRING` (plain substring, not glob), `--load`) |
 | `sightmap browser tabs list` | List open tabs |
 
 ### Component queries (CSS-shaped, over sightmap components + extracted properties)
@@ -153,6 +155,14 @@ sightmap browser fill --clear 'SearchInput' 'burrito'
 **`browser click` scrolls the target into view and refuses off-screen / covered clicks.**
 `click` scrolls the element to the center of the viewport, then verifies its center is actually the top-most element there before dispatching. It **errors** (rather than silently no-op'ing) when the target can't be positioned in the viewport, or is `covered by another element` — the signal of an open overlay/modal or a target you need to reveal first. The confirmation line reports the real post-scroll coordinates it clicked.
 
+**After an action that should navigate, wait for the destination — don't snapshot immediately.**
+SPA (client-side) navigation lands *after* `click` returns, so a snapshot taken right away shows the old page. `click` deliberately does not guess or wait; make the wait an explicit step, the way Playwright/Selenium do:
+```
+sightmap browser click 'WorkItemRow[key="FALCON-7"]'
+sightmap browser wait-for --view WorkItemDetail      # or --component 'WorkItemDetail', or --url '/browse/'
+```
+`wait-for` auto-retries until the postcondition holds or it times out (loudly). Record per-app async quirks (which actions navigate, slow routes) in the relevant view/component `memory` so the next agent knows to wait.
+
 **`browser eval` cannot return DOM elements.**
 Only JSON-serializable values are returned. `document.querySelector(...)` returns an error reference. Extract what you need instead: `document.querySelector("sel")?.textContent`.
 
@@ -163,4 +173,4 @@ Only JSON-serializable values are returned. `document.querySelector(...)` return
 Page commands auto-pick the lone content tab but error (listing tabs) when zero or several are open. `browser start` prints your tab ID; thread it through as `--tab <ID>`.
 
 **`browser navigate` prints the final URL.**
-After a server-side redirect, `navigate` prints `(redirected to FINAL)` so you know where you actually landed.
+After a redirect — server-side *or* client-side (an SPA auth guard bouncing `/login → /`, or `/ → /workspace`) — `navigate` prints `(redirected to FINAL)` so you know where you actually landed, not just the URL you asked for.


### PR DESCRIPTION
## Problem

On a single-page app, navigation triggered by an action settles **asynchronously** — the URL updates after the action's command has already returned. So:

1. An agent clicks something, snapshots immediately, sees the *old* page, and silently proceeds on a wrong assumption (the dominant failure mode in the Plane eval: "row clicks that silently don't navigate + SPA loading stalls").
2. **`navigate` under-reported where you landed** — it read the URL right after `loadEventFired`, catching only server-side (HTTP) redirects. A client-side redirect during hydration (an auth guard bouncing `/login → /`, or `/ → /workspace`) went unreported.

## Approach

The established model (Playwright, Selenium, Cypress) keeps the **act** and the **wait** separate: you act, then explicitly wait on a postcondition that auto-retries — Playwright even documents `page.click(...)` then `page.waitForURL(...)`. An earlier revision of this PR baked an implicit `<a>`-gated wait into `click`; that was the clever-but-unpredictable path (incomplete for button/`div`-triggered nav, false 3s stalls on `href="#"`), so it's dropped in favor of the explicit model.

- **`navigate` reports client-side redirects.** After load it waits briefly for a follow-up navigation and prints `(redirected to FINAL)` for client-side redirects too, so you know where you actually landed.
- **`wait-for` gains `--view` and `--component`** — the corpus-aware step boundaries to use after a navigating action:
  - `--view <Name>` — until the current URL resolves to that sightmap view.
  - `--component '<Query>'` — until a component query (with property filters, e.g. `WorkItemRow[key="FALCON-7"]`) matches a node.
  
  Both auto-retry until they hold or time out loudly; `--url`/`--selector`/`--load` remain the raw equivalents.
- **`click` is unchanged** — it acts, reports coordinates, and keeps its loud covered/off-screen refusals, but does not wait for or guess about navigation.

Adds `browser.AwaitNavigation` (waits for `Page.frameNavigated` / `Page.navigatedWithinDocument`, settling chained redirects) behind `navigate`.

## Validation

Unit tests for `AwaitNavigation`. Live against Plane (Next.js, authenticated):

```
$ browser navigate 'http://localhost:3000/'
navigated to http://localhost:3000/
  (redirected to http://localhost:3000/gnusto/)

$ browser click 'SidebarNavLink[label="Projects"]'
clicked SidebarNavLink[label="Projects"] @ (133,321)
$ browser wait-for --view ProjectsList
view "ProjectsList" now matches the page URL          # landed at /gnusto/projects/

$ browser wait-for --component 'SidebarNavLink[label="Your work"]'
component query "SidebarNavLink[label=\"Your work\"]" now matches

$ browser wait-for --view NoSuchView --timeout-ms 1500
wait-for: timed out after 1500ms waiting for view "NoSuchView"   # (exit 1)
```

`go build ./... && go vet ./... && gofmt -l . && go test ./...` clean; skills + docs updated to teach the act-then-`wait-for` pattern, embedded skills mirror regenerated.

Closes #43
