### PR TITLE
feat(cli,skill): report/capture + skill teach the `views:` schema (#116)

### DIFF
--- a/.changeset/teach-view-schema.md
+++ b/.changeset/teach-view-schema.md
@@ -1,0 +1,10 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`report` and `capture` errors now teach the `views:` file structure instead of naming a field in isolation:
+
+- `report` distinguishes "no views defined at all" from "views exist but none has a `url:`", and both print a minimal `views:` example (with `route:` and `url:` and their roles) — previously it always said "no views with URLs found / Add a url: field", which contradicted `capture`'s route-only advice.
+- `capture`'s "no view matches" error shows the same `views:` example and names `route:` explicitly.
+
+The `sightmap-authoring` skill's Phase 1a now shows a complete view-file example (the top-level `views:` list with `version:`/`route:`/`url:`), instead of only telling authors to "create a view file with `route:`" — which invited putting view fields at the file root (silently making it a globals file).

--- a/go/clitest/testdata/cases/report-error-teaches-schema/case.yaml
+++ b/go/clitest/testdata/cases/report-error-teaches-schema/case.yaml
@@ -1,6 +1,5 @@
 title: "report's 'no views with URLs' error names the wrong field and never shows the views: shape"
 issue: 116
-known_bug: true
 run:
   args: [report]
   fixture: fixture

--- a/go/clitest/testdata/cases/skill-doc-view-example/case.yaml
+++ b/go/clitest/testdata/cases/skill-doc-view-example/case.yaml
@@ -1,6 +1,5 @@
 title: "The authoring skill tells agents to create view files 'with route:' but never shows the views: wrapper"
 issue: 116
-known_bug: true
 expect:
   repo:
     - file: skills/sightmap-authoring/SKILL.md

--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -85,8 +85,9 @@ func runCapture(args []string) error {
 		return fmt.Errorf("capture: observe: %v", err)
 	}
 	if res.View == nil {
-		return fmt.Errorf("capture: no view matches %q — capture appends to a view's set; "+
-			"use `snapshot` to observe an unmapped page, or add a view with a matching route", res.URL)
+		return fmt.Errorf("capture: no view matches %q — capture appends to a matched view's set.\n"+
+			"Use `snapshot` to observe an unmapped page, or add a view whose route: matches this URL:\n%s",
+			res.URL, viewSchemaExample())
 	}
 	fmtOpts := observe.FormatOpts{Trace: *traceFlag, Selectors: *selectorsFlag}
 

--- a/go/cmd/sightmap/cmd_report.go
+++ b/go/cmd/sightmap/cmd_report.go
@@ -20,6 +20,16 @@ import (
 	"github.com/sightmap/sightmap/go/viewset"
 )
 
+// viewSchemaExample is the canonical minimal view-file snippet the CLI prints
+// when a view is missing or malformed, so report and capture teach the same
+// shape and the same field roles (route: matches the page, url: is navigated to).
+func viewSchemaExample() string {
+	return "  views:\n" +
+		"    - name: Home\n" +
+		"      route: /                    # glob matched against the URL path\n" +
+		"      url: https://example.com/   # representative URL to navigate to"
+}
+
 // captureCoverage is one capture's per-DOM coverage tiers plus its largest T2
 // scope, the unit report aggregates over a view's set.
 type captureCoverage struct {
@@ -95,8 +105,12 @@ func runReport(args []string) error {
 	}
 
 	if len(views) == 0 {
-		return fmt.Errorf("no views with URLs found\n" +
-			"Add a url: field to your views/*.yaml files")
+		if len(corpus.Views) == 0 {
+			return fmt.Errorf("no views defined — report needs at least one view with a url:.\n"+
+				"Define views under a top-level \"views:\" list:\n%s", viewSchemaExample())
+		}
+		return fmt.Errorf("%d view(s) defined but none has a url: — add a url: (the URL report navigates to) to your views:\n%s",
+			len(corpus.Views), viewSchemaExample())
 	}
 
 	// visibleOnly: visible-by-default; overridden by include_hidden: true in config.

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -326,8 +326,23 @@ sightmap discover                  # URL patterns — find unseen routes
 Prefer selectors with `data-testid`, `data-component^=`, `#id`. Avoid
 class selectors (volatile) and auto-generated IDs.
 
-Create `.sightmap/views/PAGE.yaml` with `route: "/pattern/**"`. Run
-`sightmap validate` before snapping.
+Create a view file `.sightmap/views/PAGE.yaml`. **View fields go under a
+top-level `views:` list** — `route:`/`url:`/`name:` are *not* file-root fields
+(putting them at the root silently makes the file a globals file, matching no
+view):
+
+```yaml
+version: 1
+views:
+  - name: Home
+    route: "/"                     # glob matched against the URL path (** = any depth)
+    url: "https://example.com/"    # a representative URL, used by report/capture
+    components:
+      - name: SearchBar
+        selector: '[data-testid="search"]'
+```
+
+Run `sightmap validate` before snapping.
 
 ### Step 1b — Snap and read coverage
 

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -326,8 +326,23 @@ sightmap discover                  # URL patterns — find unseen routes
 Prefer selectors with `data-testid`, `data-component^=`, `#id`. Avoid
 class selectors (volatile) and auto-generated IDs.
 
-Create `.sightmap/views/PAGE.yaml` with `route: "/pattern/**"`. Run
-`sightmap validate` before snapping.
+Create a view file `.sightmap/views/PAGE.yaml`. **View fields go under a
+top-level `views:` list** — `route:`/`url:`/`name:` are *not* file-root fields
+(putting them at the root silently makes the file a globals file, matching no
+view):
+
+```yaml
+version: 1
+views:
+  - name: Home
+    route: "/"                     # glob matched against the URL path (** = any depth)
+    url: "https://example.com/"    # a representative URL, used by report/capture
+    components:
+      - name: SearchBar
+        selector: '[data-testid="search"]'
+```
+
+Run `sightmap validate` before snapping.
 
 ### Step 1b — Snap and read coverage
 


### PR DESCRIPTION
PR C of the first-run derailment cluster: the corpus schema is now taught at the two points authors most often hit it wrong — the `report`/`capture` errors, and the authoring skill.

## CLI errors

- **`report`** collapsed two different states into one misleading message. It now distinguishes:
  - *no views defined at all* → "no views defined — report needs at least one view with a `url:`", and
  - *views exist but none has a `url:`* → "N view(s) defined but none has a `url:`",
  and both print a minimal `views:` example (with `route:` and `url:` and their roles). Previously it always said `no views with URLs found / Add a url: field`, which named the wrong thing and **contradicted `capture`'s** route-only advice.
- **`capture`**'s "no view matches" error shows the same `views:` example and names `route:` explicitly. A shared `viewSchemaExample()` guarantees the two commands teach identical shape and field roles.

## Authoring skill

Phase 1a said only *"Create `.sightmap/views/PAGE.yaml` with `route:`"* — which invited putting `route:`/`url:` at the file root, silently turning the file into a globals file that matches no view. It now shows a complete view-file example (top-level `version:` + `views:` list). The embedded `go/skills` copy is regenerated (drift gate stays green).

## Validation

`go test ./...` green. Flips `report-error-teaches-schema` and `skill-doc-view-example` to passing guards (the ratchet); `ok-report-lists-views` guard confirms `report` still works on a well-formed corpus.

Closes #116. Pairs with #138 (the loader/validate side of the same trap). Remaining in the cluster: `sightmap init` (#120, PR D).
