### PR TITLE
Hide the Ask Assistant topbar button

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -10,3 +10,13 @@
 .nav-logo {
   height: 20px !important;
 }
+
+/* Hide the "Ask Assistant" entry points. The AI assistant is disabled for this
+   site, but the topbar button is site chrome the dashboard toggle doesn't always
+   remove. If the assistant is ever enabled, delete this rule. Selectors are
+   Mintlify's documented hooks:
+   https://www.mintlify.com/docs/customize/custom-scripts */
+#assistant-entry,
+#assistant-entry-mobile {
+  display: none;
+}


### PR DESCRIPTION
Mirror of the subtext-docs change: hide the "Ask Assistant" topbar button, which renders as site chrome even when the assistant is disabled.

## Change

Appends a rule to the existing auto-included `docs/style.css` hiding Mintlify's documented topbar entry points, desktop and mobile:

```css
#assistant-entry, #assistant-entry-mobile { display: none; }
```

No-op if the button isn't present; hidden if it is. If the assistant is ever enabled, delete the rule.

## Verification

`mint validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)