### PR TITLE
docs(readme): add Install section with recommended npm flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,23 @@ implementation, and both websites in one place:
 
 Each area has its own README with build and contribution details.
 
+## Install
+
+The `sightmap` CLI is published to npm. Install it globally:
+
+```bash
+npm install -g @sightmap/sightmap
+sightmap version
+```
+
+Or run it without installing: `npx @sightmap/sightmap <command>`. Building from
+source (Go) is covered in [`go/`](go/).
+
 ## Quickstart
 
-Drop a `.sightmap/` directory at your project root. Every `*.yaml` / `*.yml`
-file under it is discovered recursively and merged.
+Install the CLI (above), then drop a `.sightmap/` directory at your project
+root. Every `*.yaml` / `*.yml` file under it is discovered recursively and
+merged.
 
 ```yaml
 # .sightmap/home.yaml


### PR DESCRIPTION
## What

The README's Quickstart jumped straight to authoring a `.sightmap/` directory without showing how to get the `sightmap` CLI, and the npm package (`@sightmap/sightmap`) was only referenced in passing in the repo table and Skills section.

## Changes

- Add an **Install** section before Quickstart, leading with the recommended global install:
  ```bash
  npm install -g @sightmap/sightmap
  sightmap version
  ```
- Note the `npx` one-off path and point to [`go/`](go/) for the from-source build.
- Quickstart now references the CLI as already installed.

Addresses review feedback that the recommended package-manager install path wasn't echoed in the Quickstart/Setup, since the blog post links to the GitHub README rather than sightmap.org.