### PR TITLE
feat(validate): view-file schema-trap diagnostics (#89)

### DIFF
--- a/.changeset/view-file-diagnostics.md
+++ b/.changeset/view-file-diagnostics.md
@@ -1,0 +1,12 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Teach the corpus schema at the point authors get it wrong, instead of failing silently or generically:
+
+- A **view field at the file root** (e.g. a top-level `route:`/`name:`) now warns that view fields belong under a top-level `views:` list, with a short example, instead of a bare "unknown field".
+- A **view-shaped file** that sets `url:` and `components:` but no `views:` now warns that it defines no views and its components are treated as global (previously it validated clean and silently became a globals file).
+- A **missing `version:`** now warns (the spec requires `version: 1` in every corpus file).
+- `validate` now warns when the **whole corpus has global components but no views** — it can never match a view, so capture, report, and per-view coverage are unavailable.
+
+All are advisory warnings (exit 0); correct corpora stay warning-free.

--- a/go/clitest/testdata/cases/missing-version-not-flagged/case.yaml
+++ b/go/clitest/testdata/cases/missing-version-not-flagged/case.yaml
@@ -1,6 +1,5 @@
 title: "Spec requires version: 1 in every corpus file; validate never mentions it"
 issue: 89
-known_bug: true
 run:
   args: [validate]
   fixture: fixture

--- a/go/clitest/testdata/cases/top-level-route-field/case.yaml
+++ b/go/clitest/testdata/cases/top-level-route-field/case.yaml
@@ -1,6 +1,5 @@
 title: "route: at the file root gets a generic unknown-field warning instead of teaching the views: structure"
 issue: 89
-known_bug: true
 run:
   args: [validate]
   fixture: fixture

--- a/go/clitest/testdata/cases/top-level-url-silent-globals/case.yaml
+++ b/go/clitest/testdata/cases/top-level-url-silent-globals/case.yaml
@@ -1,6 +1,5 @@
 title: "A view file with root-level url: + components: silently becomes a global components file"
 issue: 89
-known_bug: true
 run:
   args: [validate]
   fixture: fixture

--- a/go/clitest/testdata/cases/zero-view-corpus-unflagged/case.yaml
+++ b/go/clitest/testdata/cases/zero-view-corpus-unflagged/case.yaml
@@ -1,6 +1,5 @@
 title: "A corpus with global components and zero views validates clean"
 issue: 89
-known_bug: true
 run:
   args: [validate]
   fixture: fixture

--- a/go/cmd/sightmap/cmd_validate.go
+++ b/go/cmd/sightmap/cmd_validate.go
@@ -22,6 +22,18 @@ func runValidate(args []string) error {
 
 	findings := sightmap.Validate(corpus)
 
+	// A corpus with global components but no views can never match a view, so
+	// capture, report, per-view coverage, and route scoping are all unavailable.
+	// This is almost always an authoring mistake (the views: list was never
+	// created); nudge, but don't fail.
+	if len(corpus.Views) == 0 && len(corpus.GlobalComponents) > 0 {
+		findings = append(findings, sightmap.ValidationError{
+			Code:     "no-views",
+			Severity: sightmap.SeverityWarning,
+			Message:  fmt.Sprintf("corpus defines %d global component(s) but no views — add a top-level \"views:\" list so pages can be matched (capture, report, and per-view coverage need it)", len(corpus.GlobalComponents)),
+		})
+	}
+
 	// Print errors first, then warnings. Warnings are advisory (corpus conflicts
 	// resolved by a fallback rule) and do NOT fail validation; only errors do.
 	var errCount, warnCount int

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -2,6 +2,8 @@ package sightmap
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -88,11 +90,77 @@ func forEachItem(seq *yaml.Node, fn func(*yaml.Node)) {
 }
 
 func walkFile(node *yaml.Node, file string, out *[]ValidationError) {
-	v := checkKeys(node, fileRootFields, file, out)
+	known := fileRootFields
+	if node != nil && node.Kind == yaml.MappingNode {
+		known = fileRootDiagnostics(node, file, out)
+	}
+	v := checkKeys(node, known, file, out)
 	forEachItem(v["views"], func(n *yaml.Node) { walkView(n, file, out) })
 	forEachItem(v["components"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
 	forEachItem(v["requests"], func(n *yaml.Node) { walkRequest(n, file, out) })
 	forEachItem(v["snapshots"], func(n *yaml.Node) { checkKeys(n, snapshotFields, file, out) })
+}
+
+// fileRootDiagnostics emits targeted diagnostics for the common file-root
+// mistakes an author makes before they've discovered the schema — a misplaced
+// view field (the views: wrapper was forgotten), a missing version:, and a
+// view-shaped file (url: + components:, no views:) that silently becomes a
+// globals file. It returns the set of keys checkKeys should treat as known, so a
+// misplaced view field gets the teaching message here instead of a bare
+// "unknown field".
+func fileRootDiagnostics(node *yaml.Node, file string, out *[]ValidationError) map[string]bool {
+	seen := map[string]bool{}
+	var misplaced []string
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i].Value
+		seen[k] = true
+		if !fileRootFields[k] && viewFields[k] {
+			misplaced = append(misplaced, k)
+		}
+	}
+
+	if len(misplaced) > 0 {
+		sort.Strings(misplaced)
+		quoted := make([]string, len(misplaced))
+		for i, k := range misplaced {
+			quoted[i] = fmt.Sprintf("%q", k)
+		}
+		*out = append(*out, ValidationError{
+			File:     file,
+			Code:     "view-field-at-file-root",
+			Severity: SeverityWarning,
+			Message: fmt.Sprintf("field(s) %s at the file root look like view fields — view fields belong under a top-level \"views:\" list, e.g.:\n  views:\n    - name: Home\n      route: /",
+				strings.Join(quoted, ", ")),
+		})
+	}
+	if !seen["version"] {
+		*out = append(*out, ValidationError{
+			File:     file,
+			Code:     "missing-version",
+			Severity: SeverityWarning,
+			Message:  `missing "version:" — every corpus file should begin with "version: 1"`,
+		})
+	}
+	if seen["url"] && seen["components"] && !seen["views"] {
+		*out = append(*out, ValidationError{
+			File:     file,
+			Code:     "no-views-in-file",
+			Severity: SeverityWarning,
+			Message:  `this file sets "url:" and "components:" but defines no "views:" — its components are treated as global. Did you mean to nest them under a "views:" list?`,
+		})
+	}
+
+	if len(misplaced) == 0 {
+		return fileRootFields
+	}
+	known := make(map[string]bool, len(fileRootFields)+len(misplaced))
+	for k := range fileRootFields {
+		known[k] = true
+	}
+	for _, k := range misplaced {
+		known[k] = true
+	}
+	return known
 }
 
 func walkView(node *yaml.Node, file string, out *[]ValidationError) {

--- a/go/sightmap/validate_stability_test.go
+++ b/go/sightmap/validate_stability_test.go
@@ -49,7 +49,7 @@ components:
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			yamlPath := filepath.Join(tmpDir, "components.yaml")
-			if err := os.WriteFile(yamlPath, []byte(tt.yaml), 0644); err != nil {
+			if err := os.WriteFile(yamlPath, []byte("version: 1\n"+tt.yaml), 0644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -125,7 +125,7 @@ views:
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			yamlPath := filepath.Join(tmpDir, "views.yaml")
-			if err := os.WriteFile(yamlPath, []byte(tt.yaml), 0644); err != nil {
+			if err := os.WriteFile(yamlPath, []byte("version: 1\n"+tt.yaml), 0644); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
The single biggest "stopped an agent cold" fix we have evidence for: the view-file schema trap. An author writes `route:`/`components:` at the file root (which the authoring skill's wording invites), `validate` says only `unknown field "route"` and passes, the file is silently absorbed as a globals file, and every later snapshot prints `[No view matched]`. This teaches the schema at the exact point it goes wrong.

## New diagnostics (all advisory warnings, exit 0)

- **View field at the file root** — a top-level `route:`/`name:`/etc. now warns that view fields belong under a top-level `views:` list, with a two-line example, instead of a bare `unknown field`.
- **View-shaped file with no views** — a file that sets `url:` + `components:` but no `views:` now warns that it defines no views and its components are treated as global (previously it validated clean — the silent session-killer).
- **Missing `version:`** — warns; the spec requires `version: 1` in every file.
- **Corpus with no views** — `validate` warns when the whole corpus has global components but zero views (it can never match a view).

Correct corpora stay warning-free (guarded by `ok-correct-view-file-validates`).

## Design note

The three load-time, per-file diagnostics live in the library (`unknownfields.go`). The broad corpus-level "no views" nudge lives in the `validate` **command** rather than the library `Validate()`, so the library validator stays unopinionated for SDK/conformance callers and component-validation unit tests aren't coupled to a CLI nudge.

## Validation

`go test ./...` green. The four `#89` `known_bug` cases (`top-level-route-field`, `top-level-url-silent-globals`, `zero-view-corpus-unflagged`, `missing-version-not-flagged`) reported `FIXED` and are flipped to passing guards in the same change. Existing stability fixtures updated to carry `version: 1`. Patch changeset included.

Part of the first-run derailment cluster; follow-ups: `report`/skill teach the schema (#116, PR C) and `sightmap init` (#120, PR D). Independent of #124/#137.
