### PR TITLE
chore(web): restore analytics tag behind a consent gate

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,203 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Consent region, injected by the geo-region edge function. If the function
+       does not run, the comment stays and __CC_REGION__ is undefined, which the
+       gate below treats as REQUIRED (fail closed). -->
+  <!--CC_REGION-->
+  <!-- Fullstory. The loader is wrapped in a named function instead of
+       self-invoking: nothing is fetched or captured until the consent gate
+       calls it. The _fs_* config is inert on its own. -->
+  <script>
+    window['_fs_host'] = 'analytics.staging.fsty.io'
+    window['_fs_script'] = 'analytics.staging.fsty.io/s/fs.js'
+    window['_fs_org'] = 'thefullstory.com'
+    window['_fs_namespace'] = 'FS'
+    window['_fs_app_host'] = 'app.staging.fullstory.com'
+    window.__sightmapStartCapture = function () {
+    !(function (m, n, e, t, l, o, g, y) {
+      var s,
+        f,
+        a = (function (h) {
+          return (
+            !(h in m) ||
+            (m.console &&
+              m.console.log &&
+              m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'),
+            !1)
+          )
+        })(e)
+      function p(b) {
+        var h,
+          d = []
+        function j() {
+          h &&
+            (d.forEach(function (b) {
+              var d
+              try {
+                d = b[h[0]] && b[h[0]](h[1])
+              } catch (h) {
+                return void (b[3] && b[3](h))
+              }
+              d && d.then ? d.then(b[2], b[3]) : b[2] && b[2](d)
+            }),
+            (d.length = 0))
+        }
+        function r(b) {
+          return function (d) {
+            h || ((h = [b, d]), j())
+          }
+        }
+        return (
+          b(r(0), r(1)),
+          {
+            then: function (b, h) {
+              return p(function (r, i) {
+                ;(d.push([b, h, r, i]), j())
+              })
+            },
+          }
+        )
+      }
+      a &&
+        ((g = m[e] =
+          (function () {
+            var b = function (b, d, j, r) {
+              function i(i, c) {
+                h(b, d, j, i, c, r)
+              }
+              r = r || 2
+              var c,
+                u = /Async$/
+              return u.test(b)
+                ? ((b = b.replace(u, '')), 'function' == typeof Promise ? new Promise(i) : p(i))
+                : h(b, d, j, c, c, r)
+            }
+            function h(h, d, j, r, i, c) {
+              return b._api
+                ? b._api(h, d, j, r, i, c)
+                : (b.q && b.q.push([h, d, j, r, i, c]), null)
+            }
+            return ((b.q = []), b)
+          })()),
+        (y = function (b) {
+          function h(h) {
+            'function' == typeof h[4] && h[4](new Error(b))
+          }
+          var d = g.q
+          if (d) {
+            for (var j = 0; j < d.length; j++) h(d[j])
+            ;((d.length = 0), (d.push = h))
+          }
+        }),
+        (function () {
+          ;(((o = n.createElement(t)).async = !0),
+            (o.crossOrigin = 'anonymous'),
+            (o.src = 'https://' + l),
+            (o.onerror = function () {
+              y('Error loading ' + l)
+            }))
+          var b = n.getElementsByTagName(t)[0]
+          b && b.parentNode ? b.parentNode.insertBefore(o, b) : n.head.appendChild(o)
+        })(),
+        (function () {
+          function b() {}
+          function h(b, h, d) {
+            g(b, h, d, 1)
+          }
+          function d(b, d, j) {
+            h('setProperties', { type: b, properties: d }, j)
+          }
+          function j(b, h) {
+            d('user', b, h)
+          }
+          function r(b, h, d) {
+            ;(j(
+              {
+                uid: b,
+              },
+              d
+            ),
+              h && j(h, d))
+          }
+          ;((g.identify = r),
+            (g.setUserVars = j),
+            (g.identifyAccount = b),
+            (g.clearUserCookie = b),
+            (g.setVars = d),
+            (g.event = function (b, d, j) {
+              h(
+                'trackEvent',
+                {
+                  name: b,
+                  properties: d,
+                },
+                j
+              )
+            }),
+            (g.anonymize = function () {
+              r(!1)
+            }),
+            (g.shutdown = function () {
+              h('shutdown')
+            }),
+            (g.restart = function () {
+              h('restart')
+            }),
+            (g.log = function (b, d) {
+              h('log', { level: b, msg: d })
+            }),
+            (g.consent = function (b) {
+              h('setIdentity', { consent: !arguments.length || b })
+            }))
+        })(),
+        (s = 'fetch'),
+        (f = 'XMLHttpRequest'),
+        (g._w = {}),
+        (g._w[f] = m[f]),
+        (g._w[s] = m[s]),
+        m[s] &&
+          (m[s] = function () {
+            return g._w[s].apply(this, arguments)
+          }),
+        (g._v = '2.0.0'))
+    })(window, document, window._fs_namespace, 'script', window._fs_script)
+    }
+  </script>
+  <!-- Consent gate: decide whether to boot capture at first paint. Mirrors the
+       loadCapture rule in src/lib/consent/core.ts (this runs before the app
+       bundle, so it cannot import it). -->
+  <script>
+    ;(function () {
+      var COOKIE = 'sightmap_consent'
+      var V = 1
+      var MAX_AGE = 180 * 24 * 60 * 60 * 1000
+      function readStored() {
+        var parts = document.cookie ? document.cookie.split('; ') : []
+        for (var i = 0; i < parts.length; i++) {
+          var eq = parts[i].indexOf('=')
+          if (eq === -1 || parts[i].slice(0, eq) !== COOKIE) continue
+          try {
+            var o = JSON.parse(decodeURIComponent(parts[i].slice(eq + 1)))
+            if (
+              (o.status === 'granted' || o.status === 'denied') &&
+              o.v === V &&
+              typeof o.ts === 'number' &&
+              Date.now() - o.ts <= MAX_AGE
+            )
+              return o
+          } catch (e) {}
+          return null
+        }
+        return null
+      }
+      var region = window.__CC_REGION__ || 'REQUIRED'
+      var stored = readStored()
+      var loadCapture = stored ? stored.status === 'granted' : region === 'OPTIONAL'
+      if (loadCapture && window.__sightmapStartCapture) window.__sightmapStartCapture()
+      window.__CC_INITIAL = { region: region, stored: stored }
+    })()
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -6,3 +6,11 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+# Inject the visitor's consent region into app HTML (replaces <!--CC_REGION-->).
+# The function guards on content-type, so non-HTML responses pass through;
+# assets are excluded outright to avoid pointless invocations.
+[[edge_functions]]
+  function = "geo-region"
+  path = "/*"
+  excludedPath = ["/assets/*"]

--- a/web/netlify/edge-functions/geo-region.ts
+++ b/web/netlify/edge-functions/geo-region.ts
@@ -1,0 +1,27 @@
+// netlify/edge-functions/geo-region.ts
+//
+// Injects the visitor's consent region into app HTML by replacing the
+// <!--CC_REGION--> placeholder. Runs on HTML documents only; everything else
+// passes through untouched. If this never runs, the placeholder stays and the
+// inline gate treats the region as REQUIRED (fail closed).
+import type { Context } from '@netlify/edge-functions'
+import { classifyRegion } from '../lib/regions.ts'
+
+export default async function handler(
+  _request: Request,
+  context: Context
+): Promise<Response | undefined> {
+  const res = await context.next()
+  const contentType = res.headers.get('content-type') || ''
+  if (!contentType.includes('text/html')) return res
+
+  const html = await res.text()
+  if (!html.includes('<!--CC_REGION-->')) return new Response(html, res)
+
+  const region = classifyRegion(context.geo?.country?.code)
+  const injected = html.replace(
+    '<!--CC_REGION-->',
+    `<script>window.__CC_REGION__=${JSON.stringify(region)}</script>`
+  )
+  return new Response(injected, res)
+}

--- a/web/netlify/lib/regions.ts
+++ b/web/netlify/lib/regions.ts
@@ -1,0 +1,48 @@
+// Consent region classification, used by the geo-region edge function.
+// Kept independent of src/ so the Deno edge bundle has no app dependencies.
+
+export const CONSENT_REQUIRED_COUNTRIES = new Set<string>([
+  // EU 27
+  'AT',
+  'BE',
+  'BG',
+  'HR',
+  'CY',
+  'CZ',
+  'DK',
+  'EE',
+  'FI',
+  'FR',
+  'DE',
+  'GR',
+  'HU',
+  'IE',
+  'IT',
+  'LV',
+  'LT',
+  'LU',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SK',
+  'SI',
+  'ES',
+  'SE',
+  // EEA non-EU
+  'IS',
+  'LI',
+  'NO',
+  // UK + Switzerland
+  'GB',
+  'CH',
+])
+
+export type ConsentRegion = 'REQUIRED' | 'OPTIONAL'
+
+/** ISO-3166 alpha-2 country → consent posture. Unknown fails closed to REQUIRED. */
+export function classifyRegion(country: string | null | undefined): ConsentRegion {
+  if (!country) return 'REQUIRED'
+  return CONSENT_REQUIRED_COUNTRIES.has(country.toUpperCase()) ? 'REQUIRED' : 'OPTIONAL'
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,16 +3,21 @@ import Home from '@/pages/Home'
 import BlogIndex from '@/pages/BlogIndex'
 import BlogPost from '@/pages/BlogPost'
 import NotFound from '@/pages/NotFound'
+import { ConsentProvider } from '@/components/consent/ConsentContext'
+import ConsentUI from '@/components/consent/ConsentUI'
 
 // No <BrowserRouter> here on purpose: main.tsx supplies BrowserRouter for the
 // client and scripts/prerender.tsx supplies StaticRouter at build time.
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/blog" element={<BlogIndex />} />
-      <Route path="/blog/:slug" element={<BlogPost />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <ConsentProvider>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/blog" element={<BlogIndex />} />
+        <Route path="/blog/:slug" element={<BlogPost />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+      <ConsentUI />
+    </ConsentProvider>
   )
 }

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,4 +1,7 @@
+import { useConsent } from './consent/ConsentContext'
+
 export default function Footer() {
+  const { openPreferences } = useConsent()
   return (
     <footer data-component="Footer">
       <div className="container">
@@ -14,6 +17,7 @@ export default function Footer() {
             <a href="https://github.com/sightmap/sightmap" target="_blank" rel="noreferrer">GitHub</a>
             <a href="https://www.npmjs.com/package/@sightmap/sightmap" target="_blank" rel="noreferrer">CLI on npm</a>
             <a href="https://github.com/sightmap/sightmap/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT License</a>
+            <button type="button" onClick={openPreferences} data-action="consent-open-preferences" data-fs-element="Sightmap | Consent: Open Preferences">Privacy preferences</button>
           </div>
         </div>
       </div>

--- a/web/src/components/consent/ConsentContext.tsx
+++ b/web/src/components/consent/ConsentContext.tsx
@@ -1,0 +1,103 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  resolveConsentDecision,
+  type ConsentRegion,
+  type ConsentStatus,
+  type StoredConsent,
+} from '@/lib/consent/core'
+import { applyConsent, readConsent, writeConsent } from '@/lib/consent'
+
+interface ConsentContextValue {
+  region: ConsentRegion
+  status: ConsentStatus | null
+  captureEnabled: boolean
+  showBanner: boolean
+  isPreferencesOpen: boolean
+  openPreferences: () => void
+  closePreferences: () => void
+  setConsent: (status: ConsentStatus) => void
+}
+
+const ConsentContext = createContext<ConsentContextValue | null>(null)
+
+interface Initial {
+  region: ConsentRegion
+  stored: StoredConsent | null
+}
+
+function readInitial(): Initial {
+  if (typeof window === 'undefined') return { region: 'REQUIRED', stored: null }
+  if (window.__CC_INITIAL) return window.__CC_INITIAL
+  return { region: window.__CC_REGION__ || 'REQUIRED', stored: readConsent() }
+}
+
+export function ConsentProvider({ children }: { children: ReactNode }) {
+  // The site is prerendered, so first render also happens in Node with no
+  // window. Nothing consent-related is shown until `mounted` flips on the
+  // client, which keeps the static HTML free of a baked-in banner.
+  const [initial, setInitial] = useState<Initial>({ region: 'REQUIRED', stored: null })
+  const [mounted, setMounted] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+  const [isPreferencesOpen, setPreferencesOpen] = useState(false)
+
+  useEffect(() => {
+    setInitial(readInitial())
+    setMounted(true)
+  }, [])
+
+  const region = initial.region
+  const decision = resolveConsentDecision(region, initial.stored)
+
+  const setConsent = useCallback((next: ConsentStatus) => {
+    writeConsent(next)
+    applyConsent(next)
+    setInitial((prev) => ({ ...prev, stored: readConsent() }))
+    setDismissed(true)
+    setPreferencesOpen(false)
+  }, [])
+
+  const openPreferences = useCallback(() => setPreferencesOpen(true), [])
+  const closePreferences = useCallback(() => setPreferencesOpen(false), [])
+
+  const value = useMemo<ConsentContextValue>(
+    () => ({
+      region,
+      status: initial.stored?.status ?? null,
+      captureEnabled: decision.loadCapture,
+      showBanner: mounted && decision.autoShowBanner && !dismissed,
+      isPreferencesOpen: mounted && isPreferencesOpen,
+      openPreferences,
+      closePreferences,
+      setConsent,
+    }),
+    [
+      region,
+      initial.stored,
+      decision.loadCapture,
+      decision.autoShowBanner,
+      mounted,
+      dismissed,
+      isPreferencesOpen,
+      openPreferences,
+      closePreferences,
+      setConsent,
+    ]
+  )
+
+  return <ConsentContext.Provider value={value}>{children}</ConsentContext.Provider>
+}
+
+export function useConsent(): ConsentContextValue {
+  const ctx = useContext(ConsentContext)
+  if (!ctx) throw new Error('useConsent must be used within ConsentProvider')
+  return ctx
+}

--- a/web/src/components/consent/ConsentUI.tsx
+++ b/web/src/components/consent/ConsentUI.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef } from 'react'
+import { useConsent } from './ConsentContext'
+
+const PRIVACY_URL = 'https://www.fullstory.com/legal/privacy-policy/'
+
+export default function ConsentUI() {
+  const { showBanner, isPreferencesOpen } = useConsent()
+  if (isPreferencesOpen) return <PreferencesPanel />
+  if (showBanner) return <ConsentBanner />
+  return null
+}
+
+function ConsentBanner() {
+  const { setConsent } = useConsent()
+  return (
+    <div
+      data-component="ConsentBanner"
+      className="consent-banner"
+      role="region"
+      aria-label="Cookie consent"
+    >
+      <p className="consent-copy">
+        We use cookies to capture how the site is used and improve it. See our{' '}
+        <a href={PRIVACY_URL} data-fs-element="Sightmap | Consent: Privacy Policy">
+          Privacy Policy
+        </a>
+        .
+      </p>
+      <div className="consent-actions">
+        <button
+          type="button"
+          onClick={() => setConsent('granted')}
+          data-action="consent-accept"
+          data-fs-element="Sightmap | Consent: Accept"
+          className="consent-btn consent-btn-primary"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={() => setConsent('denied')}
+          data-action="consent-decline"
+          data-fs-element="Sightmap | Consent: Decline"
+          className="consent-btn"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function PreferencesPanel() {
+  const { status, captureEnabled, closePreferences, setConsent } = useConsent()
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Default the toggle to current capture state (on unless explicitly denied).
+  const initialOn = status ? status === 'granted' : captureEnabled
+  const toggleRef = useRef(initialOn)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const getFocusable = () =>
+      dialog
+        ? Array.from(
+            dialog.querySelectorAll<HTMLElement>(
+              'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )
+          )
+        : []
+
+    // Focus the first control on open so the dialog owns focus immediately.
+    ;(getFocusable()[0] ?? dialog)?.focus()
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closePreferences()
+        return
+      }
+      if (e.key !== 'Tab') return
+      // Trap Tab within the dialog so focus cannot land on the page behind it.
+      const items = getFocusable()
+      if (items.length === 0) {
+        e.preventDefault()
+        dialog?.focus()
+        return
+      }
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      if (e.shiftKey && (active === first || active === dialog)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      // Restore focus to whatever opened the dialog (e.g. the footer link).
+      previouslyFocused?.focus?.()
+    }
+  }, [closePreferences])
+
+  return (
+    <div className="consent-overlay" onClick={closePreferences}>
+      <div
+        ref={dialogRef}
+        data-component="ConsentPanel"
+        className="consent-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Privacy preferences"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="consent-title">Privacy preferences</h2>
+        <p className="consent-copy">
+          Manage optional capture. Necessary cookies stay on so the site works.
+        </p>
+
+        <div className="consent-rows">
+          <div className="consent-row">
+            <div>
+              <div className="consent-row-name">Necessary</div>
+              <div className="consent-row-desc">Consent preferences.</div>
+            </div>
+            <span className="consent-row-locked">Always on</span>
+          </div>
+
+          <label className="consent-row consent-row-toggle">
+            <div>
+              <div className="consent-row-name">Analytics: session capture</div>
+              <div className="consent-row-desc">
+                Fullstory session capture, used to understand and improve the site.
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              defaultChecked={initialOn}
+              onChange={(e) => {
+                toggleRef.current = e.target.checked
+              }}
+              data-action="consent-toggle-analytics"
+              data-fs-element="Sightmap | Consent: Analytics Toggle"
+            />
+          </label>
+        </div>
+
+        <div className="consent-actions consent-actions-end">
+          <button
+            type="button"
+            onClick={closePreferences}
+            data-action="consent-cancel"
+            data-fs-element="Sightmap | Consent: Cancel"
+            className="consent-btn"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => setConsent(toggleRef.current ? 'granted' : 'denied')}
+            data-action="consent-save"
+            data-fs-element="Sightmap | Consent: Save"
+            className="consent-btn consent-btn-primary"
+          >
+            Save Preferences
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1194,14 +1194,25 @@ footer {
   justify-content: center;
 }
 
-.footer-links a {
+.footer-links a,
+.footer-links button {
   font-family: var(--mono);
   font-size: 0.75rem;
   color: var(--text-dim);
   text-decoration: none;
 }
 
-.footer-links a:hover { color: var(--text); }
+/* The consent entry point is a button (it opens a dialog, it does not navigate)
+   but should read as one more footer link. */
+.footer-links button {
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.footer-links a:hover,
+.footer-links button:hover { color: var(--text); }
 
 /* ---- DIVIDERS ---- */
 .divider {
@@ -1965,4 +1976,161 @@ footer {
   display: flex;
   justify-content: center;
   gap: 1rem;
+}
+
+/* ---- CONSENT ---- */
+.consent-banner {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 50;
+  width: calc(100% - 2rem);
+  max-width: 24rem;
+  padding: 1.25rem;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-bright);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(26, 23, 20, 0.14);
+}
+
+.consent-copy {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.consent-copy a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.consent-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.consent-actions-end {
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+/* Accept and Decline are deliberately the same size and weight: steering the
+   visitor toward Accept with styling would undercut the consent being asked for. */
+.consent-btn {
+  flex: 1;
+  padding: 0.65rem 1.5rem;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid var(--border-bright);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, opacity 0.15s;
+}
+
+.consent-btn:hover {
+  border-color: var(--text-dim);
+  background: var(--bg-subtle);
+}
+
+.consent-btn-primary {
+  background: var(--text-bright);
+  color: var(--bg);
+  border-color: var(--text-bright);
+  font-weight: 600;
+}
+
+.consent-btn-primary:hover {
+  background: var(--text-bright);
+  border-color: var(--text-bright);
+  opacity: 0.88;
+}
+
+.consent-actions-end .consent-btn { flex: 0 0 auto; }
+
+.consent-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(26, 23, 20, 0.5);
+}
+
+.consent-panel {
+  width: 100%;
+  max-width: 28rem;
+  padding: 1.5rem;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-bright);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(26, 23, 20, 0.2);
+  outline: none;
+}
+
+.consent-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 0.5rem;
+}
+
+.consent-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.consent-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.consent-row-toggle { cursor: pointer; }
+
+.consent-row-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.consent-row-desc {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  margin-top: 0.15rem;
+}
+
+.consent-row-locked {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.consent-row-toggle input {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+@media (max-width: 700px) {
+  .consent-banner {
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    max-width: none;
+    border-radius: 12px 12px 0 0;
+  }
 }

--- a/web/src/lib/consent/core.test.ts
+++ b/web/src/lib/consent/core.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONSENT_MAX_AGE_MS,
+  parseStoredConsent,
+  readConsentCookieValue,
+  resolveConsentDecision,
+  serializeConsentCookie,
+} from './core'
+
+describe('resolveConsentDecision', () => {
+  it('REQUIRED + no choice → block + auto-show', () => {
+    expect(resolveConsentDecision('REQUIRED', null)).toEqual({
+      loadCapture: false,
+      autoShowBanner: true,
+    })
+  })
+  it('OPTIONAL + no choice → capture on, no banner', () => {
+    expect(resolveConsentDecision('OPTIONAL', null)).toEqual({
+      loadCapture: true,
+      autoShowBanner: false,
+    })
+  })
+  it('stored choice always wins and never auto-shows', () => {
+    const g = { status: 'granted', v: 1, ts: 0 } as const
+    const d = { status: 'denied', v: 1, ts: 0 } as const
+    expect(resolveConsentDecision('REQUIRED', g)).toEqual({
+      loadCapture: true,
+      autoShowBanner: false,
+    })
+    expect(resolveConsentDecision('REQUIRED', d)).toEqual({
+      loadCapture: false,
+      autoShowBanner: false,
+    })
+    expect(resolveConsentDecision('OPTIONAL', g)).toEqual({
+      loadCapture: true,
+      autoShowBanner: false,
+    })
+    expect(resolveConsentDecision('OPTIONAL', d)).toEqual({
+      loadCapture: false,
+      autoShowBanner: false,
+    })
+  })
+})
+
+describe('parseStoredConsent', () => {
+  const now = 1_000_000_000_000
+  it('parses a valid cookie value', () => {
+    expect(parseStoredConsent(JSON.stringify({ status: 'granted', v: 1, ts: now }), now)).toEqual({
+      status: 'granted',
+      v: 1,
+      ts: now,
+    })
+  })
+  it('returns null for missing/malformed/wrong-version/bad-status', () => {
+    expect(parseStoredConsent(null, now)).toBeNull()
+    expect(parseStoredConsent('not json', now)).toBeNull()
+    expect(parseStoredConsent(JSON.stringify({ status: 'granted', v: 2, ts: now }), now)).toBeNull()
+    expect(parseStoredConsent(JSON.stringify({ status: 'maybe', v: 1, ts: now }), now)).toBeNull()
+  })
+  it('returns null once older than the max age', () => {
+    const old = now - CONSENT_MAX_AGE_MS - 1
+    expect(parseStoredConsent(JSON.stringify({ status: 'granted', v: 1, ts: old }), now)).toBeNull()
+  })
+})
+
+describe('cookie string helpers', () => {
+  it('extracts the consent value among other cookies', () => {
+    const raw = 'theme=dark; sightmap_consent=%7B%22a%22%3A1%7D; other=x'
+    expect(readConsentCookieValue(raw)).toBe('{"a":1}')
+  })
+  it('returns null when absent or empty', () => {
+    expect(readConsentCookieValue('theme=dark')).toBeNull()
+    expect(readConsentCookieValue('')).toBeNull()
+  })
+  it('serializes a cookie that round-trips through parse', () => {
+    const now = 1_700_000_000_000
+    const cookie = serializeConsentCookie('denied', now)
+    expect(cookie).toContain('sightmap_consent=')
+    expect(cookie).toContain('Max-Age=15552000')
+    expect(cookie).toContain('Path=/')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Secure')
+    const value = readConsentCookieValue(cookie.split(';')[0])
+    expect(parseStoredConsent(value, now)).toEqual({ status: 'denied', v: 1, ts: now })
+  })
+})

--- a/web/src/lib/consent/core.ts
+++ b/web/src/lib/consent/core.ts
@@ -1,0 +1,74 @@
+// Pure consent logic — no DOM, no React. Single source of truth for the
+// decision table and cookie encoding. Mirrored (loadCapture rule only) by the
+// inline gate in index.html, which must run before this bundle loads.
+
+export type ConsentStatus = 'granted' | 'denied'
+export type ConsentRegion = 'REQUIRED' | 'OPTIONAL'
+
+export interface StoredConsent {
+  status: ConsentStatus
+  v: number
+  ts: number
+}
+
+export interface ConsentDecision {
+  loadCapture: boolean
+  autoShowBanner: boolean
+}
+
+export const CONSENT_COOKIE_NAME = 'sightmap_consent'
+export const POLICY_VERSION = 1
+export const CONSENT_MAX_AGE_MS = 180 * 24 * 60 * 60 * 1000
+
+/** Given region and any stored choice, decide capture + whether to auto-show the banner. */
+export function resolveConsentDecision(
+  region: ConsentRegion,
+  stored: StoredConsent | null
+): ConsentDecision {
+  if (stored) {
+    return { loadCapture: stored.status === 'granted', autoShowBanner: false }
+  }
+  if (region === 'OPTIONAL') {
+    return { loadCapture: true, autoShowBanner: false }
+  }
+  return { loadCapture: false, autoShowBanner: true }
+}
+
+/** Parse a raw cookie value into a valid, unexpired, current-version choice, or null. */
+export function parseStoredConsent(raw: string | null, now: number): StoredConsent | null {
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const o = parsed as Record<string, unknown>
+  if (o.status !== 'granted' && o.status !== 'denied') return null
+  if (o.v !== POLICY_VERSION) return null
+  if (typeof o.ts !== 'number') return null
+  if (now - o.ts > CONSENT_MAX_AGE_MS) return null
+  return { status: o.status, v: o.v, ts: o.ts }
+}
+
+/** Extract the decoded `sightmap_consent` value from a `document.cookie` string. */
+export function readConsentCookieValue(cookieString: string): string | null {
+  const parts = cookieString ? cookieString.split('; ') : []
+  for (const part of parts) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    if (part.slice(0, eq) === CONSENT_COOKIE_NAME) {
+      return decodeURIComponent(part.slice(eq + 1))
+    }
+  }
+  return null
+}
+
+/** Build the `document.cookie` assignment string for a choice. */
+export function serializeConsentCookie(status: ConsentStatus, now: number): string {
+  const value: StoredConsent = { status, v: POLICY_VERSION, ts: now }
+  const encoded = encodeURIComponent(JSON.stringify(value))
+  const maxAgeSec = Math.floor(CONSENT_MAX_AGE_MS / 1000)
+  return `${CONSENT_COOKIE_NAME}=${encoded}; Max-Age=${maxAgeSec}; Path=/; SameSite=Lax; Secure`
+}

--- a/web/src/lib/consent/index.ts
+++ b/web/src/lib/consent/index.ts
@@ -1,0 +1,46 @@
+// Browser glue: read/write the consent cookie and start/stop capture to match.
+import {
+  parseStoredConsent,
+  readConsentCookieValue,
+  serializeConsentCookie,
+  type ConsentRegion,
+  type ConsentStatus,
+  type StoredConsent,
+} from './core'
+
+declare global {
+  interface Window {
+    /** Fullstory loader, deferred behind consent (defined in index.html). */
+    __sightmapStartCapture?: () => void
+    /** Consent region injected by the geo-region edge function. */
+    __CC_REGION__?: ConsentRegion
+    /** Snapshot the inline gate leaves for React to read on mount. */
+    __CC_INITIAL?: { region: ConsentRegion; stored: StoredConsent | null }
+    /** Fullstory SDK, present only once the loader has run. */
+    FS?: (command: 'restart' | 'shutdown', ...args: unknown[]) => void
+  }
+}
+
+export function readConsent(now: number = Date.now()): StoredConsent | null {
+  if (typeof document === 'undefined') return null
+  return parseStoredConsent(readConsentCookieValue(document.cookie), now)
+}
+
+export function writeConsent(status: ConsentStatus): void {
+  if (typeof document === 'undefined') return
+  document.cookie = serializeConsentCookie(status, Date.now())
+}
+
+/** Start or stop Fullstory capture to match the choice. Idempotent. */
+export function applyConsent(status: ConsentStatus): void {
+  if (typeof window === 'undefined') return
+  if (status === 'granted') {
+    if (typeof window.FS === 'function') {
+      window.FS('restart')
+    } else {
+      window.__sightmapStartCapture?.()
+    }
+  } else if (typeof window.FS === 'function') {
+    window.FS('shutdown')
+  }
+}

--- a/web/src/lib/consent/regions.test.ts
+++ b/web/src/lib/consent/regions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { classifyRegion } from '../../../netlify/lib/regions'
+
+describe('classifyRegion', () => {
+  it('treats EEA, UK, and CH as consent-required', () => {
+    for (const country of ['DE', 'FR', 'IE', 'NO', 'IS', 'LI', 'GB', 'CH']) {
+      expect(classifyRegion(country)).toBe('REQUIRED')
+    }
+  })
+  it('treats everywhere else as opt-out', () => {
+    for (const country of ['US', 'CA', 'BR', 'JP', 'AU', 'IN']) {
+      expect(classifyRegion(country)).toBe('OPTIONAL')
+    }
+  })
+  it('is case-insensitive', () => {
+    expect(classifyRegion('de')).toBe('REQUIRED')
+    expect(classifyRegion('us')).toBe('OPTIONAL')
+  })
+  it('fails closed when the country is unknown', () => {
+    expect(classifyRegion(undefined)).toBe('REQUIRED')
+    expect(classifyRegion(null)).toBe('REQUIRED')
+    expect(classifyRegion('')).toBe('REQUIRED')
+  })
+})


### PR DESCRIPTION
Restores the tag removed in #88, now gated on consent.

- EEA/UK/CH, or region unresolved: no capture until the visitor accepts.
- Everywhere else: capture on by default, opt out from the footer.

Region comes from a Netlify edge function; the choice is stored in a first-party cookie for 180 days.