### PR TITLE
sightmap: read file-level memory, lower go floor to 1.23

### DIFF
--- a/.changeset/vibium-file-memory-go-floor.md
+++ b/.changeset/vibium-file-memory-go-floor.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Go library: `Corpus.Memory` now carries file-level `memory` entries (the loader previously dropped them). Lower the module's `go` directive from 1.25.2 to 1.23, its actual dependency floor, so consumers aren't forced onto a newer toolchain than the code requires.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/sightmap/sightmap/go
 
-go 1.25.2
+go 1.23
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -14,6 +14,14 @@ import (
 // handle callers hold: load one with Load (or a Loader), then MatchTree a live
 // component tree against it. Safe for concurrent use.
 type Corpus struct {
+	// Memory holds file-level memory entries from every corpus file, in
+	// file-path order. The spec activates these per source file ("applies
+	// whenever any definition from that file is active"); we don't track
+	// which flattened component or view came from which file, so entries
+	// are concatenated corpus-wide instead of scoped to their file's
+	// definitions. Tighten this if per-file activation is ever needed.
+	Memory []string
+
 	// GlobalComponents is the flat list of globally-defined components
 	// (from components.yaml), with children already flattened.
 	GlobalComponents []match.SightmapComponent

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -41,6 +41,7 @@ func DirLoader(path string) Loader {
 
 type rawFile struct {
 	Version    int            `yaml:"version"`
+	Memory     []string       `yaml:"memory"`
 	Components []rawComponent `yaml:"components"`
 	Views      []rawView      `yaml:"views"`
 	URL        string         `yaml:"url"`
@@ -134,6 +135,7 @@ func loadDir(path string) (*Corpus, error) {
 		return nil, fmt.Errorf("sightmap: walk %q: %w", path, err)
 	}
 
+	var memory []string
 	var globalRaws []rawComponent
 	type viewFileWithPath struct {
 		rf   rawFile
@@ -156,6 +158,7 @@ func loadDir(path string) (*Corpus, error) {
 		if base := filepath.Base(p); base != "config.yaml" && base != "config.yml" {
 			fieldDiags = append(fieldDiags, unknownFieldWarnings(data, base)...)
 		}
+		memory = append(memory, rf.Memory...)
 		if len(rf.Components) > 0 {
 			globalRaws = append(globalRaws, rf.Components...)
 		}
@@ -228,6 +231,7 @@ func loadDir(path string) (*Corpus, error) {
 	}
 
 	return &Corpus{
+		Memory:           memory,
 		GlobalComponents: globalComps,
 		Views:            views,
 		loadDiagnostics:  append(ctx.diagnostics, fieldDiags...),

--- a/go/sightmap/loader_test.go
+++ b/go/sightmap/loader_test.go
@@ -1,9 +1,37 @@
 package sightmap
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
+
+// File-level memory applies whenever any definition from that file is active;
+// loadDir doesn't track which component or view came from which file, so it
+// concatenates file memory across the corpus in file-path order (loadDir already
+// walks yamlPaths in that order for deterministic merging).
+func TestLoadDir_FileLevelMemoryAccumulatesInPathOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("version: 1\nmemory:\n  - from a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.yaml"),
+		[]byte("version: 1\nmemory:\n  - from b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	corpus, err := loadDir(dir)
+	if err != nil {
+		t.Fatalf("loadDir: %v", err)
+	}
+	want := []string{"from a", "from b"}
+	if !reflect.DeepEqual(corpus.Memory, want) {
+		t.Errorf("corpus.Memory = %v, want %v", corpus.Memory, want)
+	}
+}
 
 func TestSplitSelectors_ParenAware(t *testing.T) {
 	cases := []struct {

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -16,7 +16,7 @@ import (
 //
 // The known-key sets below mirror sightmap.schema.json (the source of truth),
 // NOT the Go structs — the structs are deliberately incomplete (e.g. rawFile
-// doesn't read file-level memory/requests), which would produce false positives.
+// doesn't read requests), which would produce false positives.
 // stability/access/snapshots/url/properties are all recognized here.
 
 var (


### PR DESCRIPTION
## Why

vibium is adopting `sightmap/go/sightmap` as its `.sightmap/` reader in place of a from-scratch reimplementation. The swap needs to be output-neutral, and vibium's current `[Guide]` output includes file-level `memory` notes — a gap in the Go loader, not in vibium's usage.

## Changes

- `rawFile` now reads `memory`; `Corpus.Memory` exposes the accumulated entries in file-path order (`loadDir` already walks paths in that order for deterministic merging).
- Per-file activation (the spec's "applies whenever any definition from that file is active") isn't tracked — flattened components don't carry a source-file reference — so entries are concatenated corpus-wide instead. Documented as a known simplification on the field; tighten later if a consumer needs per-file scoping.
- `go.mod`: `go 1.25.2` → `go 1.23`, the module's actual floor. Confirmed by build/vet/test at 1.23: the only things above 1.21 are `fsnotify v1.10.1`'s own `go 1.23` directive and one range-over-int in `cmd/sightmap`. Nothing needs 1.24 or 1.25.

## Testing

- New `TestLoadDir_FileLevelMemoryAccumulatesInPathOrder`
- `go build ./... && go vet ./... && go test ./...` green at the new `go 1.23` floor