### PR TITLE
ci(docs): make schema-sync drift self-explanatory + opt-in hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Opt-in pre-commit hook. Enable once with:
+#
+#   git config core.hooksPath .githooks
+#
+# Keeps generated-then-checked-in artifacts from drifting locally so you don't
+# discover it in CI. Currently guards the docs schema page, which is generated
+# from the canonical spec (see docs/scripts/sync-spec.mjs).
+#
+# Only regenerates when the inputs are staged, so ordinary commits stay fast.
+# Bypass with `git commit --no-verify` if you ever need to.
+
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Schema page: regenerate when the canonical spec or the generator is staged,
+# then re-stage the result if it changed.
+if git diff --cached --name-only | grep -qE '^(spec/v1/schema\.md|docs/scripts/sync-spec\.mjs)$'; then
+  node docs/scripts/sync-spec.mjs >/dev/null
+  if ! git diff --quiet -- docs/reference/schema.md; then
+    git add docs/reference/schema.md
+    echo "pre-commit: regenerated docs/reference/schema.md from spec/v1/schema.md and staged it."
+  fi
+fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Schema page in sync
         run: |
           node docs/scripts/sync-spec.mjs
-          git diff --exit-code docs/reference/schema.md
+          if ! git diff --exit-code docs/reference/schema.md; then
+            echo "::error::docs/reference/schema.md is out of sync with spec/v1/schema.md."
+            echo "Run 'npm run sync-docs' (or 'node docs/scripts/sync-spec.mjs') and commit docs/reference/schema.md."
+            exit 1
+          fi
 
       - name: Install Mintlify CLI
         run: npm i -g mint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,21 @@ The repo is split by area; set up only what you're touching.
 
 CI runs the relevant checks per area on every PR.
 
+### Generated files
+
+A couple of artifacts are **generated from a canonical source and checked in**, and CI fails if they drift:
+
+- `docs/reference/schema.md` — generated from `spec/v1/schema.md`. Regenerate with `npm run sync-docs` (or `node docs/scripts/sync-spec.mjs`).
+- `go/skills/<name>/` — generated from the canonical `skills/`. Regenerate with `go generate ./skills/...` from `go/`.
+
+If you edit `spec/v1/schema.md`, run `npm run sync-docs` and commit the regenerated page in the same PR. To have this happen automatically on commit, enable the opt-in git hooks once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+The hook regenerates and stages the schema page only when its inputs are staged; bypass any time with `git commit --no-verify`.
+
 ## Pull request expectations
 
 - **One concern per PR.** If you fix two unrelated bugs, that's two PRs. Small PRs get reviewed fast.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "changeset": "npx --yes @changesets/cli@^2.27.0",
-    "version-packages": "npx --yes @changesets/cli@^2.27.0 version && node scripts/sync-manifest-versions.mjs"
+    "version-packages": "npx --yes @changesets/cli@^2.27.0 version && node scripts/sync-manifest-versions.mjs",
+    "sync-docs": "node docs/scripts/sync-spec.mjs"
   }
 }


### PR DESCRIPTION
## Why

`docs/reference/schema.md` is generated from the canonical `spec/v1/schema.md` and checked in (Mintlify has no build step), guarded by a CI drift gate. When a PR edits the spec but forgets to regenerate the page, the gate failed with a bare `git diff --exit-code` — a wall of diff and no hint about the remedy. That made an easy-to-fix mistake look like a broken sync process.

## What

- **`docs.yml`** — on drift, print the exact fix (`npm run sync-docs` / `node docs/scripts/sync-spec.mjs` and commit). Mirrors the existing skills-embed drift gate in `go.yml`, which already does this.
- **`package.json`** — add a `sync-docs` script so there's one canonical, memorable regenerate command that CI, the hook, and humans all reference.
- **`.githooks/pre-commit`** — opt-in hook (enable once with `git config core.hooksPath .githooks`) that regenerates and stages the schema page, but only when its inputs (`spec/v1/schema.md` or the generator) are staged, so ordinary commits stay fast. Bypassable with `--no-verify`.
- **`CONTRIBUTING.md`** — document the generated-then-checked-in artifacts and how to enable the hook.

## Notes

The CI drift gate remains the source of truth — it's the only mechanism that can't be bypassed and that works on fork PRs. This PR just makes its failure self-explanatory and gives contributors an easy local guardrail. No auto-commit-from-CI (fork PRs get a read-only token, and bot-pushed commits don't retrigger checks).

Docs/infra-only; no changeset (doesn't touch the published `go/` package).
