### PR TITLE
feat(docs): add an entry-file changelog system

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,13 @@ jobs:
           node docs/scripts/sync-spec.mjs
           git diff --exit-code docs/reference/schema.md
 
+      # changelog.mdx is assembled from changelog/entries/ and checked in for
+      # the same reason. Fail when it drifts.
+      - name: Changelog page in sync
+        run: |
+          node docs/scripts/build-changelog.mjs
+          git diff --exit-code docs/changelog.mdx
+
       - name: Install Mintlify CLI
         run: npm i -g mint
 

--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,7 @@
+# Mintlify automatically ignores these files and directories:
+# .git, .github, .claude, .agents, .idea, node_modules,
+# README.md, LICENSE.md, CHANGELOG.md, CONTRIBUTING.md
+
+# Changelog entry fragments — assembled into changelog.mdx by
+# scripts/build-changelog.mjs; not standalone pages.
+changelog/entries/

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,143 @@
+---
+title: "Changelog"
+description: "New features, improvements, and fixes in the sightmap CLI, library, and spec."
+rss: true
+---
+
+{/* GENERATED FILE — do not edit by hand.
+    Add an entry in changelog/entries/, then run: node scripts/build-changelog.mjs
+    Docs: changelog/README.md */}
+
+<Update label="sightmap 0.16.1" description="Released July 30, 2026" tags={["go"]}>
+
+The release workflow now pushes a `go/vX.Y.Z` tag alongside the existing `vX.Y.Z` tag. This module lives in the repo's `go/` subdirectory rather than at the root, and Go's module versioning requires a nested module's tags to be prefixed with that subdirectory — so `go get github.com/sightmap/sightmap/go@vX.Y.Z` has never actually resolved to a tagged release, only to `@latest`'s branch-tip pseudo-version. The bare tag is unchanged and still drives everything else (goreleaser, npm publishing, the release-already-tagged check).
+
+</Update>
+
+<Update label="sightmap 0.16.0" description="Released July 30, 2026" tags={["go"]}>
+
+Go library: `Corpus.Memory` now carries file-level `memory` entries (the loader previously dropped them). Lower the module's `go` directive from 1.25.2 to 1.23, its actual dependency floor, so consumers aren't forced onto a newer toolchain than the code requires.
+
+</Update>
+
+<Update label="sightmap 0.15.10" description="Released July 30, 2026" tags={["cli"]}>
+
+Verify the changesets release automation end-to-end: no functional change.
+
+</Update>
+
+<Update label="sightmap 0.15.9" description="Released July 28, 2026" tags={["cli"]}>
+
+Offline selector matching now matches the live DOM for `id`, `class`, and SVG. Three gaps are closed so a selector `sel-probe` verifies live behaves the same way `snapshot`/`coverage`/`capture` see it offline:
+
+- **Attribute selectors on `id`** (`[id^="issue_"]`, `[id$=…]`, …) now match. `id` lives in a dedicated node field, so the matcher resolves `id`/`class` attribute selectors to those fields — not only to captured `attrs`.
+- **`placeholder`** is captured, so `input[placeholder="…"]` matches offline.
+- **SVG classes** are captured. On SVG elements `className` is an `SVGAnimatedString`, which broke the old extraction (it threw and dropped the whole selector); `probe.js` now uses `classList`, so `svg.lucide`, `[class*="lucide"]`, and `:has(svg.lucide-x)` match offline.
+
+The authoring skill and docs are corrected accordingly: attribute selectors on `class` and `id` are no longer described as "don't work offline" — they work, for HTML and SVG alike.
+
+Better handling of asynchronous SPA navigation, without baking implicit waits into `click`.
+
+- **`navigate` now reports client-side redirects.** It previously only saw server-side (HTTP) redirects, which are reflected by the load event; a client-side redirect that fires during hydration (an auth guard bouncing `/login → /`, or `/ → /workspace`) went unreported, so the caller was told it was somewhere it wasn't. `navigate` now waits briefly after load for a follow-up navigation and prints `(redirected to FINAL)` for those too.
+- **`wait-for` gains `--view` and `--component`.** These are the explicit, corpus-aware step boundaries to use after an action that should navigate (the act-then-wait split Playwright and Selenium use): `--view <Name>` waits until the current URL resolves to a named sightmap view, and `--component '<Query>'` waits until a component query — including property filters like `WorkItemRow[key="FALCON-7"]` — matches a node. Both auto-retry until they hold or time out loudly. `--url`, `--selector`, and `--load` remain the raw equivalents.
+
+`click` deliberately does **not** wait for or guess about resulting navigation — it acts, reports, and keeps its loud covered/off-screen refusals. Adds `browser.AwaitNavigation` (waits for `Page.frameNavigated` / `Page.navigatedWithinDocument`, settling chained redirects) behind `navigate`.
+
+</Update>
+
+<Update label="sightmap 0.15.8" description="Released July 27, 2026" tags={["cli"]}>
+
+Coverage and the annotated tree now agree on what counts as visible. `probe.js` set each node's `isVisible` from that element's _own_ computed style, which misses ancestor-driven hiding: a control inside a closed `opacity:0` overlay (a dismissed dropdown or context menu) has computed `opacity:1` of its own, so it reported visible even though it is painted nowhere. Coverage counted these while the renderer dropped the hidden container's subtree, so on real apps a large share of a page's interactive nodes (all the closed menus) silently inflated the count and tanked the score.
+
+`probe.js` now computes `isVisible` with the browser's own `Element.checkVisibility`, which accounts for ancestors hidden by `display:none`, `visibility:hidden`, `opacity:0`, or `content-visibility` — keeping the layout/rendering judgment in the real browser instead of re-deriving CSS semantics. `snapshot`/`coverage` "(visible only)" now excludes descendants of hidden containers; `--include-hidden` still counts every interactive node. The renderer also drops invisible subtrees regardless of interactivity so it and coverage read one signal.
+
+</Update>
+
+<Update label="sightmap 0.15.7" description="Released July 27, 2026" tags={["cli"]}>
+
+`snapshot` now surfaces runtime match conflicts in a `[Conflicts]` section — the ambiguities that only exist against a live page, complementing the static corpus-conflict warnings `validate` emits. Two triggers:
+
+- **A single DOM node matched by more than one distinct component name.** Matching is first-match-wins, so only one applied and the others were silently dropped — which is also why a correct-looking component can report `0 matches`. The section names the node, the competing components, and which one won.
+- **Two or more views matching the current URL at equal specificity**, where declaration order alone decided the winner.
+
+Adds `match.FindConflicts` and `Corpus.TiedViews`; both are computed during `observe.Page`. (The view-tie half is provisional pending the route-specificity decision in the functional-decomposition proposal.)
+
+`validate` now surfaces two classes of invalid corpus the loader previously dropped silently (so they shipped with a green check):
+
+- **Missing required fields** — a component with no `selector` (or no `name`), and a view with no `name`, are now errors (`missing-selector` / `missing-name` / `missing-route`) instead of being quietly discarded during load.
+- **Unresolved `$ref`** — a `$ref` naming a component that no file defines is now a `ref-unresolved` error (matching the spec's MUST), instead of the reference being silently skipped.
+
+Both exit non-zero. The spec's diagnostic-code table documents the new error codes alongside the corpus-conflict warnings.
+
+`validate` now warns on unknown fields. The typed loader silently ignored any YAML key it didn't recognize, so a typo like `memroy:` — or a half-baked field — vanished without a trace. `validate` now walks the raw YAML and emits an `unknown-field` **warning** (not an error) for any key the spec doesn't define at its position, at any nesting depth. It warns rather than rejects, so authors can stash experimental fields (e.g. `macros:`) during development; recognized fields — including the reserved tooling fields `access` and `snapshots` — are never flagged, and `.sightmap/config.yaml` is excluded. This completes strict `validate` alongside the earlier required-field and `$ref` checks.
+
+Fix `report` and make the view `url:` field first-class. `url:` is now read **per view** (with a file-level `url:` as a default for views that omit their own), instead of only at the file level. Previously per-view `url:` was silently dropped, so `report` — which needs a representative URL per view — errored with `no views with URLs found` even when every view declared one. `url:` is also now part of the published schema (SEP-accepted alongside `properties`), so a corpus that declares it validates instead of failing `additionalProperties: false`.
+
+</Update>
+
+<Update label="sightmap 0.15.6" description="Released July 27, 2026" tags={["cli"]}>
+
+`validate` now distinguishes **errors** (which fail validation, exit 1) from **warnings** (advisory, exit 0), and warns on silent corpus conflicts that a fallback rule was resolving without telling you:
+
+- **`merge-collision-view`** — two or more views share a `name`.
+- **`route-conflict`** — two or more views share the same (normalized) `route`; only the first-declared applies to that URL (this is the "same-route hijack" that can silently drop a view's components).
+- **`merge-collision-component`** — two or more root-level global components share a `name` with different selectors.
+
+Findings now carry a stable `code` and `severity`. Scoped component name reuse (the same child under multiple parents) is correctly _not_ flagged, since that is intentional. The spec's diagnostic-code table documents the new corpus codes.
+
+Make `snapshot` loud about corpus-match state instead of silently omitting it. When a corpus is loaded but no view's route matches the URL (e.g. an auth redirect to a login page), the output now shows a `[No view matched] <url>` notice instead of a headerless tree that looks identical to a normal snapshot — so an agent knows the page is off the map. And the `[Coverage]` summary is now printed whenever a corpus is applied, including for a matched view that has no components yet (every interactive node reads as an orphan); previously that case printed only the view header, leaving the documented `snapshot --coverage` bootstrap with nothing to iterate on.
+
+</Update>
+
+<Update label="sightmap 0.15.5" description="Released July 26, 2026" tags={["cli"]}>
+
+Make `browser click` and `fill` fail loudly instead of silently no-op'ing. `click` now scrolls the target to the center of the viewport and verifies its center is the top-most element there before dispatching — it errors when the target can't be positioned in the viewport (previously an off-screen target below the fold was clicked at a coordinate that hit nothing and still exited 0) or is covered by another element (an open overlay/modal). The success confirmation reports the real post-scroll coordinates. `fill` now reads the value back after typing and errors when a non-empty value was typed but the field is still empty — the signature of a React-controlled input where plain typing doesn't stick — telling you to retry with `--clear`.
+
+`sel-probe` now cross-checks the offline matcher. It queries the live DOM as before, but also runs the same selector through the offline matcher that `snapshot`/`coverage`/`capture` use, prints that count, and emits a `⚠ offline/live divergence` warning (with a hint) when the two disagree. This closes the false-confidence trap where a selector "verified" against the live DOM is silently dead in the corpus — e.g. attribute selectors on `id` (`[id^="…"]`) match live but never offline, because `id` is a dedicated node field rather than a matchable attribute.
+
+</Update>
+
+<Update label="sightmap 0.15.4" description="Released July 26, 2026" tags={["cli"]}>
+
+Make browser-use feedback loud: the interaction commands (`click`, `fill`, `hover`, `keypress`, `scroll`, `drag`, `wait-for`, `dialog`, `tabs resize`) now echo a short confirmation on success instead of exiting silently — e.g. `clicked CartNavButton @ (674,30)` — so an agent driving the browser can see what happened. Several raw CDP/Go errors are now rewritten into actionable messages: a `wait-for` timeout reads `timed out after 800ms waiting for selector "..."` (not `context deadline exceeded`), resolving a dialog when none is open says so plainly, and fetching an evicted network response body explains that bodies are only retained briefly. `snapshot` now prints a note when no `.sightmap` corpus is found at the target directory instead of silently rendering an un-annotated tree.
+
+</Update>
+
+<Update label="sightmap 0.15.3" description="Released July 26, 2026" tags={["cli"]}>
+
+Stop green-lighting broken corpora and blank pages:
+
+- `snapshot` now exits non-zero when the corpus is present but fails to parse (a missing corpus stays non-fatal — the tree still renders), and when the observed page has 0 interactive nodes (blank or still loading). It still renders whatever it observed first. `inspect` and `suggest` now warn on a bad corpus instead of silently ignoring it.
+- Coverage no longer marks a page with 0 interactive nodes as a pass. The coverage line renders a distinct `∅` mark (instead of `✓`), the `coverage` command counts empty captures as failures, and `capture` refuses to persist a blank/loading page as a view's baseline (override with `--force`).
+
+</Update>
+
+<Update label="sightmap 0.15.2" description="Released July 26, 2026" tags={["cli"]}>
+
+Make corpus loading robust against two malformed inputs that previously failed badly:
+
+- A circular `$ref` chain (`A → B → A`, or a component that references itself) sent every corpus-loading command into infinite recursion and hung the process. Loading now detects the cycle, stops expanding, and `validate` reports it as a `ref-circular` error instead of hanging.
+- `splitSelectors` only balanced parentheses, so a comma inside an attribute selector or quoted string (`[data-x="a,b"]`) was wrongly treated as a selector-list separator and split into two dead alternatives. Splitting is now aware of `[]` brackets and quoted strings (with backslash escapes), matching how CSS is actually written.
+
+Fix view route matching so it behaves as the spec documents. Trailing slashes are now normalized off both the route pattern and the URL path before matching, so a slash-free route like `/*/projects` matches the `/acme/projects/` paths that Django, Rails, and many React-Router apps emit — previously such URLs matched no view at all, silently dropping the `[View:]` header, view memory, and view-scoped components. Express-style `:param` segments in view routes now match a single path segment (and score between a literal and `*` for specificity). And `Corpus.ViewForURL` now returns the _most specific_ matching view — using declaration order only to break equal-specificity ties — instead of the first match in corpus order, closing a divergence between the exported library and the spec.
+
+</Update>
+
+<Update label="sightmap 0.15.1" description="Released July 26, 2026" tags={["cli"]}>
+
+Isolate concurrent browser sessions so agents working in different projects no longer cross-talk. The session file is now keyed to `--sightmap-dir` (it lives at `<sightmap-dir>/.session`) instead of a single shared `$TMPDIR` file, so a second `browser start` only ever reuses the Chrome for _its own_ corpus rather than piggybacking on another agent's browser. Free-port probing now checks the IPv4 loopback (where Chrome's CDP and the sightmap server bind), and the sightmap server binds `127.0.0.1`, so two daemons started on the default ports slide to non-overlapping ports instead of one daemon's server colliding with another's CDP port. Every session-aware `browser` command (including `console`/`network`, `status`/`stop`, `tabs`, and the low-level interactions) now accepts `--sightmap-dir` to select which session it talks to.
+
+Fix the Sightmap overlay getting stuck in a reload loop that flooded the captured console. The extension's version poll compared the raw `/sightmap/version` JSON text against the parsed version string, so it never matched and re-fetched every few seconds. The poll now parses the response and compares the `version` field. Also drop the post-install `chrome.runtime.reload()` step: a fresh `browser start` always relaunches Chrome with `--load-extension`, which loads the new unpacked extension directly, and the hot-reload could leave the overlay's content script uninjected until the next full restart.
+
+</Update>
+
+<Update label="sightmap 0.15.0" description="Released July 25, 2026" tags={["cli"]}>
+
+CLI teardown: reorganize the tooling around reusable library subsystems and add browser devtools.
+
+- Separate `snapshot` (observe: annotated tree + coverage) from `capture` (persist into a view's set); extract the `observe`, `coverage`, `viewset`, and `authoring` packages and merge the internal `Session` into `Corpus`.
+- Make the `browser start` daemon the single session owner: retire `--launch` and the `browser launch` subcommand (live commands attach to a started session).
+- Add `console` and `network` devtools commands, backed by a session-lifetime collector in the daemon that buffers console messages (with uncaught exceptions folded in) and network requests, with lazy response bodies.
+- Add screenshot clipping to `browser screenshot` (`--component` / `--selector` / `--expand-pct`).
+
+</Update>

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -1,0 +1,53 @@
+# Changelog
+
+The published changelog at [`/changelog`](https://docs.sightmap.org/changelog) is **generated**. Do not edit `changelog.mdx` by hand — edit the entry files here and rebuild.
+
+## Add an entry
+
+1. Create a file in `changelog/entries/` named `YYYY-MM-DD-slug.mdx`:
+
+   ```mdx
+   ---
+   label: "sightmap 0.17.0"
+   date: "2026-08-01"
+   tags: ["cli"]
+   ---
+   What changed, in prose. Markdown works — bullets, `code`, [links](https://example.com).
+   ```
+
+2. Regenerate the page:
+
+   ```bash
+   node scripts/build-changelog.mjs
+   ```
+
+3. Commit both the entry file and the regenerated `changelog.mdx`.
+
+That's the whole workflow. No build step, no dependencies — Mintlify serves the committed `changelog.mdx` directly.
+
+## Entry format
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `label` | yes | Shown as the update's title, e.g. `"sightmap 0.17.0"`. |
+| `date` | yes | `YYYY-MM-DD`. Sorts entries (newest first) and renders as "Released Month D, YYYY". |
+| `tags` | no | JSON array, e.g. `["cli"]` or `["go"]`. Rendered as filters in the changelog's right panel. |
+| `description` | no | Appended after the date in the update's subtitle. |
+
+The body below the frontmatter is the prose shown inside the entry. Keep **Markdown headings (`##`) out of the body** — Mintlify splits the RSS feed per heading, so a heading turns one release into several feed entries.
+
+## How entries get written
+
+For now, **manually** — a person drops an entry file per release.
+
+Changesets already produces essay-quality prose in `go/npm/CHANGELOG.md`. Copy the released version's block into an entry file, dropping the `### Patch Changes` heading and the `- <hash>:` prefixes. No rewriting needed.
+
+Releases that ship no user-visible change (a release-automation smoke test, for instance) still get an entry — the version appears on npm either way, and a gap in the list reads as an omission.
+
+## RSS
+
+The page sets `rss: true`, so Mintlify publishes a feed at `/changelog/rss.xml` with an RSS button on the page. Public sites only.
+
+## Keeping the page in sync (optional CI)
+
+`node scripts/build-changelog.mjs --check` exits non-zero when `changelog.mdx` is stale relative to the entry files. Wire it into CI to prevent a forgotten rebuild from shipping.

--- a/docs/changelog/entries/2026-07-25-sightmap-0.15.0.mdx
+++ b/docs/changelog/entries/2026-07-25-sightmap-0.15.0.mdx
@@ -1,0 +1,12 @@
+---
+label: "sightmap 0.15.0"
+date: "2026-07-25"
+tags: ["cli"]
+---
+
+CLI teardown: reorganize the tooling around reusable library subsystems and add browser devtools.
+
+- Separate `snapshot` (observe: annotated tree + coverage) from `capture` (persist into a view's set); extract the `observe`, `coverage`, `viewset`, and `authoring` packages and merge the internal `Session` into `Corpus`.
+- Make the `browser start` daemon the single session owner: retire `--launch` and the `browser launch` subcommand (live commands attach to a started session).
+- Add `console` and `network` devtools commands, backed by a session-lifetime collector in the daemon that buffers console messages (with uncaught exceptions folded in) and network requests, with lazy response bodies.
+- Add screenshot clipping to `browser screenshot` (`--component` / `--selector` / `--expand-pct`).

--- a/docs/changelog/entries/2026-07-26-sightmap-0.15.1.mdx
+++ b/docs/changelog/entries/2026-07-26-sightmap-0.15.1.mdx
@@ -1,0 +1,9 @@
+---
+label: "sightmap 0.15.1"
+date: "2026-07-26"
+tags: ["cli"]
+---
+
+Isolate concurrent browser sessions so agents working in different projects no longer cross-talk. The session file is now keyed to `--sightmap-dir` (it lives at `<sightmap-dir>/.session`) instead of a single shared `$TMPDIR` file, so a second `browser start` only ever reuses the Chrome for _its own_ corpus rather than piggybacking on another agent's browser. Free-port probing now checks the IPv4 loopback (where Chrome's CDP and the sightmap server bind), and the sightmap server binds `127.0.0.1`, so two daemons started on the default ports slide to non-overlapping ports instead of one daemon's server colliding with another's CDP port. Every session-aware `browser` command (including `console`/`network`, `status`/`stop`, `tabs`, and the low-level interactions) now accepts `--sightmap-dir` to select which session it talks to.
+
+Fix the Sightmap overlay getting stuck in a reload loop that flooded the captured console. The extension's version poll compared the raw `/sightmap/version` JSON text against the parsed version string, so it never matched and re-fetched every few seconds. The poll now parses the response and compares the `version` field. Also drop the post-install `chrome.runtime.reload()` step: a fresh `browser start` always relaunches Chrome with `--load-extension`, which loads the new unpacked extension directly, and the hot-reload could leave the overlay's content script uninjected until the next full restart.

--- a/docs/changelog/entries/2026-07-26-sightmap-0.15.2.mdx
+++ b/docs/changelog/entries/2026-07-26-sightmap-0.15.2.mdx
@@ -1,0 +1,12 @@
+---
+label: "sightmap 0.15.2"
+date: "2026-07-26"
+tags: ["cli"]
+---
+
+Make corpus loading robust against two malformed inputs that previously failed badly:
+
+- A circular `$ref` chain (`A → B → A`, or a component that references itself) sent every corpus-loading command into infinite recursion and hung the process. Loading now detects the cycle, stops expanding, and `validate` reports it as a `ref-circular` error instead of hanging.
+- `splitSelectors` only balanced parentheses, so a comma inside an attribute selector or quoted string (`[data-x="a,b"]`) was wrongly treated as a selector-list separator and split into two dead alternatives. Splitting is now aware of `[]` brackets and quoted strings (with backslash escapes), matching how CSS is actually written.
+
+Fix view route matching so it behaves as the spec documents. Trailing slashes are now normalized off both the route pattern and the URL path before matching, so a slash-free route like `/*/projects` matches the `/acme/projects/` paths that Django, Rails, and many React-Router apps emit — previously such URLs matched no view at all, silently dropping the `[View:]` header, view memory, and view-scoped components. Express-style `:param` segments in view routes now match a single path segment (and score between a literal and `*` for specificity). And `Corpus.ViewForURL` now returns the _most specific_ matching view — using declaration order only to break equal-specificity ties — instead of the first match in corpus order, closing a divergence between the exported library and the spec.

--- a/docs/changelog/entries/2026-07-26-sightmap-0.15.3.mdx
+++ b/docs/changelog/entries/2026-07-26-sightmap-0.15.3.mdx
@@ -1,0 +1,10 @@
+---
+label: "sightmap 0.15.3"
+date: "2026-07-26"
+tags: ["cli"]
+---
+
+Stop green-lighting broken corpora and blank pages:
+
+- `snapshot` now exits non-zero when the corpus is present but fails to parse (a missing corpus stays non-fatal — the tree still renders), and when the observed page has 0 interactive nodes (blank or still loading). It still renders whatever it observed first. `inspect` and `suggest` now warn on a bad corpus instead of silently ignoring it.
+- Coverage no longer marks a page with 0 interactive nodes as a pass. The coverage line renders a distinct `∅` mark (instead of `✓`), the `coverage` command counts empty captures as failures, and `capture` refuses to persist a blank/loading page as a view's baseline (override with `--force`).

--- a/docs/changelog/entries/2026-07-26-sightmap-0.15.4.mdx
+++ b/docs/changelog/entries/2026-07-26-sightmap-0.15.4.mdx
@@ -1,0 +1,7 @@
+---
+label: "sightmap 0.15.4"
+date: "2026-07-26"
+tags: ["cli"]
+---
+
+Make browser-use feedback loud: the interaction commands (`click`, `fill`, `hover`, `keypress`, `scroll`, `drag`, `wait-for`, `dialog`, `tabs resize`) now echo a short confirmation on success instead of exiting silently — e.g. `clicked CartNavButton @ (674,30)` — so an agent driving the browser can see what happened. Several raw CDP/Go errors are now rewritten into actionable messages: a `wait-for` timeout reads `timed out after 800ms waiting for selector "..."` (not `context deadline exceeded`), resolving a dialog when none is open says so plainly, and fetching an evicted network response body explains that bodies are only retained briefly. `snapshot` now prints a note when no `.sightmap` corpus is found at the target directory instead of silently rendering an un-annotated tree.

--- a/docs/changelog/entries/2026-07-26-sightmap-0.15.5.mdx
+++ b/docs/changelog/entries/2026-07-26-sightmap-0.15.5.mdx
@@ -1,0 +1,9 @@
+---
+label: "sightmap 0.15.5"
+date: "2026-07-26"
+tags: ["cli"]
+---
+
+Make `browser click` and `fill` fail loudly instead of silently no-op'ing. `click` now scrolls the target to the center of the viewport and verifies its center is the top-most element there before dispatching — it errors when the target can't be positioned in the viewport (previously an off-screen target below the fold was clicked at a coordinate that hit nothing and still exited 0) or is covered by another element (an open overlay/modal). The success confirmation reports the real post-scroll coordinates. `fill` now reads the value back after typing and errors when a non-empty value was typed but the field is still empty — the signature of a React-controlled input where plain typing doesn't stick — telling you to retry with `--clear`.
+
+`sel-probe` now cross-checks the offline matcher. It queries the live DOM as before, but also runs the same selector through the offline matcher that `snapshot`/`coverage`/`capture` use, prints that count, and emits a `⚠ offline/live divergence` warning (with a hint) when the two disagree. This closes the false-confidence trap where a selector "verified" against the live DOM is silently dead in the corpus — e.g. attribute selectors on `id` (`[id^="…"]`) match live but never offline, because `id` is a dedicated node field rather than a matchable attribute.

--- a/docs/changelog/entries/2026-07-27-sightmap-0.15.6.mdx
+++ b/docs/changelog/entries/2026-07-27-sightmap-0.15.6.mdx
@@ -1,0 +1,15 @@
+---
+label: "sightmap 0.15.6"
+date: "2026-07-27"
+tags: ["cli"]
+---
+
+`validate` now distinguishes **errors** (which fail validation, exit 1) from **warnings** (advisory, exit 0), and warns on silent corpus conflicts that a fallback rule was resolving without telling you:
+
+- **`merge-collision-view`** — two or more views share a `name`.
+- **`route-conflict`** — two or more views share the same (normalized) `route`; only the first-declared applies to that URL (this is the "same-route hijack" that can silently drop a view's components).
+- **`merge-collision-component`** — two or more root-level global components share a `name` with different selectors.
+
+Findings now carry a stable `code` and `severity`. Scoped component name reuse (the same child under multiple parents) is correctly _not_ flagged, since that is intentional. The spec's diagnostic-code table documents the new corpus codes.
+
+Make `snapshot` loud about corpus-match state instead of silently omitting it. When a corpus is loaded but no view's route matches the URL (e.g. an auth redirect to a login page), the output now shows a `[No view matched] <url>` notice instead of a headerless tree that looks identical to a normal snapshot — so an agent knows the page is off the map. And the `[Coverage]` summary is now printed whenever a corpus is applied, including for a matched view that has no components yet (every interactive node reads as an orphan); previously that case printed only the view header, leaving the documented `snapshot --coverage` bootstrap with nothing to iterate on.

--- a/docs/changelog/entries/2026-07-27-sightmap-0.15.7.mdx
+++ b/docs/changelog/entries/2026-07-27-sightmap-0.15.7.mdx
@@ -1,0 +1,23 @@
+---
+label: "sightmap 0.15.7"
+date: "2026-07-27"
+tags: ["cli"]
+---
+
+`snapshot` now surfaces runtime match conflicts in a `[Conflicts]` section — the ambiguities that only exist against a live page, complementing the static corpus-conflict warnings `validate` emits. Two triggers:
+
+- **A single DOM node matched by more than one distinct component name.** Matching is first-match-wins, so only one applied and the others were silently dropped — which is also why a correct-looking component can report `0 matches`. The section names the node, the competing components, and which one won.
+- **Two or more views matching the current URL at equal specificity**, where declaration order alone decided the winner.
+
+Adds `match.FindConflicts` and `Corpus.TiedViews`; both are computed during `observe.Page`. (The view-tie half is provisional pending the route-specificity decision in the functional-decomposition proposal.)
+
+`validate` now surfaces two classes of invalid corpus the loader previously dropped silently (so they shipped with a green check):
+
+- **Missing required fields** — a component with no `selector` (or no `name`), and a view with no `name`, are now errors (`missing-selector` / `missing-name` / `missing-route`) instead of being quietly discarded during load.
+- **Unresolved `$ref`** — a `$ref` naming a component that no file defines is now a `ref-unresolved` error (matching the spec's MUST), instead of the reference being silently skipped.
+
+Both exit non-zero. The spec's diagnostic-code table documents the new error codes alongside the corpus-conflict warnings.
+
+`validate` now warns on unknown fields. The typed loader silently ignored any YAML key it didn't recognize, so a typo like `memroy:` — or a half-baked field — vanished without a trace. `validate` now walks the raw YAML and emits an `unknown-field` **warning** (not an error) for any key the spec doesn't define at its position, at any nesting depth. It warns rather than rejects, so authors can stash experimental fields (e.g. `macros:`) during development; recognized fields — including the reserved tooling fields `access` and `snapshots` — are never flagged, and `.sightmap/config.yaml` is excluded. This completes strict `validate` alongside the earlier required-field and `$ref` checks.
+
+Fix `report` and make the view `url:` field first-class. `url:` is now read **per view** (with a file-level `url:` as a default for views that omit their own), instead of only at the file level. Previously per-view `url:` was silently dropped, so `report` — which needs a representative URL per view — errored with `no views with URLs found` even when every view declared one. `url:` is also now part of the published schema (SEP-accepted alongside `properties`), so a corpus that declares it validates instead of failing `additionalProperties: false`.

--- a/docs/changelog/entries/2026-07-27-sightmap-0.15.8.mdx
+++ b/docs/changelog/entries/2026-07-27-sightmap-0.15.8.mdx
@@ -1,0 +1,9 @@
+---
+label: "sightmap 0.15.8"
+date: "2026-07-27"
+tags: ["cli"]
+---
+
+Coverage and the annotated tree now agree on what counts as visible. `probe.js` set each node's `isVisible` from that element's _own_ computed style, which misses ancestor-driven hiding: a control inside a closed `opacity:0` overlay (a dismissed dropdown or context menu) has computed `opacity:1` of its own, so it reported visible even though it is painted nowhere. Coverage counted these while the renderer dropped the hidden container's subtree, so on real apps a large share of a page's interactive nodes (all the closed menus) silently inflated the count and tanked the score.
+
+`probe.js` now computes `isVisible` with the browser's own `Element.checkVisibility`, which accounts for ancestors hidden by `display:none`, `visibility:hidden`, `opacity:0`, or `content-visibility` — keeping the layout/rendering judgment in the real browser instead of re-deriving CSS semantics. `snapshot`/`coverage` "(visible only)" now excludes descendants of hidden containers; `--include-hidden` still counts every interactive node. The renderer also drops invisible subtrees regardless of interactivity so it and coverage read one signal.

--- a/docs/changelog/entries/2026-07-28-sightmap-0.15.9.mdx
+++ b/docs/changelog/entries/2026-07-28-sightmap-0.15.9.mdx
@@ -1,0 +1,20 @@
+---
+label: "sightmap 0.15.9"
+date: "2026-07-28"
+tags: ["cli"]
+---
+
+Offline selector matching now matches the live DOM for `id`, `class`, and SVG. Three gaps are closed so a selector `sel-probe` verifies live behaves the same way `snapshot`/`coverage`/`capture` see it offline:
+
+- **Attribute selectors on `id`** (`[id^="issue_"]`, `[id$=…]`, …) now match. `id` lives in a dedicated node field, so the matcher resolves `id`/`class` attribute selectors to those fields — not only to captured `attrs`.
+- **`placeholder`** is captured, so `input[placeholder="…"]` matches offline.
+- **SVG classes** are captured. On SVG elements `className` is an `SVGAnimatedString`, which broke the old extraction (it threw and dropped the whole selector); `probe.js` now uses `classList`, so `svg.lucide`, `[class*="lucide"]`, and `:has(svg.lucide-x)` match offline.
+
+The authoring skill and docs are corrected accordingly: attribute selectors on `class` and `id` are no longer described as "don't work offline" — they work, for HTML and SVG alike.
+
+Better handling of asynchronous SPA navigation, without baking implicit waits into `click`.
+
+- **`navigate` now reports client-side redirects.** It previously only saw server-side (HTTP) redirects, which are reflected by the load event; a client-side redirect that fires during hydration (an auth guard bouncing `/login → /`, or `/ → /workspace`) went unreported, so the caller was told it was somewhere it wasn't. `navigate` now waits briefly after load for a follow-up navigation and prints `(redirected to FINAL)` for those too.
+- **`wait-for` gains `--view` and `--component`.** These are the explicit, corpus-aware step boundaries to use after an action that should navigate (the act-then-wait split Playwright and Selenium use): `--view <Name>` waits until the current URL resolves to a named sightmap view, and `--component '<Query>'` waits until a component query — including property filters like `WorkItemRow[key="FALCON-7"]` — matches a node. Both auto-retry until they hold or time out loudly. `--url`, `--selector`, and `--load` remain the raw equivalents.
+
+`click` deliberately does **not** wait for or guess about resulting navigation — it acts, reports, and keeps its loud covered/off-screen refusals. Adds `browser.AwaitNavigation` (waits for `Page.frameNavigated` / `Page.navigatedWithinDocument`, settling chained redirects) behind `navigate`.

--- a/docs/changelog/entries/2026-07-30-sightmap-0.15.10.mdx
+++ b/docs/changelog/entries/2026-07-30-sightmap-0.15.10.mdx
@@ -1,0 +1,7 @@
+---
+label: "sightmap 0.15.10"
+date: "2026-07-30"
+tags: ["cli"]
+---
+
+Verify the changesets release automation end-to-end: no functional change.

--- a/docs/changelog/entries/2026-07-30-sightmap-0.16.0.mdx
+++ b/docs/changelog/entries/2026-07-30-sightmap-0.16.0.mdx
@@ -1,0 +1,7 @@
+---
+label: "sightmap 0.16.0"
+date: "2026-07-30"
+tags: ["go"]
+---
+
+Go library: `Corpus.Memory` now carries file-level `memory` entries (the loader previously dropped them). Lower the module's `go` directive from 1.25.2 to 1.23, its actual dependency floor, so consumers aren't forced onto a newer toolchain than the code requires.

--- a/docs/changelog/entries/2026-07-30-sightmap-0.16.1.mdx
+++ b/docs/changelog/entries/2026-07-30-sightmap-0.16.1.mdx
@@ -1,0 +1,7 @@
+---
+label: "sightmap 0.16.1"
+date: "2026-07-30"
+tags: ["go"]
+---
+
+The release workflow now pushes a `go/vX.Y.Z` tag alongside the existing `vX.Y.Z` tag. This module lives in the repo's `go/` subdirectory rather than at the root, and Go's module versioning requires a nested module's tags to be prefixed with that subdirectory — so `go get github.com/sightmap/sightmap/go@vX.Y.Z` has never actually resolved to a tagged release, only to `@latest`'s branch-tip pseudo-version. The bare tag is unchanged and still drives everything else (goreleaser, npm publishing, the release-already-tagged check).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -128,6 +128,12 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Changelog",
+        "pages": [
+          "changelog"
+        ]
       }
     ]
   },

--- a/docs/scripts/build-changelog.mjs
+++ b/docs/scripts/build-changelog.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Assemble changelog/entries/*.mdx into changelog.mdx.
+//
+// Each entry file is one release note. Frontmatter drives a Mintlify <Update>
+// block; the body is the prose shown inside it. Entries are ordered newest
+// first by `date`, then by filename as a tiebreak.
+//
+// Zero dependencies on purpose, so the script runs under a bare `node`. Run it
+// after adding or editing an entry, and commit the regenerated changelog.mdx
+// (Mintlify has no build step, so the rendered file is what ships).
+// See changelog/README.md.
+//
+//   node scripts/build-changelog.mjs           # regenerate
+//   node scripts/build-changelog.mjs --check   # exit 1 if out of date (CI)
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ENTRIES_DIR = join(ROOT, 'changelog', 'entries');
+const OUT = join(ROOT, 'changelog.mdx');
+
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'];
+
+// Parse an ISO YYYY-MM-DD without Date() to avoid timezone drift.
+function formatDate(iso) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!m) throw new Error(`date must be YYYY-MM-DD, got: ${iso}`);
+  return `${MONTHS[+m[2] - 1]} ${+m[3]}, ${m[1]}`;
+}
+
+// Minimal frontmatter reader for our own fixed schema. Values are either a
+// quoted string, a JSON array (tags), or a bare string.
+function parseEntry(file, text) {
+  const m = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(text);
+  if (!m) throw new Error(`${file}: missing frontmatter`);
+  const meta = {};
+  for (const line of m[1].split('\n')) {
+    if (!line.trim()) continue;
+    const kv = /^(\w+):\s*(.*)$/.exec(line);
+    if (!kv) throw new Error(`${file}: bad frontmatter line: ${line}`);
+    const [, key, rawVal] = kv;
+    let val = rawVal.trim();
+    if (val.startsWith('[')) val = JSON.parse(val);
+    else if (/^["'].*["']$/.test(val)) val = val.slice(1, -1);
+    meta[key] = val;
+  }
+  if (!meta.label) throw new Error(`${file}: 'label' is required`);
+  if (!meta.date) throw new Error(`${file}: 'date' is required`);
+  return { file, meta, body: m[2].trim() };
+}
+
+function renderUpdate({ meta, body }) {
+  const desc = meta.description
+    ? `Released ${formatDate(meta.date)} — ${meta.description}`
+    : `Released ${formatDate(meta.date)}`;
+  const attrs = [`label="${meta.label}"`, `description="${desc}"`];
+  if (Array.isArray(meta.tags) && meta.tags.length) {
+    attrs.push(`tags={${JSON.stringify(meta.tags)}}`);
+  }
+  // Blank lines around the body so Mintlify parses lists/paragraphs as
+  // markdown block content rather than JSX children.
+  return `<Update ${attrs.join(' ')}>\n\n${body}\n\n</Update>`;
+}
+
+function build() {
+  let files;
+  try {
+    files = readdirSync(ENTRIES_DIR).filter((f) => f.endsWith('.mdx') || f.endsWith('.md'));
+  } catch {
+    files = [];
+  }
+  const entries = files
+    .map((f) => parseEntry(f, readFileSync(join(ENTRIES_DIR, f), 'utf8')))
+    .sort((a, b) =>
+      a.meta.date === b.meta.date
+        ? b.file.localeCompare(a.file)
+        : b.meta.date.localeCompare(a.meta.date));
+
+  const header = `---
+title: "Changelog"
+description: "New features, improvements, and fixes in the sightmap CLI, library, and spec."
+rss: true
+---
+
+{/* GENERATED FILE — do not edit by hand.
+    Add an entry in changelog/entries/, then run: node scripts/build-changelog.mjs
+    Docs: changelog/README.md */}
+
+`;
+
+  const body = entries.length
+    ? entries.map(renderUpdate).join('\n\n') + '\n'
+    : 'No entries yet.\n';
+
+  return header + body;
+}
+
+const out = build();
+const check = process.argv.includes('--check');
+
+if (check) {
+  let current = '';
+  try { current = readFileSync(OUT, 'utf8'); } catch {}
+  if (current !== out) {
+    console.error('changelog.mdx is out of date. Run: node scripts/build-changelog.mjs');
+    process.exit(1);
+  }
+  console.log('changelog.mdx is up to date.');
+} else {
+  writeFileSync(OUT, out);
+  const n = (out.match(/<Update /g) || []).length;
+  console.log(`Wrote changelog.mdx (${n} ${n === 1 ? 'entry' : 'entries'}).`);
+}


### PR DESCRIPTION
Adds a `/changelog` page to the docs, generated from one MDX file per release.

- `changelog/entries/*.mdx` — one file per release, the source of truth.
- `scripts/build-changelog.mjs` — assembles them into `changelog.mdx` (Mintlify `<Update>` blocks, RSS on). The generated page is checked in because Mintlify has no build step; docs CI regenerates it and fails on drift, same as the schema page.
- Seeded with 13 entries from `go/npm/CHANGELOG.md` (0.15.0 → 0.16.1). Dates come from the version tags, falling back to the commit that added each version's block where the tag was never pushed.

Workflow is documented in `changelog/README.md`. Same system as the Subtext docs site.