### PR TITLE
SEP-0007: `signals:` composed classifications

### DIFF
--- a/.changeset/signals.md
+++ b/.changeset/signals.md
@@ -1,0 +1,19 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add a top-level `signals:` entity ([SEP-0007](https://github.com/sightmap/sightmap/blob/main/spec/seps/0007-signals.md)): a rule that references an existing component, request, message, or view by name and optionally filters on its declared properties, minting a named, tagged classification. A signal never redeclares a selector, route, or body pattern, so a classification cannot drift away from the thing it is about.
+
+**Filter values accept an unquoted integer or boolean.** The previous draft's schema allowed only strings, which made SEP-0007's own headline example invalid: `status: 200` is an unquoted YAML integer, and the reserved `status` identity genuinely is one. Values compare as canonical text, and an integer compares as its numeric value in decimal, so `0x1F` and `31` are the same value rather than two different strings. `null`, floats, and empty lists stay invalid.
+
+New validation:
+
+- `signal-filter-unknown` (error) rejects a filter key that does not resolve on the referenced entity. Resolution order is a declared property, then a reserved request identity (`status`/`method`/`duration`), then a component's built-in `value`. A message or view ref accepts no filter keys, since a message's own `level`/`message` already identify it and a view has no extractable property.
+
+  This is what makes SEP-0007's central claim hold. The proposal rests on a signal composing what the corpus already defines so the two cannot drift; without checking the keys, a filter naming a renamed or never-existent property passed silently and the rule simply never fired. The previous conformance fixture did exactly that, filtering on a property it declared nowhere while asserting zero diagnostics.
+
+- `field-type-invalid` (error) now covers filter values, so a bare `key:`, a float, and an empty list are rejected in Go as ajv already rejected them.
+
+`signal-ref-unresolved` and `signal-ref-ambiguous` are unchanged in behavior, but ref and filter resolution now share one entity index, and duplicate message names are caught upstream by `merge-collision-message` — previously two messages sharing a name collapsed to a single entity kind, so the ambiguity check never fired.
+
+Evaluation is not implemented: the SDK parses and validates signals but does not match them against live activity.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -30,6 +30,7 @@ views:       # optional, View[]
 components:  # optional, Component[] — global, matched on every view
 requests:    # optional, Request[] — global, matched on every view
 messages:    # optional, Message[] — console/exception patterns
+signals:     # optional, Signal[] — classifications composed from the above
 ```
 
 | Field | Type | Required | Description |
@@ -40,6 +41,7 @@ messages:    # optional, Message[] — console/exception patterns
 | `components` | (Component \| [ComponentRef](#component-references))[] | no | **Global** components — matched against every view. Entries may be either inline definitions or `$ref` reference objects. |
 | `requests` | [Request](#request)[] | no | **Global** requests — matched against every view. |
 | `messages` | [Message](#message)[] | no | Console-output and exception patterns. Corpus-root only; there is no view-scoped form. |
+| `signals` | [Signal](#signal)[] | no | Classification rules composed from other entities. Corpus-root only; there is no view-scoped form. |
 
 ## View
 
@@ -365,6 +367,72 @@ Two entries that can match the same record are reported as `message-conflict` (a
 
 A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
 
+## Signal
+
+A named, tagged classification composed from an entity the corpus already defines. A signal references that entity by name and optionally filters on its declared properties. It never declares a selector, route, or body pattern of its own, so a classification cannot drift away from the thing it is about.
+
+```yaml
+requests:
+  - name: CheckoutPayment
+    route: /api/checkout/pay
+    method: POST
+    properties:
+      - name: outcome
+        source: rsp.body
+        field: status
+
+signals:
+  - name: checkout.payment.declined
+    tags: [defect]
+    ref: CheckoutPayment
+    filter:
+      outcome: declined
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Semantic identity of the generated classification. |
+| `ref` | string | yes | Name of an existing `components:`/`requests:`/`messages:`/`views:` entry. Must resolve, and must not be ambiguous across entity kinds. |
+| `tags` | string[] | no | Labels carried onto the generated classification. See [Tags](#tags). |
+| `filter` | object | no | Property constraints, ANDed across keys. Omitted means the rule fires on every match of `ref`. |
+
+Omitting `filter` is equivalent to a static `tags:` entry on the referenced entity, so `signals:` is a superset of that mechanism rather than a parallel one. Reach for `filter` only when the entity's mere presence is not itself the classification.
+
+### Filter values
+
+A key's value is either one accepted value (equality) or a list of them (membership). Keys are ANDed; there is no `OR` in v1, so a classification needing one is expressed as several `signals:` entries.
+
+Values compare as canonical text, and an unquoted integer or boolean is accepted so the natural spelling works:
+
+```yaml
+filter:
+  status: 200                    # integer, compares as "200"
+  outcome: [queued, deferred]    # membership
+  rate_limit_remaining: "0"      # quoted, compares as "0"
+```
+
+An integer compares as its **numeric value in decimal**, not as the characters you typed. YAML accepts octal, hexadecimal, and underscore-separated integers, so `0200` is 128, `0x1F` is 31, and `1_000` is 1000. Comparing lexemes instead would make `0x1F` and `31` two different values for one number.
+
+A `null` (a bare `key:`), a float, and an empty list are all invalid: the first has nothing to compare, a float has no single canonical text (`1.50` versus `1.5`), and an empty list can never match.
+
+### Filter key resolution
+
+A filter key must resolve on the referenced entity. In order:
+
+1. A property the entity declares — `properties:` on a [Request](#request-properties) or a [Component](#component-properties).
+2. For a `Request` ref, a reserved identity name: `status`, `method`, `duration`.
+3. For a `Component` ref, the built-in `value`.
+
+A declared property shadows a reserved name of the same name; see [Request properties](#request-properties).
+
+A `Message` or `View` ref accepts **no** filter keys. A message's own `level`/`message` already identify it fully, and a view has no extractable property, so reference either without a filter.
+
+A key resolving to none of the above is an error (`signal-filter-unknown`). This is what keeps a signal tied to its entity: without it, a filter naming a property that was renamed or never existed would pass silently and the rule would simply never fire.
+
+### Multiple matching rules
+
+Each rule is evaluated independently. When more than one references the same entity and both match the same live instance, both fire — nothing is deduped or merged. A consumer sees one classification per firing rule, not one classification with several names. See [SEP-0007](https://github.com/sightmap/sightmap/blob/main/spec/seps/0007-signals.md).
+
 ## Regular expressions
 
 Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)) and a message's `message` ([Message](#message)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
@@ -520,6 +588,8 @@ A conforming SDK:
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
+- MUST reject a `signals:` entry whose `ref` does not resolve, or resolves across more than one entity kind
+- MUST reject a `signals:` `filter` key that does not resolve on the referenced entity
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -532,8 +602,10 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
+- MUST evaluate each `signals:` rule independently: a live instance matched by several rules produces one classification per matching rule
+- SHOULD carry the referenced entity's name on the generated classification, so its derivation stays explicit
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, matches no `messages:` entry against a console record, and evaluates no `signals:` rule. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -39,6 +39,11 @@ type Corpus struct {
 	// file-root `messages:` list). There is no view-scoped form.
 	Messages []MessageDef `json:"messages,omitempty"`
 
+	// Signals is the flat list of classification rules (from a file-root
+	// `signals:` list), each referencing another entity by name. There is no
+	// view-scoped form.
+	Signals []SignalDef `json:"signals,omitempty"`
+
 	// loadDiagnostics holds structural problems detected while loading that are
 	// no longer visible in the flattened data (e.g. a circular $ref chain, which
 	// is expanded away). Validate surfaces these alongside its own checks.

--- a/go/sightmap/corpus_wire_test.go
+++ b/go/sightmap/corpus_wire_test.go
@@ -74,3 +74,39 @@ func TestCorpusWireRoundTrip(t *testing.T) {
 		t.Errorf("authoring fields should be empty after a wire round-trip: %+v", back.Views[0])
 	}
 }
+
+// The three SEP entities must survive serialization into the uploaded wire
+// form. A field without a JSON tag would silently vanish from the payload.
+func TestCorpusWire_IncludesSEPEntities(t *testing.T) {
+	c := &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{{
+			Name:  "CheckoutPayment",
+			Route: "/api/checkout/pay",
+			Tags:  []string{"checkout"},
+			Properties: []sightmap.RequestProperty{
+				{Name: "outcome", Source: "rsp.body", Field: "status", Transform: "slug"},
+			},
+		}},
+		Messages: []sightmap.MessageDef{{Name: "CartVersionMismatch", Level: "ERROR", Message: "mismatch"}},
+		Signals: []sightmap.SignalDef{{
+			Name:   "checkout.payment.declined",
+			Ref:    "CheckoutPayment",
+			Tags:   []string{"defect"},
+			Filter: map[string][]string{"outcome": {"declined"}},
+		}},
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	wire := string(b)
+	for _, want := range []string{
+		`"requests"`, `"properties"`, `"source":"rsp.body"`, `"field":"status"`, `"transform":"slug"`, `"tags":["checkout"]`,
+		`"messages"`, `"level":"ERROR"`,
+		`"signals"`, `"ref":"CheckoutPayment"`, `"filter":{"outcome":["declined"]}`,
+	} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("wire form is missing %s\ngot: %s", want, wire)
+		}
+	}
+}

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -46,8 +47,65 @@ type rawFile struct {
 	Views      []rawView      `yaml:"views"`
 	Requests   []rawRequest   `yaml:"requests"`
 	Messages   []rawMessage   `yaml:"messages"`
+	Signals    []rawSignal    `yaml:"signals"`
 	URL        string         `yaml:"url"`
 	Snapshots  []rawSnapshot  `yaml:"snapshots"`
+}
+
+type rawSignal struct {
+	Name   string                    `yaml:"name"`
+	Ref    string                    `yaml:"ref"`
+	Tags   []string                  `yaml:"tags"`
+	Filter map[string]rawFilterValue `yaml:"filter"`
+}
+
+// rawFilterValue accepts either one value or a list of them, and normalizes an
+// unquoted integer or boolean to its canonical text.
+//
+// The normalization matters for cross-SDK agreement. yaml.v3 hands back the raw
+// lexeme, so `code: 0200` would compare as "0200" here while a JSON-based SDK
+// parsing the same corpus sees 200. Re-emitting from the parsed value makes both
+// agree. Tags outside string/int/bool are left verbatim for the walker to report
+// rather than failing the whole file to load.
+type rawFilterValue []string
+
+func (r *rawFilterValue) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		*r = []string{canonicalFilterScalar(value)}
+		return nil
+	case yaml.SequenceNode:
+		parts := make([]string, 0, len(value.Content))
+		for _, item := range value.Content {
+			if item.Kind != yaml.ScalarNode {
+				return fmt.Errorf("filter list values must be scalars, got node kind %v", item.Kind)
+			}
+			parts = append(parts, canonicalFilterScalar(item))
+		}
+		*r = parts
+		return nil
+	default:
+		return fmt.Errorf("unexpected YAML node kind %v for filter value", value.Kind)
+	}
+}
+
+// canonicalFilterScalar renders a scalar filter value as the text it compares
+// as. An int round-trips through strconv so leading zeros and underscores
+// normalize; a bool becomes "true"/"false"; anything else keeps its lexeme.
+func canonicalFilterScalar(n *yaml.Node) string {
+	switch n.Tag {
+	case "!!int":
+		var i int64
+		if err := n.Decode(&i); err == nil {
+			return strconv.FormatInt(i, 10)
+		}
+	case "!!bool":
+		var b bool
+		if err := n.Decode(&b); err == nil {
+			return strconv.FormatBool(b)
+		}
+	}
+	return n.Value
 }
 
 type rawMessage struct {
@@ -184,6 +242,7 @@ func loadDir(path string) (*Corpus, error) {
 	var globalRaws []rawComponent
 	var globalRequestRaws []rawRequest
 	var messageRaws []rawMessage
+	var signalRaws []rawSignal
 	type viewFileWithPath struct {
 		rf   rawFile
 		path string
@@ -214,6 +273,9 @@ func loadDir(path string) (*Corpus, error) {
 		}
 		if len(rf.Messages) > 0 {
 			messageRaws = append(messageRaws, rf.Messages...)
+		}
+		if len(rf.Signals) > 0 {
+			signalRaws = append(signalRaws, rf.Signals...)
 		}
 		if len(rf.Views) > 0 {
 			viewFiles = append(viewFiles, viewFileWithPath{rf: rf, path: p})
@@ -294,6 +356,7 @@ func loadDir(path string) (*Corpus, error) {
 		Views:            views,
 		Requests:         globalRequests,
 		Messages:         toMessageDefs(messageRaws),
+		Signals:          toSignalDefs(signalRaws),
 		loadDiagnostics:  append(ctx.diagnostics, fieldDiags...),
 	}, nil
 }
@@ -392,6 +455,31 @@ func toMessageDefs(rms []rawMessage) []MessageDef {
 			Message:     rm.Message,
 			Description: rm.Description,
 			Source:      rm.Source,
+		})
+	}
+	return out
+}
+
+// toSignalDefs converts raw classification rules (SEP-0007). Ref resolution and
+// filter-key checks happen at validation time; see validate_signal.go.
+func toSignalDefs(rss []rawSignal) []SignalDef {
+	if len(rss) == 0 {
+		return nil
+	}
+	out := make([]SignalDef, 0, len(rss))
+	for _, rs := range rss {
+		var filter map[string][]string
+		if len(rs.Filter) > 0 {
+			filter = make(map[string][]string, len(rs.Filter))
+			for k, v := range rs.Filter {
+				filter[k] = v
+			}
+		}
+		out = append(out, SignalDef{
+			Name:   rs.Name,
+			Ref:    rs.Ref,
+			Tags:   rs.Tags,
+			Filter: filter,
 		})
 	}
 	return out

--- a/go/sightmap/signal.go
+++ b/go/sightmap/signal.go
@@ -1,0 +1,50 @@
+package sightmap
+
+// SignalDef composes a named, tagged classification from an entity the corpus
+// already defines (SEP-0007). A rule references that entity by name and
+// optionally filters on its declared properties; it never redeclares a
+// selector, route, or body pattern of its own, so a classification cannot drift
+// away from the thing it is about.
+//
+// Signals are file-root only. There is no view-scoped form.
+type SignalDef struct {
+	// Name is the semantic identity of the generated classification, e.g.
+	// "checkout.payment.declined".
+	Name string `json:"name"`
+	// Ref names an existing components:/requests:/messages:/views: entry. It
+	// must resolve, and must not be ambiguous across entity kinds.
+	Ref string `json:"ref"`
+	// Tags are carried onto the generated classification (SEP-0004).
+	Tags []string `json:"tags,omitempty"`
+	// Filter constrains the referenced entity's declared properties and
+	// already-structured identity fields. Each key holds one or more accepted
+	// values: a single value is equality, several are membership. Keys are
+	// ANDed. An absent filter fires on every match of Ref.
+	//
+	// Values are canonical text. An unquoted YAML integer or boolean is
+	// accepted and normalized (200, true), so `status: 200` reads naturally
+	// while still comparing as a string.
+	Filter map[string][]string `json:"filter,omitempty"`
+}
+
+// ReservedComponentPropertyNames are component property names a signal filter
+// may name without the component declaring them. `value` is always available
+// from the accessibility tree, so a signal filtering on it is valid even when
+// the component declares no properties of its own. (The request-side analogue,
+// ReservedRequestPropertyNames, lives in request.go.)
+var ReservedComponentPropertyNames = []string{"value"}
+
+// FilterKeyKind describes how a signal's filter key resolved, for diagnostics.
+type FilterKeyKind int
+
+const (
+	// FilterKeyUnknown means the key is neither a declared property nor a
+	// reserved identity for the referenced entity's kind.
+	FilterKeyUnknown FilterKeyKind = iota
+	// FilterKeyDeclared means the key names a property the entity declares.
+	FilterKeyDeclared
+	// FilterKeyReserved means the key names an always-available field that
+	// needs no declaration: status/method/duration on a request, value on a
+	// component.
+	FilterKeyReserved
+)

--- a/go/sightmap/spec_conformance_test.go
+++ b/go/sightmap/spec_conformance_test.go
@@ -32,6 +32,10 @@ func TestSpecConformance_MessageFixtures(t *testing.T) {
 	runSpecValidateFixtures(t, "*-messages.fixture")
 }
 
+func TestSpecConformance_SignalFixtures(t *testing.T) {
+	runSpecValidateFixtures(t, "*-signals.fixture")
+}
+
 func runSpecValidateFixtures(t *testing.T, glob string) {
 	t.Helper()
 	const root = "../../spec/conformance"

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -22,7 +22,7 @@ import (
 // stability/access/snapshots/url/properties are all recognized here.
 
 var (
-	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "messages", "snapshots")
+	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "messages", "signals", "snapshots")
 	viewFields      = set("name", "route", "url", "stability", "access", "description", "source", "dependencies", "memory", "components", "requests")
 	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "tags", "properties", "children")
 	refFields       = set("$ref")
@@ -35,6 +35,7 @@ var (
 
 	requestPropertyFields = set("name", "source", "field", "pattern", "transform")
 	messageFields         = set("name", "level", "message", "description", "source")
+	signalFields          = set("name", "ref", "tags", "filter")
 )
 
 func set(keys ...string) map[string]bool {
@@ -133,6 +134,7 @@ func walkFile(node *yaml.Node, file string, out *[]ValidationError) {
 	forEachItem(v["components"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
 	forEachItem(v["requests"], func(n *yaml.Node) { walkRequest(n, file, out) })
 	forEachItem(v["messages"], func(n *yaml.Node) { walkMessage(n, file, out) })
+	forEachItem(v["signals"], func(n *yaml.Node) { walkSignal(n, file, out) })
 	forEachItem(v["snapshots"], func(n *yaml.Node) { checkKeys(n, snapshotFields, file, out) })
 }
 
@@ -260,6 +262,69 @@ func walkMessage(node *yaml.Node, file string, out *[]ValidationError) {
 	// write a pattern for an HTTP-status console error, and the JSON Schema
 	// rejects it.
 	checkStringScalars(v, []string{"name", "level", "message", "description", "source"}, file, out)
+}
+
+func walkSignal(node *yaml.Node, file string, out *[]ValidationError) {
+	v := checkKeys(node, signalFields, file, out)
+	checkStringScalars(v, []string{"name", "ref"}, file, out)
+	// filter keys are entity property names, not spec vocabulary, so they are
+	// not checked here — checkSignals resolves them against the referenced
+	// entity. Their VALUES are type-checked: a filter accepts a string, an
+	// integer, or a boolean (so `status: 200` reads naturally), and rejects a
+	// null or a float, which is what the JSON Schema says.
+	checkFilterValues(v["filter"], file, out)
+}
+
+// filterValueTags are the scalar tags a filter value may carry. An untagged
+// scalar is a plain string.
+var filterValueTags = map[string]bool{"": true, "!!str": true, "!!int": true, "!!bool": true}
+
+func checkFilterValues(filter *yaml.Node, file string, out *[]ValidationError) {
+	if filter == nil || filter.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(filter.Content); i += 2 {
+		key, val := filter.Content[i], filter.Content[i+1]
+		switch val.Kind {
+		case yaml.ScalarNode:
+			checkFilterScalar(key.Value, val, file, out)
+		case yaml.SequenceNode:
+			if len(val.Content) == 0 {
+				// A membership test against nothing can never match, so it is
+				// always an authoring mistake. The JSON Schema says minItems: 1.
+				*out = append(*out, ValidationError{
+					File:     file,
+					Code:     "field-type-invalid",
+					Severity: SeverityError,
+					Message: fmt.Sprintf("filter %q has an empty value list on line %d, which can never match; give it at least one value or drop the key",
+						key.Value, val.Line),
+				})
+				continue
+			}
+			for _, item := range val.Content {
+				if item.Kind == yaml.ScalarNode {
+					checkFilterScalar(key.Value, item, file, out)
+				}
+			}
+		}
+	}
+}
+
+func checkFilterScalar(key string, n *yaml.Node, file string, out *[]ValidationError) {
+	if filterValueTags[n.Tag] {
+		return
+	}
+	hint := "quote it to compare as text"
+	if n.Tag == "!!null" {
+		hint = "a filter value cannot be empty; give it a value or drop the key"
+	}
+	*out = append(*out, ValidationError{
+		File:     file,
+		Code:     "field-type-invalid",
+		Severity: SeverityError,
+		Message: fmt.Sprintf("filter %q has an invalid value on line %d: %s",
+			key, n.Line, hint),
+	})
 }
 
 func walkPayload(node *yaml.Node, file string, out *[]ValidationError) {

--- a/go/sightmap/unknownfields_test.go
+++ b/go/sightmap/unknownfields_test.go
@@ -301,3 +301,73 @@ messages:
 		t.Fatalf("want 1 unknown-field for the typo, got %d: %v", len(w), w)
 	}
 }
+
+// A filter accepts a string, integer, or boolean so `status: 200` reads
+// naturally. Null, float, and an empty list are rejected, matching ajv.
+func TestFieldTypeInvalid_SignalFilterValues(t *testing.T) {
+	bad := map[string]string{
+		"bare key (null)": "status:",
+		"float":           "duration: 1.5",
+		"empty list":      "code: []",
+		"float in list":   "code: [200, 1.5]",
+	}
+	for name, body := range bad {
+		t.Run(name, func(t *testing.T) {
+			got := findingsWithCode(t, "field-type-invalid",
+				"version: 1\nsignals:\n  - name: s\n    ref: R\n    filter:\n      "+body+"\n")
+			if len(got) == 0 {
+				t.Fatalf("want field-type-invalid, got none")
+			}
+		})
+	}
+
+	good := map[string]string{
+		"integer": "status: 200",
+		"boolean": "flag: true",
+		"string":  `status: "200"`,
+		"list":    "code: [200, 404]",
+	}
+	for name, body := range good {
+		t.Run(name, func(t *testing.T) {
+			got := findingsWithCode(t, "field-type-invalid",
+				"version: 1\nsignals:\n  - name: s\n    ref: R\n    filter:\n      "+body+"\n")
+			if len(got) != 0 {
+				t.Fatalf("want clean, got %v", got)
+			}
+		})
+	}
+}
+
+func TestUnknownField_SignalsNoFalsePositives(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+requests:
+  - name: R
+    route: /api/x
+    properties:
+      - name: outcome
+        field: rsp.body.status
+signals:
+  - name: checkout.payment.declined
+    ref: R
+    tags: [defect]
+    filter:
+      outcome: declined
+      status: 200
+`)
+	if len(w) != 0 {
+		t.Fatalf("valid signals must not warn: %v", w)
+	}
+}
+
+func TestUnknownField_SignalTypo(t *testing.T) {
+	w := unknownWarnings(t, `
+version: 1
+signals:
+  - name: s
+    reff: R
+`)
+	if len(w) != 1 {
+		t.Fatalf("want 1 unknown-field for the typo, got %d: %v", len(w), w)
+	}
+}

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -128,6 +128,9 @@ func Validate(c *Corpus) []ValidationError {
 	// Console/exception patterns (SEP-0006); see validate_message.go.
 	errs = append(errs, checkMessages(c.Messages)...)
 
+	// Signal refs and filter keys (SEP-0007); see validate_signal.go.
+	errs = append(errs, checkSignals(c)...)
+
 	return errs
 }
 

--- a/go/sightmap/validate_signal.go
+++ b/go/sightmap/validate_signal.go
@@ -1,0 +1,198 @@
+package sightmap
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// entityIndex maps an entity name to the kinds that claim it and the property
+// names a signal may filter on. Ref resolution and filter-key checking share one
+// index because they answer the same question about the same name.
+type entityIndex map[string]*entityEntry
+
+type entityEntry struct {
+	kinds map[string]bool
+	// props holds every filter key that resolves for this entity: the
+	// properties it declares plus the reserved names available for its kind.
+	props map[string]bool
+	// acceptsFilter is false for kinds with nothing to filter on. A message's
+	// own level/message already identify it fully, and a view has no extractable
+	// property at all, so a filter on either is authoring confusion worth
+	// reporting rather than a constraint that quietly never applies.
+	acceptsFilter bool
+}
+
+func (e *entityEntry) kindList() []string {
+	out := make([]string, 0, len(e.kinds))
+	for k := range e.kinds {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func buildEntityIndex(c *Corpus) entityIndex {
+	idx := entityIndex{}
+	entry := func(name, kind string, acceptsFilter bool) *entityEntry {
+		if name == "" {
+			return nil
+		}
+		e := idx[name]
+		if e == nil {
+			e = &entityEntry{kinds: map[string]bool{}, props: map[string]bool{}}
+			idx[name] = e
+		}
+		e.kinds[kind] = true
+		if acceptsFilter {
+			e.acceptsFilter = true
+		}
+		return e
+	}
+
+	for _, comp := range c.AllComponents() {
+		e := entry(comp.Name, "component", true)
+		if e == nil {
+			continue
+		}
+		for _, p := range comp.Properties {
+			e.props[p.Name] = true
+		}
+		// `value` resolves from the accessibility tree with no declaration.
+		for _, r := range ReservedComponentPropertyNames {
+			e.props[r] = true
+		}
+	}
+
+	addRequests := func(reqs []RequestDef) {
+		for _, req := range reqs {
+			e := entry(req.Name, "request", true)
+			if e == nil {
+				continue
+			}
+			for _, p := range req.Properties {
+				e.props[p.Name] = true
+			}
+			// status/method/duration resolve from the request's own HTTP
+			// identity with no declaration. A declared property of the same
+			// name shadows the identity; either way the key resolves, so this
+			// check does not care which won.
+			for _, r := range ReservedRequestPropertyNames {
+				e.props[r] = true
+			}
+		}
+	}
+	addRequests(c.Requests)
+	for i := range c.Views {
+		addRequests(c.Views[i].Requests)
+	}
+
+	for _, msg := range c.Messages {
+		entry(msg.Name, "message", false)
+	}
+	for _, v := range c.Views {
+		entry(v.Name, "view", false)
+	}
+	return idx
+}
+
+// checkSignals validates every signals: rule (SEP-0007): that its ref resolves
+// to exactly one entity kind, and that each filter key names something that
+// entity can actually be filtered on.
+//
+// The filter-key check is what makes SEP-0007's central claim true. The proposal
+// rests on a signal composing what the corpus already defines so the two cannot
+// drift apart; without validating the keys, a filter naming a property that was
+// renamed or never existed passes silently and the signal never fires.
+func checkSignals(c *Corpus) []ValidationError {
+	if len(c.Signals) == 0 {
+		return nil
+	}
+	idx := buildEntityIndex(c)
+
+	var out []ValidationError
+	for _, sig := range c.Signals {
+		if sig.Ref == "" {
+			continue // required by the schema; not this check's job
+		}
+		e := idx[sig.Ref]
+		if e == nil {
+			out = append(out, ValidationError{
+				Component: sig.Name,
+				Code:      "signal-ref-unresolved",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("signal %q: ref %q does not resolve to any component, request, message, or view", sig.Name, sig.Ref),
+			})
+			continue
+		}
+		if len(e.kinds) > 1 {
+			out = append(out, ValidationError{
+				Component: sig.Name,
+				Code:      "signal-ref-ambiguous",
+				Severity:  SeverityError,
+				Message: fmt.Sprintf("signal %q: ref %q is ambiguous across entity kinds (%s)",
+					sig.Name, sig.Ref, strings.Join(e.kindList(), ", ")),
+			})
+			continue
+		}
+		out = append(out, checkSignalFilter(sig, e)...)
+	}
+	return out
+}
+
+func checkSignalFilter(sig SignalDef, e *entityEntry) []ValidationError {
+	if len(sig.Filter) == 0 {
+		return nil
+	}
+	kind := e.kindList()[0]
+
+	if !e.acceptsFilter {
+		keys := sortedKeys(sig.Filter)
+		return []ValidationError{{
+			Component: sig.Name,
+			Code:      "signal-filter-unknown",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("signal %q: ref %q is a %s, which has no filterable properties, but filter declares %s; reference it without a filter to fire on every match",
+				sig.Name, sig.Ref, kind, strings.Join(quoteAll(keys), ", ")),
+		}}
+	}
+
+	available := sortedKeys(e.props)
+	var out []ValidationError
+	for _, key := range sortedKeys(sig.Filter) {
+		if e.props[key] {
+			continue
+		}
+		msg := fmt.Sprintf("signal %q: filter key %q is not a property of %s %q", sig.Name, key, kind, sig.Ref)
+		if len(available) > 0 {
+			msg += fmt.Sprintf("; available: %s", strings.Join(quoteAll(available), ", "))
+		} else {
+			msg += "; it declares no properties"
+		}
+		out = append(out, ValidationError{
+			Component: sig.Name,
+			Code:      "signal-filter-unknown",
+			Severity:  SeverityError,
+			Message:   msg,
+		})
+	}
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func quoteAll(ss []string) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = fmt.Sprintf("%q", s)
+	}
+	return out
+}

--- a/go/sightmap/validate_signal_test.go
+++ b/go/sightmap/validate_signal_test.go
@@ -1,0 +1,299 @@
+package sightmap_test
+
+import (
+	"testing"
+
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func TestValidate_SignalRefUnresolved(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		Signals: []sightmap.SignalDef{{Name: "s", Ref: "Nope"}},
+	})
+	if !hasCode(errs, "signal-ref-unresolved") {
+		t.Fatalf("want signal-ref-unresolved, got %v", findingCodes(errs))
+	}
+}
+
+func TestValidate_SignalRefAmbiguousAcrossKinds(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		GlobalComponents: []match.ComponentDef{{Name: "Shared", Selectors: []string{".x"}}},
+		Requests:         []sightmap.RequestDef{{Name: "Shared", Route: "/api/x"}},
+		Signals:          []sightmap.SignalDef{{Name: "s", Ref: "Shared"}},
+	})
+	if !hasCode(errs, "signal-ref-ambiguous") {
+		t.Fatalf("want signal-ref-ambiguous, got %v", findingCodes(errs))
+	}
+}
+
+// A child component reused under several parents flattens to several same-name
+// entries. That is intentional reuse, so it must not read as ambiguity.
+func TestValidate_SignalRefReusedComponentNameIsNotAmbiguous(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		GlobalComponents: []match.ComponentDef{
+			{Name: "Row", Selectors: []string{".a .row"}},
+			{Name: "Row", Selectors: []string{".b .row"}},
+		},
+		Signals: []sightmap.SignalDef{{Name: "s", Ref: "Row"}},
+	})
+	if hasCode(errs, "signal-ref-ambiguous") {
+		t.Fatalf("reused child component names must not be ambiguous, got %v", findingCodes(errs))
+	}
+}
+
+// Two messages sharing a name previously collapsed to one kind, so the ref
+// resolved silently. The duplicate is now caught at its source.
+func TestValidate_SignalRefDuplicateMessageIsCaught(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		Messages: []sightmap.MessageDef{
+			{Name: "Dup", Level: "ERROR", Message: "a"},
+			{Name: "Dup", Level: "WARN", Message: "b"},
+		},
+		Signals: []sightmap.SignalDef{{Name: "s", Ref: "Dup"}},
+	})
+	if !hasCode(errs, "merge-collision-message") {
+		t.Fatalf("want merge-collision-message so the ambiguous ref is not silent, got %v", findingCodes(errs))
+	}
+}
+
+func requestSignalCorpus(filter map[string][]string) *sightmap.Corpus {
+	return &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{{
+			Name:  "CheckoutPayment",
+			Route: "/api/checkout/pay",
+			Properties: []sightmap.RequestProperty{
+				{Name: "outcome", Source: "rsp.body", Field: "status"},
+			},
+		}},
+		Signals: []sightmap.SignalDef{{Name: "s", Ref: "CheckoutPayment", Filter: filter}},
+	}
+}
+
+func TestValidate_SignalFilterUnknownKey(t *testing.T) {
+	errs := sightmap.Validate(requestSignalCorpus(map[string][]string{"typo_prop": {"x"}}))
+	if !hasCode(errs, "signal-filter-unknown") {
+		t.Fatalf("want signal-filter-unknown, got %v", findingCodes(errs))
+	}
+}
+
+func TestValidate_SignalFilterDeclaredKeyIsClean(t *testing.T) {
+	errs := sightmap.Validate(requestSignalCorpus(map[string][]string{"outcome": {"declined"}}))
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// status/method/duration resolve on a request with no properties: declaration.
+func TestValidate_SignalFilterReservedRequestNames(t *testing.T) {
+	for _, key := range []string{"status", "method", "duration"} {
+		errs := sightmap.Validate(&sightmap.Corpus{
+			Requests: []sightmap.RequestDef{{Name: "R", Route: "/api/x"}},
+			Signals:  []sightmap.SignalDef{{Name: "s", Ref: "R", Filter: map[string][]string{key: {"200"}}}},
+		})
+		if len(errs) != 0 {
+			t.Errorf("reserved key %q should resolve with no declaration, got %v", key, findingCodes(errs))
+		}
+	}
+}
+
+// `value` comes from the accessibility tree, so it resolves on a component that
+// declares no properties.
+func TestValidate_SignalFilterComponentValueIsBuiltIn(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		GlobalComponents: []match.ComponentDef{{Name: "Banner", Selectors: []string{".b"}}},
+		Signals: []sightmap.SignalDef{{
+			Name: "s", Ref: "Banner", Filter: map[string][]string{"value": {"declined"}},
+		}},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("`value` should be built in, got %v", findingCodes(errs))
+	}
+}
+
+// A message and a view have nothing to filter on, so a filter there is an error
+// rather than a constraint that quietly never applies.
+func TestValidate_SignalFilterOnMessageOrViewIsRejected(t *testing.T) {
+	msg := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{{Name: "M", Level: "ERROR", Message: "x"}},
+		Signals: []sightmap.SignalDef{{
+			Name: "s", Ref: "M", Filter: map[string][]string{"level": {"ERROR"}},
+		}},
+	}
+	if !hasCode(sightmap.Validate(msg), "signal-filter-unknown") {
+		t.Errorf("a filter on a message ref should be rejected, got %v", findingCodes(sightmap.Validate(msg)))
+	}
+
+	view := &sightmap.Corpus{
+		Views: []sightmap.View{{Name: "V", Route: "/v"}},
+		Signals: []sightmap.SignalDef{{
+			Name: "s", Ref: "V", Filter: map[string][]string{"anything": {"x"}},
+		}},
+	}
+	if !hasCode(sightmap.Validate(view), "signal-filter-unknown") {
+		t.Errorf("a filter on a view ref should be rejected, got %v", findingCodes(sightmap.Validate(view)))
+	}
+}
+
+func TestValidate_SignalRefMessageAndViewWithoutFilterAreClean(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		Messages: []sightmap.MessageDef{{Name: "M", Level: "ERROR", Message: "x"}},
+		Views:    []sightmap.View{{Name: "V", Route: "/v"}},
+		Signals: []sightmap.SignalDef{
+			{Name: "s1", Ref: "M"},
+			{Name: "s2", Ref: "V"},
+		},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// A declared property shadowing a reserved name still resolves as a filter key;
+// only the shadowing warning fires, from the request check.
+func TestValidate_SignalFilterShadowedReservedResolves(t *testing.T) {
+	c := &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{{
+			Name:       "R",
+			Route:      "/api/x",
+			Properties: []sightmap.RequestProperty{{Name: "status", Source: "rsp.body", Field: "status"}},
+		}},
+		Signals: []sightmap.SignalDef{{
+			Name: "s", Ref: "R", Filter: map[string][]string{"status": {"declined"}},
+		}},
+	}
+	errs := sightmap.Validate(c)
+	if hasCode(errs, "signal-filter-unknown") {
+		t.Fatalf("a shadowed reserved name must still resolve, got %v", findingCodes(errs))
+	}
+	if !hasCode(errs, "request-property-shadows-reserved") {
+		t.Fatalf("want the shadowing warning, got %v", findingCodes(errs))
+	}
+}
+
+// A view-scoped request's properties must be visible to a signal too.
+func TestValidate_SignalFilterViewScopedRequestProperties(t *testing.T) {
+	errs := sightmap.Validate(&sightmap.Corpus{
+		Views: []sightmap.View{{
+			Name:  "Checkout",
+			Route: "/checkout",
+			Requests: []sightmap.RequestDef{{
+				Name:       "ViewScoped",
+				Route:      "/api/x",
+				Properties: []sightmap.RequestProperty{{Name: "outcome", Source: "rsp.body", Field: "status"}},
+			}},
+		}},
+		Signals: []sightmap.SignalDef{{
+			Name: "s", Ref: "ViewScoped", Filter: map[string][]string{"outcome": {"declined"}},
+		}},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("want no findings, got %v", findingCodes(errs))
+	}
+}
+
+// SEP-0007's headline example was rejected by the schema this PR previously
+// shipped, because `status: 200` is an unquoted integer. It must now load, and
+// the integer must normalize to canonical text.
+func TestLoadDir_SignalFilterScalarNormalization(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir+"/app.yaml", `
+version: 1
+requests:
+  - name: CheckoutRetryPayment
+    route: /api/checkout/pay/retry
+    method: POST
+    properties:
+      - name: rate_limit_remaining
+        source: rsp.headers
+        field: X-RateLimit-Remaining
+      - name: outcome
+        source: rsp.body
+        field: status
+signals:
+  - name: checkout.payment.throttled_silently
+    tags: [defect]
+    ref: CheckoutRetryPayment
+    filter:
+      status: 200
+      rate_limit_remaining: "0"
+      outcome: [queued, deferred]
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Signals) != 1 {
+		t.Fatalf("want 1 signal, got %d", len(c.Signals))
+	}
+	f := c.Signals[0].Filter
+	for key, want := range map[string][]string{
+		"status":               {"200"},
+		"rate_limit_remaining": {"0"},
+		"outcome":              {"queued", "deferred"},
+	} {
+		got := f[key]
+		if len(got) != len(want) {
+			t.Errorf("filter[%q] = %v, want %v", key, got, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("filter[%q][%d] = %q, want %q", key, i, got[i], want[i])
+			}
+		}
+	}
+	if errs := sightmap.Validate(c); len(errs) != 0 {
+		t.Errorf("SEP-0007's own example must validate cleanly, got %v", findingCodes(errs))
+	}
+}
+
+// An integer is re-emitted from its parsed numeric value, not its lexeme. YAML
+// accepts octal, hex, and underscore-separated integers, so comparing raw
+// lexemes would make `0x1F` and `31` different values for the same number.
+func TestLoadDir_SignalFilterIntegerCanonicalization(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir+"/app.yaml", `
+version: 1
+requests:
+  - name: R
+    route: /api/x
+    properties:
+      - name: octal
+        source: rsp.body
+        field: a
+      - name: hex
+        source: rsp.body
+        field: b
+      - name: underscored
+        source: rsp.body
+        field: c
+      - name: flag
+        source: rsp.body
+        field: d
+signals:
+  - name: s
+    ref: R
+    filter:
+      octal: 0200
+      hex: 0x1F
+      underscored: 1_000
+      flag: true
+`)
+	c, err := sightmap.DirLoader(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// 0200 is octal in YAML, so it is 128 — canonicalizing is what makes that
+	// unambiguous instead of comparing the string "0200".
+	want := map[string]string{"octal": "128", "hex": "31", "underscored": "1000", "flag": "true"}
+	for key, exp := range want {
+		got := c.Signals[0].Filter[key]
+		if len(got) != 1 || got[0] != exp {
+			t.Errorf("filter[%q] = %v, want [%q]", key, got, exp)
+		}
+	}
+	if errs := sightmap.Validate(c); len(errs) != 0 {
+		t.Errorf("want no findings, got %v", findingCodes(errs))
+	}
+}

--- a/spec/conformance/020-signals.fixture/expected.json
+++ b/spec/conformance/020-signals.fixture/expected.json
@@ -1,0 +1,14 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": {
+        "ok": true,
+        "diagnostics": [
+          { "code": "request-property-shadows-reserved", "severity": "warning" }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/conformance/020-signals.fixture/sightmap/app.yaml
+++ b/spec/conformance/020-signals.fixture/sightmap/app.yaml
@@ -1,0 +1,74 @@
+version: 1
+requests:
+  # `status` shadows the reserved HTTP identity, so the filter below sees the
+  # body value. Warned about by request-property-shadows-reserved.
+  - name: CheckoutPayment
+    route: /api/checkout/pay
+    method: POST
+    properties:
+      - name: status
+        source: rsp.body
+        field: status
+
+  - name: CheckoutRetryPayment
+    route: /api/checkout/pay/retry
+    method: POST
+    properties:
+      - name: rate_limit_remaining
+        source: rsp.headers
+        field: X-RateLimit-Remaining
+      - name: outcome
+        source: rsp.body
+        field: status
+
+views:
+  - name: CheckoutView
+    route: /checkout
+
+components:
+  - name: PaymentBanner
+    selector: .payment-status-banner
+    properties:
+      - name: text
+        extract: text
+
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+
+signals:
+  # Filters a declared property that shadows a reserved name.
+  - name: checkout.payment.declined
+    tags: [defect]
+    ref: CheckoutPayment
+    filter:
+      status: declined
+
+  # A reserved identity name needs no declaration, and an unquoted integer is
+  # accepted (compared as canonical text). Every other key is declared above.
+  - name: checkout.payment.throttled_silently
+    tags: [defect]
+    ref: CheckoutRetryPayment
+    filter:
+      method: POST
+      rate_limit_remaining: "0"
+      outcome: [queued, deferred]
+
+  # A component's declared property, plus the built-in `value`.
+  - name: checkout.payment.declined.banner
+    tags: [defect]
+    ref: PaymentBanner
+    filter:
+      text: declined
+
+  # A message ref takes no filter: its own level/message already identify it.
+  - name: cart.abandoned
+    tags: [defect]
+    ref: CartVersionMismatch
+
+  # A view ref scopes a classification to "observed while this view is active".
+  # It has no extractable property, so it takes no filter either.
+  - name: checkout.view.active
+    tags: [checkout]
+    ref: CheckoutView

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -56,6 +56,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 017 | `tags` | `tags:` validates on components (at multiple nesting levels), requests, and views ([SEP-0004](../seps/0004-component-tags.md)) |
 | 018 | `request-properties` | `properties:` on a request validates via `field` (body and header paths) and `pattern`; declaring a reserved identity name warns with `request-property-shadows-reserved` ([SEP-0005](../seps/0005-request-properties.md)) |
 | 019 | `messages` | `messages:` validates with `level`/`message`/`description`/`source`, including `level: EXCEPTION`; a level-only entry overlapping a level+message entry warns with `message-conflict` ([SEP-0006](../seps/0006-message-entity.md)) |
+| 020 | `signals` | `signals:` resolves refs to a request, component, message, and view; filter keys resolve against declared properties, reserved request identities, and the built-in `value`; an unquoted integer filter value is accepted ([SEP-0007](../seps/0007-signals.md)) |
 
 The `1NN` series verifies the [canonical format](../v1/canonical-format.md) (byte-level formatter output):
 

--- a/spec/seps/0007-signals.md
+++ b/spec/seps/0007-signals.md
@@ -146,6 +146,9 @@ A classification produced by a `signals:` match carries the referenced entity's 
 - MUST reject a `signals:` entry whose `ref:` does not resolve to a known `Component`/`Request`/`Message`/`View` name. Diagnostic code: `signal-ref-unresolved` (mirrors the existing `ref-unresolved` code for `$ref`).
 - MUST reject (not silently resolve) a `ref:` name that collides across entity kinds (e.g. a `Component` and a `Request` sharing a name) — unlike DOM tree matching, there is no adjacency/tree-position reason to prefer one over the other. Diagnostic code: `signal-ref-ambiguous`.
 - MUST evaluate every declared `filter:` key with AND semantics; MUST support both scalar (equality) and array (membership) values per key.
+- MUST reject a `filter:` key that does not resolve on the referenced entity, i.e. is neither one of its declared `properties:` nor a reserved name available for its kind (`status`/`method`/`duration` on a `Request`, `value` on a `Component`). Diagnostic code: `signal-filter-unknown`. Without this check the structural link this SEP is built on is unenforced: a filter naming a renamed or never-existent property passes silently and the rule simply never fires.
+- MUST reject any `filter:` key on a `Message` or `View` ref. A message's own `level`/`message` already identify it fully and a view has no extractable property, so a filter there is authoring confusion rather than a constraint.
+- MUST compare `filter:` values as canonical text, normalizing an integer before comparison so `0200` and `200` agree with an SDK that reads the same corpus as JSON.
 - MUST fire a rule with no `filter:` on every match of its `ref:`.
 - MUST evaluate each `signals:` rule independently — a live instance matched by more than one rule produces one classification per matching rule.
 - MUST NOT require a numeric-comparison filter operator (`>=`, ranges) in v1 — see [Open questions](#open-questions).
@@ -187,9 +190,11 @@ $defs.signal:
       description: "Property-name → value (equality) or value-list (membership) constraints, ANDed across keys, evaluated against the referenced entity's declared properties and already-structured identity fields. Omitted = unconditional."
       additionalProperties:
         oneOf:
-          - { type: string }
-          - { type: array, items: { type: string }, minItems: 1 }
+          - { type: [string, integer, boolean] }
+          - { type: array, items: { type: [string, integer, boolean] }, minItems: 1 }
 ```
+
+Note the value types. An earlier draft of this diff allowed only `string`, which made this proposal's own multi-key example above invalid: `status: 200` is an unquoted YAML integer, and the reserved `status` identity genuinely *is* an integer. Integers and booleans are accepted and compared as canonical text, so the natural spelling works. `integer` rather than `number` is deliberate: a float has no single canonical text (`1.50` versus `1.5`), which would become a cross-SDK divergence. `null` and an empty list stay invalid, the first having nothing to compare and the second never matching.
 
 `fileRootFields` gains `"signals"`.
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -22,6 +22,7 @@ views:       # optional, View[]
 components:  # optional, Component[] — global, matched on every view
 requests:    # optional, Request[] — global, matched on every view
 messages:    # optional, Message[] — console/exception patterns
+signals:     # optional, Signal[] — classifications composed from the above
 ```
 
 | Field | Type | Required | Description |
@@ -32,6 +33,7 @@ messages:    # optional, Message[] — console/exception patterns
 | `components` | (Component \| [ComponentRef](#component-references))[] | no | **Global** components — matched against every view. Entries may be either inline definitions or `$ref` reference objects. |
 | `requests` | [Request](#request)[] | no | **Global** requests — matched against every view. |
 | `messages` | [Message](#message)[] | no | Console-output and exception patterns. Corpus-root only; there is no view-scoped form. |
+| `signals` | [Signal](#signal)[] | no | Classification rules composed from other entities. Corpus-root only; there is no view-scoped form. |
 
 ## View
 
@@ -357,6 +359,72 @@ Two entries that can match the same record are reported as `message-conflict` (a
 
 A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](../seps/0006-message-entity.md).
 
+## Signal
+
+A named, tagged classification composed from an entity the corpus already defines. A signal references that entity by name and optionally filters on its declared properties. It never declares a selector, route, or body pattern of its own, so a classification cannot drift away from the thing it is about.
+
+```yaml
+requests:
+  - name: CheckoutPayment
+    route: /api/checkout/pay
+    method: POST
+    properties:
+      - name: outcome
+        source: rsp.body
+        field: status
+
+signals:
+  - name: checkout.payment.declined
+    tags: [defect]
+    ref: CheckoutPayment
+    filter:
+      outcome: declined
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Semantic identity of the generated classification. |
+| `ref` | string | yes | Name of an existing `components:`/`requests:`/`messages:`/`views:` entry. Must resolve, and must not be ambiguous across entity kinds. |
+| `tags` | string[] | no | Labels carried onto the generated classification. See [Tags](#tags). |
+| `filter` | object | no | Property constraints, ANDed across keys. Omitted means the rule fires on every match of `ref`. |
+
+Omitting `filter` is equivalent to a static `tags:` entry on the referenced entity, so `signals:` is a superset of that mechanism rather than a parallel one. Reach for `filter` only when the entity's mere presence is not itself the classification.
+
+### Filter values
+
+A key's value is either one accepted value (equality) or a list of them (membership). Keys are ANDed; there is no `OR` in v1, so a classification needing one is expressed as several `signals:` entries.
+
+Values compare as canonical text, and an unquoted integer or boolean is accepted so the natural spelling works:
+
+```yaml
+filter:
+  status: 200                    # integer, compares as "200"
+  outcome: [queued, deferred]    # membership
+  rate_limit_remaining: "0"      # quoted, compares as "0"
+```
+
+An integer compares as its **numeric value in decimal**, not as the characters you typed. YAML accepts octal, hexadecimal, and underscore-separated integers, so `0200` is 128, `0x1F` is 31, and `1_000` is 1000. Comparing lexemes instead would make `0x1F` and `31` two different values for one number.
+
+A `null` (a bare `key:`), a float, and an empty list are all invalid: the first has nothing to compare, a float has no single canonical text (`1.50` versus `1.5`), and an empty list can never match.
+
+### Filter key resolution
+
+A filter key must resolve on the referenced entity. In order:
+
+1. A property the entity declares — `properties:` on a [Request](#request-properties) or a [Component](#component-properties).
+2. For a `Request` ref, a reserved identity name: `status`, `method`, `duration`.
+3. For a `Component` ref, the built-in `value`.
+
+A declared property shadows a reserved name of the same name; see [Request properties](#request-properties).
+
+A `Message` or `View` ref accepts **no** filter keys. A message's own `level`/`message` already identify it fully, and a view has no extractable property, so reference either without a filter.
+
+A key resolving to none of the above is an error (`signal-filter-unknown`). This is what keeps a signal tied to its entity: without it, a filter naming a property that was renamed or never existed would pass silently and the rule would simply never fire.
+
+### Multiple matching rules
+
+Each rule is evaluated independently. When more than one references the same entity and both match the same live instance, both fire — nothing is deduped or merged. A consumer sees one classification per firing rule, not one classification with several names. See [SEP-0007](../seps/0007-signals.md).
+
 ## Regular expressions
 
 Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)) and a message's `message` ([Message](#message)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
@@ -512,6 +580,8 @@ A conforming SDK:
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
+- MUST reject a `signals:` entry whose `ref` does not resolve, or resolves across more than one entity kind
+- MUST reject a `signals:` `filter` key that does not resolve on the referenced entity
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -524,8 +594,10 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
+- MUST evaluate each `signals:` rule independently: a live instance matched by several rules produces one classification per matching rule
+- SHOULD carry the referenced entity's name on the generated classification, so its derivation stays explicit
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, matches no `messages:` entry against a console record, and evaluates no `signals:` rule. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -38,6 +38,11 @@
       "description": "Declarative console/exception patterns, addressable by name. Corpus-root only — no view-scoping. See SEP-0006.",
       "items": { "$ref": "#/$defs/message" }
     },
+    "signals": {
+      "type": "array",
+      "description": "Rules composing a named, tagged classification from an existing entity's identity and declared properties. Corpus-root only — no view-scoping. See SEP-0007.",
+      "items": { "$ref": "#/$defs/signal" }
+    },
     "snapshots": {
       "$comment": "Reserved tooling field. Not part of the spec's matching or merge semantics; conforming SDKs MAY ignore it. Consumed by the reference CLI's capture/probe workflow.",
       "type": "array",
@@ -268,6 +273,46 @@
           "type": "string",
           "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
           "description": "Optional post-processing applied to the extracted string. Same vocabulary as componentProperty.transform (SEP-0003)."
+        }
+      }
+    },
+    "signal": {
+      "type": "object",
+      "description": "A rule composing a named, tagged classification from an existing entity. See SEP-0007.",
+      "required": ["name", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic identity of the generated classification, e.g. checkout.payment.declined."
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of an existing components:/requests:/messages:/views: entry this rule composes. Must resolve; must not be ambiguous across entity kinds."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Open-vocabulary classification labels carried onto the generated classification. See SEP-0004."
+        },
+        "filter": {
+          "type": "object",
+          "description": "Property name → an accepted value (equality) or list of them (membership), ANDed across keys, evaluated against the referenced entity's declared properties and already-structured identity fields. Omitted means unconditional. A key must resolve on the referenced entity; a message or view ref accepts no keys.",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": ["string", "integer", "boolean"],
+                "description": "Compared as canonical text, so an unquoted 200 or true reads naturally. Quote anything whose exact text matters."
+              },
+              {
+                "type": "array",
+                "items": { "type": ["string", "integer", "boolean"] },
+                "minItems": 1
+              }
+            ]
+          }
         }
       }
     },


### PR DESCRIPTION
Declaration and validation layer for [SEP-0007](https://github.com/sightmap/sightmap/blob/main/spec/seps/0007-signals.md). Evaluation is not implemented; `spec/v1/schema.md` says so explicitly.

Stacked on #113.

## Rebased onto the Def convention

`SignalDef` in `go/sightmap/signal.go`, replacing `match.SignalRule`, with a JSON wire tag on `Corpus.Signals`. The previous version had no wire tag, so signals would not have appeared in the uploaded corpus at all.

## SEP-0007's own example was schema-invalid

The filter schema allowed only strings. SEP-0007's headline example writes:

```yaml
filter:
  status: 200                    # unquoted YAML integer
  rate_limit_remaining: "0"
  outcome: [queued, deferred]
```

ajv rejected that document, while the Go loader silently accepted it by taking the raw lexeme. Two conformance checkers disagreeing about the SEP's own normative example.

Filter values now accept string, integer, and boolean. An unquoted `200` reads naturally, and the reserved `status` identity genuinely is an integer. Values compare as canonical text, and **an integer compares as its numeric value in decimal, not its lexeme** — YAML reads `0200` as octal 128 and `0x1F` as 31, so comparing lexemes would turn one number into several distinct values. `null`, floats, and empty lists stay invalid; a float has no single canonical text (`1.50` vs `1.5`) and an empty membership test can never match.

## `signal-filter-unknown`

Nothing validated that a filter key exists on the referenced entity. This matters more than a missing check usually does, because it is precisely the guarantee SEP-0007 is built on: a signal composes what the corpus already defines *so the two cannot drift apart*. Without the check, a filter naming a renamed or never-existent property passes silently and the rule simply never fires.

The old fixture 020 demonstrated the gap. It filtered on `outcome`, which it declared nowhere, and asserted zero diagnostics — encoding the missing check as correct behavior.

Resolution order for a filter key:

1. A property the entity declares.
2. For a `Request` ref, a reserved identity: `status`, `method`, `duration`.
3. For a `Component` ref, the built-in `value` from the accessibility tree.

A `Message` or `View` ref accepts no filter keys: a message's own `level`/`message` already identify it fully, and a view has no extractable property.

## Fixture 020 rewritten

Now exercises a shadowed reserved name, a reserved identity filtered with an unquoted integer, a membership list, a component property, the built-in `value`, and filter-less message and view refs. Its single asserted diagnostic (`request-property-shadows-reserved`) is confirmed against the real CLI, not just assumed.

## Also

- Ref and filter resolution share one entity index rather than two passes.
- Component ambiguity stays name-counted, not entity-counted: a child component reused under several parents legitimately flattens to several same-name entries, and `validateComponent`'s own comment says so.
- `field-type-invalid` extended to filter values. Parity with ajv verified across all eight cases (integer, boolean, string, list accepted; null, float, empty list, float-in-list rejected).
- A wire-form test asserts `requests[].properties`, `messages`, and `signals` all appear in the serialized corpus.

Verified: `go build`/`vet`/`test ./...`, `npm run validate:conformance`, `npm run validate:examples`, docs sync guardrail.