### PR TITLE
SEP-0006: a console/exception `messages:` entity

### DIFF
--- a/.changeset/message-entity.md
+++ b/.changeset/message-entity.md
@@ -8,7 +8,7 @@ Add a top-level `messages:` entity ([SEP-0006](https://github.com/sightmap/sight
 
 New validation:
 
-- `message-regex-invalid` (error) compiles `message` at validation time, matching how component selectors are already checked. The corpus no longer stores a pattern nobody has proven is a pattern.
+- `message-regex-invalid` (error) compiles `message` at validation time, matching how component selectors are already checked. The corpus no longer stores a pattern nobody has proven is a pattern. The dialect is pinned to **RE2** (Go `regexp` / the `re2` npm package for JS): a linear-time syntax with no backreferences or lookaround, so authoring-time validation and runtime matching agree across SDKs.
 - `merge-collision-message` (warning) reports a duplicated name. This one is load-bearing for SEP-0007: `ref:` resolution counts distinct entity kinds, so two messages sharing a name collapse to one kind and the ambiguity check never fires.
 - `message-conflict` (warning) reports two entries that can match the same record, where that overlap is statically decidable: same `level`, identical or absent `message`.
 - `message-level-unknown` (lint) catches a level outside the emitted vocabulary. The realistic trap is `WARNING`, CDP's own spelling, which the capture normalizes to `warn`.

--- a/.changeset/message-entity.md
+++ b/.changeset/message-entity.md
@@ -1,0 +1,19 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add a top-level `messages:` entity ([SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md)): named console-output and exception patterns, matched by `level` and a `message` regex. This gives console activity what `requests:` gives network activity, a named entity the rest of the corpus can reference by name.
+
+**An uncaught exception arrives as `level: exception`, not `level: error`.** The reference capture emits `log`, `debug`, `info`, `warn`, `error`, and `exception`, so `level: ERROR` matches `console.error` and does not match an exception. SEP-0006 still needs no `kind:` discriminator, because the origin is carried as a level value, but a corpus that wants exceptions has to name them.
+
+New validation:
+
+- `message-regex-invalid` (error) compiles `message` at validation time, matching how component selectors are already checked. The corpus no longer stores a pattern nobody has proven is a pattern.
+- `merge-collision-message` (warning) reports a duplicated name. This one is load-bearing for SEP-0007: `ref:` resolution counts distinct entity kinds, so two messages sharing a name collapse to one kind and the ambiguity check never fires.
+- `message-conflict` (warning) reports two entries that can match the same record, where that overlap is statically decidable: same `level`, identical or absent `message`.
+- `message-level-unknown` (lint) catches a level outside the emitted vocabulary. The realistic trap is `WARNING`, CDP's own spelling, which the capture normalizes to `warn`.
+- `field-type-invalid` (error) now covers message fields, so `message: 404` and `level: 500` are rejected in Go as ajv already rejected them.
+
+This resolves SEP-0006's open question on ambiguous-match diagnostics, which the SEP delegated to its implementation.
+
+Matching is not implemented: the SDK parses and validates these declarations but does not evaluate them against console records, even though the capture layer already collects both console output and exceptions.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -278,12 +278,10 @@ A named API endpoint.
 | `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
 | `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
 | `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
-| `pattern` | string | see below | An RE2 regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
+| `pattern` | string | see below | An [RE2](#regular-expressions) regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
 | `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
 
-At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes).
-
-`pattern` uses **RE2** syntax (Go's `regexp`; no backreferences or lookaround) — a linear-time, predictable dialect, so authoring-time validation and runtime matching agree across SDKs. The reference CLI rejects an invalid pattern (`request-property-pattern-invalid`).
+At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes). `pattern` is an [RE2 regular expression](#regular-expressions); the reference CLI rejects an invalid one (`request-property-pattern-invalid`).
 
 **Value omission is silent** — a property that doesn't resolve (a missing key, an out-of-range index, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
 
@@ -340,15 +338,11 @@ messages:
 |---|---|---|---|
 | `name` | string | yes | Stable identifier, addressable by name by other tooling. |
 | `level` | string | no | Exact, case-insensitive match against the observed record's level. Match-any if omitted. |
-| `message` | string | no | [RE2](#regular-expression-syntax) regex matched against the record's text. Match-any if omitted. |
+| `message` | string | no | [RE2](#regular-expressions) regex matched against the record's text. Match-any if omitted. |
 | `description` | string | no | What this pattern means, for a human reading the corpus. |
 | `source` | string | no | Relative path to the source most likely to emit this. |
 
-A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful.
-
-### Regular expression syntax
-
-The `message` regex uses **RE2** syntax — the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately: it matches in guaranteed linear time (no catastrophic backtracking), and because these patterns are validated at authoring time by one SDK and matched against a live console/exception stream at runtime by another, a single predictable dialect is what keeps the two from disagreeing about the same pattern. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and groups all work, which covers essentially every message pattern in practice. A conforming SDK MUST reject a `message` that is not a valid RE2 pattern (the reference CLI reports `message-regex-invalid`).
+A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful. `message` is an [RE2 regular expression](#regular-expressions).
 
 ### Message levels
 
@@ -370,6 +364,12 @@ The vocabulary is open: `level` is free text, not an enum, so a corpus may name 
 Two entries that can match the same record are reported as `message-conflict` (a warning) when the overlap is statically decidable: the same `level`, or one omitting it, with an identical or absent `message`. Deciding whether two different regexes can both match some record is not decidable in general.
 
 A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
+
+## Regular expressions
+
+Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)) and a message's `message` ([Message](#message)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
+
+A conforming SDK MUST reject a regular expression that is not valid RE2; the reference CLI reports `request-property-pattern-invalid` for a `pattern` and `message-regex-invalid` for a `message`.
 
 ## Memory
 
@@ -518,8 +518,8 @@ A conforming SDK:
 - MUST reject a `RequestProperty` with no `source`, or a `source` outside the four-value enum (`req.body`/`rsp.body`/`req.headers`/`rsp.headers`)
 - MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
-- MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
-- MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expression syntax](#regular-expression-syntax))
+- MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
+- MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -29,6 +29,7 @@ memory:      # optional, string[] — file-level notes (see "Memory")
 views:       # optional, View[]
 components:  # optional, Component[] — global, matched on every view
 requests:    # optional, Request[] — global, matched on every view
+messages:    # optional, Message[] — console/exception patterns
 ```
 
 | Field | Type | Required | Description |
@@ -38,6 +39,7 @@ requests:    # optional, Request[] — global, matched on every view
 | `views` | [View](#view)[] | no | Views defined in this file. |
 | `components` | (Component \| [ComponentRef](#component-references))[] | no | **Global** components — matched against every view. Entries may be either inline definitions or `$ref` reference objects. |
 | `requests` | [Request](#request)[] | no | **Global** requests — matched against every view. |
+| `messages` | [Message](#message)[] | no | Console-output and exception patterns. Corpus-root only; there is no view-scoped form. |
 
 ## View
 
@@ -313,6 +315,58 @@ request:
 | `type` | string | no | Free-text type label: `string`, `number`, `boolean`, `array`, `object`, or anything else an SDK author finds useful. |
 | `description` | string | no | Free-text description. |
 
+## Message
+
+A named console-output or runtime-exception pattern. This gives console activity what `requests:` gives network activity: a named entity the rest of the corpus can point at, so "a cart version mismatch broke checkout" is stated once rather than re-matched by every consumer.
+
+```yaml
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+    description: The cart was mutated by another tab; checkout will fail.
+    source: src/cart/sync.ts
+
+  - name: SlowNetworkWarning
+    level: WARN
+    message: 'request .* took over \d+ms'
+
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+    message: 'Cannot read propert(y|ies) .* of (null|undefined)'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Stable identifier, addressable by name by other tooling. |
+| `level` | string | no | Exact, case-insensitive match against the observed record's level. Match-any if omitted. |
+| `message` | string | no | Regex matched against the record's text. Match-any if omitted. |
+| `description` | string | no | What this pattern means, for a human reading the corpus. |
+| `source` | string | no | Relative path to the source most likely to emit this. |
+
+A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful.
+
+### Message levels
+
+The reference capture emits these levels:
+
+| Level | Origin |
+|---|---|
+| `log`, `debug`, `info` | `console.log` / `.debug` / `.info` |
+| `warn` | `console.warn` |
+| `error` | `console.error`, `console.assert` |
+| `exception` | An uncaught exception or unhandled rejection |
+
+**An uncaught exception arrives as `exception`, not as `error`.** So `level: ERROR` does not match one, and a corpus that wants exceptions must say `level: EXCEPTION`. Console output and exceptions still share one entity rather than needing a `kind:` discriminator, because the origin is carried as a level value.
+
+The vocabulary is open: `level` is free text, not an enum, so a corpus may name a level this capture never emits. That is deliberate, since another consumer's capture may have levels of its own. The tradeoff is that a typo (`level: WARNING`, which this capture normalizes to `warn`) matches nothing rather than being rejected.
+
+### Ambiguous matches
+
+Two entries that can match the same record are reported as `message-conflict` (a warning) when the overlap is statically decidable: the same `level`, or one omitting it, with an identical or absent `message`. Deciding whether two different regexes can both match some record is not decidable in general.
+
+A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
+
 ## Memory
 
 Memory entries are short freeform notes attached to any definition — file, view, component, or request. They exist so that agents can carry forward context that isn't recoverable from the source code: quirks, invariants, workarounds, "you have to click this twice" lore.
@@ -461,6 +515,7 @@ A conforming SDK:
 - MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
+- MUST reject a `messages:` entry whose `message` is not a valid regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -471,8 +526,10 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - MUST omit an unresolved property value silently, without a diagnostic
 - MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
+- MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
+- MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern` and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -340,11 +340,15 @@ messages:
 |---|---|---|---|
 | `name` | string | yes | Stable identifier, addressable by name by other tooling. |
 | `level` | string | no | Exact, case-insensitive match against the observed record's level. Match-any if omitted. |
-| `message` | string | no | Regex matched against the record's text. Match-any if omitted. |
+| `message` | string | no | [RE2](#regular-expression-syntax) regex matched against the record's text. Match-any if omitted. |
 | `description` | string | no | What this pattern means, for a human reading the corpus. |
 | `source` | string | no | Relative path to the source most likely to emit this. |
 
 A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful.
+
+### Regular expression syntax
+
+The `message` regex uses **RE2** syntax — the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately: it matches in guaranteed linear time (no catastrophic backtracking), and because these patterns are validated at authoring time by one SDK and matched against a live console/exception stream at runtime by another, a single predictable dialect is what keeps the two from disagreeing about the same pattern. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and groups all work, which covers essentially every message pattern in practice. A conforming SDK MUST reject a `message` that is not a valid RE2 pattern (the reference CLI reports `message-regex-invalid`).
 
 ### Message levels
 
@@ -515,7 +519,7 @@ A conforming SDK:
 - MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
-- MUST reject a `messages:` entry whose `message` is not a valid regular expression
+- MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expression syntax](#regular-expression-syntax))
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs

--- a/go/docs/reference/lint-rules.md
+++ b/go/docs/reference/lint-rules.md
@@ -156,3 +156,31 @@ selector: "#modal_12849"
 ```
 
 **Fix:** Add a `properties:` entry that extracts unique data from each instance. If the selector can be narrowed to unique attributes, update the selector instead. For child components, nest them under their parent component definition. For selector-unstable components (category D), mark as `stability: unstable` and document in `memory:`.
+
+## `message-level-unknown`
+
+**Triggers when:** a `messages:` entry declares a `level` outside the vocabulary the reference capture emits (`log`, `debug`, `info`, `warn`, `error`, `exception`).
+
+**Why it matters:** the entry can never match. Level comparison is case-insensitive equality, so a near-miss fails silently rather than erroring, and there is no output to tell you the pattern never fired.
+
+The realistic trap is `WARNING`. That is CDP's own spelling for the level, but the capture normalizes it to `warn`, so a corpus copied from CDP output matches nothing.
+
+```yaml
+# TRIGGERS — CDP spells it "warning", the capture normalizes to "warn"
+- name: SlowRequest
+  level: WARNING
+  message: 'took over \d+ms'
+
+# DOES NOT TRIGGER
+- name: SlowRequest
+  level: WARN
+  message: 'took over \d+ms'
+
+# DOES NOT TRIGGER — an uncaught exception arrives as its own level, not as error
+- name: UncaughtCheckoutError
+  level: EXCEPTION
+```
+
+This is advisory rather than a validation error because `level` is deliberately open: a consumer whose capture emits levels of its own is free to name them.
+
+**Fix:** use one of the six levels above, matching case-insensitively. If your consumer genuinely emits a different level, the warning is safe to ignore.

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -35,6 +35,10 @@ type Corpus struct {
 	// RequestsForURL.
 	Requests []RequestDef `json:"requests,omitempty"`
 
+	// Messages is the flat list of console-output and exception patterns (from a
+	// file-root `messages:` list). There is no view-scoped form.
+	Messages []MessageDef `json:"messages,omitempty"`
+
 	// loadDiagnostics holds structural problems detected while loading that are
 	// no longer visible in the flattened data (e.g. a circular $ref chain, which
 	// is expanded away). Validate surfaces these alongside its own checks.

--- a/go/sightmap/corpus_wire_test.go
+++ b/go/sightmap/corpus_wire_test.go
@@ -20,6 +20,7 @@ func TestCorpusWireRoundTrip(t *testing.T) {
 			{Name: "Search", Route: "/api/search", Method: "POST",
 				Request: &sightmap.Payload{Fields: []sightmap.Field{{Name: "q", Type: "string"}}}},
 		},
+		Messages: []sightmap.MessageDef{{Name: "CartVersionMismatch", Level: "ERROR", Message: "cart version mismatch"}},
 		Views: []sightmap.View{{
 			Name:       "Home",
 			Route:      "/",
@@ -40,7 +41,7 @@ func TestCorpusWireRoundTrip(t *testing.T) {
 	}
 	js := string(blob)
 
-	for _, want := range []string{`"memory"`, `"globals"`, `"views"`, `"requests"`, `"route":"/api/search"`, `"method":"POST"`, `"fields"`} {
+	for _, want := range []string{`"memory"`, `"globals"`, `"views"`, `"requests"`, `"route":"/api/search"`, `"method":"POST"`, `"fields"`, `"messages"`, `"level":"ERROR"`} {
 		if !strings.Contains(js, want) {
 			t.Errorf("wire JSON missing %s:\n%s", want, js)
 		}
@@ -64,6 +65,10 @@ func TestCorpusWireRoundTrip(t *testing.T) {
 	if len(back.Requests) != 1 || back.Requests[0].Method != "POST" ||
 		back.Requests[0].Request == nil || len(back.Requests[0].Request.Fields) != 1 {
 		t.Errorf("global request did not round-trip: %+v", back.Requests)
+	}
+	if len(back.Messages) != 1 || back.Messages[0].Name != "CartVersionMismatch" ||
+		back.Messages[0].Level != "ERROR" || back.Messages[0].Message != "cart version mismatch" {
+		t.Errorf("messages did not round-trip: %+v", back.Messages)
 	}
 	if back.Views[0].URL != "" || back.Views[0].Stability != "" || back.Views[0].SourceFile != "" {
 		t.Errorf("authoring fields should be empty after a wire round-trip: %+v", back.Views[0])

--- a/go/sightmap/lint.go
+++ b/go/sightmap/lint.go
@@ -3,6 +3,7 @@ package sightmap
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -67,6 +68,8 @@ func Lint(c *Corpus) []LintWarning {
 			warnings = append(warnings, lintComponent(comp, false)...)
 		}
 	}
+
+	warnings = append(warnings, lintMessageLevels(c.Messages)...)
 
 	// Deduplicate: view lists include $ref-expanded globals, so the same
 	// component can appear multiple times. Keep first occurrence of each
@@ -228,6 +231,8 @@ func LintWithCounts(c *Corpus, counts map[string]int) []LintWarning {
 		}
 	}
 
+	warnings = append(warnings, lintMessageLevels(c.Messages)...)
+
 	type warnKey struct{ rule, comp, sel string }
 	seen := make(map[warnKey]bool, len(warnings))
 	deduped := warnings[:0]
@@ -239,6 +244,35 @@ func LintWithCounts(c *Corpus, counts map[string]int) []LintWarning {
 		}
 	}
 	return deduped
+}
+
+// lintMessageLevels warns when a messages: entry names a level the reference
+// capture never emits, so it can never match.
+//
+// This is advisory rather than a validation error because `level` is
+// deliberately open: another consumer's capture may have levels of its own. But
+// the failure mode is silent, and the near-miss is easy to hit — CDP itself
+// spells the level "warning", which this capture normalizes to "warn", so
+// `level: WARNING` matches nothing and says nothing.
+func lintMessageLevels(msgs []MessageDef) []LintWarning {
+	var warnings []LintWarning
+	for _, m := range msgs {
+		if m.Level == "" || m.Name == "" {
+			continue
+		}
+		if slices.ContainsFunc(KnownMessageLevels, func(k string) bool {
+			return strings.EqualFold(k, m.Level)
+		}) {
+			continue
+		}
+		warnings = append(warnings, LintWarning{
+			Component: m.Name,
+			Rule:      "message-level-unknown",
+			Message: fmt.Sprintf("level %q is not one of %s, so this entry can never match a record from the reference capture",
+				m.Level, strings.Join(KnownMessageLevels, ", ")),
+		})
+	}
+	return warnings
 }
 
 // lintComponent runs per-component lint rules.

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -45,8 +45,17 @@ type rawFile struct {
 	Components []rawComponent `yaml:"components"`
 	Views      []rawView      `yaml:"views"`
 	Requests   []rawRequest   `yaml:"requests"`
+	Messages   []rawMessage   `yaml:"messages"`
 	URL        string         `yaml:"url"`
 	Snapshots  []rawSnapshot  `yaml:"snapshots"`
+}
+
+type rawMessage struct {
+	Name        string `yaml:"name"`
+	Level       string `yaml:"level"`
+	Message     string `yaml:"message"`
+	Description string `yaml:"description"`
+	Source      string `yaml:"source"`
 }
 
 type rawSnapshot struct {
@@ -174,6 +183,7 @@ func loadDir(path string) (*Corpus, error) {
 	var memory []string
 	var globalRaws []rawComponent
 	var globalRequestRaws []rawRequest
+	var messageRaws []rawMessage
 	type viewFileWithPath struct {
 		rf   rawFile
 		path string
@@ -201,6 +211,9 @@ func loadDir(path string) (*Corpus, error) {
 		}
 		if len(rf.Requests) > 0 {
 			globalRequestRaws = append(globalRequestRaws, rf.Requests...)
+		}
+		if len(rf.Messages) > 0 {
+			messageRaws = append(messageRaws, rf.Messages...)
 		}
 		if len(rf.Views) > 0 {
 			viewFiles = append(viewFiles, viewFileWithPath{rf: rf, path: p})
@@ -280,6 +293,7 @@ func loadDir(path string) (*Corpus, error) {
 		GlobalComponents: globalComps,
 		Views:            views,
 		Requests:         globalRequests,
+		Messages:         toMessageDefs(messageRaws),
 		loadDiagnostics:  append(ctx.diagnostics, fieldDiags...),
 	}, nil
 }
@@ -357,6 +371,27 @@ func toRequestProperties(rps []rawRequestProperty) []RequestProperty {
 			Field:     rp.Field,
 			Pattern:   rp.Pattern,
 			Transform: rp.Transform,
+		})
+	}
+	return out
+}
+
+// toMessageDefs converts raw console/exception patterns (SEP-0006). Shape
+// problems (a missing name, a duplicate, an uncompilable regex) are reported by
+// checkMessages at validation time rather than dropped here, so an author sees
+// every problem at once.
+func toMessageDefs(rms []rawMessage) []MessageDef {
+	if len(rms) == 0 {
+		return nil
+	}
+	out := make([]MessageDef, 0, len(rms))
+	for _, rm := range rms {
+		out = append(out, MessageDef{
+			Name:        rm.Name,
+			Level:       rm.Level,
+			Message:     rm.Message,
+			Description: rm.Description,
+			Source:      rm.Source,
 		})
 	}
 	return out

--- a/go/sightmap/message.go
+++ b/go/sightmap/message.go
@@ -22,9 +22,10 @@ type MessageDef struct {
 	// An uncaught exception arrives as level "exception", NOT as "error", so
 	// `level: ERROR` does not match one. See LevelException.
 	Level string `json:"level,omitempty"`
-	// Message is a regex matched against the record's text. Match-any when
-	// empty. Compiled at validation time so a malformed pattern is reported to
-	// the author rather than failing later.
+	// Message is an RE2 regex (Go's regexp; no backreferences or lookaround)
+	// matched against the record's text. Match-any when empty. Compiled at
+	// validation time so a malformed pattern is reported to the author rather
+	// than failing later.
 	Message     string `json:"message,omitempty"`
 	Description string `json:"description,omitempty"`
 	Source      string `json:"source,omitempty"`

--- a/go/sightmap/message.go
+++ b/go/sightmap/message.go
@@ -1,0 +1,55 @@
+package sightmap
+
+// MessageDef is a named console-output or runtime-exception pattern from the
+// sightmap corpus (SEP-0006). It gives console activity the same thing
+// RequestDef gives network activity: a named entity other parts of the corpus
+// can reference, so "a cart version mismatch broke checkout" can be stated once
+// and pointed at by name.
+//
+// A record matches when both declared constraints hold: Level compared
+// case-insensitively for equality, and Message as a regex against the record's
+// text. An omitted constraint matches anything.
+//
+// Messages are file-root only. Unlike components and requests there is no
+// view-scoped form, because a console record is not scoped to a page the way a
+// DOM element is.
+type MessageDef struct {
+	Name string `json:"name"`
+	// Level is compared case-insensitively for equality against the observed
+	// record's level. Match-any when empty.
+	//
+	// The reference capture emits log, debug, info, warn, error, and exception.
+	// An uncaught exception arrives as level "exception", NOT as "error", so
+	// `level: ERROR` does not match one. See LevelException.
+	Level string `json:"level,omitempty"`
+	// Message is a regex matched against the record's text. Match-any when
+	// empty. Compiled at validation time so a malformed pattern is reported to
+	// the author rather than failing later.
+	Message     string `json:"message,omitempty"`
+	Description string `json:"description,omitempty"`
+	Source      string `json:"source,omitempty"`
+}
+
+// Console levels the reference capture emits. An observed record carries one of
+// these; a MessageDef.Level is matched against it case-insensitively.
+//
+// LevelException is the one worth noting: SEP-0006 argues that console output
+// and exceptions need one entity rather than two, and that holds because the
+// origin is carried as a level value. It does not mean an exception is folded
+// into "error" — the two stay distinguishable, so a corpus that wants
+// exceptions must say so.
+const (
+	LevelLog       = "log"
+	LevelDebug     = "debug"
+	LevelInfo      = "info"
+	LevelWarn      = "warn"
+	LevelError     = "error"
+	LevelException = "exception"
+)
+
+// KnownMessageLevels is the vocabulary above, in increasing-severity order. The
+// `level` field is deliberately open (a corpus may name a level this capture
+// never emits), so this drives an advisory lint rather than validation.
+var KnownMessageLevels = []string{
+	LevelLog, LevelDebug, LevelInfo, LevelWarn, LevelError, LevelException,
+}

--- a/go/sightmap/spec_conformance_test.go
+++ b/go/sightmap/spec_conformance_test.go
@@ -28,6 +28,10 @@ func TestSpecConformance_RequestPropertyFixtures(t *testing.T) {
 	runSpecValidateFixtures(t, "*-request-properties.fixture")
 }
 
+func TestSpecConformance_MessageFixtures(t *testing.T) {
+	runSpecValidateFixtures(t, "*-messages.fixture")
+}
+
 func runSpecValidateFixtures(t *testing.T, glob string) {
 	t.Helper()
 	const root = "../../spec/conformance"

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -22,7 +22,7 @@ import (
 // stability/access/snapshots/url/properties are all recognized here.
 
 var (
-	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "snapshots")
+	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "messages", "snapshots")
 	viewFields      = set("name", "route", "url", "stability", "access", "description", "source", "dependencies", "memory", "components", "requests")
 	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "tags", "properties", "children")
 	refFields       = set("$ref")
@@ -34,6 +34,7 @@ var (
 	snapshotFields  = set("name", "notes", "url")
 
 	requestPropertyFields = set("name", "source", "field", "pattern", "transform")
+	messageFields         = set("name", "level", "message", "description", "source")
 )
 
 func set(keys ...string) map[string]bool {
@@ -131,6 +132,7 @@ func walkFile(node *yaml.Node, file string, out *[]ValidationError) {
 	forEachItem(v["views"], func(n *yaml.Node) { walkView(n, file, out) })
 	forEachItem(v["components"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
 	forEachItem(v["requests"], func(n *yaml.Node) { walkRequest(n, file, out) })
+	forEachItem(v["messages"], func(n *yaml.Node) { walkMessage(n, file, out) })
 	forEachItem(v["snapshots"], func(n *yaml.Node) { checkKeys(n, snapshotFields, file, out) })
 }
 
@@ -249,6 +251,15 @@ func walkRequest(node *yaml.Node, file string, out *[]ValidationError) {
 		pv := checkKeys(n, requestPropertyFields, file, out)
 		checkStringScalars(pv, []string{"name", "source", "field", "pattern", "transform"}, file, out)
 	})
+}
+
+func walkMessage(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, messageFields, file, out)
+	// `message` is a regex and `level` a fixed vocabulary word, so an unquoted
+	// number here is always a mistake: `message: 404` is the natural way to
+	// write a pattern for an HTTP-status console error, and the JSON Schema
+	// rejects it.
+	checkStringScalars(v, []string{"name", "level", "message", "description", "source"}, file, out)
 }
 
 func walkPayload(node *yaml.Node, file string, out *[]ValidationError) {

--- a/go/sightmap/unknownfields_test.go
+++ b/go/sightmap/unknownfields_test.go
@@ -239,3 +239,65 @@ requests:
 		t.Fatalf("want 1 unknown-field for the typo, got %d: %v", len(w), w)
 	}
 }
+
+// Message level/message are a vocabulary word and a regex, so an unquoted
+// number is always a mistake — and `message: 404` is the natural way to write a
+// pattern for an HTTP-status console error. ajv rejects all of these.
+func TestFieldTypeInvalid_MessageNonStringScalars(t *testing.T) {
+	for _, body := range []string{"message: 404", "level: 500", "message: true", "message:"} {
+		got := findingsWithCode(t, "field-type-invalid", "version: 1\nmessages:\n  - name: M\n    "+body+"\n")
+		if len(got) != 1 {
+			t.Errorf("%q: want 1 field-type-invalid, got %d: %v", body, len(got), got)
+		}
+	}
+}
+
+func TestFieldTypeInvalid_MessageQuotedIsClean(t *testing.T) {
+	got := findingsWithCode(t, "field-type-invalid", `
+version: 1
+messages:
+  - name: M
+    message: "404"
+    level: EXCEPTION
+`)
+	if len(got) != 0 {
+		t.Fatalf("quoted scalars must be clean, got %v", got)
+	}
+}
+
+// ajv rejects a message with no name or an empty one; Go must agree.
+func TestValidate_MessageEmptyNameMatchesAjv(t *testing.T) {
+	for _, body := range []string{"level: ERROR", `name: ""`} {
+		got := findingsWithCode(t, "missing-name", "version: 1\nmessages:\n  - "+body+"\n")
+		if len(got) != 1 {
+			t.Errorf("%q: want 1 missing-name, got %d: %v", body, len(got), got)
+		}
+	}
+}
+
+func TestUnknownField_MessagesNoFalsePositives(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+    description: Cart mutated elsewhere
+    source: src/cart/sync.ts
+`)
+	if len(w) != 0 {
+		t.Fatalf("valid messages must not warn: %v", w)
+	}
+}
+
+func TestUnknownField_MessageTypo(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+messages:
+  - name: M
+    lvl: ERROR
+`)
+	if len(w) != 1 {
+		t.Fatalf("want 1 unknown-field for the typo, got %d: %v", len(w), w)
+	}
+}

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -125,6 +125,9 @@ func Validate(c *Corpus) []ValidationError {
 	// Request property shape (SEP-0005); see validate_request.go.
 	errs = append(errs, checkRequestProperties(c)...)
 
+	// Console/exception patterns (SEP-0006); see validate_message.go.
+	errs = append(errs, checkMessages(c.Messages)...)
+
 	return errs
 }
 

--- a/go/sightmap/validate_message.go
+++ b/go/sightmap/validate_message.go
@@ -1,0 +1,137 @@
+package sightmap
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// checkMessages validates console/exception patterns (SEP-0006).
+//
+// The name-uniqueness check here is load-bearing beyond messages themselves: a
+// signals rule resolves its ref against entity names, and that resolution counts
+// distinct entity KINDS rather than entries. Two messages sharing a name
+// therefore collapse to one kind, so neither signal-ref-unresolved nor
+// signal-ref-ambiguous fires and the ref silently resolves to an ambiguous pair.
+// Catching the duplicate at its source is what keeps that state from existing.
+func checkMessages(msgs []MessageDef) []ValidationError {
+	var errs []ValidationError
+
+	for _, m := range msgs {
+		if m.Name == "" {
+			errs = append(errs, ValidationError{
+				Code:     "missing-name",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("message is missing a name (level %q, message %q)", m.Level, m.Message),
+			})
+		}
+		// A `message:` is a regex an author wrote by hand. The corpus already
+		// compiles author-supplied component selectors at validation time for
+		// exactly this reason; do the same rather than storing a pattern nobody
+		// has proven is a pattern.
+		if m.Message != "" {
+			if _, err := regexp.Compile(m.Message); err != nil {
+				errs = append(errs, ValidationError{
+					Component: m.Name,
+					Code:      "message-regex-invalid",
+					Severity:  SeverityError,
+					Message:   fmt.Sprintf("message %q: message regex parse error: %v", m.Name, err),
+				})
+			}
+		}
+	}
+
+	errs = append(errs, checkMessageNameCollisions(msgs)...)
+	errs = append(errs, checkMessageConflicts(msgs)...)
+	return errs
+}
+
+// checkMessageNameCollisions warns when two or more messages share a name.
+// Mirrors checkViewNameCollisions: the corpus still loads, but a reference to
+// that name is ambiguous and resolves silently.
+func checkMessageNameCollisions(msgs []MessageDef) []ValidationError {
+	byName := map[string]int{}
+	for _, m := range msgs {
+		if m.Name == "" {
+			continue // reported as missing-name
+		}
+		byName[m.Name]++
+	}
+
+	names := make([]string, 0, len(byName))
+	for name, n := range byName {
+		if n > 1 {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	var errs []ValidationError
+	for _, name := range names {
+		errs = append(errs, ValidationError{
+			Component: name,
+			Code:      "merge-collision-message",
+			Severity:  SeverityWarning,
+			Message: fmt.Sprintf("message name %q is declared %d times; a signals rule referencing it cannot distinguish them",
+				name, byName[name]),
+		})
+	}
+	return errs
+}
+
+// checkMessageConflicts warns when two entries can match the same record, which
+// SEP-0006 requires be surfaced rather than silently resolved to a first match.
+//
+// Only the statically decidable half is checked: same level (or one omitting
+// it) plus an identical or absent message pattern. Deciding whether two
+// different regexes can both match some record is undecidable in general, and
+// full multi-match ambiguity needs a live record, which is a consumer-side
+// obligation. This catches the realistic authoring mistake: the same pattern
+// declared twice under different names.
+func checkMessageConflicts(msgs []MessageDef) []ValidationError {
+	var errs []ValidationError
+	for i := range msgs {
+		for j := i + 1; j < len(msgs); j++ {
+			a, b := msgs[i], msgs[j]
+			if a.Name == "" || b.Name == "" || a.Name == b.Name {
+				continue // reported as missing-name / merge-collision-message
+			}
+			if !levelsOverlap(a.Level, b.Level) {
+				continue
+			}
+			if a.Message != "" && b.Message != "" && a.Message != b.Message {
+				continue
+			}
+			errs = append(errs, ValidationError{
+				Component: a.Name,
+				Code:      "message-conflict",
+				Severity:  SeverityWarning,
+				Message: fmt.Sprintf("messages %q and %q can match the same record (level %s, pattern %s); a consumer must surface the ambiguity rather than pick one",
+					a.Name, b.Name, narrower(a.Level, b.Level), narrower(a.Message, b.Message)),
+			})
+		}
+	}
+	return errs
+}
+
+// levelsOverlap reports whether two declared levels can describe one record. An
+// empty level is match-any, so it overlaps everything.
+func levelsOverlap(a, b string) bool {
+	if a == "" || b == "" {
+		return true
+	}
+	return strings.EqualFold(a, b)
+}
+
+// narrower renders the more specific of two overlapping constraints for a
+// diagnostic message. Both empty means neither constrains anything.
+func narrower(a, b string) string {
+	if a == "" && b == "" {
+		return "any"
+	}
+	if a == "" {
+		return fmt.Sprintf("%q", b)
+	}
+	return fmt.Sprintf("%q", a)
+}

--- a/go/sightmap/validate_message_test.go
+++ b/go/sightmap/validate_message_test.go
@@ -1,0 +1,195 @@
+package sightmap_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func messageCorpus(msgs ...sightmap.MessageDef) *sightmap.Corpus {
+	return &sightmap.Corpus{Messages: msgs}
+}
+
+func TestValidate_MessageMissingName(t *testing.T) {
+	errs := sightmap.Validate(messageCorpus(sightmap.MessageDef{Level: "ERROR"}))
+	if !hasCode(errs, "missing-name") {
+		t.Fatalf("want missing-name, got %v", findingCodes(errs))
+	}
+}
+
+// A `message:` is an author-written regex. The corpus already compiles
+// author-written component selectors at validation time; patterns get the same
+// treatment rather than being stored unverified.
+func TestValidate_MessageRegexInvalid(t *testing.T) {
+	for _, pat := range []string{"(", "[a-", `a{2,1}`, `(?P<`} {
+		errs := sightmap.Validate(messageCorpus(sightmap.MessageDef{
+			Name:    "Bad",
+			Message: pat,
+		}))
+		if !hasCode(errs, "message-regex-invalid") {
+			t.Errorf("pattern %q: want message-regex-invalid, got %v", pat, findingCodes(errs))
+		}
+	}
+}
+
+func TestValidate_MessageRegexValidIsClean(t *testing.T) {
+	errs := sightmap.Validate(messageCorpus(sightmap.MessageDef{
+		Name:    "SlowNetworkWarning",
+		Level:   "WARN",
+		Message: `request .* took over \d+ms`,
+	}))
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// Two messages sharing a name is the case that silently defeats a signals
+// ref: resolution counts distinct entity kinds, so the duplicate collapses to
+// one kind and neither unresolved nor ambiguous fires.
+func TestValidate_MessageNameCollision(t *testing.T) {
+	errs := sightmap.Validate(messageCorpus(
+		sightmap.MessageDef{Name: "CartVersionMismatch", Level: "ERROR", Message: "a"},
+		sightmap.MessageDef{Name: "CartVersionMismatch", Level: "WARN", Message: "b"},
+	))
+	var found *sightmap.ValidationError
+	for i := range errs {
+		if errs[i].Code == "merge-collision-message" {
+			found = &errs[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("want merge-collision-message, got %v", findingCodes(errs))
+	}
+	if found.IsError() {
+		t.Error("a name collision should be a warning, matching merge-collision-view")
+	}
+}
+
+func TestValidate_MessageConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b sightmap.MessageDef
+		want bool
+	}{
+		{
+			name: "same level, identical pattern",
+			a:    sightmap.MessageDef{Name: "A", Level: "ERROR", Message: "boom"},
+			b:    sightmap.MessageDef{Name: "B", Level: "ERROR", Message: "boom"},
+			want: true,
+		},
+		{
+			name: "same level, one pattern absent",
+			a:    sightmap.MessageDef{Name: "A", Level: "ERROR"},
+			b:    sightmap.MessageDef{Name: "B", Level: "ERROR", Message: "boom"},
+			want: true,
+		},
+		{
+			name: "one level absent matches any",
+			a:    sightmap.MessageDef{Name: "A", Message: "boom"},
+			b:    sightmap.MessageDef{Name: "B", Level: "ERROR", Message: "boom"},
+			want: true,
+		},
+		{
+			name: "level differs in case only",
+			a:    sightmap.MessageDef{Name: "A", Level: "error", Message: "boom"},
+			b:    sightmap.MessageDef{Name: "B", Level: "ERROR", Message: "boom"},
+			want: true,
+		},
+		{
+			name: "different levels cannot overlap",
+			a:    sightmap.MessageDef{Name: "A", Level: "ERROR", Message: "boom"},
+			b:    sightmap.MessageDef{Name: "B", Level: "WARN", Message: "boom"},
+			want: false,
+		},
+		{
+			name: "different patterns are not statically decidable",
+			a:    sightmap.MessageDef{Name: "A", Level: "ERROR", Message: "boom"},
+			b:    sightmap.MessageDef{Name: "B", Level: "ERROR", Message: "crash"},
+			want: false,
+		},
+		{
+			name: "exception does not overlap error",
+			a:    sightmap.MessageDef{Name: "A", Level: "EXCEPTION", Message: "boom"},
+			b:    sightmap.MessageDef{Name: "B", Level: "ERROR", Message: "boom"},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := sightmap.Validate(messageCorpus(tc.a, tc.b))
+			got := hasCode(errs, "message-conflict")
+			if got != tc.want {
+				t.Fatalf("message-conflict = %v, want %v (findings: %v)", got, tc.want, findingCodes(errs))
+			}
+		})
+	}
+}
+
+// SEP-0006 permits an entry declaring neither constraint. It matches every
+// record, which is legal and rarely useful, but not a diagnostic on its own.
+func TestValidate_MessageNoConstraintsIsLegal(t *testing.T) {
+	errs := sightmap.Validate(messageCorpus(sightmap.MessageDef{Name: "AnyRecord"}))
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// level: WARNING is CDP's own spelling, normalized to warn by the capture, so it
+// matches nothing. Advisory rather than an error because level is open.
+func TestLint_MessageLevelUnknown(t *testing.T) {
+	warns := sightmap.Lint(messageCorpus(
+		sightmap.MessageDef{Name: "Typo", Level: "WARNING", Message: "x"},
+		sightmap.MessageDef{Name: "Fine", Level: "EXCEPTION", Message: "y"},
+	))
+	var got []string
+	for _, w := range warns {
+		if w.Rule == "message-level-unknown" {
+			got = append(got, w.Component)
+		}
+	}
+	if len(got) != 1 || got[0] != "Typo" {
+		t.Fatalf("want message-level-unknown on Typo only, got %v", got)
+	}
+}
+
+func TestLoadDir_Messages(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir+"/app.yaml", `
+version: 1
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+    description: Cart mutated elsewhere
+    source: src/cart/sync.ts
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Messages) != 2 {
+		t.Fatalf("want 2 messages, got %d", len(c.Messages))
+	}
+	got := c.Messages[0]
+	want := sightmap.MessageDef{
+		Name:        "CartVersionMismatch",
+		Level:       "ERROR",
+		Message:     "cart version mismatch",
+		Description: "Cart mutated elsewhere",
+		Source:      "src/cart/sync.ts",
+	}
+	if got != want {
+		t.Errorf("messages[0] = %+v, want %+v", got, want)
+	}
+	// The declared level is preserved verbatim; case-insensitivity applies when
+	// matching a record, not at load.
+	if c.Messages[1].Level != "EXCEPTION" {
+		t.Errorf("declared level should round-trip verbatim, got %q", c.Messages[1].Level)
+	}
+	if !strings.EqualFold(c.Messages[1].Level, sightmap.LevelException) {
+		t.Errorf("level %q should case-insensitively equal %q", c.Messages[1].Level, sightmap.LevelException)
+	}
+}

--- a/spec/conformance/019-messages.fixture/expected.json
+++ b/spec/conformance/019-messages.fixture/expected.json
@@ -1,0 +1,9 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": { "ok": true, "diagnostics": [] }
+    }
+  ]
+}

--- a/spec/conformance/019-messages.fixture/expected.json
+++ b/spec/conformance/019-messages.fixture/expected.json
@@ -3,7 +3,12 @@
     {
       "command": "validate",
       "args": {},
-      "expected": { "ok": true, "diagnostics": [] }
+      "expected": {
+        "ok": true,
+        "diagnostics": [
+          { "code": "message-conflict", "severity": "warning" }
+        ]
+      }
     }
   ]
 }

--- a/spec/conformance/019-messages.fixture/sightmap/app.yaml
+++ b/spec/conformance/019-messages.fixture/sightmap/app.yaml
@@ -1,0 +1,20 @@
+version: 1
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+    description: The cart was mutated by another tab; checkout will fail.
+    source: src/cart/sync.ts
+
+  - name: SlowNetworkWarning
+    level: WARN
+    message: 'request .* took over \d+ms'
+
+  # An uncaught exception arrives as level `exception`, not `error`, so a corpus
+  # that wants exceptions has to say so.
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+    message: 'Cannot read propert(y|ies) .* of (null|undefined)'
+
+  # Neither level nor message: legal, matches every record.
+  - name: AnyRecord

--- a/spec/conformance/019-messages.fixture/sightmap/app.yaml
+++ b/spec/conformance/019-messages.fixture/sightmap/app.yaml
@@ -16,5 +16,8 @@ messages:
     level: EXCEPTION
     message: 'Cannot read propert(y|ies) .* of (null|undefined)'
 
-  # Neither level nor message: legal, matches every record.
-  - name: AnyRecord
+  # A level-only entry is legal, but it overlaps CartVersionMismatch: both match
+  # an ERROR record, so `message-conflict` warns that a consumer must surface the
+  # ambiguity rather than silently pick one.
+  - name: AnyCartError
+    level: ERROR

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -55,6 +55,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 016 | `stability-tooling-fields` | `stability:` (view + component) validates; reserved tooling fields `access:`/`snapshots:` are permitted |
 | 017 | `tags` | `tags:` validates on components (at multiple nesting levels), requests, and views ([SEP-0004](../seps/0004-component-tags.md)) |
 | 018 | `request-properties` | `properties:` on a request validates via `field` (body and header paths) and `pattern`; declaring a reserved identity name warns with `request-property-shadows-reserved` ([SEP-0005](../seps/0005-request-properties.md)) |
+| 019 | `messages` | `messages:` validates with `level`/`message`/`description`/`source`, including `level: EXCEPTION` and an entry declaring neither constraint ([SEP-0006](../seps/0006-message-entity.md)) |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -55,7 +55,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 016 | `stability-tooling-fields` | `stability:` (view + component) validates; reserved tooling fields `access:`/`snapshots:` are permitted |
 | 017 | `tags` | `tags:` validates on components (at multiple nesting levels), requests, and views ([SEP-0004](../seps/0004-component-tags.md)) |
 | 018 | `request-properties` | `properties:` on a request validates via `field` (body and header paths) and `pattern`; declaring a reserved identity name warns with `request-property-shadows-reserved` ([SEP-0005](../seps/0005-request-properties.md)) |
-| 019 | `messages` | `messages:` validates with `level`/`message`/`description`/`source`, including `level: EXCEPTION` and an entry declaring neither constraint ([SEP-0006](../seps/0006-message-entity.md)) |
+| 019 | `messages` | `messages:` validates with `level`/`message`/`description`/`source`, including `level: EXCEPTION`; a level-only entry overlapping a level+message entry warns with `message-conflict` ([SEP-0006](../seps/0006-message-entity.md)) |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 
@@ -73,6 +73,7 @@ The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byt
 ## Consumers
 
 - CI schema-validates every `sightmap/*.yaml` here against `sightmap.schema.json` (`npm run validate:conformance`).
-- **The `cases` arrays are not executed yet.** `scripts/validate-sightmap.mjs` reads `expected.json` only to look for `fmt.schema-invalid`/`fmt.parse-error`, which tell it to skip a deliberately-invalid input. Nothing runs the `command`/`args` or asserts the `diagnostics`. The reference implementation's own fixture runner (`go/match/conformance_test.go`) reads a different corpus, under [`go/conformance/fixtures/`](../../go/conformance/fixtures/).
-- So a `cases` entry is a **contract for ports and a record of intent**, not a passing assertion. Treat a green `validate:conformance` as "these files are schema-valid", nothing more, and keep the Go unit tests as the real coverage for any diagnostic asserted here.
+- **Most `cases` arrays are not executed yet.** `scripts/validate-sightmap.mjs` reads `expected.json` only to look for `fmt.schema-invalid`/`fmt.parse-error`, which tell it to skip a deliberately-invalid input. It does not run the `command`/`args` or assert the `diagnostics`. The reference implementation's own match runner (`go/match/conformance_test.go`) reads a different corpus, under [`go/conformance/fixtures/`](../../go/conformance/fixtures/).
+- **Exception:** the message fixtures (`*-messages.fixture`) *are* executed. `go/sightmap/spec_conformance_test.go` runs the reference validator (`sightmap.Validate`, the same path the `validate` command uses) over each and asserts its `validate` case's `diagnostics` exactly. Extending this executor to the `match`/`lint`/`explain` commands and the rest of the suite is tracked separately (one fixture, 017-tags, currently diverges from its own `expected.json` and must be reconciled first).
+- So for every *other* fixture a `cases` entry is still a **contract for ports and a record of intent**, not a passing assertion. Treat a green `validate:conformance` as "these files are schema-valid", nothing more, and keep the Go unit tests as the real coverage for any diagnostic asserted here.
 - Community ports in other languages are expected to run the same fixtures via a port-specific runner.

--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -4,9 +4,9 @@ title: A console/exception message entity (`messages[]`)
 author: Clint Ayres (@jurassix)
 status: Draft
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-10
 spec-version-target: 1
-related-issues: []
+related-issues: [158]
 related-discussions: []
 ---
 
@@ -145,4 +145,4 @@ Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-l
 
 ## References
 
-- Subtext (a sightmap consumer) models a JS exception as an ERROR-level console record rather than a distinct entity — the real-world precedent behind this proposal's "one entity, not two" call in Semantics.
+- Subtext (a sightmap consumer) folds uncaught exceptions into the same console-record stream under their own `exception` level (not `error`) — the real-world precedent behind this proposal's "one entity, not two" call in Semantics, and the reason a corpus that wants exceptions writes `level: EXCEPTION`.

--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -47,7 +47,9 @@ At least one of `level`/`message` should be declared in practice (an entry match
 
 #### One entity, not two ("console" vs "exception")
 
-The obvious first cut of this proposal used a `kind: console | exception` discriminator, splitting the entity by origin. It's dropped: at least one real consumer implementation already models a JS exception as simply an ERROR-level console record, with no second axis to discriminate origin beyond `level` itself, which this proposal already has. A `messages:` entry with `level: ERROR` matches what another implementation might call an "exception"; one with `level: WARN`/`INFO` matches what it might call a plain console message. No `kind` field is needed to express that distinction — see [Alternatives considered #1](#1-a-kind-console--exception-discriminator-field).
+The obvious first cut of this proposal used a `kind: console | exception` discriminator, splitting the entity by origin. It's dropped, because **origin is already carried as a level value**. The reference capture emits `log`, `debug`, `info`, `warn`, `error`, and `exception`, folding uncaught exceptions and unhandled rejections into the same record stream under their own level. So a `messages:` entry with `level: EXCEPTION` selects exceptions, one with `level: ERROR` selects `console.error`, and one with `level: WARN`/`INFO` selects plain console output. A second axis would only restate what `level` says.
+
+Note the correction this implies for anyone reading an earlier draft: `level: ERROR` does **not** match an exception. The two levels stay distinct, so a corpus that wants exceptions has to name them. That is a sharper distinction than a `kind:` field would have given, not a weaker one, and it still needs no extra field — see [Alternatives considered #1](#1-a-kind-console--exception-discriminator-field).
 
 #### No extraction mechanism (yet)
 
@@ -60,7 +62,10 @@ A live console record matches a `messages:` entry when every declared field (`le
 ### Conformance
 
 - MUST match a live console record against a `messages:` entry using case-insensitive exact match on `level` (when declared) and regex match on `message` (when declared); an omitted field imposes no constraint.
-- MUST warn (not silently resolve) when a live record matches more than one `messages:` entry with the same `name` collision potential — mirrors the existing `$ref`/component-name-collision diagnostic discipline.
+- MUST reject a `message` that is not a valid regular expression. Diagnostic code: `message-regex-invalid`.
+- MUST warn when two or more `messages:` entries share a `name`. Diagnostic code: `merge-collision-message`, mirroring `merge-collision-view`. Without this, a name is ambiguous and a [SEP-0007](0007-signals.md) `ref:` resolves to it silently.
+- MUST warn when two entries can match the same record and that overlap is statically decidable: the same `level` (or one omitting it) with an identical or absent `message`. Diagnostic code: `message-conflict`, mirroring `route-conflict`. Deciding whether two *different* regexes can both match some record is not decidable in general and is out of scope.
+- MUST warn (not silently resolve) when a **live** record matches more than one `messages:` entry. This is the runtime half of the rule above and applies only to a consumer that evaluates records.
 - MUST NOT require `properties:` support for `messages:` entries in this SEP's scope.
 - MAY additionally match `source` for tooling purposes (e.g. surfacing "likely emitted from `src/cart/sync.ts`" in a UI); this SEP does not require any behavior tied to `source` beyond documentary purposes, mirroring `Request.source`/`Component.source`.
 
@@ -136,7 +141,7 @@ Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-l
 
 1. **Naming.** `messages:` vs. `errors:` vs. something else — `errors:` reads naturally for the ERROR-level case but oddly for an INFO/WARN-level console message that isn't an "error" at all. `messages:` is the more neutral choice made here; open to reviewer pushback.
 2. **Should `properties:`/extraction ever be added here?** Flagged as future, non-blocking work in Semantics — worth confirming reviewers agree it's genuinely not needed for v1 rather than a gap being silently deferred.
-3. **Ambiguous-match diagnostics.** This SEP requires a diagnosable warning on ambiguous matches (Conformance) but doesn't specify an exact diagnostic code — left for the implementation PR to define, consistent with existing codes like `ref-unresolved`.
+3. ~~**Ambiguous-match diagnostics.**~~ **Resolved.** The static half is split across `merge-collision-message` (a duplicated name) and `message-conflict` (two entries that can match the same record), both warnings, both named in [Conformance](#conformance). The runtime half stays a consumer obligation, since it needs a live record.
 
 ## References
 

--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -57,12 +57,12 @@ Unlike `requests:` ([SEP-0005](0005-request-properties.md)), `messages:` has no 
 
 #### Matching
 
-A live console record matches a `messages:` entry when every declared field (`level`, `message`) agrees; an omitted field matches anything. When more than one `messages:` entry could match the same live record, conformance requires a diagnosable ambiguity, not silent first-match-wins — see [Conformance](#conformance).
+A live console record matches a `messages:` entry when every declared field (`level`, `message`) agrees; an omitted field matches anything. `message` is an **RE2** regular expression (Go's `regexp`, the `re2` npm package for JavaScript): a predictable, linear-time dialect with no backreferences or lookaround, pinned so that authoring-time validation and runtime matching agree across SDKs. When more than one `messages:` entry could match the same live record, conformance requires a diagnosable ambiguity, not silent first-match-wins — see [Conformance](#conformance).
 
 ### Conformance
 
 - MUST match a live console record against a `messages:` entry using case-insensitive exact match on `level` (when declared) and regex match on `message` (when declared); an omitted field imposes no constraint.
-- MUST reject a `message` that is not a valid regular expression. Diagnostic code: `message-regex-invalid`.
+- MUST reject a `message` that is not a valid RE2 regular expression (Go `regexp` semantics; no backreferences or lookaround). Diagnostic code: `message-regex-invalid`.
 - MUST warn when two or more `messages:` entries share a `name`. Diagnostic code: `merge-collision-message`, mirroring `merge-collision-view`. Without this, a name is ambiguous and a [SEP-0007](0007-signals.md) `ref:` resolves to it silently.
 - MUST warn when two entries can match the same record and that overlap is statically decidable: the same `level` (or one omitting it) with an identical or absent `message`. Diagnostic code: `message-conflict`, mirroring `route-conflict`. Deciding whether two *different* regexes can both match some record is not decidable in general and is out of scope.
 - MUST warn (not silently resolve) when a **live** record matches more than one `messages:` entry. This is the runtime half of the rule above and applies only to a consumer that evaluates records.

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -332,11 +332,15 @@ messages:
 |---|---|---|---|
 | `name` | string | yes | Stable identifier, addressable by name by other tooling. |
 | `level` | string | no | Exact, case-insensitive match against the observed record's level. Match-any if omitted. |
-| `message` | string | no | Regex matched against the record's text. Match-any if omitted. |
+| `message` | string | no | [RE2](#regular-expression-syntax) regex matched against the record's text. Match-any if omitted. |
 | `description` | string | no | What this pattern means, for a human reading the corpus. |
 | `source` | string | no | Relative path to the source most likely to emit this. |
 
 A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful.
+
+### Regular expression syntax
+
+The `message` regex uses **RE2** syntax — the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately: it matches in guaranteed linear time (no catastrophic backtracking), and because these patterns are validated at authoring time by one SDK and matched against a live console/exception stream at runtime by another, a single predictable dialect is what keeps the two from disagreeing about the same pattern. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and groups all work, which covers essentially every message pattern in practice. A conforming SDK MUST reject a `message` that is not a valid RE2 pattern (the reference CLI reports `message-regex-invalid`).
 
 ### Message levels
 
@@ -507,7 +511,7 @@ A conforming SDK:
 - MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
-- MUST reject a `messages:` entry whose `message` is not a valid regular expression
+- MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expression syntax](#regular-expression-syntax))
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -270,12 +270,10 @@ A named API endpoint.
 | `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
 | `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
 | `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
-| `pattern` | string | see below | An RE2 regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
+| `pattern` | string | see below | An [RE2](#regular-expressions) regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
 | `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
 
-At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes).
-
-`pattern` uses **RE2** syntax (Go's `regexp`; no backreferences or lookaround) — a linear-time, predictable dialect, so authoring-time validation and runtime matching agree across SDKs. The reference CLI rejects an invalid pattern (`request-property-pattern-invalid`).
+At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes). `pattern` is an [RE2 regular expression](#regular-expressions); the reference CLI rejects an invalid one (`request-property-pattern-invalid`).
 
 **Value omission is silent** — a property that doesn't resolve (a missing key, an out-of-range index, no pattern match) is simply absent; consumers MUST NOT treat omission as an error. Omission is the normal case, not an edge case: whether a body or header is even available to read depends on the capture layer's own payload and privacy settings.
 
@@ -332,15 +330,11 @@ messages:
 |---|---|---|---|
 | `name` | string | yes | Stable identifier, addressable by name by other tooling. |
 | `level` | string | no | Exact, case-insensitive match against the observed record's level. Match-any if omitted. |
-| `message` | string | no | [RE2](#regular-expression-syntax) regex matched against the record's text. Match-any if omitted. |
+| `message` | string | no | [RE2](#regular-expressions) regex matched against the record's text. Match-any if omitted. |
 | `description` | string | no | What this pattern means, for a human reading the corpus. |
 | `source` | string | no | Relative path to the source most likely to emit this. |
 
-A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful.
-
-### Regular expression syntax
-
-The `message` regex uses **RE2** syntax — the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately: it matches in guaranteed linear time (no catastrophic backtracking), and because these patterns are validated at authoring time by one SDK and matched against a live console/exception stream at runtime by another, a single predictable dialect is what keeps the two from disagreeing about the same pattern. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and groups all work, which covers essentially every message pattern in practice. A conforming SDK MUST reject a `message` that is not a valid RE2 pattern (the reference CLI reports `message-regex-invalid`).
+A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful. `message` is an [RE2 regular expression](#regular-expressions).
 
 ### Message levels
 
@@ -362,6 +356,12 @@ The vocabulary is open: `level` is free text, not an enum, so a corpus may name 
 Two entries that can match the same record are reported as `message-conflict` (a warning) when the overlap is statically decidable: the same `level`, or one omitting it, with an identical or absent `message`. Deciding whether two different regexes can both match some record is not decidable in general.
 
 A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](../seps/0006-message-entity.md).
+
+## Regular expressions
+
+Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)) and a message's `message` ([Message](#message)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
+
+A conforming SDK MUST reject a regular expression that is not valid RE2; the reference CLI reports `request-property-pattern-invalid` for a `pattern` and `message-regex-invalid` for a `message`.
 
 ## Memory
 
@@ -510,8 +510,8 @@ A conforming SDK:
 - MUST reject a `RequestProperty` with no `source`, or a `source` outside the four-value enum (`req.body`/`rsp.body`/`req.headers`/`rsp.headers`)
 - MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
-- MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
-- MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expression syntax](#regular-expression-syntax))
+- MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
+- MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -21,6 +21,7 @@ memory:      # optional, string[] — file-level notes (see "Memory")
 views:       # optional, View[]
 components:  # optional, Component[] — global, matched on every view
 requests:    # optional, Request[] — global, matched on every view
+messages:    # optional, Message[] — console/exception patterns
 ```
 
 | Field | Type | Required | Description |
@@ -30,6 +31,7 @@ requests:    # optional, Request[] — global, matched on every view
 | `views` | [View](#view)[] | no | Views defined in this file. |
 | `components` | (Component \| [ComponentRef](#component-references))[] | no | **Global** components — matched against every view. Entries may be either inline definitions or `$ref` reference objects. |
 | `requests` | [Request](#request)[] | no | **Global** requests — matched against every view. |
+| `messages` | [Message](#message)[] | no | Console-output and exception patterns. Corpus-root only; there is no view-scoped form. |
 
 ## View
 
@@ -305,6 +307,58 @@ request:
 | `type` | string | no | Free-text type label: `string`, `number`, `boolean`, `array`, `object`, or anything else an SDK author finds useful. |
 | `description` | string | no | Free-text description. |
 
+## Message
+
+A named console-output or runtime-exception pattern. This gives console activity what `requests:` gives network activity: a named entity the rest of the corpus can point at, so "a cart version mismatch broke checkout" is stated once rather than re-matched by every consumer.
+
+```yaml
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+    description: The cart was mutated by another tab; checkout will fail.
+    source: src/cart/sync.ts
+
+  - name: SlowNetworkWarning
+    level: WARN
+    message: 'request .* took over \d+ms'
+
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+    message: 'Cannot read propert(y|ies) .* of (null|undefined)'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Stable identifier, addressable by name by other tooling. |
+| `level` | string | no | Exact, case-insensitive match against the observed record's level. Match-any if omitted. |
+| `message` | string | no | Regex matched against the record's text. Match-any if omitted. |
+| `description` | string | no | What this pattern means, for a human reading the corpus. |
+| `source` | string | no | Relative path to the source most likely to emit this. |
+
+A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful.
+
+### Message levels
+
+The reference capture emits these levels:
+
+| Level | Origin |
+|---|---|
+| `log`, `debug`, `info` | `console.log` / `.debug` / `.info` |
+| `warn` | `console.warn` |
+| `error` | `console.error`, `console.assert` |
+| `exception` | An uncaught exception or unhandled rejection |
+
+**An uncaught exception arrives as `exception`, not as `error`.** So `level: ERROR` does not match one, and a corpus that wants exceptions must say `level: EXCEPTION`. Console output and exceptions still share one entity rather than needing a `kind:` discriminator, because the origin is carried as a level value.
+
+The vocabulary is open: `level` is free text, not an enum, so a corpus may name a level this capture never emits. That is deliberate, since another consumer's capture may have levels of its own. The tradeoff is that a typo (`level: WARNING`, which this capture normalizes to `warn`) matches nothing rather than being rejected.
+
+### Ambiguous matches
+
+Two entries that can match the same record are reported as `message-conflict` (a warning) when the overlap is statically decidable: the same `level`, or one omitting it, with an identical or absent `message`. Deciding whether two different regexes can both match some record is not decidable in general.
+
+A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](../seps/0006-message-entity.md).
+
 ## Memory
 
 Memory entries are short freeform notes attached to any definition — file, view, component, or request. They exist so that agents can carry forward context that isn't recoverable from the source code: quirks, invariants, workarounds, "you have to click this twice" lore.
@@ -453,6 +507,7 @@ A conforming SDK:
 - MUST reject a `RequestProperty` that declares neither `field` nor `pattern`
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression
+- MUST reject a `messages:` entry whose `message` is not a valid regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -463,8 +518,10 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - MUST omit an unresolved property value silently, without a diagnostic
 - MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
+- MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
+- MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern` and applies no `transform`. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -288,7 +288,7 @@
         },
         "message": {
           "type": "string",
-          "description": "Regex matched against the observed record's message text. Match-any if omitted. Compiled at validation time, so a malformed pattern is reported to the author."
+          "description": "RE2 regex (no backreferences or lookaround) matched against the observed record's message text. Match-any if omitted. Compiled at validation time, so a malformed pattern is reported to the author."
         },
         "description": {
           "type": "string"

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -33,6 +33,11 @@
       "description": "Global requests — matched against every view.",
       "items": { "$ref": "#/$defs/request" }
     },
+    "messages": {
+      "type": "array",
+      "description": "Declarative console/exception patterns, addressable by name. Corpus-root only — no view-scoping. See SEP-0006.",
+      "items": { "$ref": "#/$defs/message" }
+    },
     "snapshots": {
       "$comment": "Reserved tooling field. Not part of the spec's matching or merge semantics; conforming SDKs MAY ignore it. Consumed by the reference CLI's capture/probe workflow.",
       "type": "array",
@@ -263,6 +268,34 @@
           "type": "string",
           "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
           "description": "Optional post-processing applied to the extracted string. Same vocabulary as componentProperty.transform (SEP-0003)."
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "A declarative console/exception pattern, matched by level and a message regex. See SEP-0006.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "A stable identifier for this pattern, addressable by name by other tooling."
+        },
+        "level": {
+          "type": "string",
+          "description": "Exact, case-insensitive match against the observed record's level. Match-any if omitted. The reference capture emits log, debug, info, warn, error, and exception; an uncaught exception arrives as \"exception\", so level: ERROR does not match one. The vocabulary is open, so this is not an enum."
+        },
+        "message": {
+          "type": "string",
+          "description": "Regex matched against the observed record's message text. Match-any if omitted. Compiled at validation time, so a malformed pattern is reported to the author."
+        },
+        "description": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "Relative path to the source most likely to emit this pattern."
         }
       }
     },


### PR DESCRIPTION
Declaration and validation layer for [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md). Matching is not implemented; `spec/v1/schema.md` says so explicitly.

Stacked on #112.

## Rebased onto the Def convention

`MessageDef` in `go/sightmap/message.go`, replacing `match.Message`, with a JSON wire tag on `Corpus.Messages` so the entity survives serialization into the uploaded corpus. The previous version had no wire tag, so messages would have vanished from the payload.

## `level: ERROR` never matched an exception

SEP-0006's central argument for one entity rather than two was that `level: ERROR` also covers exceptions. It does not. The reference collector labels `Runtime.exceptionThrown` records `level: "exception"`, a distinct value, so under the case-insensitive-exact rule this PR ships, `level: ERROR` could never match one.

The argument survives in stronger form: origin is carried *as a level value*, so no `kind:` discriminator is needed, but a corpus that wants exceptions writes `level: EXCEPTION`. The SEP is amended to say that, and `spec/v1/schema.md` now documents the full emitted vocabulary (`log`, `debug`, `info`, `warn`, `error`, `exception`).

## Validation

| Code | Severity | Condition |
|---|---|---|
| `missing-name` | error | empty name (matching the component and view checks) |
| `message-regex-invalid` | error | `message` does not compile |
| `merge-collision-message` | warning | two entries share a name |
| `message-conflict` | warning | two entries can match the same record, where decidable |
| `message-level-unknown` | lint | a level outside the emitted vocabulary |

`message-regex-invalid` compiles the pattern at validation time. `validateComponent` already does exactly this for author-written selectors three functions away, and the corpus was otherwise storing a regex nobody had proven was a regex.

`merge-collision-message` is load-bearing for #114. `checkSignals` resolves a `ref:` by counting distinct entity *kinds*, so two messages sharing a name collapsed to one kind: neither `signal-ref-unresolved` nor `signal-ref-ambiguous` fired, and the ref resolved silently to an ambiguous pair. Catching the duplicate at its source is what prevents that state.

`message-conflict` covers only the statically decidable overlap (same `level`, identical or absent `message`). Whether two *different* regexes can both match some record is not decidable in general.

`message-level-unknown` is a lint rule rather than a validation error because `level` is deliberately open. The realistic trap is `WARNING`, CDP's own spelling, which the capture normalizes to `warn`, so a corpus copied from CDP output matches nothing and says nothing.

`field-type-invalid` now covers message fields, so `message: 404` and `level: 500` reject in Go as ajv already rejected them. Parity verified on `404`, `500`, `true`, `null`, missing name, and empty name.

## Resolves SEP-0006's open question 3

The SEP explicitly left the ambiguity diagnostic code to its implementation PR. Resolved as `merge-collision-message` plus `message-conflict` for the static half, with the runtime half staying a consumer obligation. That second conformance MUST had been dropped from the earlier draft without being carried into `schema.md`; it is restored.

Verified: `go build`/`vet`/`test ./...`, `npm run validate:conformance`, `npm run validate:examples`, docs sync guardrail.