### PR TITLE
test(clitest): intake cases from the Twenty CRM evaluation

### DIFF
--- a/go/clitest/README.md
+++ b/go/clitest/README.md
@@ -51,10 +51,14 @@ expect:
       must_match: '(?s)views:\s*\n\s+- name:'
 ```
 
-`requires: [manual]` marks cases needing a live browser against a real page;
-they are always skipped but stay in the dataset with their desired behaviour
-encoded. `requires: [chrome]` runs only where a Chrome is on PATH (override
-with `SIGHTMAP_TEST_CHROME=1`).
+`requires: [manual]` marks cases the suite must never run on its own — usually
+because they need a live browser against a real page, occasionally because the
+*current* behaviour has side effects unsafe for CI (e.g. a `--help` that starts
+a 184 MB download). They are always skipped but stay in the dataset with their
+desired behaviour encoded; ship the runnable fixture (page + corpus) and put the
+hand-repro steps in a `why`, so a human can replay the case in minutes.
+`requires: [chrome]` runs only where a Chrome is on PATH (override with
+`SIGHTMAP_TEST_CHROME=1`).
 
 ## The xfail ratchet
 
@@ -81,6 +85,9 @@ If a moment is worth a checked-in case it's worth a public issue (or it's an
 ordinary unit test with no external ref). Decontextualized provenance — the
 transcript or report a case came from, scrubbed so a later reader needs no prior
 knowledge of the app it was captured against — belongs in that issue, not here.
+For an outside evaluation, that means linking the report (or its PR) and naming
+the finding's ID in the issue body, so the case → issue → report chain survives
+without any of the three repeating the others.
 
 ## Intake ritual — turning a real session into cases
 
@@ -103,3 +110,7 @@ evaluation, often against a private or unreproducible app. Route each finding:
    thing it did say). Mark it `known_bug: true` and link the `issue:`.
 5. When the behaviour ships, drop `known_bug` in the same PR — the `FIXED`
    failure will remind you if you forget.
+6. **A claim that does not reproduce** — after a genuine attempt against both
+   HEAD and the released binary — is still information: pin the correct
+   behaviour with an `ok-` case so the suite proves the claim false from now
+   on, and report the non-repro back to the source instead of filing an issue.

--- a/go/clitest/harness_test.go
+++ b/go/clitest/harness_test.go
@@ -236,7 +236,7 @@ func requirementsMet(requires []string) (string, bool) {
 				return "requires chrome (none in PATH; set SIGHTMAP_TEST_CHROME=1 to force)", false
 			}
 		case "manual":
-			return "manual: needs a live browser session against a real page", false
+			return "manual: not CI-runnable (live browser or unsafe side effects) — see the case's why for hand-repro steps", false
 		default:
 			return "unknown requirement: " + req, false
 		}

--- a/go/clitest/testdata/cases/browser-install-help-executes/case.yaml
+++ b/go/clitest/testdata/cases/browser-install-help-executes/case.yaml
@@ -1,0 +1,19 @@
+title: "browser install --help executes the 184 MB install instead of printing usage"
+issue: 143
+known_bug: true
+requires: [manual]
+run:
+  args: [browser, install, --help]
+  timeout_seconds: 30
+expect:
+  exit: zero
+  output:
+    - must_match: '(?i)usage'
+      why: >
+        --help on any subcommand must print usage and exit 0 with no side
+        effects. runBrowserInstall discards its args entirely, so --help (or
+        any typo) starts the Chrome for Testing download and creates
+        ~/.sightmap/browsers/. Manual not because a browser is needed, but
+        because running the current behaviour in CI downloads 184 MB.
+    - must_not_match: '(?i)download'
+      why: a help request must not begin an install.

--- a/go/clitest/testdata/cases/navigate-misses-slow-client-redirect/case.yaml
+++ b/go/clitest/testdata/cases/navigate-misses-slow-client-redirect/case.yaml
@@ -1,0 +1,17 @@
+title: "navigate reports the pre-redirect URL when a client-side redirect resolves ~3s after load"
+issue: 141
+known_bug: true
+requires: [manual]
+run:
+  args: [browser, navigate, "http://127.0.0.1:8901/guard.html"]
+  fixture: fixture
+expect:
+  output:
+    - must_match: 'redirected to .*landed\.html'
+      why: >
+        guard.html client-redirects to landed.html 3s after load — slower than
+        AwaitNavigation's 2s budget — so today no "(redirected to …)" prints
+        and the caller is told it is on guard.html while the browser is on
+        landed.html. The same page redirecting at 1s does print the line, so
+        the budget, not the mechanism, is the bug. Manual steps: serve page/,
+        browser start, then run.

--- a/go/clitest/testdata/cases/navigate-misses-slow-client-redirect/fixture/page/guard.html
+++ b/go/clitest/testdata/cases/navigate-misses-slow-client-redirect/fixture/page/guard.html
@@ -1,0 +1,7 @@
+<!doctype html><html><head><title>Guarded</title></head><body>
+<p>Checking auth…</p>
+<script>
+  window.addEventListener('load', () => {
+    setTimeout(() => { location.replace('landed.html'); }, 3000);
+  });
+</script></body></html>

--- a/go/clitest/testdata/cases/navigate-misses-slow-client-redirect/fixture/page/landed.html
+++ b/go/clitest/testdata/cases/navigate-misses-slow-client-redirect/fixture/page/landed.html
@@ -1,0 +1,2 @@
+<!doctype html><html><head><title>Login</title></head><body>
+<h1>Sign in</h1><button>Continue with email</button></body></html>

--- a/go/clitest/testdata/cases/ok-lint-parse-error-exits-nonzero/case.yaml
+++ b/go/clitest/testdata/cases/ok-lint-parse-error-exits-nonzero/case.yaml
@@ -1,0 +1,13 @@
+title: "lint exits non-zero and names the file when the corpus does not parse"
+run:
+  args: [lint]
+  fixture: fixture
+expect:
+  exit: nonzero
+  output:
+    - must_match: 'parse "\.sightmap/broken\.yaml"'
+      why: >
+        CI gates on lint; a corpus that cannot parse must be a hard, named
+        failure. Pinned after an outside evaluation reported lint exiting 0
+        here — that did not reproduce on HEAD or the published 0.17.0, and
+        this case keeps it that way.

--- a/go/clitest/testdata/cases/ok-lint-parse-error-exits-nonzero/fixture/.sightmap/broken.yaml
+++ b/go/clitest/testdata/cases/ok-lint-parse-error-exits-nonzero/fixture/.sightmap/broken.yaml
@@ -1,0 +1,6 @@
+version: 1
+views:
+  - name: [unclosed
+      route: /x
+   components:
+  - selector

--- a/go/clitest/testdata/cases/partial-page-passes-silently/case.yaml
+++ b/go/clitest/testdata/cases/partial-page-passes-silently/case.yaml
@@ -1,0 +1,20 @@
+title: "snapshot exits 0 on a partial page even while printing 'wrong page captured?' and 0-match warnings"
+issue: 142
+known_bug: true
+requires: [manual]
+run:
+  args: [snapshot]
+  fixture: fixture
+expect:
+  exit: nonzero
+  output:
+    - must_match: 'wrong page captured'
+      why: >
+        The page is a 2-button shell of a view whose root components are all
+        absent; snapshot already detects and prints every wrong-page signal it
+        has ([Snapshot check], per-component 0-match warnings, 100% orphans ✗)
+        — and still exits 0, so automation gating on the exit code sees
+        success. The blank-page guard fires only at exactly 0 interactive
+        nodes. Manual steps: serve page/, browser start, navigate to
+        /partial.html, then run. Coordinate with #51 before coupling exit
+        status to this check.

--- a/go/clitest/testdata/cases/partial-page-passes-silently/fixture/.sightmap/partial.yaml
+++ b/go/clitest/testdata/cases/partial-page-passes-silently/fixture/.sightmap/partial.yaml
@@ -1,0 +1,10 @@
+version: 1
+views:
+  - name: PartialPage
+    route: /partial.html
+    url: http://127.0.0.1:8901/partial.html
+    components:
+      - name: SearchBar
+        selector: '[data-component="SearchBar"]'
+      - name: BigTable
+        selector: '[data-component="BigTable"]'

--- a/go/clitest/testdata/cases/partial-page-passes-silently/fixture/page/partial.html
+++ b/go/clitest/testdata/cases/partial-page-passes-silently/fixture/page/partial.html
@@ -1,0 +1,4 @@
+<!doctype html><html><head><title>Partially hydrated</title></head><body>
+<button>Skip to content</button>
+<button>Help</button>
+</body></html>

--- a/go/clitest/testdata/cases/search-view-name-no-matches/case.yaml
+++ b/go/clitest/testdata/cases/search-view-name-no-matches/case.yaml
@@ -1,0 +1,15 @@
+title: "search prints a bare 'no matches' when the pattern names a view the corpus contains"
+issue: 144
+known_bug: true
+run:
+  args: [search, TablePage]
+  fixture: fixture
+expect:
+  exit: zero
+  output:
+    - must_match: '(?i)view'
+      why: >
+        search covers component fields only (documented) — but "no matches for
+        TablePage" reads as "not in the corpus" when TablePage exists as a
+        view. The output should name the near-miss: it exists as a view, and
+        search skips view/request fields.

--- a/go/clitest/testdata/cases/search-view-name-no-matches/fixture/.sightmap/views.yaml
+++ b/go/clitest/testdata/cases/search-view-name-no-matches/fixture/.sightmap/views.yaml
@@ -1,0 +1,7 @@
+version: 1
+views:
+  - name: TablePage
+    route: /table
+    components:
+      - name: RecordTable
+        selector: '[data-component="RecordTable"]'

--- a/go/clitest/testdata/cases/skill-inapp-search-undocumented/case.yaml
+++ b/go/clitest/testdata/cases/skill-inapp-search-undocumented/case.yaml
@@ -1,0 +1,12 @@
+title: "The authoring skill does not treat in-app search as a first-class navigation surface to map"
+issue: 146
+known_bug: true
+expect:
+  repo:
+    - file: skills/sightmap-authoring/SKILL.md
+      must_match: '(?i)in-app search|app''s (own )?search'
+      why: >
+        In the Twenty evaluation's consumption trials the app's own search box
+        won 5 of 6 runs and the corpus didn't map it. Agents will find search
+        anyway; the skill should direct authors to map the search surface (and
+        its quirks) early. (Repo-content case: no run.)

--- a/go/clitest/testdata/cases/skill-memory-placement-undocumented/case.yaml
+++ b/go/clitest/testdata/cases/skill-memory-placement-undocumented/case.yaml
@@ -1,0 +1,14 @@
+title: "The authoring skill never teaches that navigation quirks belong on the component you act on"
+issue: 146
+known_bug: true
+expect:
+  repo:
+    - file: skills/sightmap-authoring/SKILL.md
+      must_match: '(?i)component you (act on|click)'
+      why: >
+        Component memory surfaces wherever the component matches — before the
+        action; view memory appears only after arrival, too late to steer
+        navigation. The skill should state the placement rule: quirks about
+        reaching a view go on the component you act on, not the destination
+        view. (Repo-content case: no run. Wording may vary — adjust the regex
+        with the fix if needed.)

--- a/go/clitest/testdata/cases/snapshot-elides-matched-subtrees/case.yaml
+++ b/go/clitest/testdata/cases/snapshot-elides-matched-subtrees/case.yaml
@@ -1,0 +1,21 @@
+title: "snapshot renders a matched container as a leaf: 60 rows counted in [Guide] never appear in the tree"
+issue: 139
+known_bug: true
+requires: [manual]
+run:
+  args: [snapshot]
+  fixture: fixture
+expect:
+  exit: zero
+  output:
+    - must_match: 'Cisco'
+      why: >
+        Content matched by the corpus must be present (greppable) in the
+        printed tree. The fixture's rowgroup uses display:contents (a box-less
+        wrapper), which the probe marks isVisible:false, and render.Filter
+        drops the whole subtree — 60 visible, matched rows — while [Guide]
+        counts them and coverage reports 100% scoped ✓. Manual steps: serve
+        page/ (python3 -m http.server 8901), browser start, navigate to
+        /table.html, then run snapshot from this directory.
+    - must_match: '\[RecordTableRow'
+      why: matched rows should render with their component annotation, not vanish.

--- a/go/clitest/testdata/cases/snapshot-elides-matched-subtrees/fixture/.sightmap/table.yaml
+++ b/go/clitest/testdata/cases/snapshot-elides-matched-subtrees/fixture/.sightmap/table.yaml
@@ -1,0 +1,10 @@
+version: 1
+views:
+  - name: TablePage
+    route: /table.html
+    url: http://127.0.0.1:8901/table.html
+    components:
+      - name: RecordTable
+        selector: '[data-component="RecordTable"]'
+      - name: RecordTableRow
+        selector: '[data-testid^="row-id-"]'

--- a/go/clitest/testdata/cases/snapshot-elides-matched-subtrees/fixture/page/table.html
+++ b/go/clitest/testdata/cases/snapshot-elides-matched-subtrees/fixture/page/table.html
@@ -1,0 +1,21 @@
+<!doctype html><html><head><title>Companies</title><style>
+  .scroller { overflow: auto; height: 400px; }
+  .rowgroup { display: contents; }  /* box-less "tbody": zero-size box, visible children */
+  .row { display: flex; gap: 12px; padding: 4px; }
+</style></head><body>
+<div data-component="RecordTable" class="scroller" role="table"><div class="rowgroup" role="rowgroup"></div></div>
+<script>
+  const g = document.querySelector('.rowgroup');
+  const names = ["Cisco","Microsoft","Google","Airbnb","Figma"];
+  for (let i = 1; i <= 60; i++) {
+    const name = names[i % names.length] + " " + i;
+    const row = document.createElement('div');
+    row.className = 'row';
+    row.setAttribute('role', 'row');
+    row.setAttribute('data-testid', 'row-id-' + crypto.randomUUID());
+    row.innerHTML = '<a href="/c/' + i + '">' + name + '</a>' +
+                    '<span>' + name.toLowerCase().replace(/ /g,'') + '.com</span>' +
+                    '<button>Open ' + i + '</button>';
+    g.appendChild(row);
+  }
+</script></body></html>

--- a/go/clitest/testdata/cases/snapshot-url-races-hydration/case.yaml
+++ b/go/clitest/testdata/cases/snapshot-url-races-hydration/case.yaml
@@ -1,0 +1,21 @@
+title: "snapshot --url re-navigates a page the browser is already on and races SPA hydration to a 0-node error"
+issue: 140
+known_bug: true
+requires: [manual]
+run:
+  args: [snapshot, --url, "http://127.0.0.1:8901/spa.html"]
+  fixture: fixture
+expect:
+  exit: zero
+  output:
+    - must_match: 'Action 1'
+      why: >
+        The browser is already sitting on the fully rendered URL; --url must
+        observe it (navigate only when the current URL differs, then wait for
+        render), not re-navigate and snapshot the pre-hydration shell. Manual
+        steps: serve page/, browser start, browser navigate to /spa.html, wait
+        4s (content renders 2.5s after load with no network activity — first
+        networkIdle fires before it), then run. Without --url the identical
+        snapshot succeeds; with it, today: "0 interactive nodes" hard error.
+    - must_not_match: '0 interactive nodes'
+      why: re-navigation must not turn an already-rendered page into a blank observation.

--- a/go/clitest/testdata/cases/snapshot-url-races-hydration/fixture/.sightmap/spa.yaml
+++ b/go/clitest/testdata/cases/snapshot-url-races-hydration/fixture/.sightmap/spa.yaml
@@ -1,0 +1,8 @@
+version: 1
+views:
+  - name: SpaPage
+    route: /spa.html
+    url: http://127.0.0.1:8901/spa.html
+    components:
+      - name: ActionList
+        selector: '#app'

--- a/go/clitest/testdata/cases/snapshot-url-races-hydration/fixture/page/spa.html
+++ b/go/clitest/testdata/cases/snapshot-url-races-hydration/fixture/page/spa.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><title>SPA</title></head><body>
+<div id="app"></div>
+<script>
+  window.addEventListener('load', () => {
+    setTimeout(() => {
+      const app = document.getElementById('app');
+      for (let i = 1; i <= 20; i++) {
+        const b = document.createElement('button');
+        b.textContent = 'Action ' + i;
+        app.appendChild(b);
+      }
+    }, 2500);
+  });
+</script></body></html>

--- a/go/clitest/testdata/cases/version-2-not-flagged/case.yaml
+++ b/go/clitest/testdata/cases/version-2-not-flagged/case.yaml
@@ -1,0 +1,16 @@
+title: "Spec says version must be 1; a version: 2 file validates clean with no error or warning"
+issue: 89
+known_bug: true
+run:
+  args: [validate]
+  fixture: fixture
+expect:
+  exit: nonzero
+  output:
+    - must_match: '(?i)version'
+      why: >
+        The spec's conformance section requires rejecting any version other
+        than 1 (schema.md "Must be 1"; JSON Schema const: 1). An explicit
+        version: 2 must be a named error so the forward-compat story holds —
+        today the loader parses the field and nothing checks it. Companion to
+        missing-version-not-flagged, which covers the absent-field warning.

--- a/go/clitest/testdata/cases/version-2-not-flagged/fixture/.sightmap/components.yaml
+++ b/go/clitest/testdata/cases/version-2-not-flagged/fixture/.sightmap/components.yaml
@@ -1,0 +1,4 @@
+version: 2
+components:
+  - name: Nav
+    selector: nav


### PR DESCRIPTION
Reconciles the third-party evaluation run against Twenty CRM
(chiplay/twenty#1, SIGHTMAP-EVALUATION.md) into the case dataset,
following the intake ritual. Every finding was re-verified against a
CLI built from HEAD (and, where it mattered, the published 0.17.0):

New known-bug cases (red until their issue ships):
- version-2-not-flagged            -> #89   (version: 2 validates clean)
- search-view-name-no-matches      -> #144  (bare "no matches" for view names)
- skill-memory-placement-undocumented -> #146
- skill-inapp-search-undocumented  -> #146

New manual cases (desired behaviour encoded, runnable fixtures shipped):
- snapshot-elides-matched-subtrees -> #139  (display:contents subtree drop)
- snapshot-url-races-hydration     -> #140  (--url re-navigation race)
- navigate-misses-slow-client-redirect -> #141 (2s AwaitNavigation budget)
- partial-page-passes-silently     -> #142  (exit 0 beside "wrong page captured?")
- browser-install-help-executes    -> #143  (--help runs the install; CI-unsafe)

Regression pin:
- ok-lint-parse-error-exits-nonzero — the eval's "lint exits 0 on an
  unparseable corpus" did not reproduce on HEAD or on the published
  0.17.0 binary; this pins the correct behaviour instead.

Intake-ritual updates from this round: requires:[manual] now covers
CI-unsafe side effects (with hand-repro steps required in a why),
outside-eval provenance shape documented, and a step 6 for claims that
do not reproduce (pin with an ok- case, report back, no issue).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YR9YRMiJSzFdUMkKQzuTBy