### PR TITLE
Re-land SEP-0006 & SEP-0007 proposals (#110, #111)

### DIFF
--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -1,0 +1,143 @@
+---
+sep: 0006
+title: A console/exception message entity (`messages[]`)
+author: Clint Ayres (@jurassix)
+status: Draft
+created: 2026-07-31
+updated: 2026-07-31
+spec-version-target: 1
+related-issues: []
+related-discussions: []
+---
+
+## Summary
+
+Introduce a new top-level `messages` concept, peer to `views`/`components`/`requests`: a named, declarative pattern matching console output and runtime exceptions by `level` and a `message` regex. It gives console/exception activity the same thing `requests:` already gives network activity — a named, referenceable entity.
+
+## Motivation
+
+Every other kind of runtime activity the spec can name has an entity for it: a DOM element has `components:`, a network call has `requests:`. Console output and exceptions have nothing. There is no way today to say, declaratively, "a `cart version mismatch` error means the checkout flow is broken" — a consumer wanting that has to hand-roll its own level/message matching, independently, with no shared vocabulary, and nothing else in the corpus can point at it by name.
+
+## Proposal
+
+### Shape
+
+```yaml
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+
+  - name: SlowNetworkWarning
+    level: WARN
+    message: 'request .* took over \d+ms'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | A stable identifier for this pattern, addressable by name by other tooling. |
+| `level` | string | no | Exact match, case-insensitive, against the console record's level (`ERROR`, `WARN`, `INFO`, …). Match-any if omitted. |
+| `message` | string | no | Regex matched against the console record's message text. Match-any if omitted. |
+| `description` | string | no | What this pattern means, for a human reading the corpus. |
+| `source` | string | no | Relative path to the source most likely to emit this, mirroring `Request.source`/`Component.source`. |
+
+At least one of `level`/`message` should be declared in practice (an entry matching everything isn't useful), but the schema doesn't require it — mirrors `request.method` and `component.selector`'s own optionality where a real corpus might still want to declare a placeholder.
+
+### Semantics
+
+#### One entity, not two ("console" vs "exception")
+
+The obvious first cut of this proposal used a `kind: console | exception` discriminator, splitting the entity by origin. It's dropped: at least one real consumer implementation already models a JS exception as simply an ERROR-level console record, with no second axis to discriminate origin beyond `level` itself, which this proposal already has. A `messages:` entry with `level: ERROR` matches what another implementation might call an "exception"; one with `level: WARN`/`INFO` matches what it might call a plain console message. No `kind` field is needed to express that distinction — see [Alternatives considered #1](#1-a-kind-console--exception-discriminator-field).
+
+#### No extraction mechanism (yet)
+
+Unlike `requests:` ([SEP-0005](0005-request-properties.md)), `messages:` has no `properties:`/extraction mechanism in this proposal. A network endpoint is hit under both good and bad conditions with the same route — extraction exists to tell those instances apart. A console/exception pattern's own `level`+`message` combination usually already fully identifies the case a corpus author cares about; there's rarely a "successful instance" of the exact same message to distinguish from. If a real case needs structured extraction from message text (an error code embedded in a string, say), that's additive future work, not something this SEP blocks.
+
+#### Matching
+
+A live console record matches a `messages:` entry when every declared field (`level`, `message`) agrees; an omitted field matches anything. When more than one `messages:` entry could match the same live record, conformance requires a diagnosable ambiguity, not silent first-match-wins — see [Conformance](#conformance).
+
+### Conformance
+
+- MUST match a live console record against a `messages:` entry using case-insensitive exact match on `level` (when declared) and regex match on `message` (when declared); an omitted field imposes no constraint.
+- MUST warn (not silently resolve) when a live record matches more than one `messages:` entry with the same `name` collision potential — mirrors the existing `$ref`/component-name-collision diagnostic discipline.
+- MUST NOT require `properties:` support for `messages:` entries in this SEP's scope.
+- MAY additionally match `source` for tooling purposes (e.g. surfacing "likely emitted from `src/cart/sync.ts`" in a UI); this SEP does not require any behavior tied to `source` beyond documentary purposes, mirroring `Request.source`/`Component.source`.
+
+### JSON Schema diff
+
+New top-level property, peer to `views`/`components`/`requests`:
+
+```
+properties.messages:
+  type: array
+  items: { $ref: "#/$defs/message" }
+  description: "Declarative console/exception patterns, addressable by name."
+```
+
+New `$defs` entry:
+
+```
+$defs.message:
+  type: object
+  required: [name]
+  additionalProperties: false
+  properties:
+    name:
+      type: string
+      minLength: 1
+      description: "A stable identifier for this pattern."
+    level:
+      type: string
+      description: "Exact, case-insensitive match against the console record's level. Match-any if omitted."
+    message:
+      type: string
+      description: "Regex matched against the console record's message text. Match-any if omitted."
+    description:
+      type: string
+    source:
+      type: string
+      description: "Relative path to the source most likely to emit this pattern."
+```
+
+`fileRootFields` (the top-level unknown-field allowlist) gains `"messages"`.
+
+## Alternatives considered
+
+### 1. A `kind: console | exception` discriminator field
+
+Split the entity explicitly by origin, with a `kind` field alongside `level`/`message`.
+
+Ruled out — see [Semantics](#semantics): at least one real consumer already collapses both into one console-record concept distinguished by `level` alone. Adding `kind` back would ask every implementation to maintain a distinction that at least one real implementation doesn't have, for no matching behavior it would actually gate. If a future implementation genuinely needs to distinguish uncaught exceptions from explicit console calls at the entity level, that's additive — this SEP doesn't foreclose it, just doesn't require it now.
+
+### 2. Fold into a generalized `events:` supertype that could later absorb `requests:` too
+
+Instead of a new, narrow `messages:` entity, introduce a generic `events:` concept with a `kind:` field selecting `network | console | exception`, unifying what's currently split across `requests:` and this proposal.
+
+Deferred, not rejected. `requests:` is an established, widely-used entity with its own field set (`route`, `method`, `headers`, `Payload`) that doesn't map cleanly onto a console pattern's fields (`level`, `message`) — forcing them under one polymorphic shape now would either bloat every entry with irrelevant optional fields or require a discriminated-union schema this spec hasn't needed anywhere else yet. A narrow, purpose-built `messages:` entity is the smaller, more legible change; generalizing later — once there's a second or third entity kind with the same shape — is the point at which a supertype would actually pay for its complexity.
+
+### 3. Do nothing — leave console/exception patterns unnameable
+
+The status quo: no shared vocabulary for "this recurring console/exception pattern means X," and nothing else in the corpus can point at one by name.
+
+Ruled out per Motivation.
+
+## Migration
+
+`messages:` is a new top-level key — purely additive, no existing corpus references it. No migration required for existing sightmaps.
+
+Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-level field; under `additionalProperties: false` at the root, existing SDKs reject sightmaps that use it until they implement this SEP — the same constraint every additive top-level concept in this spec carries. Release playbook, matching SEP-0001/SEP-0003/SEP-0005's pattern:
+
+1. This SEP merges (status: Accepted).
+2. `sightmap/sightmap` implements `messages:` parsing and matching. Bumped to a minor release.
+3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `messages:`.
+
+## Open questions
+
+1. **Naming.** `messages:` vs. `errors:` vs. something else — `errors:` reads naturally for the ERROR-level case but oddly for an INFO/WARN-level console message that isn't an "error" at all. `messages:` is the more neutral choice made here; open to reviewer pushback.
+2. **Should `properties:`/extraction ever be added here?** Flagged as future, non-blocking work in Semantics — worth confirming reviewers agree it's genuinely not needed for v1 rather than a gap being silently deferred.
+3. **Ambiguous-match diagnostics.** This SEP requires a diagnosable warning on ambiguous matches (Conformance) but doesn't specify an exact diagnostic code — left for the implementation PR to define, consistent with existing codes like `ref-unresolved`.
+
+## References
+
+- Subtext (a sightmap consumer) models a JS exception as an ERROR-level console record rather than a distinct entity — the real-world precedent behind this proposal's "one entity, not two" call in Semantics.

--- a/spec/seps/0007-signals.md
+++ b/spec/seps/0007-signals.md
@@ -1,0 +1,242 @@
+---
+sep: 0007
+title: Signals — composing a named, tagged classification from existing entities
+author: Clint Ayres (@jurassix)
+status: Draft
+created: 2026-07-31
+updated: 2026-07-31
+spec-version-target: 1
+related-issues: []
+related-discussions: []
+---
+
+## Summary
+
+Add a new top-level `signals` concept: a rule that references an existing entity by name (a `Component`, `Request`, or `Message` — see [SEP-0005](0005-request-properties.md), [SEP-0006](0006-message-entity.md)) and, optionally, filters on that entity's own declared properties, minting a named, tagged classification when it matches. A `signals:` rule never redeclares a selector, route, or body pattern of its own — it only composes what the corpus already defines.
+
+## Motivation
+
+A consumer reasoning about a session (or any other stream of runtime activity a sightmap corpus describes) regularly needs to surface a classification that no single existing field captures: a `200 OK` network response whose body says a payment was declined; a component whose extracted text reads "declined" even though its mere presence is expected either way. Today, expressing this means writing bespoke match logic outside the spec entirely, independent of whatever entity (component/request) the classification is actually about — a rule that redeclares its own route glob and body pattern has no structural relationship to the `Request` entity it's actually about, so the two silently drift apart the moment the endpoint's declared route changes.
+
+This SEP proposes the fix directly: a `signals:` rule must reference an entity (`ref:`) and, optionally, filter on that entity's own already-declared properties — never redeclare a selector, route, or body pattern of its own.
+
+## Proposal
+
+### Shape
+
+```yaml
+signals:
+  - name: <string>              # required, semantic identity of the generated classification
+    ref: <entity name>          # required, name of a components:/requests:/messages: entry
+    tags: [<string>, ...]       # optional
+    filter:                     # optional; omitted = fires on every match of ref
+      <property>: <value>       # equality
+      <property>: [<value>...]  # membership (any of)
+```
+
+The checkout example from Motivation, under this shape, using the request's declared property from SEP-0005:
+
+```yaml
+requests:
+  - name: CheckoutPayment
+    route: "/api/checkout/pay"
+    method: POST
+    properties:
+      - name: status
+        field: "rsp.body.status"
+
+signals:
+  - name: checkout.payment.declined
+    tags: [defect]
+    ref: CheckoutPayment
+    filter:
+      status: declined
+```
+
+### Semantics
+
+#### `filter:` evaluates against the referenced entity's properties, plus its already-structured identity
+
+For a `Request` ref, `filter:` may name any of its declared `properties:` (SEP-0005), or one of the reserved already-structured identity names (`status`, `method`, `duration`) without any `properties:` declaration at all — a real asymmetry worth stating plainly: a request's *identity* is free to filter on, its *extracted content* is not. The following example needs both, ANDed:
+
+```yaml
+requests:
+  - name: CheckoutRetryPayment
+    route: "/api/checkout/pay/retry"
+    method: POST
+    properties:
+      - name: rate_limit_remaining
+        field: "rsp.headers.X-RateLimit-Remaining"
+      - name: outcome
+        field: "rsp.body.status"
+
+signals:
+  - name: checkout.payment.throttled_silently
+    tags: [defect]
+    ref: CheckoutRetryPayment
+    filter:
+      status: 200                    # already-structured identity — no properties: needed
+      rate_limit_remaining: "0"        # declared property, extracted from a response header
+      outcome: [queued, deferred]    # declared property, extracted from the response body; membership match
+```
+
+For a `Component` ref, `filter:` may name any of its declared `properties:` ([existing DOM extraction](0003-component-properties.md)):
+
+```yaml
+components:
+  - name: PaymentBanner
+    selector: ".payment-status-banner"
+    properties:
+      - name: text
+        extract: text
+
+signals:
+  - name: checkout.payment.declined.banner
+    tags: [defect]
+    ref: PaymentBanner
+    filter:
+      text: "*declined*"
+```
+
+For a `Message` ref ([SEP-0006](0006-message-entity.md)), `filter:` is typically omitted — a message entity's own `level`/`message` usually already fully identifies the case:
+
+```yaml
+messages:
+  - name: CartVersionMismatch
+    level: ERROR
+    message: cart version mismatch
+
+signals:
+  - name: cart.abandoned
+    tags: [defect]
+    ref: CartVersionMismatch
+```
+
+A `View` ref has no extractable property at all, so a view-referencing signal always omits `filter:` — it scopes a classification to "any activity observed while this view is active," a different kind of statement than a content match:
+
+```yaml
+views:
+  - name: CheckoutView
+    route: "/checkout"
+
+signals:
+  - name: checkout.view.active
+    tags: [checkout]
+    ref: CheckoutView
+```
+
+#### No `filter:` means unconditional
+
+Omitting `filter:` means the rule fires on every match of `ref`. This is deliberately the same case a `Component`'s or `Request`'s static `tags:` field already covers ([SEP-0004](0004-component-tags.md)) — referencing an entity with no `filter:` is equivalent to a static tag on it. `signals:` is a strict superset of that mechanism, not a parallel one; an author reaches for `filter:` only when the entity's mere presence isn't itself the classification.
+
+#### Multiple `filter:` keys are ANDed
+
+`filter: {status: 200, outcome: [queued, deferred]}` requires both — there is no `OR` composition in v1. A classification needing OR semantics across otherwise-unrelated conditions is expressed as multiple `signals:` entries.
+
+#### Multiple matching rules fire independently
+
+If more than one `signals:` rule references the same entity and both match the same live instance, both fire — nothing is deduped or merged into a single result. Each rule is evaluated independently; a consumer sees one classification per firing rule, not one classification with multiple names.
+
+#### Derivation is explicit
+
+A classification produced by a `signals:` match carries the referenced entity's `name` as its link back to what produced it (`CheckoutPayment`, not merely "a network request") — the reference itself, required by this SEP's Shape, is what makes this link structural rather than something a consumer has to reconstruct.
+
+### Conformance
+
+- MUST reject a `signals:` entry whose `ref:` does not resolve to a known `Component`/`Request`/`Message`/`View` name. Diagnostic code: `signal-ref-unresolved` (mirrors the existing `ref-unresolved` code for `$ref`).
+- MUST reject (not silently resolve) a `ref:` name that collides across entity kinds (e.g. a `Component` and a `Request` sharing a name) — unlike DOM tree matching, there is no adjacency/tree-position reason to prefer one over the other. Diagnostic code: `signal-ref-ambiguous`.
+- MUST evaluate every declared `filter:` key with AND semantics; MUST support both scalar (equality) and array (membership) values per key.
+- MUST fire a rule with no `filter:` on every match of its `ref:`.
+- MUST evaluate each `signals:` rule independently — a live instance matched by more than one rule produces one classification per matching rule.
+- MUST NOT require a numeric-comparison filter operator (`>=`, ranges) in v1 — see [Open questions](#open-questions).
+- SHOULD surface the referenced entity's `name` as part of the classification's own identity, per [Derivation is explicit](#derivation-is-explicit).
+
+### JSON Schema diff
+
+New top-level property, peer to `views`/`components`/`requests`/`messages`:
+
+```
+properties.signals:
+  type: array
+  items: { $ref: "#/$defs/signal" }
+  description: "Rules composing a named, tagged classification from an existing entity's identity and declared properties. See SEP-0007."
+```
+
+New `$defs` entry:
+
+```
+$defs.signal:
+  type: object
+  required: [name, ref]
+  additionalProperties: false
+  properties:
+    name:
+      type: string
+      minLength: 1
+      description: "Semantic identity of the generated classification."
+    ref:
+      type: string
+      minLength: 1
+      description: "Name of an existing components:/requests:/messages:/views: entry this rule composes. Must resolve; must not be ambiguous across entity kinds."
+    tags:
+      type: array
+      items: { type: string, minLength: 1 }
+      description: "Open-vocabulary classification labels carried onto the generated classification. See SEP-0004."
+    filter:
+      type: object
+      description: "Property-name → value (equality) or value-list (membership) constraints, ANDed across keys, evaluated against the referenced entity's declared properties and already-structured identity fields. Omitted = unconditional."
+      additionalProperties:
+        oneOf:
+          - { type: string }
+          - { type: array, items: { type: string }, minItems: 1 }
+```
+
+`fileRootFields` gains `"signals"`.
+
+## Alternatives considered
+
+### 1. Independent match criteria per rule
+
+A `signals:` rule declares its own `kind`/`method`/`route`/`status`/`body` fields directly, matching signal fields with no reference to any other entity:
+
+```yaml
+signals:
+  - name: checkout.payment.declined
+    tags: [defect]
+    kind: network
+    method: POST
+    route: "/api/checkout/pay"
+    rsp_body: '"status"\s*:\s*"declined"'
+```
+
+Ruled out: it re-implements matching logic the corpus already does elsewhere, and creates no structural link between the classification and the entity it's actually about — if the referenced endpoint's declared route changes, an independent rule silently drifts out of sync with it, since nothing connects them. The reference-based shape in this proposal makes that link unbreakable by construction: there's no route/selector for the rule to independently duplicate or let drift.
+
+### 2. Mutate the matched entity/instance directly instead of generating a new classification
+
+Instead of producing a new, named classification, apply the rule's `tags:` directly onto the matched request/component instance itself — no new entity in the output, just an annotation on the existing one.
+
+Ruled out: a classification frequently needs to survive independently of how its source instance is later aggregated, deduplicated, or collapsed by a consumer (e.g. a burst of identical retried requests collapsed to one representative in a transcript) — mutating the instance directly means the classification can be silently dropped whenever the instance it rode on isn't the one a consumer's own collapsing logic keeps. A concrete trace: five identical-looking retried requests collapse to one representative entry; if only the third instance's mutation carried the classification, and the first instance is what survives collapsing, the classification vanishes with no error. Producing an independent classification means it collapses (or doesn't) under its own identity, not the source instance's.
+
+## Migration
+
+`signals:` is a new top-level key — purely additive, no existing sightmap corpus references it today. No migration is required for existing sightmaps.
+
+Existing SDKs that encounter a `signals:` key MUST treat it as an unknown top-level field; under `additionalProperties: false` at the root, existing SDKs reject sightmaps that use it until they implement this SEP. Release playbook, matching SEP-0001/SEP-0003's pattern:
+
+1. This SEP merges (status: Accepted) — depends on [SEP-0005](0005-request-properties.md) and [SEP-0006](0006-message-entity.md) also being accepted, since this proposal's `Request`/`Message` examples assume both exist.
+2. `sightmap/sightmap` implements `signals:` parsing and `ref:`/`filter:` resolution. Bumped to a minor release.
+3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `signals:`.
+
+## Open questions
+
+1. **Reference key naming.** `ref:` is used throughout this proposal; `signal:` and `from:` were both considered and read worse for a rule referencing a `Component` or `Message` specifically (`signal: PaymentBanner` reads oddly when nothing about `PaymentBanner` is itself a signal). Open to reviewer pushback on the final name.
+2. **Should `views:` be referenceable at all in v1?** Included in this proposal (see the `CheckoutView` example) since it costs little and is a natural instance of "no filter = unconditional," but it's the least load-bearing of the four entity kinds — worth confirming reviewers see real demand for it versus deferring.
+3. **Comparison-operator filters.** `filter:` supports only equality/membership in v1. A numeric range or comparison operator (`filter: {duration: ">=1000"}`) was considered and deferred — an intrinsic, non-`signals:` mechanism already handles the one case that came up (HTTP status-code ranges) — but a future SEP could add operator support if a real case needs it that intrinsic handling doesn't cover.
+4. **Fan-out policy revisit.** This SEP requires independent firing for multiple matching rules ([Conformance](#conformance)) as the simplest, least-surprising default. A future SEP could introduce a dedup/union mode if real corpora show independent firing producing noise.
+
+## References
+
+- [SEP-0003](0003-component-properties.md) — the DOM `properties:` mechanism a `Component`-referencing `signals:` rule filters against.
+- [SEP-0004](0004-component-tags.md) — the static-tag mechanism `signals:` with no `filter:` is a strict superset of.
+- [SEP-0005](0005-request-properties.md) — the request-property mechanism a `Request`-referencing `signals:` rule filters against; a direct dependency of this proposal.
+- [SEP-0006](0006-message-entity.md) — the console/exception entity a `Message`-referencing `signals:` rule composes; a direct dependency of this proposal.


### PR DESCRIPTION
The stacked PRs #110 and #111 were squash-merged onto their stacked `impl/*` base branches instead of `main`, so their proposal docs never reached `main`.

This re-lands the two squash commits verbatim (cherry-picked, zero conflicts, original authorship preserved):

- `spec/seps/0006-message-entity.md` (from #110)
- `spec/seps/0007-signals.md` (from #111)

Content is identical to what was already reviewed and approved in #110/#111. Merge via **rebase** to keep the two distinct commits.