### PR TITLE
chore(analytics): capture into the production Fullstory org

### DIFF
--- a/docs/fullstory.js
+++ b/docs/fullstory.js
@@ -1,11 +1,10 @@
-// FullStory analytics — staging org, same as sightmap.org.
+// FullStory analytics — production org.
 // Mintlify includes every root-level .js file globally on all pages.
 
-    window['_fs_host'] = 'analytics.staging.fsty.io'
-    window['_fs_script'] = 'analytics.staging.fsty.io/s/fs.js'
-    window['_fs_org'] = 'thefullstory.com'
+    window['_fs_host'] = 'fullstory.com'
+    window['_fs_script'] = 'edge.fullstory.com/s/fs.js'
+    window['_fs_org'] = 'o-24FZWQ-na1'
     window['_fs_namespace'] = 'FS'
-    window['_fs_app_host'] = 'app.staging.fullstory.com'
     !(function (m, n, e, t, l, o, g, y) {
       var s,
         f,

--- a/web/index.html
+++ b/web/index.html
@@ -34,11 +34,10 @@
        self-invoking: nothing is fetched or captured until the consent gate
        calls it. The _fs_* config is inert on its own. -->
   <script>
-    window['_fs_host'] = 'analytics.staging.fsty.io'
-    window['_fs_script'] = 'analytics.staging.fsty.io/s/fs.js'
-    window['_fs_org'] = 'thefullstory.com'
+    window['_fs_host'] = 'fullstory.com'
+    window['_fs_script'] = 'edge.fullstory.com/s/fs.js'
+    window['_fs_org'] = 'o-24FZWQ-na1'
     window['_fs_namespace'] = 'FS'
-    window['_fs_app_host'] = 'app.staging.fullstory.com'
     window.__sightmapStartCapture = function () {
     !(function (m, n, e, t, l, o, g, y) {
       var s,


### PR DESCRIPTION
Reverses eef9115, which pointed both properties at the staging edge so traffic from all sightmap properties funneled into one org for dogfooding. docs.sightmap.org and sightmap.org now capture into production org `o-24FZWQ-na1` via `edge.fullstory.com`.

`_fs_app_host` is dropped: it existed only to aim the loader at `app.staging.fullstory.com`, and production resolves the app host on its own.

## Consent gate is untouched

`web/index.html` keeps the `__sightmapStartCapture` wrapper from #106 — only the `_fs_*` config lines change. Capture still boots solely when the gate says so, so EEA/UK/CH visitors remain uncaptured until they accept and an unresolved region still fails closed. The loader body is identical between the staging and production snippets (both v2.0.0). `src/lib/consent/` needed no change; it only calls `__sightmapStartCapture` and `FS('restart'|'shutdown')`, with no host or org baked in.

## Scope

`web/index.html` is the shell `scripts/prerender.tsx` renders every route from, so one edit covers the homepage, `/blog`, and each post. There is no CSP on the site to widen for the new `edge.fullstory.com` origin.

## Verification

`pnpm build` output — `dist/index.html`, `dist/blog/index.html`, and `dist/blog/sightmap/index.html` each emit `_fs_org'] = 'o-24FZWQ-na1'`, no staging hostname appears anywhere in `dist/`, and the wrapper is still present in all three. 45/45 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)