### PR TITLE
fix(cli): three first-run papercuts (`--help` exit, session-file honesty, survey.yaml)

### DIFF
--- a/.changeset/first-run-papercuts.md
+++ b/.changeset/first-run-papercuts.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": patch
+---
+
+First-run papercuts fixed:
+
+- Subcommand `--help`/`-h` now exits 0 and no longer prints `flag: help requested` — a help request is a success, not an error (#117).
+- `browser status` on a session file that exists but doesn't parse (e.g. hand-written or corrupted, so no valid `port`) now reports it as an unrecognized format with the expected shape, instead of a misleading "server and CDP were assigned the same port (0)" collision hint. The collision hint is also gated on a real server port (#118).
+- `validate` no longer warns about unknown fields in tooling files it owns (`survey.yaml`), as it already skips `config.yaml` (#119).

--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -47,6 +47,12 @@ func ReadSessionInfo(sightmapDir string) (SessionInfo, error) {
 		if err := json.Unmarshal([]byte(s), &info); err != nil {
 			return SessionInfo{}, fmt.Errorf("session file: %w", err)
 		}
+		// A parsed-but-portless object (e.g. a hand-written file whose keys don't
+		// match, so Port stays 0) is not a usable session — surface it as an
+		// unrecognized format rather than returning a silent Port:0.
+		if info.Port <= 0 || info.Port > 65535 {
+			return SessionInfo{}, fmt.Errorf(`session file: unrecognized format (expected {"port":N,"pid":N,...})`)
+		}
 		return info, nil
 	}
 	// Legacy format: plain port number.

--- a/go/clitest/testdata/cases/help-exits-nonzero/case.yaml
+++ b/go/clitest/testdata/cases/help-exits-nonzero/case.yaml
@@ -1,6 +1,5 @@
 title: "--help exits 1 and appends 'flag: help requested' to every help text"
 issue: 117
-known_bug: true
 run:
   args: [validate, --help]
   fixture: fixture

--- a/go/clitest/testdata/cases/session-file-red-herring/case.yaml
+++ b/go/clitest/testdata/cases/session-file-red-herring/case.yaml
@@ -1,6 +1,5 @@
 title: "A session file with unrecognized keys parses to port 0 and triggers a misleading 'known startup collision' hint"
 issue: 118
-known_bug: true
 run:
   args: [browser, status]
   fixture: fixture

--- a/go/clitest/testdata/cases/survey-yaml-corpus-warning/case.yaml
+++ b/go/clitest/testdata/cases/survey-yaml-corpus-warning/case.yaml
@@ -1,6 +1,5 @@
 title: "The tool's own survey.yaml is flagged with a corpus unknown-field warning"
 issue: 119
-known_bug: true
 run:
   args: [validate]
   fixture: fixture

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -249,6 +249,15 @@ func runStatus(args []string) error {
 
 	info, err := browser.ReadSessionInfo(sightmapDir)
 	if err != nil {
+		// A session file that exists but doesn't parse is a different situation
+		// from no session at all: report it loudly with the expected shape so a
+		// hand-written or corrupted file is a one-step fix, not a red herring.
+		if _, statErr := os.Stat(browser.SessionFilePath(sightmapDir)); statErr == nil {
+			fmt.Printf("✗ unreadable session file: %v\n"+
+				"  expected shape: {\"port\":N,\"pid\":N,...}\n"+
+				"  delete it and run 'browser start' to launch a fresh session.\n", err)
+			return nil
+		}
 		// No session file — but an orphan Chrome for this profile may still be alive
 		// (e.g. a prior stop dropped the file without reaping the process).
 		if profile := defaultProfileDir(sightmapDir); profileProcessAlive(profile) {
@@ -267,7 +276,7 @@ func runStatus(args []string) error {
 		// session is unusable — clear it and tell the user how to recover.
 		fmt.Printf("✗ unreachable  cdp=%d pid=%d  (CDP not responding; removing stale session file)\n",
 			info.Port, info.PID)
-		if info.ServerPort == info.Port {
+		if info.ServerPort > 0 && info.ServerPort == info.Port {
 			fmt.Printf("  the sightmap server and CDP were assigned the same port (%d) — a known startup collision\n", info.Port)
 		}
 		if profileProcessAlive(info.Profile) {

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"os"
 )
@@ -84,6 +86,11 @@ func main() {
 	}
 
 	if err != nil {
+		// A subcommand's --help/-h parses to flag.ErrHelp; the flag package has
+		// already printed its usage, so a help request is success, not an error.
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
 		fmt.Fprintf(os.Stderr, "sightmap %s: %v\n", cmd, err)
 		os.Exit(1)
 	}

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -155,9 +155,9 @@ func loadDir(path string) (*Corpus, error) {
 		if err := yaml.Unmarshal(data, &rf); err != nil {
 			return nil, fmt.Errorf("sightmap: parse %q: %w", p, err)
 		}
-		// config.yaml is tooling config (its own schema), not a corpus file —
-		// don't run the corpus unknown-field check over it.
-		if base := filepath.Base(p); base != "config.yaml" && base != "config.yml" {
+		// Tooling files (config.yaml, survey.yaml) have their own schemas and are
+		// not corpus files — don't run the corpus unknown-field check over them.
+		if base := filepath.Base(p); base != "config.yaml" && base != "config.yml" && base != "survey.yaml" && base != "survey.yml" {
 			fieldDiags = append(fieldDiags, unknownFieldWarnings(data, base)...)
 		}
 		memory = append(memory, rf.Memory...)


### PR DESCRIPTION
Three small first-run papercuts that showed up derailing agents in early tire-kicking. Each closes its issue and flips the corresponding `clitest` `known_bug` case to a passing regression guard.

## Fixes

- **`--help` exits non-zero (#117).** A subcommand's `--help`/`-h` parses to `flag.ErrHelp`, which `main` printed as an error and turned into exit 1 with a trailing `flag: help requested`. First contact with any subcommand looked like a failure. Now a help request exits 0 with no error line (usage is still printed by the flag package).
- **Session-file red herring (#118).** A `.sightmap/.session` that exists but doesn't parse into the expected fields (e.g. hand-written with different keys, so `port` stayed 0) was read as `Port: 0` and `browser status` printed *"the sightmap server and CDP were assigned the same port (0) — a known startup collision"* — a real hint for a different situation, here a red herring. `ReadSessionInfo` now rejects a portless object, `status` reports it as an unrecognized format with the expected shape (`{"port":N,"pid":N,...}`), and the collision hint is gated on a real server port.
- **Tool warns about its own file (#119).** `validate` warned `survey.yaml: unknown field …` about a file the tooling itself writes. It now exempts `survey.yaml`/`survey.yml` from the corpus unknown-field check, as it already does for `config.yaml`.

## Validation

`go test ./...` is green. The three `known_bug` cases (`help-exits-nonzero`, `session-file-red-herring`, `survey-yaml-corpus-warning`) reported `FIXED` and are flipped to passing guards in the same change — the ratchet working end to end. Patch changeset included.

Follow-ups from the same first-run cluster (B/C/D): view-file schema-trap diagnostics (#89), `report`/skill teach the schema (#116), and `sightmap init` (#120).



Closes #117
Closes #118
Closes #119
