### PR TITLE
feat(cli): add `sightmap init` to scaffold a schema-correct corpus (#120)

### DIFF
--- a/.changeset/init-scaffold.md
+++ b/.changeset/init-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add `sightmap init`: scaffold a schema-correct `.sightmap/` corpus (a commented `components.yaml` and `views/example.yaml` carrying `version: 1` and the top-level `views:` wrapper) so the first files an author sees are already valid instead of written from memory. Existing files are never overwritten, and the scaffolded corpus passes `sightmap validate` as-is.

--- a/go/clitest/testdata/cases/init-scaffold-missing/case.yaml
+++ b/go/clitest/testdata/cases/init-scaffold-missing/case.yaml
@@ -1,6 +1,5 @@
 title: "There is no `sightmap init` — an agent's literal first guess — so the first YAML is always written from memory"
 issue: 120
-known_bug: true
 run:
   args: [init]
   fixture: fixture

--- a/go/cmd/sightmap/cmd_init.go
+++ b/go/cmd/sightmap/cmd_init.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// runInit scaffolds a schema-correct .sightmap/ corpus so the first files an
+// author sees are already valid (version:, the views: wrapper, correct nesting)
+// rather than written from memory. Existing files are never overwritten.
+func runInit(args []string) error {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	sightmapDir := fs.String("sightmap-dir", ".sightmap", "Path to the .sightmap/ directory to create")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	files := []struct{ path, content string }{
+		{"components.yaml", initComponentsYAML},
+		{filepath.Join("views", "example.yaml"), initViewYAML},
+	}
+
+	if err := os.MkdirAll(*sightmapDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", *sightmapDir, err)
+	}
+
+	var created, skipped []string
+	for _, f := range files {
+		abs := filepath.Join(*sightmapDir, f.path)
+		if _, err := os.Stat(abs); err == nil {
+			skipped = append(skipped, f.path)
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			return fmt.Errorf("create dir for %s: %w", f.path, err)
+		}
+		if err := os.WriteFile(abs, []byte(f.content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", f.path, err)
+		}
+		created = append(created, f.path)
+	}
+
+	for _, p := range created {
+		fmt.Printf("  created  %s\n", filepath.Join(*sightmapDir, p))
+	}
+	for _, p := range skipped {
+		fmt.Printf("  skipped  %s (already exists)\n", filepath.Join(*sightmapDir, p))
+	}
+	if len(created) == 0 {
+		fmt.Printf("%s is already scaffolded — nothing to do.\n", *sightmapDir)
+		return nil
+	}
+	fmt.Printf("\nScaffolded %s. Next:\n"+
+		"  1. edit %s for your app (route:, url:, component selectors)\n"+
+		"  2. sightmap validate\n"+
+		"  3. sightmap browser start  &&  sightmap snapshot --coverage\n",
+		*sightmapDir, filepath.Join(*sightmapDir, "views", "example.yaml"))
+	return nil
+}
+
+const initComponentsYAML = `# .sightmap/components.yaml — global components, matched on every view.
+# Put shared UI (nav, footer, …) here so one definition improves every page.
+# Full schema: https://sightmap.org/docs
+#
+# components:
+#   - name: SiteNav
+#     selector: 'nav[data-component="SiteNav"]'
+version: 1
+`
+
+const initViewYAML = `# A view is one screen of your app, identified by its URL route. Copy this file
+# per screen (e.g. views/home.yaml) and edit the fields below.
+# Full schema: https://sightmap.org/docs
+version: 1
+views:
+  - name: Home
+    route: "/"                       # glob matched against the URL path (** = any depth)
+    url: "http://localhost:3000/"    # a representative URL, used by report/capture
+    components:
+      - name: ExampleButton
+        selector: '[data-testid="example"]'   # ← replace with a real selector
+`

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -33,6 +33,8 @@ func main() {
 
 	var err error
 	switch cmd {
+	case "init":
+		err = runInit(args)
 	case "browser":
 		err = runBrowser(args)
 	case "inspect":
@@ -129,6 +131,7 @@ Commands:
   network  list [--type T] [--url SUBSTR] [--tab T] [--limit N]  captured network requests
   network  get INDEX [--response-file F] [--request-file F]  one request + body by index
 
+  init     [--sightmap-dir DIR]                             scaffold a schema-correct .sightmap/ corpus
   skills install [--target DIR]                             install sightmap authoring skill to ~/.agents/skills/
   version                                                    print version and exit
 


### PR DESCRIPTION
PR D — the last piece of the first-run derailment cluster. An agent's literal first guess is `sightmap init`; it didn't exist (`unknown command "init"`), so the first corpus file was always written from memory — and often in the wrong shape (the file-root schema trap #89/#116 address from the other side). `init` removes the blank-page start entirely.

## Behavior

`sightmap init` scaffolds `.sightmap/` with two commented, schema-correct files:
- `components.yaml` — `version: 1` + a commented global-component example.
- `views/example.yaml` — `version: 1` + a top-level `views:` list with a `Home` view (`route:`/`url:`/a component), so the correct shape is the first thing an author sees.

It never overwrites existing files (reports `created` vs `skipped`), prints a next-steps hint (`edit` → `validate` → `snapshot`), and the scaffolded corpus **passes `sightmap validate` as-is** (verified end-to-end).

```
$ sightmap init
  created  .sightmap/components.yaml
  created  .sightmap/views/example.yaml
$ sightmap validate
✓ no validation errors
```

## Validation

`go test ./...` green. Flips the `init-scaffold-missing` clitest case to a passing guard. Closes #120.

Deliberately command-only to stay independent of #151 (which also edits the authoring skill). Making `init` the *documented* first step in the skill/docs is a small follow-up once #151 lands, to avoid an embed merge conflict.
