### PR TITLE
sightmap: components can carry source/tags; add Corpus.AllComponents()

### DIFF
--- a/.changeset/component-tags-source-allcomponents.md
+++ b/.changeset/component-tags-source-allcomponents.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Go library: components can now carry `source:` (relative path to the implementing file — already schema-recognized, previously dropped by the loader) and `tags:` (authored classification labels, e.g. `defect`). Neither is inherited by children, matching `memory`/`properties`/`stability`'s existing convention. `Tags` also flows through `ApplySightmap`'s match result alongside `Memory`. New `Corpus.AllComponents()` returns every component in the corpus (globals plus every view's), deduped by first-seen name — the flat, whole-corpus list a consumer building an upload payload or a lint/coverage report wants, replacing an equivalent hand-rolled loop in `cmd_lint.go`.

--- a/go/cmd/sightmap/cmd_lint.go
+++ b/go/cmd/sightmap/cmd_lint.go
@@ -97,48 +97,23 @@ func findLintSnapshotTreeFiles(sightmapDir string) ([]string, error) {
 // Components absent from any of the tree files will have a count of 0 in the
 // returned map.
 func computeSnapshotCounts(corpus *sightmap.Corpus, treeFiles []string) (map[string]int, error) {
-	// Collect unique (name, selectors) pairs from the corpus.
-	// View lists include $ref-expanded globals, so deduplicate by name.
-	type compEntry struct {
-		name      string
-		selectors []string
-	}
-	seen := make(map[string]bool)
-	var components []compEntry
-
-	addComp := func(name string, selectors []string) {
-		if name == "" || seen[name] {
-			return
-		}
-		seen[name] = true
-		components = append(components, compEntry{name: name, selectors: selectors})
-	}
-
-	for _, c := range corpus.GlobalComponents {
-		addComp(c.Name, c.Selectors)
-	}
-	for _, view := range corpus.Views {
-		for _, c := range view.Components {
-			addComp(c.Name, c.Selectors)
-		}
-	}
-
 	// Pre-parse selectors: component index → slice of last SelectorParts.
 	type parsedEntry struct {
 		name      string
 		lastParts []*comps.SelectorPart
 	}
-	parsed := make([]parsedEntry, 0, len(components))
-	for _, comp := range components {
+	all := corpus.AllComponents()
+	parsed := make([]parsedEntry, 0, len(all))
+	for _, comp := range all {
 		var lasts []*comps.SelectorPart
-		for _, selStr := range comp.selectors {
+		for _, selStr := range comp.Selectors {
 			ps, err := sel.ParseSightmapSelector(selStr)
 			if err != nil || len(ps.Parts) == 0 {
 				continue
 			}
 			lasts = append(lasts, ps.Parts[len(ps.Parts)-1])
 		}
-		parsed = append(parsed, parsedEntry{name: comp.name, lastParts: lasts})
+		parsed = append(parsed, parsedEntry{name: comp.Name, lastParts: lasts})
 	}
 
 	// counts starts at 0 for every component (explicit presence distinguishes

--- a/go/match/sightmap.go
+++ b/go/match/sightmap.go
@@ -13,7 +13,9 @@ import (
 type SightmapComponent struct {
 	Name        string     `json:"name"`
 	Selectors   []string   `json:"selectors"`
+	Source      string     `json:"source,omitempty"`
 	Memory      []string   `json:"memory,omitempty"`
+	Tags        []string   `json:"tags,omitempty"`
 	Properties  []Property `json:"properties,omitempty"`
 	ParentChain []string   `json:"parentChain,omitempty"` // ancestor component names, root-first
 	Stability   string     `json:"stability,omitempty"`   // "" (default), "uncertain", or "unstable"
@@ -30,6 +32,7 @@ type Property struct {
 type SightmapMatch struct {
 	Name   string
 	Memory []string
+	Tags   []string
 }
 
 // ParseQueries parses SightmapComponent definitions into MatchQuery values.
@@ -92,6 +95,7 @@ func ApplySightmap(root *comps.ComponentNode, defs []SightmapComponent) map[*com
 		result[node] = &SightmapMatch{
 			Name:   q.Name,
 			Memory: def.Memory,
+			Tags:   def.Tags,
 		}
 	})
 

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -131,6 +131,33 @@ func (c *Corpus) ComponentsForURL(pageURL string) []match.SightmapComponent {
 	return result
 }
 
+// AllComponents returns every component definition in the corpus — GlobalComponents plus
+// every View's Components — deduped by first-seen name. View lists include $ref-expanded
+// globals, so a global reused in a view would otherwise appear twice; the first occurrence
+// (global list first, then views in corpus order) wins. Route is not considered — this is
+// for a whole-corpus consumer (a linter, a coverage report, an upload payload builder), not
+// a per-page match; use ComponentsForURL for a single page's applicable list.
+func (c *Corpus) AllComponents() []match.SightmapComponent {
+	seen := make(map[string]bool)
+	var out []match.SightmapComponent
+	add := func(comp match.SightmapComponent) {
+		if comp.Name == "" || seen[comp.Name] {
+			return
+		}
+		seen[comp.Name] = true
+		out = append(out, comp)
+	}
+	for _, gc := range c.GlobalComponents {
+		add(gc)
+	}
+	for _, v := range c.Views {
+		for _, vc := range v.Components {
+			add(vc)
+		}
+	}
+	return out
+}
+
 // ViewForURL returns the View whose route most specifically matches pageURL's
 // path, or nil if no view matches. Specificity follows the spec's per-segment
 // scoring (literal > :param > * > **); when scores tie, the first-declared view

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -372,6 +372,36 @@ func TestComponentsForURL(t *testing.T) {
 	})
 }
 
+func TestAllComponents(t *testing.T) {
+	globalA := match.SightmapComponent{Name: "A", Selectors: []string{"#a"}}
+	globalB := match.SightmapComponent{Name: "B", Selectors: []string{"#b-global"}}
+	viewB := match.SightmapComponent{Name: "B", Selectors: []string{"#b-view"}} // $ref-expanded global, same name
+	viewC := match.SightmapComponent{Name: "C", Selectors: []string{"#c"}}
+
+	corpus := &sightmap.Corpus{
+		GlobalComponents: []match.SightmapComponent{globalA, globalB},
+		Views: []sightmap.View{
+			{Route: "/page", Components: []match.SightmapComponent{viewB, viewC}},
+		},
+	}
+
+	list := corpus.AllComponents()
+	byName := indexByName(list)
+	if len(byName) != 3 {
+		t.Fatalf("want 3 unique comps, got %d: %v", len(byName), compNames(list))
+	}
+	// B appears in both GlobalComponents and a view; the global (first-seen) wins.
+	if b := byName["B"]; len(b.Selectors) == 0 || b.Selectors[0] != "#b-global" {
+		t.Errorf("B: first-seen (global) should win; got selectors %v", byName["B"].Selectors)
+	}
+	if _, ok := byName["A"]; !ok {
+		t.Error("A missing from AllComponents")
+	}
+	if _, ok := byName["C"]; !ok {
+		t.Error("C missing from AllComponents")
+	}
+}
+
 // ---- 6. MatchTree end-to-end ------------------------------------------------
 
 func TestMatchTreeEndToEnd(t *testing.T) {

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -81,7 +81,9 @@ type rawComponent struct {
 	Ref         string         `yaml:"$ref"`
 	Selector    rawSelector    `yaml:"selector"`
 	Description string         `yaml:"description"`
+	Source      string         `yaml:"source"`
 	Memory      []string       `yaml:"memory"`
+	Tags        []string       `yaml:"tags"`
 	Children    []rawComponent `yaml:"children"`
 	Properties  []rawProperty  `yaml:"properties"`
 	Stability   string         `yaml:"stability"`
@@ -415,7 +417,9 @@ func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentCha
 	result := []match.SightmapComponent{{
 		Name:        rc.Name,
 		Selectors:   mySels,
+		Source:      rc.Source,
 		Memory:      rc.Memory,
+		Tags:        rc.Tags,
 		Properties:  rawPropsToMatch(rc.Properties),
 		ParentChain: parentChain, // nil for top-level; omitted from JSON
 		Stability:   rc.Stability,

--- a/go/sightmap/loader_test.go
+++ b/go/sightmap/loader_test.go
@@ -33,6 +33,49 @@ func TestLoadDir_FileLevelMemoryAccumulatesInPathOrder(t *testing.T) {
 	}
 }
 
+// A component's tags: and source: flatten onto its match.SightmapComponent, and neither
+// is inherited by children — matching Memory/Properties/Stability's existing convention
+// (only the selector prefix cascades to a child).
+func TestLoadDir_ComponentTagsAndSourceDoNotInheritToChildren(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+version: 1
+components:
+  - name: CheckoutError
+    selector: .error-banner
+    source: src/components/CheckoutForm.tsx
+    tags: [defect]
+    children:
+      - name: CheckoutErrorText
+        selector: .error-text
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	corpus, err := loadDir(dir)
+	if err != nil {
+		t.Fatalf("loadDir: %v", err)
+	}
+	if len(corpus.GlobalComponents) != 2 {
+		t.Fatalf("want 2 flattened components, got %d: %+v", len(corpus.GlobalComponents), corpus.GlobalComponents)
+	}
+	parent, child := corpus.GlobalComponents[0], corpus.GlobalComponents[1]
+
+	if parent.Source != "src/components/CheckoutForm.tsx" {
+		t.Errorf("parent.Source = %q, want the declared source", parent.Source)
+	}
+	if !reflect.DeepEqual(parent.Tags, []string{"defect"}) {
+		t.Errorf("parent.Tags = %v, want [defect]", parent.Tags)
+	}
+	if child.Source != "" {
+		t.Errorf("child.Source = %q, want empty (source is not inherited)", child.Source)
+	}
+	if child.Tags != nil {
+		t.Errorf("child.Tags = %v, want nil (tags are not inherited)", child.Tags)
+	}
+}
+
 func TestSplitSelectors_ParenAware(t *testing.T) {
 	cases := []struct {
 		input string

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -22,7 +22,7 @@ import (
 var (
 	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "snapshots")
 	viewFields      = set("name", "route", "url", "stability", "access", "description", "source", "dependencies", "memory", "components", "requests")
-	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "properties", "children")
+	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "tags", "properties", "children")
 	refFields       = set("$ref")
 	requestFields   = set("name", "route", "method", "description", "source", "request", "response", "headers", "memory")
 	payloadFields   = set("fields")


### PR DESCRIPTION
## Why

`subtext-cli` and  fullstory internal each maintain their own YAML-flattening walker instead of importing this library, in part because it can't yet express what they need:
- a component's `source:` file (already schema-recognized in `componentFields`/`unknownfields.go`, just never implemented in the Go struct)
- authored classification `tags:` (SEP-0004, schema-recognized, never implemented in Go)
- a flat, whole-corpus component list — only `ComponentsForURL` (per-page) exists today

This lands the library side of that consolidation.

## Changes

- `rawComponent`/`match.SightmapComponent` gain `Source` and `Tags`. Neither is inherited by children — matches `Memory`/`Properties`/`Stability`'s existing convention (only the selector prefix cascades to a child).
- `Tags` also flows through `ApplySightmap`'s match result (`SightmapMatch`), alongside `Memory`.
- New `Corpus.AllComponents()`: `GlobalComponents` plus every view's, deduped by first-seen name. Replaces an equivalent hand-rolled loop in `cmd_lint.go`'s `computeSnapshotCounts`.
- `unknownfields.go`: `componentFields` now allowlists `tags` (`source` was already there).