### PR TITLE
docs: frame getting-started steps from the agent's point of view

### DIFF
--- a/docs/authoring/overview.mdx
+++ b/docs/authoring/overview.mdx
@@ -14,11 +14,11 @@ Complete [Install](/start/install) and [Quickstart](/start/quickstart) first. Yo
 - A running copy of the web app.
 - A `.sightmap/` directory in the project.
 
-The CLI drives Chrome, applies the corpus to the live DOM, and reports which interactive nodes remain unnamed.
+The agent drives Chrome through the CLI, applies the corpus to the live DOM, and reads back which interactive nodes remain unnamed.
 
 ## Run the edit-verify loop
 
-Work through one route at a time.
+The commands below are what the agent runs through the `sightmap-authoring` skill; you review the diff before it lands. The agent works through one route at a time.
 
 <Steps>
 <Step title="Start a session">
@@ -28,12 +28,12 @@ cd my-app
 sightmap browser start --url 'https://example.com/products'
 ```
 
-`browser start` launches Chrome and the corpus server in the foreground. Leave it running and use another terminal for the remaining commands. The server reloads the YAML whenever it changes.
+The agent starts the session with `browser start`, which launches Chrome and the corpus server. The server reloads the YAML whenever the agent changes it.
 
 </Step>
 <Step title="Iterate a page">
 
-Run `snapshot --coverage` with the page URL:
+The agent runs `snapshot --coverage` with the page URL:
 
 ```bash
 sightmap snapshot --coverage --url 'https://example.com/products'
@@ -65,20 +65,20 @@ Coverage assigns every interactive node a tier:
 </Step>
 <Step title="Verify the suggested selector">
 
-Probe the suggested selector against the live page before adding it to YAML:
+The agent probes the suggested selector against the live page before adding it to YAML:
 
 ```bash
 sightmap sel-probe -- '[data-testid="product-pod"] button'
 ```
 
-`sel-probe` reports the match count, key attributes, and parent chain for each match. Check that the count and matched elements are what you intended.
+`sel-probe` reports the match count, key attributes, and parent chain for each match — the agent checks that the count and matched elements are what it intended.
 
 See [Selector tools](/cli/selectors) for live and offline checks, and [Selectors](/concepts/selectors) for selector strategy.
 
 </Step>
 <Step title="Name what's unnamed">
 
-Add the component to the matching view:
+The agent adds the component to the matching view:
 
 ```yaml .sightmap/views/products.yaml
 version: 1
@@ -94,7 +94,7 @@ views:
             selector: 'button[data-testid="atc"]'
 ```
 
-Validate after each edit:
+It validates after each edit:
 
 ```bash
 sightmap validate
@@ -107,7 +107,7 @@ See [Components](/spec/components) for the complete component format.
 </Step>
 <Step title="Repeat">
 
-Re-run `snapshot --coverage` and work through the remaining T3 clusters. A route reaches the baseline when coverage reports `0 orphaned T3 ✓`. Then review its T2 scopes.
+The agent re-runs `snapshot --coverage` and works through the remaining T3 clusters. A route reaches the baseline when coverage reports `0 orphaned T3 ✓`. Then it reviews the T2 scopes.
 
 </Step>
 </Steps>
@@ -122,7 +122,7 @@ Zero T3 means every interactive node has a named ancestor. It does not mean ever
 
 A **T2-tight** scope has one unnamed interactive child under a named component. Its role and accessible name may be enough to identify it. A **T2-loose** scope has several unnamed interactive children under the same component, which makes attribution ambiguous.
 
-Run `sightmap snapshot --trace` to inspect those scopes. Add child components where stable selectors exist. If a third-party widget or generated markup has no stable selector, record that limitation in `memory`.
+The agent runs `sightmap snapshot --trace` to inspect those scopes and adds child components where stable selectors exist. If a third-party widget or generated markup has no stable selector, it records that limitation in `memory`.
 
 See [Coverage](/cli/coverage) for the complete T1, T2, and T3 model.
 
@@ -149,7 +149,7 @@ sightmap lint
 
 Keep the corpus current as the app changes:
 
-- Re-run `snapshot --coverage` on affected pages. Coverage exposes new orphaned nodes while existing selectors and `memory` remain in the corpus.
+- Have your agent re-run `snapshot --coverage` on affected pages. Coverage exposes new orphaned nodes while existing selectors and `memory` remain in the corpus.
 - Remove stale selectors and `memory`. If you can fix a documented quirk in the app, fix it and delete the note.
 - Run `sightmap validate` and `sightmap lint` in CI.
 - If you maintain saved view sets, refresh them with `sightmap capture --all`, then run `sightmap report`.

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -6,6 +6,8 @@ description: "Learn the flag placement, session flags, visibility defaults, and 
 
 The `sightmap` CLI drives Chrome for Testing over the Chrome DevTools Protocol (CDP). Its commands apply `.sightmap/` to the live page, capture annotated snapshots, measure coverage, validate selectors, and interact with page elements. This page covers conventions shared across command groups.
 
+In the standard authoring workflow, the `sightmap-authoring` and `sightmap-browser` skills run these commands for the agent; this reference documents the surface they drive. You can also run any command directly.
+
 <Note>
 See [Install the Sightmap CLI](/start/install) for all install options. To install directly, run `npm install -g @sightmap/sightmap` or `go install github.com/sightmap/sightmap/go/cmd/sightmap@latest`.
 </Note>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -52,7 +52,7 @@ A bare accessibility snapshot has no view name, component identity, or indicatio
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/start/quickstart">
-    Install the CLI, start a browser session, and build a `.sightmap/` against any running web app.
+    Install the CLI, then have your agent build a `.sightmap/` against any running web app.
   </Card>
   <Card title="CLI reference" icon="terminal" href="/cli/overview">
     `sightmap` commands for browser sessions, snapshots, coverage, selectors, and corpus health.
@@ -67,18 +67,20 @@ A bare accessibility snapshot has no view name, component identity, or indicatio
 
 ## How Sightmap works
 
+An agent does the mapping. You install the skills once and review the diff before it lands.
+
 <Steps>
-  <Step title="Install the CLI and skills">
-    Install the `sightmap` binary with `npm install -g @sightmap/sightmap`, then run `sightmap skills install` to add the bundled authoring and browser skills to your agent harness.
+  <Step title="Install the skills (once)">
+    Run `npm install -g @sightmap/sightmap`, then `sightmap skills install` to add the `sightmap-authoring` and `sightmap-browser` skills to your agent harness. This is the one-time human setup.
   </Step>
-  <Step title="Start a browser session">
-    `sightmap browser start` launches Chrome and a local corpus server that reloads the YAML when it changes.
+  <Step title="Point your agent at the running app">
+    Give your agent the app's URL and ask it to build a sightmap. It runs `sightmap browser start` to launch Chrome and a local corpus server that reloads the YAML as it changes.
   </Step>
-  <Step title="Let an agent iterate">
-    Run `sightmap snapshot --coverage --url <url>` for each route. The command reads the page and identifies unattributed interactive nodes. The agent names those components and runs it again until the view reports zero orphaned nodes.
+  <Step title="The agent maps each view">
+    Through the `sightmap-authoring` skill, the agent runs `sightmap snapshot --coverage` on each route, names the interactive nodes that come back unattributed, and repeats until every view reports zero orphaned nodes.
   </Step>
-  <Step title="Check it in">
-    Run `sightmap validate`, `sightmap lint`, and `sightmap report`, then commit `.sightmap/`. Sightmap-enabled agents and tools can now read the same checked-in context.
+  <Step title="Review and check in">
+    The agent validates and lints as it goes. You review the diff and commit `.sightmap/` — Sightmap-enabled agents and tools then read the same checked-in context.
   </Step>
 </Steps>
 

--- a/docs/start/install.mdx
+++ b/docs/start/install.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Install"
 description: "Install the Sightmap CLI and agent skills, or add the Go library and schema validation to your project."
 ---
 
-Most users should install the `sightmap` CLI from npm, then add the bundled agent skills.
+Most users should install the `sightmap` CLI from npm, then add the bundled agent skills. This is a one-time setup — afterward your agent drives the browser session and runs the CLI through those skills.
 
 ## The CLI
 

--- a/docs/start/quickstart.mdx
+++ b/docs/start/quickstart.mdx
@@ -4,33 +4,40 @@ sidebarTitle: "Quickstart"
 description: "Install the CLI, start a browser session, and build a checked-in .sightmap/ against your running app."
 ---
 
-Use the `sightmap-authoring` skill to inspect a running app and write a `.sightmap/` directory in your repo. The CLI can reach a local dev server, preview deployment, or hosted URL. The agent writes the YAML; you review the diff before committing it.
+Hand a running app to your agent and it builds a `.sightmap/` directory in your repo — driving the browser and running the CLI through the `sightmap-authoring` skill. The app can be a local dev server, preview deployment, or hosted URL. The agent writes the YAML; you review the diff before committing it.
 
 <Steps>
-  <Step title="Install the CLI and skills">
+  <Step title="Install the CLI and skills (once)">
     ```bash
     npm install -g @sightmap/sightmap
     sightmap skills install
     ```
 
     `sightmap skills install` writes `sightmap-authoring` and `sightmap-browser` to `~/.agents/skills`. Pass `--target <dir>` to use another directory. See [Install](/start/install) for the `npx`, Go, and browser-install options.
+
+    This is the one-time human setup. From here on, your agent runs the browser session and the CLI through these skills.
   </Step>
 
-  <Step title="Start a browser session">
+  <Step title="Hand your agent the app">
+    Point your agent at the running app and give it a prompt like:
+
+    > Build a sightmap for this app at `http://localhost:3000/`. Start a browser session, inspect the main routes with `sightmap snapshot --coverage`, verify each selector with `sightmap sel-probe`, and name components until every view has zero orphaned T3 nodes. Let me review the YAML before committing it.
+
+    Through the `sightmap-authoring` skill, the agent starts the session itself:
+
     ```bash
-    cd my-app
     sightmap browser start --url 'http://localhost:3000/'
     ```
 
-    Run this from your project root. `browser start` launches Chrome and the local corpus server in the foreground. Leave it running, then use another terminal for the remaining commands.
+    `browser start` launches Chrome and the local corpus server, which reloads the YAML whenever the agent changes it.
+
+    <Note>
+    Prefer to drive it yourself? Run `sightmap browser start` from your project root, leave it in the foreground, and use another terminal for the loop commands below.
+    </Note>
   </Step>
 
-  <Step title="Have an agent build the corpus">
-    Give your agent this prompt:
-
-    > Build a sightmap for this app. Inspect the main routes with `sightmap snapshot --coverage`, verify each selector with `sightmap sel-probe`, and name components until every view has zero orphaned T3 nodes. Let me review the YAML before committing it.
-
-    The agent repeats this edit-and-verify loop:
+  <Step title="The agent runs the edit-verify loop">
+    For each route, the agent repeats this loop:
 
     ```bash
     sightmap snapshot --coverage --url 'http://localhost:3000/'
@@ -50,16 +57,18 @@ Use the `sightmap-authoring` skill to inspect a running app and write a `.sightm
            → [data-testid="product-pod"] button
     ```
 
-    `T1` nodes have their own component name. `T2` nodes sit inside a named component. `T3` nodes have no named ancestor. Keep iterating until each view reports `0 orphaned T3 ✓`.
+    `T1` nodes have their own component name. `T2` nodes sit inside a named component. `T3` nodes have no named ancestor. The agent keeps iterating until each view reports `0 orphaned T3 ✓`.
   </Step>
 
-  <Step title="Validate and review">
+  <Step title="Review and commit">
+    The agent validates and lints as it works:
+
     ```bash
     sightmap validate
     sightmap lint
     ```
 
-    `validate` checks the YAML structure and exits nonzero on errors. `lint` reports advisory quality issues. Review the new or changed YAML before committing it:
+    `validate` checks the YAML structure and exits nonzero on errors; `lint` reports advisory quality issues. When the agent reports the views clean, review the new or changed YAML and commit it:
 
     ```text
     .sightmap/
@@ -76,7 +85,7 @@ Use the `sightmap-authoring` skill to inspect a running app and write a `.sightm
 
 If the app has no stable selector for a component, add `data-component="ComponentName"` to the source. This gives Sightmap an explicit runtime hook.
 
-When a route or component changes, rerun `sightmap snapshot --coverage` on the affected pages. Existing selectors and `memory` entries remain in the corpus, while coverage exposes new orphaned nodes.
+When a route or component changes, have your agent rerun `sightmap snapshot --coverage` on the affected pages. Existing selectors and `memory` entries remain in the corpus, while coverage exposes new orphaned nodes.
 
 ## Next steps
 

--- a/docs/start/what-is-sightmap.mdx
+++ b/docs/start/what-is-sightmap.mdx
@@ -24,7 +24,7 @@ The format is plain YAML validated against a [public JSON Schema](/reference/jso
 
 ## Where to go next
 
-- [Quickstart](/start/quickstart) to install the CLI and build a `.sightmap/` against a running app.
+- [Quickstart](/start/quickstart) to install the CLI and have an agent build a `.sightmap/` against a running app.
 - [Authoring overview](/authoring/overview) for the complete curation and maintenance workflow.
 - [Sightmap vs. other formats](/concepts/vs) to compare Sightmap with README files, agent rules, sitemaps, and OpenAPI.
 - [Schema reference](/reference/schema) for every version 1 field and constraint.


### PR DESCRIPTION
The getting-started docs read as if a human types the `sightmap` commands. In practice the agent runs the browser session and the full edit-verify loop through the `sightmap-authoring` and `sightmap-browser` skills; the human installs once and reviews the diff.

Reframed accordingly:

- **Overview, Quickstart, Authoring workflow** — the agent drives the browser and runs the CLI loop; the human installs the skills once and reviews/commits. Quickstart splits the old human-run "start a browser session" step into an agent-run session plus the edit-verify loop, keeping manual driving as a secondary note.
- **CLI reference, Install, What is Sightmap** — one-line framing notes; the reference stays command-neutral.

No command, YAML, or output examples changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)