### PR TITLE
SEP-0005: request `properties:` on RequestDef

### DIFF
--- a/.changeset/request-properties.md
+++ b/.changeset/request-properties.md
@@ -1,0 +1,17 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add `properties:` to request definitions ([SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md)): named values a consumer extracts from a live request/response pair, so a `200 OK` whose body says a payment was declined can be reasoned about.
+
+- `field` addresses a rooted path: `req`/`rsp`, then `.body.<path>` for JSON object-key traversal or `.headers.<name>` for one header value.
+- `pattern` is a regex against the raw response body, for a body `field` cannot traverse.
+- `transform` shares the component-property vocabulary.
+
+New validation, closing a gap where the Go SDK accepted corpora the JSON Schema rejected:
+
+- `request-property-invalid-name`, `request-property-no-extractor`, and `request-property-both-extractors` (errors) enforce in Go what only ajv enforced before.
+- `request-property-shadows-reserved` (warning) fires when a property is named `status`, `method`, or `duration`, which shadows the request's HTTP identity and makes it unreachable from a signal filter.
+- `field-type-invalid` (error) rejects an unquoted non-string scalar in a schema-string field. yaml.v3 decodes any scalar into a Go string by taking the raw lexeme, so `field: 200` used to load as `"200"` while ajv rejected it.
+
+Extraction itself is not implemented: the SDK parses and validates these declarations but resolves no path and applies no transform. `spec/v1/schema.md` now marks the evaluation requirements as such.

--- a/.changeset/request-properties.md
+++ b/.changeset/request-properties.md
@@ -4,14 +4,15 @@
 
 Add `properties:` to request definitions ([SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md)): named values a consumer extracts from a live request/response pair, so a `200 OK` whose body says a payment was declined can be reasoned about.
 
-- `field` addresses a rooted path: `req`/`rsp`, then `.body.<path>` for JSON object-key traversal or `.headers.<name>` for one header value.
-- `pattern` is a regex against the raw response body, for a body `field` cannot traverse.
-- `transform` shares the component-property vocabulary.
+- `source` names the root (a closed enum: `req.body`/`rsp.body`/`req.headers`/`rsp.headers`).
+- `field` selects a value within `source`: an object-key dot-path for a body source, a header name for a headers source (required there).
+- `pattern` is an **RE2** regex (Go `regexp` / the `re2` npm package for JS; no backreferences or lookaround) that refines what `field` resolved, or scans the raw source text when `field` is absent. `field` and `pattern` compose (`anyOf`) instead of being mutually exclusive.
+- `transform` shares the component-property vocabulary (unchanged; cleanup tracked separately).
 
 New validation, closing a gap where the Go SDK accepted corpora the JSON Schema rejected:
 
-- `request-property-invalid-name`, `request-property-no-extractor`, and `request-property-both-extractors` (errors) enforce in Go what only ajv enforced before.
+- `request-property-invalid-name`, `request-property-no-extractor`, `request-property-source-invalid`, `request-property-headers-require-field`, and `request-property-pattern-invalid` (errors) enforce in Go what only ajv enforced before.
 - `request-property-shadows-reserved` (warning) fires when a property is named `status`, `method`, or `duration`, which shadows the request's HTTP identity and makes it unreachable from a signal filter.
-- `field-type-invalid` (error) rejects an unquoted non-string scalar in a schema-string field. yaml.v3 decodes any scalar into a Go string by taking the raw lexeme, so `field: 200` used to load as `"200"` while ajv rejected it.
+- `field-type-invalid` (error) rejects an unquoted non-string scalar in a schema-string field. yaml.v3 decodes any scalar into a Go string by taking the raw lexeme, so `source: 200` used to load as `"200"` while ajv rejected it.
 
-Extraction itself is not implemented: the SDK parses and validates these declarations but resolves no path and applies no transform. `spec/v1/schema.md` now marks the evaluation requirements as such.
+Extraction itself is not implemented: the SDK parses and validates these declarations but resolves no `source`/`field`/`pattern` and applies no transform. `spec/v1/schema.md` marks the evaluation requirements as such, and the `018-request-properties` conformance fixture is now executed by the Go test suite.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -244,39 +244,50 @@ A named API endpoint.
   route: /api/checkout/pay
   method: POST
   properties:
+    # A JSON body value: `field` is an object-key path within `source`.
     - name: outcome
-      field: rsp.body.status
+      source: rsp.body
+      field: status
 
 - name: CheckoutRetryPayment
   route: /api/checkout/pay/retry
   method: POST
   properties:
+    # A header value refined by a regex: `field` names the header, `pattern`
+    # extracts a substring from what it resolves to.
     - name: rate_limit_remaining
-      field: rsp.headers.X-RateLimit-Remaining
-      transform: number
+      source: rsp.headers
+      field: X-RateLimit-Remaining
+      pattern: '(\d+)'
 
-# `pattern` is for a body `field` cannot traverse — here the response is
-# form-encoded, so it has no JSON keys to walk.
 - name: LegacyCheckoutCallback
   route: /api/checkout/callback
   method: POST
   properties:
-    - name: outcome
+    # No `field`: the response is form-encoded, so there's no JSON body to
+    # traverse — `pattern` scans the raw source text directly.
+    - name: legacy_outcome
+      source: rsp.body
       pattern: '(?:declined|approved|deferred)'
 ```
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
-| `field` | string | one of `field`/`pattern` | A rooted path: `req` or `rsp`, then `.body.<path>` (object-key traversal into the parsed JSON body) or `.headers.<name>` (one header's value, name matched case-insensitively). Also accepts a reserved identity name (`status`, `method`, `duration`). |
-| `pattern` | string | one of `field`/`pattern` | Regex matched against the raw text of the response body, for content `field`'s object-key traversal cannot reach (a non-JSON body, or a value embedded in a larger string). Carries no root of its own. |
+| `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
+| `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
+| `pattern` | string | see below | An RE2 regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
 | `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
 
-Exactly one of `field`/`pattern` is required. **Value omission is silent** — a property that doesn't resolve (a missing key, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
+At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes).
+
+`pattern` uses **RE2** syntax (Go's `regexp`; no backreferences or lookaround) — a linear-time, predictable dialect, so authoring-time validation and runtime matching agree across SDKs. The reference CLI rejects an invalid pattern (`request-property-pattern-invalid`).
+
+**Value omission is silent** — a property that doesn't resolve (a missing key, an out-of-range index, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
 
 Extraction requires **live traffic**. A tool operating on static corpus definitions alone MUST treat `properties:` as declared-but-unavailable, not an error.
 
-`status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. A consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
+`status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. They sit outside `source` entirely — a consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
 
 `properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md).
 
@@ -446,7 +457,10 @@ A conforming SDK:
 - MUST implement route matching as specified
 - MUST implement global vs view-scoped precedence as specified
 - MUST implement tag resolution as a union across every applicable definition, as specified in [Tags](#tags) — never narrowed by identity-resolution rules (nearest-wins, most-specific-wins)
-- MUST reject a `RequestProperty` declaring both `field` and `pattern`, or neither
+- MUST reject a `RequestProperty` with no `source`, or a `source` outside the four-value enum (`req.body`/`rsp.body`/`req.headers`/`rsp.headers`)
+- MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
+- MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
+- MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -455,9 +469,10 @@ An SDK that also **evaluates live activity** (observed network requests, console
 
 - MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
 - MUST omit an unresolved property value silently, without a diagnostic
+- MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `field`/`pattern` path and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern` and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -233,6 +233,52 @@ A named API endpoint.
 | `headers` | string[] | no | Notable header names to highlight in the network detail view. |
 | `memory` | string[] | no | Request-level memory entries. |
 | `tags` | string[] | no | Open-vocabulary classification labels for this request. See [Tags](#tags). |
+| `properties` | [RequestProperty](#request-properties)[] | no | Values to extract from live traffic. |
+
+### Request properties
+
+`properties:` declares named values to pull out of a live request/response pair, so a consumer can reason about what an endpoint's traffic actually said. An HTTP status of `200` does not distinguish an approved payment from a declined one when the outcome lives in the response body.
+
+```yaml
+- name: CheckoutPayment
+  route: /api/checkout/pay
+  method: POST
+  properties:
+    - name: outcome
+      field: rsp.body.status
+
+- name: CheckoutRetryPayment
+  route: /api/checkout/pay/retry
+  method: POST
+  properties:
+    - name: rate_limit_remaining
+      field: rsp.headers.X-RateLimit-Remaining
+      transform: number
+
+# `pattern` is for a body `field` cannot traverse — here the response is
+# form-encoded, so it has no JSON keys to walk.
+- name: LegacyCheckoutCallback
+  route: /api/checkout/callback
+  method: POST
+  properties:
+    - name: outcome
+      pattern: '(?:declined|approved|deferred)'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
+| `field` | string | one of `field`/`pattern` | A rooted path: `req` or `rsp`, then `.body.<path>` (object-key traversal into the parsed JSON body) or `.headers.<name>` (one header's value, name matched case-insensitively). Also accepts a reserved identity name (`status`, `method`, `duration`). |
+| `pattern` | string | one of `field`/`pattern` | Regex matched against the raw text of the response body, for content `field`'s object-key traversal cannot reach (a non-JSON body, or a value embedded in a larger string). Carries no root of its own. |
+| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+
+Exactly one of `field`/`pattern` is required. **Value omission is silent** — a property that doesn't resolve (a missing key, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
+
+Extraction requires **live traffic**. A tool operating on static corpus definitions alone MUST treat `properties:` as declared-but-unavailable, not an error.
+
+`status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. A consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
+
+`properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md).
 
 ### Payload
 
@@ -400,9 +446,18 @@ A conforming SDK:
 - MUST implement route matching as specified
 - MUST implement global vs view-scoped precedence as specified
 - MUST implement tag resolution as a union across every applicable definition, as specified in [Tags](#tags) — never narrowed by identity-resolution rules (nearest-wins, most-specific-wins)
+- MUST reject a `RequestProperty` declaring both `field` and `pattern`, or neither
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
+
+An SDK that also **evaluates live activity** (observed network requests, console records, DOM state) additionally:
+
+- MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
+- MUST omit an unresolved property value silently, without a diagnostic
+- SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
+
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `field`/`pattern` path and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -79,15 +79,24 @@ type rawProperty struct {
 }
 
 type rawRequest struct {
-	Name        string      `yaml:"name"`
-	Route       string      `yaml:"route"`
-	Method      string      `yaml:"method"`
-	Description string      `yaml:"description"`
-	Source      string      `yaml:"source"`
-	Request     *rawPayload `yaml:"request"`
-	Response    *rawPayload `yaml:"response"`
-	Headers     []string    `yaml:"headers"`
-	Memory      []string    `yaml:"memory"`
+	Name        string               `yaml:"name"`
+	Route       string               `yaml:"route"`
+	Method      string               `yaml:"method"`
+	Description string               `yaml:"description"`
+	Source      string               `yaml:"source"`
+	Request     *rawPayload          `yaml:"request"`
+	Response    *rawPayload          `yaml:"response"`
+	Headers     []string             `yaml:"headers"`
+	Memory      []string             `yaml:"memory"`
+	Tags        []string             `yaml:"tags"`
+	Properties  []rawRequestProperty `yaml:"properties"`
+}
+
+type rawRequestProperty struct {
+	Name      string `yaml:"name"`
+	Field     string `yaml:"field"`
+	Pattern   string `yaml:"pattern"`
+	Transform string `yaml:"transform"`
 }
 
 type rawPayload struct {
@@ -324,6 +333,28 @@ func toRequestDefs(rrs []rawRequest, ctx *flattenCtx) []RequestDef {
 			Response:    toPayload(rr.Response),
 			Headers:     rr.Headers,
 			Memory:      rr.Memory,
+			Tags:        rr.Tags,
+			Properties:  toRequestProperties(rr.Properties),
+		})
+	}
+	return out
+}
+
+// toRequestProperties converts raw property declarations (SEP-0005). Shape
+// constraints (a valid name, exactly one of field/pattern) are reported by
+// checkRequestProperties at validation time rather than dropped here, so an
+// author sees every problem at once instead of losing entries silently.
+func toRequestProperties(rps []rawRequestProperty) []RequestProperty {
+	if len(rps) == 0 {
+		return nil
+	}
+	out := make([]RequestProperty, 0, len(rps))
+	for _, rp := range rps {
+		out = append(out, RequestProperty{
+			Name:      rp.Name,
+			Field:     rp.Field,
+			Pattern:   rp.Pattern,
+			Transform: rp.Transform,
 		})
 	}
 	return out

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -94,6 +94,7 @@ type rawRequest struct {
 
 type rawRequestProperty struct {
 	Name      string `yaml:"name"`
+	Source    string `yaml:"source"`
 	Field     string `yaml:"field"`
 	Pattern   string `yaml:"pattern"`
 	Transform string `yaml:"transform"`
@@ -352,6 +353,7 @@ func toRequestProperties(rps []rawRequestProperty) []RequestProperty {
 	for _, rp := range rps {
 		out = append(out, RequestProperty{
 			Name:      rp.Name,
+			Source:    rp.Source,
 			Field:     rp.Field,
 			Pattern:   rp.Pattern,
 			Transform: rp.Transform,

--- a/go/sightmap/request.go
+++ b/go/sightmap/request.go
@@ -34,7 +34,10 @@ type RequestDef struct {
 }
 
 // RequestProperty declares a named value to extract from a live request/response
-// pair (SEP-0005). Exactly one of Field or Pattern is set.
+// pair (SEP-0005). Source names which root to read (a request/response body or
+// header block); Field selects a value within it; Pattern optionally refines
+// what Field resolved (or scans the raw source text when Field is absent). At
+// least one of Field or Pattern is set.
 //
 // Extraction is a live-traffic concern: these declarations name where a value
 // lives, and a consumer observing real traffic resolves them. A tool working
@@ -42,19 +45,27 @@ type RequestDef struct {
 // declared-but-unavailable rather than an error.
 type RequestProperty struct {
 	Name string `json:"name"`
-	// Field is a rooted path: "req" or "rsp", then either ".body.<path>"
-	// (object-key traversal into the parsed JSON body) or ".headers.<name>"
-	// (one header's value, name matched case-insensitively). The reserved
-	// identity names in ReservedRequestPropertyNames are also accepted.
+	// Source is the root to read from: one of RequestPropertySources
+	// ("req.body", "rsp.body", "req.headers", "rsp.headers").
+	Source string `json:"source"`
+	// Field selects a value within Source. For a body source it is a
+	// dot-separated object-key path (a numeric segment indexes an array when the
+	// value at that level is one). For a headers source it is a header name,
+	// matched case-insensitively, and is required.
 	Field string `json:"field,omitempty"`
-	// Pattern is a regex matched against the raw text of the response body,
-	// for content Field's object-key traversal cannot reach. It carries no
-	// root of its own.
+	// Pattern is an RE2 regex (Go's regexp; no backreferences or lookaround)
+	// applied to what Field resolved, or to the raw source text when Field is
+	// absent. Capture group 1 is the extracted value when present, else the
+	// entire match.
 	Pattern string `json:"pattern,omitempty"`
 	// Transform is optional post-processing, sharing componentProperty's
 	// vocabulary (SEP-0003).
 	Transform string `json:"transform,omitempty"`
 }
+
+// RequestPropertySources is the closed set of roots a RequestProperty.Source
+// may name (SEP-0005 §Extraction root).
+var RequestPropertySources = []string{"req.body", "rsp.body", "req.headers", "rsp.headers"}
 
 // ReservedRequestPropertyNames are the already-structured identity fields of a
 // request. A consumer may reference these wherever a property name is expected
@@ -62,12 +73,6 @@ type RequestProperty struct {
 // these names shadows the HTTP identity and makes it unreachable. Validation
 // warns on that shadowing; see checkRequestProperties.
 var ReservedRequestPropertyNames = []string{"status", "method", "duration"}
-
-// ReservedComponentPropertyNames are component property names that resolve
-// without a properties: declaration. `value` is always available from the
-// accessibility tree, so a signal filtering on it is valid even when the
-// component declares no properties of its own.
-var ReservedComponentPropertyNames = []string{"value"}
 
 // Payload is the expected shape of a request or response body. The field list
 // is advisory and not exhaustive — extra fields on the wire are not rejected.

--- a/go/sightmap/request.go
+++ b/go/sightmap/request.go
@@ -20,16 +20,54 @@ import (
 // sibling View / component definition types are regularized onto the same
 // convention separately.
 type RequestDef struct {
-	Name        string   `json:"name"`
-	Route       string   `json:"route,omitempty"`  // glob pattern; express-style ":param" segments match one segment
-	Method      string   `json:"method,omitempty"` // optional HTTP method filter; "" matches any method
-	Description string   `json:"description,omitempty"`
-	Source      string   `json:"source,omitempty"`
-	Request     *Payload `json:"request,omitempty"`  // expected request payload shape
-	Response    *Payload `json:"response,omitempty"` // expected response payload shape
-	Headers     []string `json:"headers,omitempty"`  // notable header names to highlight
-	Memory      []string `json:"memory,omitempty"`   // request-level memory entries
+	Name        string            `json:"name"`
+	Route       string            `json:"route,omitempty"`  // glob pattern; express-style ":param" segments match one segment
+	Method      string            `json:"method,omitempty"` // optional HTTP method filter; "" matches any method
+	Description string            `json:"description,omitempty"`
+	Source      string            `json:"source,omitempty"`
+	Request     *Payload          `json:"request,omitempty"`  // expected request payload shape
+	Response    *Payload          `json:"response,omitempty"` // expected response payload shape
+	Headers     []string          `json:"headers,omitempty"`  // notable header names to highlight
+	Memory      []string          `json:"memory,omitempty"`   // request-level memory entries
+	Tags        []string          `json:"tags,omitempty"`     // open-vocabulary labels (SEP-0004)
+	Properties  []RequestProperty `json:"properties,omitempty"`
 }
+
+// RequestProperty declares a named value to extract from a live request/response
+// pair (SEP-0005). Exactly one of Field or Pattern is set.
+//
+// Extraction is a live-traffic concern: these declarations name where a value
+// lives, and a consumer observing real traffic resolves them. A tool working
+// from static corpus definitions alone treats every property as
+// declared-but-unavailable rather than an error.
+type RequestProperty struct {
+	Name string `json:"name"`
+	// Field is a rooted path: "req" or "rsp", then either ".body.<path>"
+	// (object-key traversal into the parsed JSON body) or ".headers.<name>"
+	// (one header's value, name matched case-insensitively). The reserved
+	// identity names in ReservedRequestPropertyNames are also accepted.
+	Field string `json:"field,omitempty"`
+	// Pattern is a regex matched against the raw text of the response body,
+	// for content Field's object-key traversal cannot reach. It carries no
+	// root of its own.
+	Pattern string `json:"pattern,omitempty"`
+	// Transform is optional post-processing, sharing componentProperty's
+	// vocabulary (SEP-0003).
+	Transform string `json:"transform,omitempty"`
+}
+
+// ReservedRequestPropertyNames are the already-structured identity fields of a
+// request. A consumer may reference these wherever a property name is expected
+// without any properties: declaration, so declaring a property under one of
+// these names shadows the HTTP identity and makes it unreachable. Validation
+// warns on that shadowing; see checkRequestProperties.
+var ReservedRequestPropertyNames = []string{"status", "method", "duration"}
+
+// ReservedComponentPropertyNames are component property names that resolve
+// without a properties: declaration. `value` is always available from the
+// accessibility tree, so a signal filtering on it is valid even when the
+// component declares no properties of its own.
+var ReservedComponentPropertyNames = []string{"value"}
 
 // Payload is the expected shape of a request or response body. The field list
 // is advisory and not exhaustive — extra fields on the wire are not rejected.

--- a/go/sightmap/spec_conformance_test.go
+++ b/go/sightmap/spec_conformance_test.go
@@ -1,0 +1,121 @@
+package sightmap_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// The spec conformance fixtures under spec/conformance/*.fixture each carry an
+// expected.json whose `cases` are executed by almost nothing: the JS runner
+// (spec/scripts/validate-sightmap.mjs) only schema-validates the YAML, and the
+// Go match runner (go/match/conformance_test.go) reads a different corpus under
+// go/conformance/fixtures. So a fixture could assert diagnostics the reference
+// validator never produces and still stay green.
+//
+// runSpecValidateFixtures closes that gap for `validate` cases: it runs the
+// reference validator (the same sightmap.Validate the `validate` command calls)
+// over each fixture matching glob and asserts its `validate` case's diagnostics
+// exactly. It is scoped by glob on purpose — a whole-suite executor also needs
+// the match/lint/explain commands, and at least one existing fixture (017-tags)
+// currently diverges from its own expected.json, so a full executor is separate
+// work.
+func TestSpecConformance_RequestPropertyFixtures(t *testing.T) {
+	runSpecValidateFixtures(t, "*-request-properties.fixture")
+}
+
+func runSpecValidateFixtures(t *testing.T, glob string) {
+	t.Helper()
+	const root = "../../spec/conformance"
+	if _, err := os.Stat(root); err != nil {
+		t.Skipf("spec conformance fixtures not reachable from the module (%v)", err)
+	}
+	fixtures, err := filepath.Glob(filepath.Join(root, glob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatalf("no fixtures matched %q; did a fixture move or get renamed?", glob)
+	}
+	for _, dir := range fixtures {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			corpus, err := sightmap.Load(filepath.Join(dir, "sightmap"))
+			if err != nil {
+				t.Fatalf("load corpus: %v", err)
+			}
+			got := validateDiagnostics(corpus)
+			want := expectedValidateDiagnostics(t, filepath.Join(dir, "expected.json"))
+
+			sortDiags(got)
+			sortDiags(want)
+			if len(got) != len(want) {
+				t.Fatalf("validate diagnostics do not match expected.json\n got: %v\nwant: %v", got, want)
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("validate diagnostics do not match expected.json\n got: %v\nwant: %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+type specDiag struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+}
+
+// validateDiagnostics runs the checks the `validate` command runs and returns
+// each finding as a {code, severity} pair. Validate() is the whole story for a
+// property/message corpus (the command's extra "no-views" nudge only fires for
+// a corpus with global components).
+func validateDiagnostics(c *sightmap.Corpus) []specDiag {
+	var out []specDiag
+	for _, f := range sightmap.Validate(c) {
+		sev := "warning"
+		if f.IsError() {
+			sev = "error"
+		}
+		out = append(out, specDiag{Code: f.Code, Severity: sev})
+	}
+	return out
+}
+
+func expectedValidateDiagnostics(t *testing.T, path string) []specDiag {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read expected.json: %v", err)
+	}
+	var doc struct {
+		Cases []struct {
+			Command  string `json:"command"`
+			Expected struct {
+				Diagnostics []specDiag `json:"diagnostics"`
+			} `json:"expected"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse expected.json: %v", err)
+	}
+	for _, c := range doc.Cases {
+		if c.Command == "validate" {
+			return c.Expected.Diagnostics
+		}
+	}
+	t.Fatalf("expected.json has no validate case")
+	return nil
+}
+
+func sortDiags(d []specDiag) {
+	sort.Slice(d, func(i, j int) bool {
+		if d[i].Code != d[j].Code {
+			return d[i].Code < d[j].Code
+		}
+		return d[i].Severity < d[j].Severity
+	})
+}

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -33,7 +33,7 @@ var (
 	accessFields    = set("status", "reason")
 	snapshotFields  = set("name", "notes", "url")
 
-	requestPropertyFields = set("name", "field", "pattern", "transform")
+	requestPropertyFields = set("name", "source", "field", "pattern", "transform")
 )
 
 func set(keys ...string) map[string]bool {
@@ -247,7 +247,7 @@ func walkRequest(node *yaml.Node, file string, out *[]ValidationError) {
 	}
 	forEachItem(v["properties"], func(n *yaml.Node) {
 		pv := checkKeys(n, requestPropertyFields, file, out)
-		checkStringScalars(pv, []string{"name", "field", "pattern", "transform"}, file, out)
+		checkStringScalars(pv, []string{"name", "source", "field", "pattern", "transform"}, file, out)
 	})
 }
 

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -26,12 +26,14 @@ var (
 	viewFields      = set("name", "route", "url", "stability", "access", "description", "source", "dependencies", "memory", "components", "requests")
 	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "tags", "properties", "children")
 	refFields       = set("$ref")
-	requestFields   = set("name", "route", "method", "description", "source", "request", "response", "headers", "memory")
+	requestFields   = set("name", "route", "method", "description", "source", "request", "response", "headers", "memory", "tags", "properties")
 	payloadFields   = set("fields")
 	fieldFields     = set("name", "type", "description")
 	propertyFields  = set("name", "extract", "transform")
 	accessFields    = set("status", "reason")
 	snapshotFields  = set("name", "notes", "url")
+
+	requestPropertyFields = set("name", "field", "pattern", "transform")
 )
 
 func set(keys ...string) map[string]bool {
@@ -77,6 +79,37 @@ func checkKeys(node *yaml.Node, known map[string]bool, file string, out *[]Valid
 		}
 	}
 	return vals
+}
+
+// checkStringScalars reports a scalar value whose resolved YAML tag is not
+// !!str for a field the schema types as a string.
+//
+// This exists because yaml.v3 decodes any scalar into a Go string field by
+// taking the raw lexeme, without consulting the resolved tag. So `level: 500`
+// and `message: 404` load cleanly as "500" and "404", while ajv rejects both —
+// the Go SDK would accept corpora the reference JSON Schema refuses. A bare
+// `key:` is worse than a type mismatch: it resolves to !!null and lands as the
+// empty string, so a filter or pattern silently matches nothing.
+//
+// Only scalars need checking. A mapping or sequence where the schema wants a
+// string already fails in yaml.Unmarshal before this walker runs.
+func checkStringScalars(vals map[string]*yaml.Node, fields []string, file string, out *[]ValidationError) {
+	for _, name := range fields {
+		n := vals[name]
+		if n == nil || n.Kind != yaml.ScalarNode {
+			continue
+		}
+		if n.Tag == "" || n.Tag == "!!str" {
+			continue
+		}
+		*out = append(*out, ValidationError{
+			File:     file,
+			Code:     "field-type-invalid",
+			Severity: SeverityError,
+			Message: fmt.Sprintf("field %q must be a string (line %d); quote the value: %s: %q",
+				name, n.Line, name, n.Value),
+		})
+	}
 }
 
 // forEachItem calls fn on each element of a sequence node (no-op otherwise).
@@ -212,6 +245,10 @@ func walkRequest(node *yaml.Node, file string, out *[]ValidationError) {
 	if p := v["response"]; p != nil {
 		walkPayload(p, file, out)
 	}
+	forEachItem(v["properties"], func(n *yaml.Node) {
+		pv := checkKeys(n, requestPropertyFields, file, out)
+		checkStringScalars(pv, []string{"name", "field", "pattern", "transform"}, file, out)
+	})
 }
 
 func walkPayload(node *yaml.Node, file string, out *[]ValidationError) {

--- a/go/sightmap/unknownfields_test.go
+++ b/go/sightmap/unknownfields_test.go
@@ -213,9 +213,11 @@ requests:
           type: string
     properties:
       - name: outcome
-        field: rsp.body.status
+        source: rsp.body
+        field: status
         transform: slug
       - name: legacy
+        source: rsp.body
         pattern: 'declined'
 `)
 	if len(w) != 0 {

--- a/go/sightmap/unknownfields_test.go
+++ b/go/sightmap/unknownfields_test.go
@@ -116,3 +116,124 @@ views:
 		t.Errorf("expected no unknown-field warnings for an all-blessed corpus, got %v", w)
 	}
 }
+
+// findingsWithCode is unknownWarnings' generalization: filter a validation run
+// by any diagnostic code, not just unknown-field.
+func findingsWithCode(t *testing.T, code, yaml string) []sightmap.ValidationError {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "app.yaml"), yaml)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	var out []sightmap.ValidationError
+	for _, f := range sightmap.Validate(c) {
+		if f.Code == code {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// yaml.v3 decodes any scalar into a Go string field by taking the raw lexeme,
+// so an unquoted number used to load cleanly here while ajv rejected it. The
+// two conformance checkers have to agree.
+func TestFieldTypeInvalid_RequestPropertyNonStringScalars(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"integer field", "field: 200"},
+		{"integer pattern", "pattern: 404"},
+		{"bool field", "field: true"},
+		{"null field", "field:"},
+		{"float field", "field: 1.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findingsWithCode(t, "field-type-invalid", `
+version: 1
+requests:
+  - name: R
+    route: /api/x
+    properties:
+      - name: p
+        `+tc.yaml+`
+`)
+			if len(got) != 1 {
+				t.Fatalf("want 1 field-type-invalid, got %d: %v", len(got), got)
+			}
+			if !got[0].IsError() {
+				t.Error("a type mismatch must be an error, not a warning")
+			}
+		})
+	}
+}
+
+func TestFieldTypeInvalid_QuotedScalarsAreClean(t *testing.T) {
+	got := findingsWithCode(t, "field-type-invalid", `
+version: 1
+requests:
+  - name: R
+    route: /api/x
+    properties:
+      - name: p
+        field: "200"
+      - name: q
+        pattern: "404"
+`)
+	if len(got) != 0 {
+		t.Fatalf("quoted scalars must be clean, got %v", got)
+	}
+}
+
+// The requestFields / requestPropertyFields allowlists need a corpus that is
+// entirely valid, or a typo in either set would go unnoticed.
+func TestUnknownField_RequestPropertiesNoFalsePositives(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+requests:
+  - name: CheckoutPayment
+    route: /api/checkout/pay
+    method: POST
+    description: Pay
+    source: src/api/pay.ts
+    headers: [x-request-id]
+    memory:
+      - 429s past 10/min
+    tags: [checkout]
+    request:
+      fields:
+        - name: amount
+          type: number
+    response:
+      fields:
+        - name: status
+          type: string
+    properties:
+      - name: outcome
+        field: rsp.body.status
+        transform: slug
+      - name: legacy
+        pattern: 'declined'
+`)
+	if len(w) != 0 {
+		t.Fatalf("valid request properties must not warn: %v", w)
+	}
+}
+
+func TestUnknownField_RequestPropertyTypo(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+requests:
+  - name: R
+    route: /api/x
+    properties:
+      - name: p
+        feild: rsp.body.status
+`)
+	if len(w) != 1 {
+		t.Fatalf("want 1 unknown-field for the typo, got %d: %v", len(w), w)
+	}
+}

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -122,6 +122,9 @@ func Validate(c *Corpus) []ValidationError {
 	errs = append(errs, checkViewNameCollisions(c.Views)...)
 	errs = append(errs, checkRouteCollisions(c.Views)...)
 
+	// Request property shape (SEP-0005); see validate_request.go.
+	errs = append(errs, checkRequestProperties(c)...)
+
 	return errs
 }
 

--- a/go/sightmap/validate_request.go
+++ b/go/sightmap/validate_request.go
@@ -1,0 +1,100 @@
+package sightmap
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+)
+
+// requestPropertyNamePattern mirrors $defs.requestProperty.properties.name in
+// sightmap.schema.json, and componentProperty.name before it.
+var requestPropertyNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// checkRequestProperties validates the shape of every declared request property
+// (SEP-0005).
+//
+// These constraints live in the JSON Schema too, but only ajv enforces them
+// there. The Go CLI never validates against sightmap.schema.json, so without
+// this a corpus declaring both field and pattern (or neither, or an invalid
+// name) passes `sightmap validate` and fails `npm run validate:conformance` —
+// two conformance checkers disagreeing about the same file.
+//
+// Requests are read from Corpus.Requests and each View.Requests directly rather
+// than through a whole-corpus accessor: those dedupe by first-seen name, which
+// would skip a view-scoped request whose name matches a global one.
+func checkRequestProperties(c *Corpus) []ValidationError {
+	var errs []ValidationError
+	seen := map[string]bool{}
+
+	check := func(reqs []RequestDef) {
+		for _, req := range reqs {
+			for _, prop := range req.Properties {
+				for _, e := range validateRequestProperty(req.Name, prop) {
+					// Dedupe on code + request + property so a request declared
+					// both globally and under a view reports once.
+					key := e.Code + "\x00" + req.Name + "\x00" + prop.Name
+					if seen[key] {
+						continue
+					}
+					seen[key] = true
+					errs = append(errs, e)
+				}
+			}
+		}
+	}
+
+	check(c.Requests)
+	for i := range c.Views {
+		check(c.Views[i].Requests)
+	}
+	return errs
+}
+
+func validateRequestProperty(reqName string, prop RequestProperty) []ValidationError {
+	var errs []ValidationError
+
+	if !requestPropertyNamePattern.MatchString(prop.Name) {
+		errs = append(errs, ValidationError{
+			Component: reqName,
+			Code:      "request-property-invalid-name",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("request %q declares a property named %q; names must match %s",
+				reqName, prop.Name, requestPropertyNamePattern),
+		})
+	}
+
+	switch {
+	case prop.Field != "" && prop.Pattern != "":
+		errs = append(errs, ValidationError{
+			Component: reqName,
+			Code:      "request-property-both-extractors",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("request %q property %q declares both field and pattern; exactly one is allowed",
+				reqName, prop.Name),
+		})
+	case prop.Field == "" && prop.Pattern == "":
+		errs = append(errs, ValidationError{
+			Component: reqName,
+			Code:      "request-property-no-extractor",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("request %q property %q declares neither field nor pattern; exactly one is required",
+				reqName, prop.Name),
+		})
+	}
+
+	// A declared property shadows the reserved identity name, which is legal and
+	// is what SEP-0005's own motivating example does (`name: status` extracting
+	// `rsp.body.status`). It is worth a warning because the HTTP identity then
+	// becomes unreachable from a signal filter.
+	if slices.Contains(ReservedRequestPropertyNames, prop.Name) {
+		errs = append(errs, ValidationError{
+			Component: reqName,
+			Code:      "request-property-shadows-reserved",
+			Severity:  SeverityWarning,
+			Message: fmt.Sprintf("request %q declares a property named %q, shadowing the reserved request identity of the same name; a signal filtering on %q will see the extracted value, not the HTTP %s",
+				reqName, prop.Name, prop.Name, prop.Name),
+		})
+	}
+
+	return errs
+}

--- a/go/sightmap/validate_request.go
+++ b/go/sightmap/validate_request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 )
 
 // requestPropertyNamePattern mirrors $defs.requestProperty.properties.name in
@@ -15,9 +16,10 @@ var requestPropertyNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 //
 // These constraints live in the JSON Schema too, but only ajv enforces them
 // there. The Go CLI never validates against sightmap.schema.json, so without
-// this a corpus declaring both field and pattern (or neither, or an invalid
-// name) passes `sightmap validate` and fails `npm run validate:conformance` —
-// two conformance checkers disagreeing about the same file.
+// this a corpus with a bad source, no extractor, a headers source missing its
+// field, an invalid pattern, or an invalid name passes `sightmap validate` and
+// fails `npm run validate:conformance` — two conformance checkers disagreeing
+// about the same file.
 //
 // Requests are read from Corpus.Requests and each View.Requests directly rather
 // than through a whole-corpus accessor: those dedupe by first-seen name, which
@@ -63,23 +65,55 @@ func validateRequestProperty(reqName string, prop RequestProperty) []ValidationE
 		})
 	}
 
-	switch {
-	case prop.Field != "" && prop.Pattern != "":
+	// source is required and closed. field+pattern compose (anyOf), so both
+	// together is legal; only declaring neither is an error.
+	validSource := slices.Contains(RequestPropertySources, prop.Source)
+	if !validSource {
 		errs = append(errs, ValidationError{
 			Component: reqName,
-			Code:      "request-property-both-extractors",
+			Code:      "request-property-source-invalid",
 			Severity:  SeverityError,
-			Message: fmt.Sprintf("request %q property %q declares both field and pattern; exactly one is allowed",
-				reqName, prop.Name),
+			Message: fmt.Sprintf("request %q property %q has source %q; must be one of %s",
+				reqName, prop.Name, prop.Source, strings.Join(RequestPropertySources, ", ")),
 		})
-	case prop.Field == "" && prop.Pattern == "":
+	}
+
+	if prop.Field == "" && prop.Pattern == "" {
 		errs = append(errs, ValidationError{
 			Component: reqName,
 			Code:      "request-property-no-extractor",
 			Severity:  SeverityError,
-			Message: fmt.Sprintf("request %q property %q declares neither field nor pattern; exactly one is required",
+			Message: fmt.Sprintf("request %q property %q declares neither field nor pattern; at least one is required",
 				reqName, prop.Name),
 		})
+	}
+
+	// A headers source has no structure below a header value, so a bare regex
+	// scan across the raw header block is the addressing foot-gun this shape
+	// removes: field must name the header.
+	if validSource && strings.HasSuffix(prop.Source, ".headers") && prop.Field == "" {
+		errs = append(errs, ValidationError{
+			Component: reqName,
+			Code:      "request-property-headers-require-field",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("request %q property %q reads from %q but omits field; a headers source must name a header in field",
+				reqName, prop.Name, prop.Source),
+		})
+	}
+
+	// pattern is an RE2 regex (SEP-0005). Compile it at validation time, as the
+	// message entity does for its own author-written regex, rather than storing a
+	// pattern nobody has proven is one.
+	if prop.Pattern != "" {
+		if _, err := regexp.Compile(prop.Pattern); err != nil {
+			errs = append(errs, ValidationError{
+				Component: reqName,
+				Code:      "request-property-pattern-invalid",
+				Severity:  SeverityError,
+				Message: fmt.Sprintf("request %q property %q: pattern regex parse error: %v",
+					reqName, prop.Name, err),
+			})
+		}
 	}
 
 	// A declared property shadows the reserved identity name, which is legal and

--- a/go/sightmap/validate_request_test.go
+++ b/go/sightmap/validate_request_test.go
@@ -37,19 +37,22 @@ func requestCorpus(props ...sightmap.RequestProperty) *sightmap.Corpus {
 	}
 }
 
-func TestValidate_RequestPropertyBothExtractors(t *testing.T) {
+// field and pattern compose now (anyOf), so declaring both is legal, not an
+// error. This is the SEP-0005 reshape: `field` selects, `pattern` refines.
+func TestValidate_RequestPropertyBothExtractorsCompose(t *testing.T) {
 	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
 		Name:    "outcome",
-		Field:   "rsp.body.status",
-		Pattern: "declined",
+		Source:  "rsp.body",
+		Field:   "status",
+		Pattern: `(\w+)`,
 	}))
-	if !hasCode(errs, "request-property-both-extractors") {
-		t.Fatalf("want request-property-both-extractors, got %v", findingCodes(errs))
+	if len(errs) != 0 {
+		t.Fatalf("field+pattern must compose cleanly, got %v", findingCodes(errs))
 	}
 }
 
 func TestValidate_RequestPropertyNoExtractor(t *testing.T) {
-	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{Name: "outcome"}))
+	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{Name: "outcome", Source: "rsp.body"}))
 	if !hasCode(errs, "request-property-no-extractor") {
 		t.Fatalf("want request-property-no-extractor, got %v", findingCodes(errs))
 	}
@@ -58,8 +61,9 @@ func TestValidate_RequestPropertyNoExtractor(t *testing.T) {
 func TestValidate_RequestPropertyInvalidName(t *testing.T) {
 	for _, name := range []string{"", "Outcome", "1st", "out-come", "out.come"} {
 		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
-			Name:  name,
-			Field: "rsp.body.status",
+			Name:   name,
+			Source: "rsp.body",
+			Field:  "status",
 		}))
 		if !hasCode(errs, "request-property-invalid-name") {
 			t.Errorf("name %q: want request-property-invalid-name, got %v", name, findingCodes(errs))
@@ -67,27 +71,74 @@ func TestValidate_RequestPropertyInvalidName(t *testing.T) {
 	}
 }
 
-// A header path through `field` is the form SEP-0007's example depends on. It
-// must validate cleanly; the contradicting "headers are always via pattern"
-// rule was removed from SEP-0005.
+// source is required and closed to four values.
+func TestValidate_RequestPropertySourceInvalid(t *testing.T) {
+	for _, src := range []string{"", "rsp", "rsp.cookies", "body", "req.query"} {
+		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+			Name:   "outcome",
+			Source: src,
+			Field:  "status",
+		}))
+		if !hasCode(errs, "request-property-source-invalid") {
+			t.Errorf("source %q: want request-property-source-invalid, got %v", src, findingCodes(errs))
+		}
+	}
+}
+
+// A headers source has no structure below a header value, so field is required
+// there — a bare pattern scan across the raw header block is the foot-gun the
+// source/field split removes.
+func TestValidate_RequestPropertyHeadersRequireField(t *testing.T) {
+	for _, src := range []string{"req.headers", "rsp.headers"} {
+		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+			Name:    "rate_limit_remaining",
+			Source:  src,
+			Pattern: `(\d+)`,
+		}))
+		if !hasCode(errs, "request-property-headers-require-field") {
+			t.Errorf("source %q: want request-property-headers-require-field, got %v", src, findingCodes(errs))
+		}
+	}
+}
+
+// A header value refined by a regex is the motivating rate-limit case: source
+// names the block, field names the header, pattern extracts the digits.
 func TestValidate_RequestPropertyHeaderFieldIsClean(t *testing.T) {
 	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
-		Name:      "rate_limit_remaining",
-		Field:     "rsp.headers.X-RateLimit-Remaining",
-		Transform: "number",
+		Name:    "rate_limit_remaining",
+		Source:  "rsp.headers",
+		Field:   "X-RateLimit-Remaining",
+		Pattern: `(\d+)`,
 	}))
 	if len(errs) != 0 {
 		t.Fatalf("want no findings, got %v", findingCodes(errs))
 	}
 }
 
+// A body source may carry pattern with no field (the form-encoded body case).
 func TestValidate_RequestPropertyPatternOnlyIsClean(t *testing.T) {
 	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
 		Name:    "outcome",
+		Source:  "rsp.body",
 		Pattern: `(?:declined|approved)`,
 	}))
 	if len(errs) != 0 {
 		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// pattern is an RE2 regex, compiled at validation time (mirrors the message
+// entity). An uncompilable pattern is an error, not a silently stored string.
+func TestValidate_RequestPropertyPatternInvalid(t *testing.T) {
+	for _, pat := range []string{"(", "[a-", `a{2,1}`} {
+		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+			Name:    "outcome",
+			Source:  "rsp.body",
+			Pattern: pat,
+		}))
+		if !hasCode(errs, "request-property-pattern-invalid") {
+			t.Errorf("pattern %q: want request-property-pattern-invalid, got %v", pat, findingCodes(errs))
+		}
 	}
 }
 
@@ -96,8 +147,9 @@ func TestValidate_RequestPropertyPatternOnlyIsClean(t *testing.T) {
 func TestValidate_RequestPropertyShadowsReserved(t *testing.T) {
 	for _, name := range []string{"status", "method", "duration"} {
 		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
-			Name:  name,
-			Field: "rsp.body." + name,
+			Name:   name,
+			Source: "rsp.body",
+			Field:  name,
 		}))
 		var found *sightmap.ValidationError
 		for i := range errs {
@@ -128,12 +180,12 @@ func TestValidate_RequestPropertyViewScoped(t *testing.T) {
 				Name:  "ViewScoped",
 				Route: "/api/x",
 				Properties: []sightmap.RequestProperty{
-					{Name: "outcome", Field: "rsp.body.a", Pattern: "b"},
+					{Name: "outcome", Source: "rsp.body"}, // no extractor
 				},
 			}},
 		}},
 	}
-	if !hasCode(sightmap.Validate(c), "request-property-both-extractors") {
+	if !hasCode(sightmap.Validate(c), "request-property-no-extractor") {
 		t.Fatalf("view-scoped request properties must be checked, got %v", findingCodes(sightmap.Validate(c)))
 	}
 }
@@ -141,7 +193,7 @@ func TestValidate_RequestPropertyViewScoped(t *testing.T) {
 // The same request name declared globally and under a view must report once,
 // not once per copy.
 func TestValidate_RequestPropertyDedupedAcrossScopes(t *testing.T) {
-	bad := []sightmap.RequestProperty{{Name: "outcome"}}
+	bad := []sightmap.RequestProperty{{Name: "outcome", Source: "rsp.body"}}
 	c := &sightmap.Corpus{
 		Requests: []sightmap.RequestDef{{Name: "Shared", Route: "/api/x", Properties: bad}},
 		Views: []sightmap.View{{

--- a/go/sightmap/validate_request_test.go
+++ b/go/sightmap/validate_request_test.go
@@ -1,0 +1,162 @@
+package sightmap_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// findingCodes returns the diagnostic codes from a validation run, so tests can
+// assert on codes rather than message text.
+func findingCodes(errs []sightmap.ValidationError) []string {
+	out := make([]string, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, e.Code)
+	}
+	return out
+}
+
+func hasCode(errs []sightmap.ValidationError, code string) bool {
+	for _, e := range errs {
+		if e.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func requestCorpus(props ...sightmap.RequestProperty) *sightmap.Corpus {
+	return &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{{
+			Name:       "CheckoutPayment",
+			Route:      "/api/checkout/pay",
+			Method:     "POST",
+			Properties: props,
+		}},
+	}
+}
+
+func TestValidate_RequestPropertyBothExtractors(t *testing.T) {
+	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+		Name:    "outcome",
+		Field:   "rsp.body.status",
+		Pattern: "declined",
+	}))
+	if !hasCode(errs, "request-property-both-extractors") {
+		t.Fatalf("want request-property-both-extractors, got %v", findingCodes(errs))
+	}
+}
+
+func TestValidate_RequestPropertyNoExtractor(t *testing.T) {
+	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{Name: "outcome"}))
+	if !hasCode(errs, "request-property-no-extractor") {
+		t.Fatalf("want request-property-no-extractor, got %v", findingCodes(errs))
+	}
+}
+
+func TestValidate_RequestPropertyInvalidName(t *testing.T) {
+	for _, name := range []string{"", "Outcome", "1st", "out-come", "out.come"} {
+		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+			Name:  name,
+			Field: "rsp.body.status",
+		}))
+		if !hasCode(errs, "request-property-invalid-name") {
+			t.Errorf("name %q: want request-property-invalid-name, got %v", name, findingCodes(errs))
+		}
+	}
+}
+
+// A header path through `field` is the form SEP-0007's example depends on. It
+// must validate cleanly; the contradicting "headers are always via pattern"
+// rule was removed from SEP-0005.
+func TestValidate_RequestPropertyHeaderFieldIsClean(t *testing.T) {
+	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+		Name:      "rate_limit_remaining",
+		Field:     "rsp.headers.X-RateLimit-Remaining",
+		Transform: "number",
+	}))
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+func TestValidate_RequestPropertyPatternOnlyIsClean(t *testing.T) {
+	errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+		Name:    "outcome",
+		Pattern: `(?:declined|approved)`,
+	}))
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// Declaring a reserved identity name is legal (SEP-0005's motivating example
+// does it) but shadows the HTTP identity, so it warns rather than erroring.
+func TestValidate_RequestPropertyShadowsReserved(t *testing.T) {
+	for _, name := range []string{"status", "method", "duration"} {
+		errs := sightmap.Validate(requestCorpus(sightmap.RequestProperty{
+			Name:  name,
+			Field: "rsp.body." + name,
+		}))
+		var found *sightmap.ValidationError
+		for i := range errs {
+			if errs[i].Code == "request-property-shadows-reserved" {
+				found = &errs[i]
+			}
+		}
+		if found == nil {
+			t.Fatalf("name %q: want request-property-shadows-reserved, got %v", name, findingCodes(errs))
+		}
+		if found.IsError() {
+			t.Errorf("name %q: shadowing must be a warning, not an error", name)
+		}
+		if !strings.Contains(found.Message, name) {
+			t.Errorf("name %q: message should name the property: %s", name, found.Message)
+		}
+	}
+}
+
+// View-scoped requests carry properties too, and are not reachable through the
+// dedupe-by-name whole-corpus accessors.
+func TestValidate_RequestPropertyViewScoped(t *testing.T) {
+	c := &sightmap.Corpus{
+		Views: []sightmap.View{{
+			Name:  "Checkout",
+			Route: "/checkout",
+			Requests: []sightmap.RequestDef{{
+				Name:  "ViewScoped",
+				Route: "/api/x",
+				Properties: []sightmap.RequestProperty{
+					{Name: "outcome", Field: "rsp.body.a", Pattern: "b"},
+				},
+			}},
+		}},
+	}
+	if !hasCode(sightmap.Validate(c), "request-property-both-extractors") {
+		t.Fatalf("view-scoped request properties must be checked, got %v", findingCodes(sightmap.Validate(c)))
+	}
+}
+
+// The same request name declared globally and under a view must report once,
+// not once per copy.
+func TestValidate_RequestPropertyDedupedAcrossScopes(t *testing.T) {
+	bad := []sightmap.RequestProperty{{Name: "outcome"}}
+	c := &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{{Name: "Shared", Route: "/api/x", Properties: bad}},
+		Views: []sightmap.View{{
+			Name:     "Checkout",
+			Route:    "/checkout",
+			Requests: []sightmap.RequestDef{{Name: "Shared", Route: "/api/x", Properties: bad}},
+		}},
+	}
+	n := 0
+	for _, e := range sightmap.Validate(c) {
+		if e.Code == "request-property-no-extractor" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("want 1 request-property-no-extractor, got %d", n)
+	}
+}

--- a/spec/conformance/018-request-properties.fixture/expected.json
+++ b/spec/conformance/018-request-properties.fixture/expected.json
@@ -1,0 +1,14 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": {
+        "ok": true,
+        "diagnostics": [
+          { "code": "request-property-shadows-reserved", "severity": "warning" }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/conformance/018-request-properties.fixture/sightmap/app.yaml
+++ b/spec/conformance/018-request-properties.fixture/sightmap/app.yaml
@@ -8,24 +8,29 @@ requests:
     method: POST
     properties:
       - name: status
-        field: rsp.body.status
+        source: rsp.body
+        field: status
 
-  # A header, addressed by `field`. No shadowing, so no diagnostic.
+  # A header value refined by a regex: `field` names the header, `pattern`
+  # extracts the digits. No shadowing, so no diagnostic. Also a plain body value.
   - name: CheckoutRetryPayment
     route: /api/checkout/pay/retry
     method: POST
     properties:
       - name: rate_limit_remaining
-        field: rsp.headers.X-RateLimit-Remaining
-        transform: number
+        source: rsp.headers
+        field: X-RateLimit-Remaining
+        pattern: '(\d+)'
       - name: outcome
-        field: rsp.body.status
+        source: rsp.body
+        field: status
 
-  # `pattern` reaches a body `field` cannot traverse: this response is
-  # form-encoded, so it has no JSON keys to walk.
+  # No `field`: the response is form-encoded, so `pattern` scans the raw body
+  # text directly.
   - name: LegacyCheckoutCallback
     route: /api/checkout/callback
     method: POST
     properties:
-      - name: outcome
+      - name: legacy_outcome
+        source: rsp.body
         pattern: '(?:declined|approved|deferred)'

--- a/spec/conformance/018-request-properties.fixture/sightmap/app.yaml
+++ b/spec/conformance/018-request-properties.fixture/sightmap/app.yaml
@@ -1,0 +1,31 @@
+version: 1
+requests:
+  # `status` shadows the reserved request identity of the same name. Legal, and
+  # warned about: a signal filtering on `status` here sees the body value, not
+  # the HTTP status code.
+  - name: CheckoutPayment
+    route: /api/checkout/pay
+    method: POST
+    properties:
+      - name: status
+        field: rsp.body.status
+
+  # A header, addressed by `field`. No shadowing, so no diagnostic.
+  - name: CheckoutRetryPayment
+    route: /api/checkout/pay/retry
+    method: POST
+    properties:
+      - name: rate_limit_remaining
+        field: rsp.headers.X-RateLimit-Remaining
+        transform: number
+      - name: outcome
+        field: rsp.body.status
+
+  # `pattern` reaches a body `field` cannot traverse: this response is
+  # form-encoded, so it has no JSON keys to walk.
+  - name: LegacyCheckoutCallback
+    route: /api/checkout/callback
+    method: POST
+    properties:
+      - name: outcome
+        pattern: '(?:declined|approved|deferred)'

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -54,6 +54,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 015 | `view-url` | `url:` on a view (and a file-level default) validates |
 | 016 | `stability-tooling-fields` | `stability:` (view + component) validates; reserved tooling fields `access:`/`snapshots:` are permitted |
 | 017 | `tags` | `tags:` validates on components (at multiple nesting levels), requests, and views ([SEP-0004](../seps/0004-component-tags.md)) |
+| 018 | `request-properties` | `properties:` on a request validates via `field` (body and header paths) and `pattern`; declaring a reserved identity name warns with `request-property-shadows-reserved` ([SEP-0005](../seps/0005-request-properties.md)) |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 
@@ -70,5 +71,7 @@ The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byt
 
 ## Consumers
 
-- The reference implementation under [`go/`](../../go/) runs these fixtures in CI.
+- CI schema-validates every `sightmap/*.yaml` here against `sightmap.schema.json` (`npm run validate:conformance`).
+- **The `cases` arrays are not executed yet.** `scripts/validate-sightmap.mjs` reads `expected.json` only to look for `fmt.schema-invalid`/`fmt.parse-error`, which tell it to skip a deliberately-invalid input. Nothing runs the `command`/`args` or asserts the `diagnostics`. The reference implementation's own fixture runner (`go/match/conformance_test.go`) reads a different corpus, under [`go/conformance/fixtures/`](../../go/conformance/fixtures/).
+- So a `cases` entry is a **contract for ports and a record of intent**, not a passing assertion. Treat a green `validate:conformance` as "these files are schema-valid", nothing more, and keep the Go unit tests as the real coverage for any diagnostic asserted here.
 - Community ports in other languages are expected to run the same fixtures via a port-specific runner.

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -225,6 +225,52 @@ A named API endpoint.
 | `headers` | string[] | no | Notable header names to highlight in the network detail view. |
 | `memory` | string[] | no | Request-level memory entries. |
 | `tags` | string[] | no | Open-vocabulary classification labels for this request. See [Tags](#tags). |
+| `properties` | [RequestProperty](#request-properties)[] | no | Values to extract from live traffic. |
+
+### Request properties
+
+`properties:` declares named values to pull out of a live request/response pair, so a consumer can reason about what an endpoint's traffic actually said. An HTTP status of `200` does not distinguish an approved payment from a declined one when the outcome lives in the response body.
+
+```yaml
+- name: CheckoutPayment
+  route: /api/checkout/pay
+  method: POST
+  properties:
+    - name: outcome
+      field: rsp.body.status
+
+- name: CheckoutRetryPayment
+  route: /api/checkout/pay/retry
+  method: POST
+  properties:
+    - name: rate_limit_remaining
+      field: rsp.headers.X-RateLimit-Remaining
+      transform: number
+
+# `pattern` is for a body `field` cannot traverse — here the response is
+# form-encoded, so it has no JSON keys to walk.
+- name: LegacyCheckoutCallback
+  route: /api/checkout/callback
+  method: POST
+  properties:
+    - name: outcome
+      pattern: '(?:declined|approved|deferred)'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
+| `field` | string | one of `field`/`pattern` | A rooted path: `req` or `rsp`, then `.body.<path>` (object-key traversal into the parsed JSON body) or `.headers.<name>` (one header's value, name matched case-insensitively). Also accepts a reserved identity name (`status`, `method`, `duration`). |
+| `pattern` | string | one of `field`/`pattern` | Regex matched against the raw text of the response body, for content `field`'s object-key traversal cannot reach (a non-JSON body, or a value embedded in a larger string). Carries no root of its own. |
+| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+
+Exactly one of `field`/`pattern` is required. **Value omission is silent** — a property that doesn't resolve (a missing key, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
+
+Extraction requires **live traffic**. A tool operating on static corpus definitions alone MUST treat `properties:` as declared-but-unavailable, not an error.
+
+`status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. A consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
+
+`properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](../seps/0005-request-properties.md).
 
 ### Payload
 
@@ -392,9 +438,18 @@ A conforming SDK:
 - MUST implement route matching as specified
 - MUST implement global vs view-scoped precedence as specified
 - MUST implement tag resolution as a union across every applicable definition, as specified in [Tags](#tags) — never narrowed by identity-resolution rules (nearest-wins, most-specific-wins)
+- MUST reject a `RequestProperty` declaring both `field` and `pattern`, or neither
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
+
+An SDK that also **evaluates live activity** (observed network requests, console records, DOM state) additionally:
+
+- MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
+- MUST omit an unresolved property value silently, without a diagnostic
+- SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
+
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `field`/`pattern` path and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -236,39 +236,50 @@ A named API endpoint.
   route: /api/checkout/pay
   method: POST
   properties:
+    # A JSON body value: `field` is an object-key path within `source`.
     - name: outcome
-      field: rsp.body.status
+      source: rsp.body
+      field: status
 
 - name: CheckoutRetryPayment
   route: /api/checkout/pay/retry
   method: POST
   properties:
+    # A header value refined by a regex: `field` names the header, `pattern`
+    # extracts a substring from what it resolves to.
     - name: rate_limit_remaining
-      field: rsp.headers.X-RateLimit-Remaining
-      transform: number
+      source: rsp.headers
+      field: X-RateLimit-Remaining
+      pattern: '(\d+)'
 
-# `pattern` is for a body `field` cannot traverse — here the response is
-# form-encoded, so it has no JSON keys to walk.
 - name: LegacyCheckoutCallback
   route: /api/checkout/callback
   method: POST
   properties:
-    - name: outcome
+    # No `field`: the response is form-encoded, so there's no JSON body to
+    # traverse — `pattern` scans the raw source text directly.
+    - name: legacy_outcome
+      source: rsp.body
       pattern: '(?:declined|approved|deferred)'
 ```
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
-| `field` | string | one of `field`/`pattern` | A rooted path: `req` or `rsp`, then `.body.<path>` (object-key traversal into the parsed JSON body) or `.headers.<name>` (one header's value, name matched case-insensitively). Also accepts a reserved identity name (`status`, `method`, `duration`). |
-| `pattern` | string | one of `field`/`pattern` | Regex matched against the raw text of the response body, for content `field`'s object-key traversal cannot reach (a non-JSON body, or a value embedded in a larger string). Carries no root of its own. |
+| `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
+| `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
+| `pattern` | string | see below | An RE2 regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
 | `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
 
-Exactly one of `field`/`pattern` is required. **Value omission is silent** — a property that doesn't resolve (a missing key, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
+At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes).
+
+`pattern` uses **RE2** syntax (Go's `regexp`; no backreferences or lookaround) — a linear-time, predictable dialect, so authoring-time validation and runtime matching agree across SDKs. The reference CLI rejects an invalid pattern (`request-property-pattern-invalid`).
+
+**Value omission is silent** — a property that doesn't resolve (a missing key, an out-of-range index, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
 
 Extraction requires **live traffic**. A tool operating on static corpus definitions alone MUST treat `properties:` as declared-but-unavailable, not an error.
 
-`status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. A consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
+`status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. They sit outside `source` entirely — a consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
 
 `properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](../seps/0005-request-properties.md).
 
@@ -438,7 +449,10 @@ A conforming SDK:
 - MUST implement route matching as specified
 - MUST implement global vs view-scoped precedence as specified
 - MUST implement tag resolution as a union across every applicable definition, as specified in [Tags](#tags) — never narrowed by identity-resolution rules (nearest-wins, most-specific-wins)
-- MUST reject a `RequestProperty` declaring both `field` and `pattern`, or neither
+- MUST reject a `RequestProperty` with no `source`, or a `source` outside the four-value enum (`req.body`/`rsp.body`/`req.headers`/`rsp.headers`)
+- MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
+- MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
+- MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -447,9 +461,10 @@ An SDK that also **evaluates live activity** (observed network requests, console
 
 - MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
 - MUST omit an unresolved property value silently, without a diagnostic
+- MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `field`/`pattern` path and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern` and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -222,6 +222,40 @@
           "type": "array",
           "items": { "type": "string", "minLength": 1 },
           "description": "Open-vocabulary classification labels for this request. Every request definition that matches applies its own tags — there is no single-winner resolution to shadow, unlike components or views. See SEP-0004."
+        },
+        "properties": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/requestProperty" },
+          "description": "Ordered list of live-traffic value extractions, for a consumer to filter or reason about. See SEP-0005."
+        }
+      }
+    },
+    "requestProperty": {
+      "type": "object",
+      "description": "A named value extracted from a live request/response pair. See SEP-0005.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "oneOf": [{ "required": ["field"] }, { "required": ["pattern"] }],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Key a consumer refers to this value by. Declaring one of the reserved request identity names (status, method, duration) shadows that identity; the reference CLI warns."
+        },
+        "field": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Rooted path: req|rsp, then .body.<path> for JSON object-key traversal or .headers.<name> for one header value (name matched case-insensitively). Also accepts a reserved identity name: status, method, duration. See SEP-0005 §Extraction root."
+        },
+        "pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Regex matched against the raw text of the response body, for content field's object-key traversal cannot reach (a non-JSON body, or a value embedded in a larger string). Carries no root of its own."
+        },
+        "transform": {
+          "type": "string",
+          "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
+          "description": "Optional post-processing applied to the extracted string. Same vocabulary as componentProperty.transform (SEP-0003)."
         }
       }
     },

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -233,24 +233,31 @@
     "requestProperty": {
       "type": "object",
       "description": "A named value extracted from a live request/response pair. See SEP-0005.",
-      "required": ["name"],
+      "required": ["name", "source"],
       "additionalProperties": false,
-      "oneOf": [{ "required": ["field"] }, { "required": ["pattern"] }],
+      "anyOf": [{ "required": ["field"] }, { "required": ["pattern"] }],
+      "if": { "properties": { "source": { "enum": ["req.headers", "rsp.headers"] } } },
+      "then": { "required": ["field"] },
       "properties": {
         "name": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9_]*$",
           "description": "Key a consumer refers to this value by. Declaring one of the reserved request identity names (status, method, duration) shadows that identity; the reference CLI warns."
         },
+        "source": {
+          "type": "string",
+          "enum": ["req.body", "rsp.body", "req.headers", "rsp.headers"],
+          "description": "Which root to read from. See SEP-0005 §Extraction root."
+        },
         "field": {
           "type": "string",
           "minLength": 1,
-          "description": "Rooted path: req|rsp, then .body.<path> for JSON object-key traversal or .headers.<name> for one header value (name matched case-insensitively). Also accepts a reserved identity name: status, method, duration. See SEP-0005 §Extraction root."
+          "description": "Value to select within source: an object-key path for a body source, a header name (case-insensitive) for a headers source. Required when source is a headers source. See SEP-0005 §Extraction root."
         },
         "pattern": {
           "type": "string",
           "minLength": 1,
-          "description": "Regex matched against the raw text of the response body, for content field's object-key traversal cannot reach (a non-JSON body, or a value embedded in a larger string). Carries no root of its own."
+          "description": "RE2 regex (no backreferences or lookaround) applied to what field resolved, or to the raw source text when field is absent. Capture group 1 is the value if present, else the full match."
         },
         "transform": {
           "type": "string",


### PR DESCRIPTION
Declaration and validation layer for [SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md). Extraction itself is not implemented, and `spec/v1/schema.md` now says so rather than asserting MUSTs the SDK does not meet.

## Rebased onto #162's request model

Previously this PR declared `match.Request`/`Payload`/`Field` plus `Corpus.GlobalRequests`, a second model of the same YAML that #162 also models as `sightmap.RequestDef` + `Corpus.Requests`. That duplicate is gone. `RequestDef` gains `Properties` and `Tags`, both with JSON wire tags so they survive serialization into the uploaded corpus.

Base is `joel/sightmap-matcher-engine` (#163) until that stack lands.

## The header contradiction

SEP-0005 specified header extraction two incompatible ways: its field reference permitted `.headers.<name>` for `field`, its Semantics section said headers are "always via `pattern`", and SEP-0007's example depends on the `field` form. The prose fix is #165; this PR carries the same resolution into `spec/v1/schema.md`, whose own 4-row table contradicted itself in adjacent rows.

The example changes accordingly. It previously read `pattern: 'X-RateLimit-Remaining:\s*(\d+)'`, a regex with no stated root or target, and now uses `field: rsp.headers.X-RateLimit-Remaining` with a separate entry that genuinely needs `pattern`.

## Validation

The JSON Schema already constrained these, but only ajv enforced it: the Go CLI never validates against `sightmap.schema.json`, so a corpus could pass `sightmap validate` and fail `npm run validate:conformance`.

| Code | Severity | Condition |
|---|---|---|
| `request-property-invalid-name` | error | empty, or fails `^[a-z][a-z0-9_]*$` |
| `request-property-no-extractor` | error | neither `field` nor `pattern` |
| `request-property-both-extractors` | error | both |
| `request-property-shadows-reserved` | warning | named `status`, `method`, or `duration` |
| `field-type-invalid` | error | an unquoted non-string scalar in a string field |

`field-type-invalid` closes a divergence worth naming: yaml.v3 decodes any scalar into a Go string field by taking the raw lexeme without checking the resolved tag, so `field: 200` loaded as `"200"` while ajv rejected it. Verified both layers now agree on `200`, `404`, `true`, `null`, `1.5`, and quoted `"200"`.

Shadowing is a warning rather than an error because SEP-0005's own motivating example does it (`name: status` extracting `rsp.body.status`). The cost is that the request's HTTP identity becomes unreachable from a signal filter, which the diagnostic explains.

## Also

- `spec/conformance/README.md` drops its claim that `go/` runs these fixtures in CI. It does not: `validate-sightmap.mjs` only schema-validates the YAML and reads `expected.json` for `fmt.*` skip codes, and the only Go fixture runner reads `go/conformance/fixtures/`. The `cases` arrays are contracts for ports, not executed assertions, and the README now says that.
- Fixture table gains its missing 018 row.
- Changeset added.

Verified: `go build`/`vet`/`test ./...`, `npm run validate:conformance`, `npm run validate:examples`, and the `docs/reference/schema.md` sync guardrail.