### PR TITLE
fix(cli): three first-run papercuts (version≠1, install --help, search near-miss)

### DIFF
--- a/.changeset/papercuts-round2.md
+++ b/.changeset/papercuts-round2.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Three first-run papercuts:
+
+- `validate` now errors on an unsupported `version:` value (e.g. `version: 2`) — the spec requires `version: 1`. This is the companion to the missing-`version:` warning.
+- `browser install --help` prints usage and exits 0 instead of ignoring its arguments and starting the 184 MB Chrome-for-Testing download (the subcommand now parses its flags).
+- `search` names the near-miss when a pattern matches a **view** or **request** name (search covers component fields only), instead of a bare "no matches".

--- a/go/clitest/testdata/cases/browser-install-help-executes/case.yaml
+++ b/go/clitest/testdata/cases/browser-install-help-executes/case.yaml
@@ -1,6 +1,5 @@
 title: "browser install --help executes the 184 MB install instead of printing usage"
 issue: 143
-known_bug: true
 requires: [manual]
 run:
   args: [browser, install, --help]

--- a/go/clitest/testdata/cases/search-view-name-no-matches/case.yaml
+++ b/go/clitest/testdata/cases/search-view-name-no-matches/case.yaml
@@ -1,6 +1,5 @@
 title: "search prints a bare 'no matches' when the pattern names a view the corpus contains"
 issue: 144
-known_bug: true
 run:
   args: [search, TablePage]
   fixture: fixture

--- a/go/clitest/testdata/cases/version-2-not-flagged/case.yaml
+++ b/go/clitest/testdata/cases/version-2-not-flagged/case.yaml
@@ -1,6 +1,5 @@
 title: "Spec says version must be 1; a version: 2 file validates clean with no error or warning"
 issue: 89
-known_bug: true
 run:
   args: [validate]
   fixture: fixture

--- a/go/cmd/sightmap/cmd_browser_install.go
+++ b/go/cmd/sightmap/cmd_browser_install.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 
@@ -13,7 +14,18 @@ import (
 // Downloads and installs the latest stable Chrome for Testing into
 // ~/.sightmap/browsers/. Idempotent: if the current stable version is already
 // present it just prints the binary path and exits 0.
-func runBrowserInstall(_ []string) error {
+func runBrowserInstall(args []string) error {
+	// Parse args so `--help` (or any unknown flag) is handled before the
+	// download starts, rather than being ignored while the 184 MB install runs.
+	fs := flag.NewFlagSet("browser install", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: sightmap browser install")
+		fmt.Fprintln(os.Stderr, "  Download the managed Chrome for Testing into ~/.sightmap/browsers/ (idempotent).")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err // flag.ErrHelp is treated as success (exit 0) by main
+	}
+
 	binPath, err := browser.InstallCfT(context.Background(), os.Stderr)
 	if err != nil {
 		return err

--- a/go/cmd/sightmap/cmd_search.go
+++ b/go/cmd/sightmap/cmd_search.go
@@ -17,6 +17,11 @@ type srchFile struct {
 	Version    int        `yaml:"version"`
 	Components []srchComp `yaml:"components"`
 	Views      []srchView `yaml:"views"`
+	Requests   []srchReq  `yaml:"requests"`
+}
+
+type srchReq struct {
+	Name string `yaml:"name"`
 }
 
 type srchView struct {
@@ -69,6 +74,10 @@ func runSearch(args []string) error {
 	}
 
 	matchCount := 0
+	// Name hits on views/requests — search covers component fields only, so these
+	// don't count as matches, but they explain a "no matches" near-miss.
+	var viewHits, reqHits []string
+	nameSearch := *field == "all" || *field == "name"
 
 	walkErr := filepath.WalkDir(*sightmapDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -117,10 +126,18 @@ func runSearch(args []string) error {
 
 		// Walk views.
 		for _, view := range sf.Views {
+			if nameSearch && view.Name != "" && re.MatchString(view.Name) {
+				viewHits = append(viewHits, view.Name)
+			}
 			viewCrumb := fmt.Sprintf("%s [%s %s]", relPath, view.Name, view.Route)
 			for _, comp := range view.Components {
 				n := searchComp(comp, re, *field, []string{viewCrumb}, relPath, view.Name, view.Route)
 				matchCount += n
+			}
+		}
+		for _, r := range sf.Requests {
+			if nameSearch && r.Name != "" && re.MatchString(r.Name) {
+				reqHits = append(reqHits, r.Name)
 			}
 		}
 
@@ -132,7 +149,20 @@ func runSearch(args []string) error {
 	}
 
 	if matchCount == 0 {
-		fmt.Fprintf(os.Stderr, "no matches for %s\n", pattern)
+		var notes []string
+		if len(viewHits) > 0 {
+			notes = append(notes, fmt.Sprintf("a view named %s", strings.Join(viewHits, ", ")))
+		}
+		if len(reqHits) > 0 {
+			notes = append(notes, fmt.Sprintf("a request named %s", strings.Join(reqHits, ", ")))
+		}
+		if len(notes) > 0 {
+			fmt.Fprintf(os.Stderr, "no component matches for %q — but the corpus has %s. "+
+				"search covers component fields (name, selector, description, memory), not view or request names.\n",
+				pattern, strings.Join(notes, " and "))
+		} else {
+			fmt.Fprintf(os.Stderr, "no matches for %s\n", pattern)
+		}
 	}
 
 	return nil

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -111,9 +111,13 @@ func walkFile(node *yaml.Node, file string, out *[]ValidationError) {
 func fileRootDiagnostics(node *yaml.Node, file string, out *[]ValidationError) map[string]bool {
 	seen := map[string]bool{}
 	var misplaced []string
+	versionVal := ""
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		k := node.Content[i].Value
 		seen[k] = true
+		if k == "version" {
+			versionVal = node.Content[i+1].Value
+		}
 		if !fileRootFields[k] && viewFields[k] {
 			misplaced = append(misplaced, k)
 		}
@@ -139,6 +143,13 @@ func fileRootDiagnostics(node *yaml.Node, file string, out *[]ValidationError) m
 			Code:     "missing-version",
 			Severity: SeverityWarning,
 			Message:  `missing "version:" — every corpus file should begin with "version: 1"`,
+		})
+	} else if versionVal != "1" {
+		*out = append(*out, ValidationError{
+			File:     file,
+			Code:     "unsupported-version",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("unsupported version %q — this tooling supports version: 1", versionVal),
 		})
 	}
 	if seen["url"] && seen["components"] && !seen["views"] {


### PR DESCRIPTION
Round 2 of the first-run papercuts from the Twenty CRM intake (#149) — three small, independent OOTB fixes, each flipping its `clitest` case.

## Fixes

- **`version != 1` → error (#89).** `version: 2` (or any non-`1`) validated clean; the spec requires `version: 1`. `validate` now errors (exit non-zero) on an unsupported version — the companion to the missing-`version:` warning shipped in #138. Sub-issue of the #89 loudness umbrella; #89 stays open.
- **`browser install --help` (#143).** The subcommand discarded its arguments, so `--help` (or any typo) started the 184 MB Chrome-for-Testing download. It now parses its flags: `--help` prints usage and exits 0 with no side effects (verified — no `~/.sightmap/browsers/` created).
- **`search` near-miss (#144).** `search` covers component fields only, so a pattern naming a **view** or **request** got a bare "no matches" that read as "not in the corpus". It now names the near-miss: *"no component matches for X — but the corpus has a view named X. search covers component fields (…), not view or request names."*

## Validation

`go test ./...` green. Flips `version-2-not-flagged`, `search-view-name-no-matches`, and `browser-install-help-executes` to passing guards. The install case stays `requires: [manual]` on purpose — a regression would re-introduce the 184 MB download, which must never run in CI — but is now a fixed guard.

`Closes #143, #144`. #89 stays open (umbrella); its `version-2` sub-case is now green.
