### PR TITLE
ci(changelog): generate the docs changelog entry during the release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,14 @@
 name: docs
 
+# go/npm/CHANGELOG.md is in the path filter so the changelog-coverage check
+# below runs on the "Version Packages" PR, which touches no docs/ files but is
+# exactly where a release without an entry would slip through.
 on:
   push:
     branches: [main]
-    paths: ['docs/**', 'spec/v1/**', '.github/workflows/docs.yml']
+    paths: ['docs/**', 'spec/v1/**', 'go/npm/CHANGELOG.md', 'scripts/changelog-entry.mjs', '.github/workflows/docs.yml']
   pull_request:
-    paths: ['docs/**', 'spec/v1/**', '.github/workflows/docs.yml']
+    paths: ['docs/**', 'spec/v1/**', 'go/npm/CHANGELOG.md', 'scripts/changelog-entry.mjs', '.github/workflows/docs.yml']
 
 permissions:
   contents: read
@@ -42,6 +45,13 @@ jobs:
         run: |
           node docs/scripts/build-changelog.mjs
           git diff --exit-code docs/changelog.mdx
+
+      # The drift check above only proves the page matches the entries — it
+      # passes just fine when a release has no entry at all, which is how the
+      # docs site fell a version behind npm. This asserts coverage instead:
+      # every released version in go/npm/CHANGELOG.md has an entry.
+      - name: Every release has a changelog entry
+        run: node scripts/changelog-entry.mjs --check
 
       - name: Install Mintlify CLI
         run: npm i -g mint

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,6 +8,60 @@ rss: true
     Add an entry in changelog/entries/, then run: node scripts/build-changelog.mjs
     Docs: changelog/README.md */}
 
+<Update label="sightmap 0.18.0" description="Released August 5, 2026" tags={["go","cli"]}>
+
+**Breaking:** rename the rule-side corpus types to the `Def` convention — `match.SightmapComponent` → `match.ComponentDef` and `match.SightmapMatch` → `match.ComponentMatch`. A `ComponentDef` describes what to match; a `ComponentMatch` is the result of matching one. No behaviour change; callers update to the new names.
+
+Add `sightmap init`: scaffold a schema-correct `.sightmap/` corpus (a commented `components.yaml` and `views/example.yaml` carrying `version: 1` and the top-level `views:` wrapper) so the first files an author sees are already valid instead of written from memory. Existing files are never overwritten, and the scaffolded corpus passes `sightmap validate` as-is.
+
+**Breaking:** split the matching engine out of `Corpus`. `Corpus` is now pure, serializable data; build a `Matcher` with `NewMatcher(corpus)` to match a live component tree. `Corpus.MatchTree` and `Corpus.Components` move to `Matcher.MatchTree` / `Matcher.Components` (the per-URL compiled-query cache now lives on the `Matcher`). Read-only corpus queries (`ComponentsForURL`, `ViewForURL`, `RequestsForURL`, `GlobalComponentNames`) stay on `Corpus`.
+
+Model `requests:` in the corpus and make it serializable to a stable wire form:
+
+- Global and view-scoped API request definitions (`RequestDef` / `Payload` / `Field`) are now parsed into the corpus — previously `requests:` was known to the schema but silently dropped.
+- New `Corpus.RequestsForURL(url, method)` returns every request whose route glob (and optional method) matches the observed request — "all matches apply", per the spec. Reuses the existing route matcher (`:param`, trailing-slash, `**`).
+- `Corpus`, `View`, and `RequestDef` now carry JSON tags, so a corpus serializes to a lean wire form (`memory` / `globals` / `views` / `requests`); authoring-only `View` fields (`url` / `access` / `snapshots` / `sourceFile` / `stability`) are excluded. The flattened list is emitted in a stable pre-order (lexical file order, then declaration-order depth-first), locked by a test, so the wire form is reproducible.
+
+First-run papercuts fixed:
+
+- Subcommand `--help`/`-h` now exits 0 and no longer prints `flag: help requested` — a help request is a success, not an error (#117).
+- `browser status` on a session file that exists but doesn't parse (e.g. hand-written or corrupted, so no valid `port`) now reports it as an unrecognized format with the expected shape, instead of a misleading "server and CDP were assigned the same port (0)" collision hint. The collision hint is also gated on a real server port (#118).
+- `validate` no longer warns about unknown fields in tooling files it owns (`survey.yaml`), as it already skips `config.yaml` (#119).
+
+Make `browser start` work — and fail legibly — on Linux and in root containers (the standard agent/CI environment):
+
+- `FindChrome` now checks the sightmap-managed Chrome for Testing install (`~/.sightmap/browsers/`) on Linux and Windows, not just macOS, so the documented `browser install` → `browser start` flow works. The "no Chrome found" errors now point at `browser install`.
+- `browser start` adds `--no-sandbox` automatically when running as root (Chrome refuses to start otherwise), and accepts `--chrome-flag` (repeatable) and `--chrome-binary` to override the launch.
+- On a startup timeout, `browser start` now reports the resolved binary, the full argument list, and the tail of Chrome's stderr — instead of a bare "timed out waiting for CDP" that hid the real cause.
+
+Three first-run papercuts:
+
+- `validate` now errors on an unsupported `version:` value (e.g. `version: 2`) — the spec requires `version: 1`. This is the companion to the missing-`version:` warning.
+- `browser install --help` prints usage and exits 0 instead of ignoring its arguments and starting the 184 MB Chrome-for-Testing download (the subcommand now parses its flags).
+- `search` names the near-miss when a pattern matches a **view** or **request** name (search covers component fields only), instead of a bare "no matches".
+
+Route matching: `**` is now a proper globstar. As a whole path segment it matches zero or more segments, so `/admin/**` matches `/admin` itself (as the spec always stated) as well as `/admin/users` and deeper, and `/a/**/b` matches `/a/b`. A `**` glued into a segment (e.g. `/foo**`) is treated as a regular single-segment `*` that does not cross a `/`. This fixes the previous behaviour where `/admin/**` failed to match `/admin` and `/messages**` failed to match `/messages`.
+
+Remove the authoring skill's instruction to run `sightmap browser register --addr localhost:PORT` — that subcommand does not exist, so agents following it dead-ended. Attaching to an externally-launched browser remains a possible future feature (tracked upstream); until it lands the skill no longer documents it.
+
+`report` and `capture` errors now teach the `views:` file structure instead of naming a field in isolation:
+
+- `report` distinguishes "no views defined at all" from "views exist but none has a `url:`", and both print a minimal `views:` example (with `route:` and `url:` and their roles) — previously it always said "no views with URLs found / Add a url: field", which contradicted `capture`'s route-only advice.
+- `capture`'s "no view matches" error shows the same `views:` example and names `route:` explicitly.
+
+The `sightmap-authoring` skill's Phase 1a now shows a complete view-file example (the top-level `views:` list with `version:`/`route:`/`url:`), instead of only telling authors to "create a view file with `route:`" — which invited putting view fields at the file root (silently making it a globals file).
+
+Teach the corpus schema at the point authors get it wrong, instead of failing silently or generically:
+
+- A **view field at the file root** (e.g. a top-level `route:`/`name:`) now warns that view fields belong under a top-level `views:` list, with a short example, instead of a bare "unknown field".
+- A **view-shaped file** that sets `url:` and `components:` but no `views:` now warns that it defines no views and its components are treated as global (previously it validated clean and silently became a globals file).
+- A **missing `version:`** now warns (the spec requires `version: 1` in every corpus file).
+- `validate` now warns when the **whole corpus has global components but no views** — it can never match a view, so capture, report, and per-view coverage are unavailable.
+
+All are advisory warnings (exit 0); correct corpora stay warning-free.
+
+</Update>
+
 <Update label="sightmap 0.17.0" description="Released July 31, 2026" tags={["go"]}>
 
 Go library: components can now carry `source:` (relative path to the implementing file — already schema-recognized, previously dropped by the loader) and `tags:` (authored classification labels, e.g. `defect`). Neither is inherited by children, matching `memory`/`properties`/`stability`'s existing convention. `Tags` also flows through `ApplySightmap`'s match result alongside `Memory`. New `Corpus.AllComponents()` returns every component in the corpus (globals plus every view's), deduped by first-seen name — the flat, whole-corpus list a consumer building an upload payload or a lint/coverage report wants, replacing an equivalent hand-rolled loop in `cmd_lint.go`.

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -38,9 +38,23 @@ The body below the frontmatter is the prose shown inside the entry. Keep **Markd
 
 ## How entries get written
 
-For now, **manually** — a person drops an entry file per release.
+**Automatically, as part of the release.** `npm run version-packages` — the command `changesets/action` runs to open the "Version Packages" PR — chains `scripts/changelog-entry.mjs` after `changeset version`. So the moment changesets writes a new block to `go/npm/CHANGELOG.md`, the matching entry file and the regenerated `changelog.mdx` are written too, and all of it lands in that same PR alongside the version bump.
 
-Changesets already produces essay-quality prose in `go/npm/CHANGELOG.md`. Copy the released version's block into an entry file, dropping the `### Patch Changes` heading and the `- <hash>:` prefixes. No rewriting needed.
+That means the entry is reviewable before the release merges, and the docs site can't fall behind npm. Two things to check while reviewing the release PR:
+
+- **`tags`** is a guess (`["go"]` if the prose reads like library surface, else `["cli"]`). It's a judgment call about audience that the prose doesn't state — fix it in the PR if the guess is wrong.
+- **`date`** is the day the Version Packages PR was generated. If that PR sits unmerged across a date boundary, adjust it to the release date.
+
+The prose is copied from the changesets block verbatim — changesets output is already the published wording, so there is nothing to rewrite. Only the scaffolding is stripped: the `### Patch Changes` heading and the `- <hash>:` prefixes.
+
+To write or regenerate one by hand:
+
+```bash
+node scripts/changelog-entry.mjs --version 0.17.1   # or --date YYYY-MM-DD
+node docs/scripts/build-changelog.mjs
+```
+
+It never overwrites an entry that already exists, so a hand-edited entry survives a re-run.
 
 Releases that ship no user-visible change (a release-automation smoke test, for instance) still get an entry — the version appears on npm either way, and a gap in the list reads as an omission.
 
@@ -48,6 +62,13 @@ Releases that ship no user-visible change (a release-automation smoke test, for 
 
 The page sets `rss: true`, so Mintlify publishes a feed at `/changelog/rss.xml` with an RSS button on the page. Public sites only.
 
-## Keeping the page in sync (optional CI)
+## Keeping the page in sync (CI)
 
-`node scripts/build-changelog.mjs --check` exits non-zero when `changelog.mdx` is stale relative to the entry files. Wire it into CI to prevent a forgotten rebuild from shipping.
+The `docs` workflow enforces both halves, and they catch different failures:
+
+| Check | Catches |
+|-------|---------|
+| `node docs/scripts/build-changelog.mjs --check` | `changelog.mdx` is stale relative to the entry files — someone edited an entry and forgot to rebuild. |
+| `node scripts/changelog-entry.mjs --check` | A released version in `go/npm/CHANGELOG.md` has no entry at all — the docs site is a version behind npm. |
+
+The first passes happily when a release has no entry (there's nothing to be stale against), which is how 0.17.0 shipped without one. The second is why `go/npm/CHANGELOG.md` is in the workflow's path filter: the "Version Packages" PR touches no `docs/` files, so without it the job wouldn't run on the one PR that matters.

--- a/docs/changelog/entries/2026-08-05-sightmap-0.18.0.mdx
+++ b/docs/changelog/entries/2026-08-05-sightmap-0.18.0.mdx
@@ -1,0 +1,55 @@
+---
+label: "sightmap 0.18.0"
+date: "2026-08-05"
+tags: ["go", "cli"]
+---
+
+**Breaking:** rename the rule-side corpus types to the `Def` convention — `match.SightmapComponent` → `match.ComponentDef` and `match.SightmapMatch` → `match.ComponentMatch`. A `ComponentDef` describes what to match; a `ComponentMatch` is the result of matching one. No behaviour change; callers update to the new names.
+
+Add `sightmap init`: scaffold a schema-correct `.sightmap/` corpus (a commented `components.yaml` and `views/example.yaml` carrying `version: 1` and the top-level `views:` wrapper) so the first files an author sees are already valid instead of written from memory. Existing files are never overwritten, and the scaffolded corpus passes `sightmap validate` as-is.
+
+**Breaking:** split the matching engine out of `Corpus`. `Corpus` is now pure, serializable data; build a `Matcher` with `NewMatcher(corpus)` to match a live component tree. `Corpus.MatchTree` and `Corpus.Components` move to `Matcher.MatchTree` / `Matcher.Components` (the per-URL compiled-query cache now lives on the `Matcher`). Read-only corpus queries (`ComponentsForURL`, `ViewForURL`, `RequestsForURL`, `GlobalComponentNames`) stay on `Corpus`.
+
+Model `requests:` in the corpus and make it serializable to a stable wire form:
+
+- Global and view-scoped API request definitions (`RequestDef` / `Payload` / `Field`) are now parsed into the corpus — previously `requests:` was known to the schema but silently dropped.
+- New `Corpus.RequestsForURL(url, method)` returns every request whose route glob (and optional method) matches the observed request — "all matches apply", per the spec. Reuses the existing route matcher (`:param`, trailing-slash, `**`).
+- `Corpus`, `View`, and `RequestDef` now carry JSON tags, so a corpus serializes to a lean wire form (`memory` / `globals` / `views` / `requests`); authoring-only `View` fields (`url` / `access` / `snapshots` / `sourceFile` / `stability`) are excluded. The flattened list is emitted in a stable pre-order (lexical file order, then declaration-order depth-first), locked by a test, so the wire form is reproducible.
+
+First-run papercuts fixed:
+
+- Subcommand `--help`/`-h` now exits 0 and no longer prints `flag: help requested` — a help request is a success, not an error (#117).
+- `browser status` on a session file that exists but doesn't parse (e.g. hand-written or corrupted, so no valid `port`) now reports it as an unrecognized format with the expected shape, instead of a misleading "server and CDP were assigned the same port (0)" collision hint. The collision hint is also gated on a real server port (#118).
+- `validate` no longer warns about unknown fields in tooling files it owns (`survey.yaml`), as it already skips `config.yaml` (#119).
+
+Make `browser start` work — and fail legibly — on Linux and in root containers (the standard agent/CI environment):
+
+- `FindChrome` now checks the sightmap-managed Chrome for Testing install (`~/.sightmap/browsers/`) on Linux and Windows, not just macOS, so the documented `browser install` → `browser start` flow works. The "no Chrome found" errors now point at `browser install`.
+- `browser start` adds `--no-sandbox` automatically when running as root (Chrome refuses to start otherwise), and accepts `--chrome-flag` (repeatable) and `--chrome-binary` to override the launch.
+- On a startup timeout, `browser start` now reports the resolved binary, the full argument list, and the tail of Chrome's stderr — instead of a bare "timed out waiting for CDP" that hid the real cause.
+
+Three first-run papercuts:
+
+- `validate` now errors on an unsupported `version:` value (e.g. `version: 2`) — the spec requires `version: 1`. This is the companion to the missing-`version:` warning.
+- `browser install --help` prints usage and exits 0 instead of ignoring its arguments and starting the 184 MB Chrome-for-Testing download (the subcommand now parses its flags).
+- `search` names the near-miss when a pattern matches a **view** or **request** name (search covers component fields only), instead of a bare "no matches".
+
+Route matching: `**` is now a proper globstar. As a whole path segment it matches zero or more segments, so `/admin/**` matches `/admin` itself (as the spec always stated) as well as `/admin/users` and deeper, and `/a/**/b` matches `/a/b`. A `**` glued into a segment (e.g. `/foo**`) is treated as a regular single-segment `*` that does not cross a `/`. This fixes the previous behaviour where `/admin/**` failed to match `/admin` and `/messages**` failed to match `/messages`.
+
+Remove the authoring skill's instruction to run `sightmap browser register --addr localhost:PORT` — that subcommand does not exist, so agents following it dead-ended. Attaching to an externally-launched browser remains a possible future feature (tracked upstream); until it lands the skill no longer documents it.
+
+`report` and `capture` errors now teach the `views:` file structure instead of naming a field in isolation:
+
+- `report` distinguishes "no views defined at all" from "views exist but none has a `url:`", and both print a minimal `views:` example (with `route:` and `url:` and their roles) — previously it always said "no views with URLs found / Add a url: field", which contradicted `capture`'s route-only advice.
+- `capture`'s "no view matches" error shows the same `views:` example and names `route:` explicitly.
+
+The `sightmap-authoring` skill's Phase 1a now shows a complete view-file example (the top-level `views:` list with `version:`/`route:`/`url:`), instead of only telling authors to "create a view file with `route:`" — which invited putting view fields at the file root (silently making it a globals file).
+
+Teach the corpus schema at the point authors get it wrong, instead of failing silently or generically:
+
+- A **view field at the file root** (e.g. a top-level `route:`/`name:`) now warns that view fields belong under a top-level `views:` list, with a short example, instead of a bare "unknown field".
+- A **view-shaped file** that sets `url:` and `components:` but no `views:` now warns that it defines no views and its components are treated as global (previously it validated clean and silently became a globals file).
+- A **missing `version:`** now warns (the spec requires `version: 1` in every corpus file).
+- `validate` now warns when the **whole corpus has global components but no views** — it can never match a view, so capture, report, and per-view coverage are unavailable.
+
+All are advisory warnings (exit 0); correct corpora stay warning-free.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "changeset": "npx --yes @changesets/cli@^2.27.0",
-    "version-packages": "npx --yes @changesets/cli@^2.27.0 version && node scripts/sync-manifest-versions.mjs",
+    "version-packages": "npx --yes @changesets/cli@^2.27.0 version && node scripts/sync-manifest-versions.mjs && node scripts/changelog-entry.mjs && node docs/scripts/build-changelog.mjs",
     "sync-docs": "node docs/scripts/sync-spec.mjs"
   }
 }

--- a/scripts/changelog-entry.mjs
+++ b/scripts/changelog-entry.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Generate the docs-site changelog entry for the version being released.
+//
+// The published changelog at docs/changelog.mdx is assembled from per-release
+// entry files in docs/changelog/entries/ (see docs/changelog/README.md). Those
+// entries were written by hand, which meant a release could ship with no entry
+// at all — the docs site sat a version behind npm until someone noticed.
+//
+// This closes that loop at the source. It runs from `npm run version-packages`,
+// immediately after `changeset version` has written the new block to
+// go/npm/CHANGELOG.md and bumped go/npm/package.json — so the entry lands in
+// the same "Version Packages" PR as the bump that caused it, reviewable before
+// merge. Same hook, and the same shape, as scripts/sync-manifest-versions.mjs.
+//
+// The prose is copied from the changesets block verbatim: changesets output is
+// already the published wording, so there is nothing to rewrite. Only the
+// changesets scaffolding is stripped — the `### Patch Changes` heading and the
+// `- <commit>:` prefixes — matching how the entries were formatted by hand.
+//
+// Pure Node.js (no deps). Idempotent: an entry that already exists is left
+// alone, so re-running never clobbers a hand-edited entry.
+//
+//   node scripts/changelog-entry.mjs                  # entry for the current version
+//   node scripts/changelog-entry.mjs --version 0.17.1 # a specific version
+//   node scripts/changelog-entry.mjs --date 2026-07-31 # override the date stamp
+//   node scripts/changelog-entry.mjs --check          # CI: every release has an entry
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CHANGELOG = join(REPO_ROOT, 'go', 'npm', 'CHANGELOG.md');
+const PKG = join(REPO_ROOT, 'go', 'npm', 'package.json');
+const ENTRIES_DIR = join(REPO_ROOT, 'docs', 'changelog', 'entries');
+
+function arg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : undefined;
+}
+
+// Split CHANGELOG.md into its per-version blocks, newest first.
+function releases(text) {
+  const out = [];
+  const re = /^## (\d+\.\d+\.\d+)\s*$/gm;
+  const marks = [...text.matchAll(re)];
+  for (let i = 0; i < marks.length; i++) {
+    const start = marks[i].index + marks[i][0].length;
+    const end = i + 1 < marks.length ? marks[i + 1].index : text.length;
+    out.push({ version: marks[i][1], raw: text.slice(start, end).trim() });
+  }
+  return out;
+}
+
+// Strip the changesets scaffolding, leaving the prose as the hand-written
+// entries formatted it: one paragraph per changeset, nested bullets dedented
+// to column 0, blank line between changesets.
+function toEntryBody(raw) {
+  const lines = raw
+    .split('\n')
+    .filter((l) => !/^### (Patch|Minor|Major) Changes\s*$/.test(l));
+
+  // A changeset starts at a column-0 bullet carrying a commit hash. Continuation
+  // lines are indented two spaces by changesets; everything else is body.
+  const START = /^- [0-9a-f]{7,40}: ?/i;
+  const chunks = [];
+  let cur = null;
+  for (const line of lines) {
+    if (START.test(line)) {
+      if (cur) chunks.push(cur);
+      cur = [line.replace(START, '')];
+    } else if (cur) {
+      cur.push(line.startsWith('  ') ? line.slice(2) : line);
+    } else if (line.trim()) {
+      // No hash prefix (a changeset written without `commit`) — keep as-is.
+      cur = [line];
+    }
+  }
+  if (cur) chunks.push(cur);
+
+  return chunks.map((c) => c.join('\n').trim()).filter(Boolean).join('\n\n');
+}
+
+// cli vs go decides which filter the entry sits under in the changelog's right
+// panel. It is a judgment call about audience, not something the prose states,
+// so this is a guess the reviewer is expected to confirm in the release PR.
+function guessTags(body) {
+  return /\bGo library\b|\bgo get\b|\bgo directive\b|\bnested Go module\b/i.test(body)
+    ? ['go']
+    : ['cli'];
+}
+
+// Which versions already have an entry, keyed off the frontmatter label rather
+// than the filename — the label is what the build script actually renders.
+function entryVersions() {
+  if (!existsSync(ENTRIES_DIR)) return new Set();
+  const found = new Set();
+  for (const f of readdirSync(ENTRIES_DIR)) {
+    if (!/\.mdx?$/.test(f)) continue;
+    const m = /^label:\s*["']?sightmap\s+(\d+\.\d+\.\d+)/m.exec(
+      readFileSync(join(ENTRIES_DIR, f), 'utf8'),
+    );
+    if (m) found.add(m[1]);
+  }
+  return found;
+}
+
+const all = releases(readFileSync(CHANGELOG, 'utf8'));
+const have = entryVersions();
+
+if (process.argv.includes('--check')) {
+  const missing = all.filter((r) => !have.has(r.version)).map((r) => r.version);
+  if (missing.length) {
+    console.error(
+      `Released ${missing.length === 1 ? 'version has' : 'versions have'} no changelog entry: ${missing.join(', ')}\n` +
+        'The docs site would ship a version behind npm. Generate with:\n' +
+        '  node scripts/changelog-entry.mjs --version <X.Y.Z>\n' +
+        '  node docs/scripts/build-changelog.mjs\n' +
+        'See docs/changelog/README.md.',
+    );
+    process.exit(1);
+  }
+  console.log(`All ${all.length} released versions have a changelog entry.`);
+  process.exit(0);
+}
+
+const version = arg('version') ?? JSON.parse(readFileSync(PKG, 'utf8')).version;
+const release = all.find((r) => r.version === version);
+if (!release) {
+  console.error(`No "## ${version}" block in go/npm/CHANGELOG.md — nothing to generate.`);
+  process.exit(1);
+}
+
+if (have.has(version)) {
+  console.log(`changelog-entry: ${version} already has an entry, leaving it alone.`);
+  process.exit(0);
+}
+
+const date = arg('date') ?? new Date().toISOString().slice(0, 10);
+const body = toEntryBody(release.raw);
+const tags = guessTags(body);
+const out = join(ENTRIES_DIR, `${date}-sightmap-${version}.mdx`);
+
+writeFileSync(
+  out,
+  `---\nlabel: "sightmap ${version}"\ndate: "${date}"\ntags: ${JSON.stringify(tags)}\n---\n\n${body}\n`,
+);
+
+console.log(`changelog-entry: wrote docs/changelog/entries/${date}-sightmap-${version}.mdx`);
+console.log(`  tags: ${JSON.stringify(tags)} — guessed from the prose; confirm before merging.`);


### PR DESCRIPTION
## What this changes

Adds `scripts/changelog-entry.mjs` and chains it into `npm run version-packages`, so the docs-site changelog entry for a release is generated from `go/npm/CHANGELOG.md` at release time instead of being written by hand afterward. Adds a `--check` mode, wired into the `docs` workflow, asserting that every released version has an entry.

## Why

The entries in `docs/changelog/entries/` were authored manually, so a release could ship with no entry at all. That's what happened with **0.17.0**: npm was a minor version ahead of docs.sightmap.org until it was noticed (#153 adds the missing entry).

The existing CI guard couldn't catch it. `build-changelog.mjs` + `git diff --exit-code` only proves `changelog.mdx` matches the entry files — with no entry, there's nothing to be stale against, so it passes. And `docs.yml` was path-filtered to `docs/**`, so it never ran on the "Version Packages" PR, which touches only `go/` and the plugin manifests.

The fix follows a pattern already in the repo. `version-packages` is `changeset version && node scripts/sync-manifest-versions.mjs` — the release PR already regenerates derived files (the plugin manifest versions), and `changesets/action` sweeps whatever that command touched into the PR branch. The changelog entry was simply the one derived artifact never wired into that hook:

```
changeset version && sync-manifest-versions.mjs && changelog-entry.mjs && build-changelog.mjs
```

The entry now lands in the same "Version Packages" PR as the bump that caused it — reviewable before merge, atomic with the release, and drift becomes structurally impossible rather than something to detect afterward.

### Prose is copied, not rewritten

Changesets output is already the published wording. Only the scaffolding is stripped — the `### Patch Changes` heading and the `- <hash>:` prefixes — reproducing how the entries were formatted by hand (one paragraph per changeset, nested bullets dedented to column 0).

Verified two ways:

- Regenerating **0.17.0** from `main` produces a file **byte-identical** to the hand-written entry in #153, tag included.
- Generating **0.17.1** from the in-flight release PR (#147) — three changesets, nested bullets, a trailing paragraph — reproduces the multi-changeset convention established by `0.15.7`.

A full rehearsal of the post-`changeset version` half of the command against #147's tree produces the correct manifests, entry, and rebuilt page, and is idempotent: re-running leaves an existing entry untouched, so a hand-edited entry survives.

### Two fields stay a reviewer's call

The script prints both on stdout rather than pretending to be sure:

- **`tags`** — `["go"]` vs `["cli"]` is a judgment about audience that the prose doesn't state. Guessed from library-surface phrasing; it got 0.17.0 and 0.17.1 right, but it is a heuristic.
- **`date`** — the day the Version Packages PR is generated. Skews by a day if that PR sits unmerged across a date boundary.

Both are trivially fixable in the release PR, which is the point of generating them there.

## Area

- [ ] Spec (`spec/`)
- [ ] Go implementation / CLI (`go/`)
- [x] Docs site (`docs/`)
- [ ] Marketing site (`web/`)
- [x] Maintainer / infrastructure

## Type of change

- [ ] Bug fix
- [ ] Docs / wording / typo
- [x] Feature
- [ ] Spec clarification (no semantic change)
- [ ] Spec change (requires an accepted SEP — link below)
- [ ] Example or conformance fixture added/updated

## Linked issues or SEPs

Follows #153, which adds the 0.17.0 entry this would have generated automatically.

## Merge order

**Merge #153 first.** Until it lands, `main` has no 0.17.0 entry, so this PR's new coverage check fails — the check correctly reporting the real gap it was written to catch. It goes green once #153 merges; no changes needed here.

Worth noting #147 ("Version Packages", 0.17.1) is open now. If it merges before this, 0.17.1 also ships without an entry and will need one added by hand — the last release that would.

## Checklist

- [x] I read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [ ] ~~Every commit on this branch is signed off~~ — **not done, needs a maintainer.** The commit is authored by `Claude <noreply@anthropic.com>`; a DCO sign-off is a certification by a human contributor, so it isn't mine to make. Please `git commit --amend -s` (or squash-merge with sign-off) before merging. The same applies to #153.
- [x] I kept this PR focused on a single concern
- [ ] If this changes the spec, there is an accepted SEP linked above — n/a
- [ ] If this changes the JSON Schema, I updated the schema file, `spec/v1/schema.md`, and any affected examples — n/a
- [x] Relevant checks pass locally — generator and both `--check` modes verified; no Go or site build affected

---
_Generated by [Claude Code](https://claude.ai/code/session_0138rvrzy5eip9a6x8C2UZAs)_