### PR TITLE
test: add changeset to verify release automation

### DIFF
--- a/.changeset/verify-changeset-workflow.md
+++ b/.changeset/verify-changeset-workflow.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Verify the changesets release automation end-to-end: no functional change.


### PR DESCRIPTION
## Summary
- Adds a patch changeset for `@sightmap/sightmap` with no functional change, to confirm the changesets release workflow (`.github/workflows/release.yml`) opens a "Version Packages" PR on merge.

## Test plan
- [ ] Merge this PR
- [ ] Confirm a "Version Packages" PR appears, bumping `go/npm/package.json` and `go/npm/CHANGELOG.md`
- [ ] Merge the Version Packages PR and confirm the release job tags, builds, and publishes