### PR TITLE
release: also push a go/vX.Y.Z tag for the nested Go module

### DIFF
--- a/.changeset/dual-tag-go-subdirectory-releases.md
+++ b/.changeset/dual-tag-go-subdirectory-releases.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+The release workflow now pushes a `go/vX.Y.Z` tag alongside the existing `vX.Y.Z` tag. This module lives in the repo's `go/` subdirectory rather than at the root, and Go's module versioning requires a nested module's tags to be prefixed with that subdirectory — so `go get github.com/sightmap/sightmap/go@vX.Y.Z` has never actually resolved to a tagged release, only to `@latest`'s branch-tip pseudo-version. The bare tag is unchanged and still drives everything else (goreleaser, npm publishing, the release-already-tagged check).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,12 @@ name: release
 #      go/npm/CHANGELOG.md, and syncs the plugin manifest versions
 #      (scripts/sync-manifest-versions.mjs). Nothing is tagged or published
 #      yet. Once that PR merges (no changesets left), this job also tags the
-#      release and pushes the tag.
+#      release and pushes the tag — both a bare vX.Y.Z (what goreleaser/npm/
+#      the "already tagged" check below key off) and go/vX.Y.Z (required for
+#      `go get github.com/sightmap/sightmap/go@vX.Y.Z` to resolve at all,
+#      since Go's module versioning requires a nested module's tags to be
+#      prefixed with its subdirectory — this module lives in go/, not the
+#      repo root).
 #
 #   2. goreleaser: builds cross-platform binaries (config: go/.goreleaser.yml)
 #      and publishes a GitHub release on sightmap/sightmap; its archives are
@@ -87,7 +92,8 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         run: |
           git tag "v${{ steps.check.outputs.version }}"
-          git push origin "v${{ steps.check.outputs.version }}"
+          git tag "go/v${{ steps.check.outputs.version }}"
+          git push origin "v${{ steps.check.outputs.version }}" "go/v${{ steps.check.outputs.version }}"
 
   goreleaser:
     needs: version


### PR DESCRIPTION
## Why

`go/go.mod` lives in a subdirectory, not the repo root, so Go's module versioning requires this module's tags to be prefixed with that subdirectory. `go get github.com/sightmap/sightmap/go@v0.16.0` fails today with `unknown revision go/v0.16.0` — the bare tag we've been cutting has never actually produced a resolvable release for `go get`; every consumer either uses `@latest` (a branch-tip pseudo-version) or pins a raw commit hash.

## Change

The "Tag release" step now pushes `go/vX.Y.Z` alongside the existing `vX.Y.Z`, both pointing at the same commit, in one push. Nothing else changes: goreleaser, the npm publish steps, and the "already tagged" check all keep keying off the bare tag, since it's pushed atomically with the prefixed one.

Changeset included (patch).

## Test plan
- [x] Workflow YAML reviewed by hand (no CI step exercises `release.yml` itself pre-merge)
- [x] Confirmed the failure this fixes: `go get github.com/sightmap/sightmap/go@v0.16.0` → `unknown revision go/v0.16.0` today
- [ ] Confirm after the next release: `go get github.com/sightmap/sightmap/go@v<next>` resolves cleanly