### PR TITLE
docs(skill): drop the nonexistent `browser register` attach instruction

### DIFF
--- a/.changeset/skill-drop-register.md
+++ b/.changeset/skill-drop-register.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Remove the authoring skill's instruction to run `sightmap browser register --addr localhost:PORT` — that subcommand does not exist, so agents following it dead-ended. Attaching to an externally-launched browser remains a possible future feature (tracked upstream); until it lands the skill no longer documents it.

--- a/go/clitest/testdata/cases/skill-documents-nonexistent-register/case.yaml
+++ b/go/clitest/testdata/cases/skill-documents-nonexistent-register/case.yaml
@@ -1,6 +1,5 @@
 title: "The authoring skill documents `browser register --addr`, a command that does not exist"
 issue: 122
-known_bug: true
 expect:
   repo:
     - file: skills/sightmap-authoring/SKILL.md

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -307,11 +307,6 @@ The overlay extension is embedded in the binary and auto-extracted to
 
 If the site has a `package.json` with `g:*` scripts, those are convenience wrappers around the same commands and work equally well.
 
-To connect to an existing Chrome session:
-```bash
-sightmap browser register --addr localhost:PORT
-```
-
 ---
 
 ## Phase 1: Per-page iteration

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -307,11 +307,6 @@ The overlay extension is embedded in the binary and auto-extracted to
 
 If the site has a `package.json` with `g:*` scripts, those are convenience wrappers around the same commands and work equally well.
 
-To connect to an existing Chrome session:
-```bash
-sightmap browser register --addr localhost:PORT
-```
-
 ---
 
 ## Phase 1: Per-page iteration


### PR DESCRIPTION
The `sightmap-authoring` skill told agents they could connect to an existing Chrome with:

```
sightmap browser register --addr localhost:PORT
```

That subcommand does not exist — running it prints `unknown subcommand "register"`, so an agent following the instruction dead-ended. This removes the block. Attaching to an externally-launched browser is a possible future feature (tracked separately); until it lands the skill shouldn't document it.

The embedded `go/skills/sightmap-authoring/SKILL.md` copy is regenerated via `go generate ./skills/...` (CI's drift gate stays green). Flips the `skill-documents-nonexistent-register` clitest case to a passing guard.

Closes #122.
