### PR TITLE
fix(route): `**` is a globstar (zero-or-more segments); glued `**` is a regular `*`

### DIFF
--- a/.changeset/route-globstar.md
+++ b/.changeset/route-globstar.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Route matching: `**` is now a proper globstar. As a whole path segment it matches zero or more segments, so `/admin/**` matches `/admin` itself (as the spec always stated) as well as `/admin/users` and deeper, and `/a/**/b` matches `/a/b`. A `**` glued into a segment (e.g. `/foo**`) is treated as a regular single-segment `*` that does not cross a `/`. This fixes the previous behaviour where `/admin/**` failed to match `/admin` and `/messages**` failed to match `/messages`.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -280,7 +280,8 @@ Design points:
 Routes use glob patterns against the URL pathname.
 
 - `*` matches exactly one path segment: `/users/*` matches `/users/42`, not `/users/42/edit`
-- `**` matches any depth of segments: `/admin/**` matches `/admin`, `/admin/users`, `/admin/users/42/edit`
+- `**` is a globstar: **as a whole path segment** it matches zero or more segments, so `/admin/**` matches `/admin`, `/admin/users`, and `/admin/users/42/edit`, and `/a/**/b` matches `/a/b`, `/a/x/b`, …
+- A `**` **glued into a segment** (e.g. `/foo**`) is treated as a regular `*` — an in-segment wildcard that does not cross a `/`. Write `**` as its own segment when you mean "any depth".
 - Literal segments match themselves
 - Matching is case-sensitive
 - Query string and fragment are ignored

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -222,9 +222,13 @@ func (c *Corpus) TiedViews(pageURL string) []string {
 // MatchRoute reports whether the glob-style route pattern matches path.
 // trailing slash is normalized off both sides first (except the root "/"), so
 // "/*/projects" matches "/acme/projects/".
-//   - **      matches any sequence of characters including slashes (one or more)
-//   - *       matches a single path segment (no slashes)
-//   - :param  matches a single path segment (no slashes)
+//   - literal  matches itself
+//   - *        matches exactly one path segment (no slashes)
+//   - :param   matches exactly one path segment (like *, but scores higher)
+//   - **       a whole "**" segment matches zero or more path segments, so
+//     "/admin/**" matches "/admin", "/admin/x", and "/admin/x/y"
+//   - a "**" glued into a segment (e.g. "/foo**") is treated as a regular *,
+//     matching within that one segment only
 func MatchRoute(pattern, path string) bool {
 	re := regexp.MustCompile(routeToRegex(normalizeRoutePath(pattern)))
 	return re.MatchString(normalizeRoutePath(path))
@@ -241,49 +245,60 @@ func normalizeRoutePath(p string) string {
 	return trimmed
 }
 
-// routeToRegex converts a normalized route glob pattern to an anchored regexp
-// string. `*` and `:param` segments each match a single path segment; `**`
-// matches any depth.
+// routeToRegex converts a normalized route glob pattern into an anchored regexp
+// string. It is segment-oriented: the pattern is split on "/", and each segment
+// becomes a regex fragment. A whole-segment "**" is a globstar that matches zero
+// or more path segments (consuming the slash that would precede them, so
+// "/a/**/b" matches "/a/b"); "*" and ":param" each match exactly one segment; any
+// other segment is a literal in which a run of "*" (including a glued "**") is an
+// in-segment wildcard that never crosses a slash.
 func routeToRegex(pattern string) string {
+	if pattern == "/" {
+		return "^/$"
+	}
 	var sb strings.Builder
 	sb.WriteByte('^')
-	atSegStart := true
-	for i := 0; i < len(pattern); {
-		c := pattern[i]
-		if c == '*' {
-			if i+1 < len(pattern) && pattern[i+1] == '*' {
-				sb.WriteString("(.+)")
-				i += 2
-			} else {
-				sb.WriteString("([^/]+)")
+	for i, seg := range strings.Split(pattern, "/") {
+		if i == 0 && seg == "" {
+			continue // leading slash
+		}
+		if seg == "**" {
+			// Globstar: zero or more segments, including the leading slash. An
+			// empty match collapses with the next segment's slash.
+			sb.WriteString("(?:/.*)?")
+			continue
+		}
+		sb.WriteByte('/')
+		sb.WriteString(routeSegBody(seg))
+	}
+	sb.WriteByte('$')
+	return sb.String()
+}
+
+// routeSegBody converts a single non-globstar route segment (without its leading
+// slash) to a regex fragment. A bare "*" or ":param" is one whole segment; inside
+// any other segment a run of "*" (including a glued "**") is an in-segment
+// wildcard that never crosses a "/".
+func routeSegBody(seg string) string {
+	if seg == "*" || strings.HasPrefix(seg, ":") {
+		return "[^/]+" // exactly one segment
+	}
+	var sb strings.Builder
+	for i := 0; i < len(seg); {
+		if seg[i] == '*' {
+			for i < len(seg) && seg[i] == '*' { // collapse a run of stars (incl. glued **)
 				i++
 			}
-			atSegStart = false
+			sb.WriteString("[^/]*") // in-segment wildcard
 			continue
 		}
-		// Express-style :param — a whole segment starting with ':' — matches a
-		// single path segment, exactly like `*` but scoring higher (see
-		// routeSpecificity).
-		if c == ':' && atSegStart {
-			j := i + 1
-			for j < len(pattern) && pattern[j] != '/' {
-				j++
-			}
-			sb.WriteString("([^/]+)")
-			i = j
-			atSegStart = false
-			continue
-		}
-		// Escape regex metacharacters that can appear in URL patterns.
-		switch c {
+		switch seg[i] {
 		case '.', '+', '?', '(', ')', '[', ']', '{', '}', '\\', '|', '^', '$':
 			sb.WriteByte('\\')
 		}
-		sb.WriteByte(c)
-		atSegStart = c == '/'
+		sb.WriteByte(seg[i])
 		i++
 	}
-	sb.WriteByte('$')
 	return sb.String()
 }
 

--- a/go/sightmap/route_test.go
+++ b/go/sightmap/route_test.go
@@ -39,6 +39,45 @@ func TestMatchRouteTrailingSlash(t *testing.T) {
 	}
 }
 
+// ---- Route matching: ** globstar semantics ----------------------------------
+
+func TestMatchRouteGlobstar(t *testing.T) {
+	cases := []struct {
+		pattern, path string
+		want          bool
+	}{
+		// A whole "**" segment matches zero or more segments, including the
+		// parent itself (the spec's stated behaviour).
+		{"/admin/**", "/admin", true},
+		{"/admin/**", "/admin/", true},
+		{"/admin/**", "/admin/users", true},
+		{"/admin/**", "/admin/users/42/edit", true},
+		{"/admin/**", "/adminx", false}, // ** is segment-bounded, not a bare prefix
+		{"/admin/**", "/other", false},
+		// Interior globstar matches zero or more segments between literals.
+		{"/a/**/b", "/a/b", true},
+		{"/a/**/b", "/a/x/b", true},
+		{"/a/**/b", "/a/x/y/b", true},
+		{"/a/**/b", "/a/b/c", false},
+		// Leading globstar.
+		{"/**/foo", "/foo", true},
+		{"/**/foo", "/x/y/foo", true},
+		// Bare "/**" matches any path, including the root.
+		{"/**", "/", true},
+		{"/**", "/anything/at/all", true},
+		// A "**" glued into a segment is a regular *, matching within one segment
+		// only (it does not cross a slash).
+		{"/messages**", "/messages", true},
+		{"/messages**", "/messages-archive", true},
+		{"/messages**", "/messages/compose", false},
+	}
+	for _, tc := range cases {
+		if got := sightmap.MatchRoute(tc.pattern, tc.path); got != tc.want {
+			t.Errorf("MatchRoute(%q, %q) = %v, want %v", tc.pattern, tc.path, got, tc.want)
+		}
+	}
+}
+
 // ---- View resolution: most specific wins ------------------------------------
 
 func TestViewForURLMostSpecificWins(t *testing.T) {

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -272,7 +272,8 @@ Design points:
 Routes use glob patterns against the URL pathname.
 
 - `*` matches exactly one path segment: `/users/*` matches `/users/42`, not `/users/42/edit`
-- `**` matches any depth of segments: `/admin/**` matches `/admin`, `/admin/users`, `/admin/users/42/edit`
+- `**` is a globstar: **as a whole path segment** it matches zero or more segments, so `/admin/**` matches `/admin`, `/admin/users`, and `/admin/users/42/edit`, and `/a/**/b` matches `/a/b`, `/a/x/b`, …
+- A `**` **glued into a segment** (e.g. `/foo**`) is treated as a regular `*` — an in-segment wildcard that does not cross a `/`. Write `**` as its own segment when you mean "any depth".
 - Literal segments match themselves
 - Matching is case-sensitive
 - Query string and fragment are ignored


### PR DESCRIPTION
## What

Route matching mapped `**` to `(.+)` — one-or-more of *any* character, slashes included — which produced two surprises:

- `/admin/**` compiled to `^/admin/(.+)$`, so it **did not match `/admin`**, even though the spec (Route matching) explicitly says it should.
- `/messages**` compiled to `^/messages(.+)$`, so it **didn't match `/messages`** but *did* match `/messages/compose`.

## Fix

`routeToRegex` is reworked to be segment-oriented, matching the near-universal path-glob convention (gitignore, minimatch/picomatch, bash `globstar`, `doublestar`):

- A **whole `**` segment** is a globstar that matches **zero or more** path segments. `/admin/**` matches `/admin`, `/admin/users`, `/admin/users/42`; `/a/**/b` matches `/a/b`, `/a/x/b`, …
- A **`**` glued into a segment** (e.g. `/foo**`) is treated as a regular single-segment `*` that never crosses a `/`. `/messages**` now matches `/messages` and `/messages-archive`, not `/messages/compose`. (Author `**` as its own segment when you mean "any depth".)
- `*` and `:param` are unchanged (exactly one segment).

## Scope

- `go/sightmap/corpus.go` — `routeToRegex` rewrite + `routeSegBody` helper + corrected `MatchRoute` doc.
- `spec/v1/schema.md` — Route matching section documents the globstar/glued rules; `docs/reference/schema.md` regenerated.
- `go/sightmap/route_test.go` — new `TestMatchRouteGlobstar` cases; existing route/precedence tests and the `003-route-precedence` conformance fixture are unaffected.

Full `go test ./...` passes. Patch changeset included.
