### PR TITLE
fix(browser): make browser start work + fail legibly on Linux/root containers (#44, #45)

### DIFF
--- a/.changeset/linux-container-start.md
+++ b/.changeset/linux-container-start.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Make `browser start` work — and fail legibly — on Linux and in root containers (the standard agent/CI environment):
+
+- `FindChrome` now checks the sightmap-managed Chrome for Testing install (`~/.sightmap/browsers/`) on Linux and Windows, not just macOS, so the documented `browser install` → `browser start` flow works. The "no Chrome found" errors now point at `browser install`.
+- `browser start` adds `--no-sandbox` automatically when running as root (Chrome refuses to start otherwise), and accepts `--chrome-flag` (repeatable) and `--chrome-binary` to override the launch.
+- On a startup timeout, `browser start` now reports the resolved binary, the full argument list, and the tail of Chrome's stderr — instead of a bare "timed out waiting for CDP" that hid the real cause.

--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -117,66 +117,68 @@ func WriteSessionInfo(sightmapDir string, info SessionInfo) error {
 // FindChrome returns the path to the Chrome binary on the current platform,
 // or an error if none is found.
 func FindChrome() (string, error) {
-	switch runtime.GOOS {
+	return findChrome(runtime.GOOS, InstalledCfTPath)
+}
+
+// findChrome resolves a Chrome binary for goos. managed supplies the
+// sightmap-managed Chrome-for-Testing path (what `browser install` downloads);
+// it is preferred on every platform because it supports --load-extension.
+// InstalledCfTPath only reports ok when the binary actually exists. goos is a
+// parameter so per-OS resolution is unit-testable on any host.
+func findChrome(goos string, managed func() (string, bool)) (string, error) {
+	// Managed Chrome for Testing first, on every platform. This is the #44 fix:
+	// Linux and Windows previously ignored the managed install, so the documented
+	// `browser install` → `browser start` flow failed on those OSes.
+	if p, ok := managed(); ok {
+		return p, nil
+	}
+
+	switch goos {
 	case "darwin":
-		// Build candidate list: prefer Chrome for Testing (supports --load-extension),
-		// then Canary, then stable Chrome (which blocks --load-extension on macOS).
+		// Prefer a legacy agent-browser CfT, then system Chrome (Canary before
+		// stable; both block --load-extension but work for non-extension flows).
 		var candidates []string
-
-		// 1. Sightmap-managed CfT install (~/.sightmap/browsers/).
-		if p, ok := InstalledCfTPath(); ok {
-			candidates = append(candidates, p)
-		}
-
-		// 2. agent-browser-managed CfT (~/.agent-browser/browsers/) — legacy.
 		if home, err := os.UserHomeDir(); err == nil {
 			if matches, _ := filepath.Glob(filepath.Join(home, ".agent-browser", "browsers", "chrome-*",
 				"Google Chrome for Testing.app", "Contents", "MacOS", "Google Chrome for Testing")); len(matches) > 0 {
-				// filepath.Glob returns sorted; take the last for the highest version.
 				candidates = append(candidates, matches[len(matches)-1])
 			}
 		}
-
-		// 3. System Chrome (Canary before stable; both block --load-extension but
-		//    are useful as a fallback for non-extension workflows).
 		candidates = append(candidates,
 			"/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
 			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
 			"/Applications/Chromium.app/Contents/MacOS/Chromium",
 		)
 		for _, p := range candidates {
-			if p == "" {
-				continue
-			}
-			if _, err := os.Stat(p); err == nil {
-				return p, nil
+			if p != "" {
+				if _, err := os.Stat(p); err == nil {
+					return p, nil
+				}
 			}
 		}
-		return "", fmt.Errorf("chrome: no Chrome binary found on macOS")
+		return "", fmt.Errorf("chrome: no Chrome found — run `sightmap browser install` for a managed Chrome for Testing, or install Google Chrome")
 
 	case "linux":
-		names := []string{"google-chrome", "google-chrome-stable", "chromium", "chromium-browser"}
-		for _, name := range names {
+		for _, name := range []string{"google-chrome", "google-chrome-stable", "chromium", "chromium-browser"} {
 			if p, err := exec.LookPath(name); err == nil {
 				return p, nil
 			}
 		}
-		return "", fmt.Errorf("chrome: no Chrome binary found in PATH on Linux")
+		return "", fmt.Errorf("chrome: no Chrome found — run `sightmap browser install` to fetch a managed Chrome for Testing into ~/.sightmap/browsers/, or put google-chrome/chromium on PATH")
 
 	case "windows":
-		candidates := []string{
+		for _, p := range []string{
 			filepath.Join(os.Getenv("LOCALAPPDATA"), "Google", "Chrome", "Application", "chrome.exe"),
 			filepath.Join(os.Getenv("PROGRAMFILES"), "Google", "Chrome", "Application", "chrome.exe"),
-		}
-		for _, p := range candidates {
+		} {
 			if _, err := os.Stat(p); err == nil {
 				return p, nil
 			}
 		}
-		return "", fmt.Errorf("chrome: no Chrome binary found on Windows")
+		return "", fmt.Errorf("chrome: no Chrome found — run `sightmap browser install` for a managed Chrome for Testing, or install Google Chrome")
 
 	default:
-		return "", fmt.Errorf("chrome: unsupported OS %q", runtime.GOOS)
+		return "", fmt.Errorf("chrome: unsupported OS %q", goos)
 	}
 }
 

--- a/go/browser/launcher_test.go
+++ b/go/browser/launcher_test.go
@@ -3,9 +3,50 @@ package browser
 import (
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// TestFindChromeManagedPreferredPerOS is the #44 regression guard: a managed
+// Chrome-for-Testing install must be returned on every platform (Linux and
+// Windows previously ignored it, so `browser install` → `browser start` failed).
+func TestFindChromeManagedPreferredPerOS(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "chrome")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managed := func() (string, bool) { return bin, true }
+	for _, goos := range []string{"linux", "windows", "darwin"} {
+		got, err := findChrome(goos, managed)
+		if err != nil {
+			t.Errorf("findChrome(%q, managed) error: %v", goos, err)
+			continue
+		}
+		if got != bin {
+			t.Errorf("findChrome(%q, managed) = %q, want managed %q", goos, got, bin)
+		}
+	}
+}
+
+// TestFindChromeLinuxErrorMentionsInstall verifies the Linux no-Chrome error
+// points at `browser install` (the docs' remedy), rather than the old bare
+// "no Chrome binary found in PATH".
+func TestFindChromeLinuxErrorMentionsInstall(t *testing.T) {
+	for _, name := range []string{"google-chrome", "google-chrome-stable", "chromium", "chromium-browser"} {
+		if _, err := exec.LookPath(name); err == nil {
+			t.Skip("a system chrome is on PATH; skipping the no-chrome error test")
+		}
+	}
+	_, err := findChrome("linux", func() (string, bool) { return "", false })
+	if err == nil {
+		t.Fatal("expected an error with no managed install and no PATH chrome")
+	}
+	if !strings.Contains(err.Error(), "browser install") {
+		t.Errorf("Linux no-chrome error should mention `browser install`, got: %v", err)
+	}
+}
 
 // TestSessionFileIsolationByCorpus is the regression guard for cross-agent
 // crosstalk: the session file must live inside the corpus directory so that

--- a/go/clitest/testdata/cases/browser-start-no-diagnostics/case.yaml
+++ b/go/clitest/testdata/cases/browser-start-no-diagnostics/case.yaml
@@ -1,6 +1,5 @@
 title: "browser start times out, kills Chrome, and reports nothing about which binary ran or why it failed"
 issue: 45
-known_bug: true
 requires: [linux]
 run:
   args: [browser, start, --url, "http://127.0.0.1:1/"]

--- a/go/cmd/sightmap/cmd_browser_launch.go
+++ b/go/cmd/sightmap/cmd_browser_launch.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+	"sync"
+)
+
+// stringSliceFlag collects a repeatable string flag (e.g. --chrome-flag).
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, " ") }
+
+func (s *stringSliceFlag) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+// finalChromeArgs appends the root --no-sandbox default (euid 0) and any
+// caller-supplied flags to base, without mutating base. Chrome refuses to start
+// as root without --no-sandbox, which is the standard agent/CI/container env.
+// euid is a parameter (rather than reading os.Geteuid directly) so the root
+// behaviour is unit-testable on any host.
+func finalChromeArgs(base []string, euid int, extra []string) []string {
+	out := append([]string(nil), base...)
+	if euid == 0 {
+		out = append(out, "--no-sandbox")
+	}
+	out = append(out, extra...)
+	return out
+}
+
+// chromeStderrCap bounds how many bytes of Chrome's stderr we retain for the
+// failure report — enough for the tail that names the real cause.
+const chromeStderrCap = 8 << 10
+
+// boundedBuffer is an io.Writer that retains only the last chromeStderrCap
+// bytes, so a chatty child can't grow it without bound. Safe for concurrent
+// writes: os/exec copies a process's stderr on its own goroutine.
+type boundedBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > chromeStderrCap {
+		b.buf = b.buf[len(b.buf)-chromeStderrCap:]
+	}
+	return len(p), nil
+}
+
+// tailReport renders the retained stderr as an indented block for the
+// "did not become ready" error, so the real cause (e.g. the root/--no-sandbox
+// message) is visible in one shot instead of hidden behind a bare CDP timeout.
+func (b *boundedBuffer) tailReport() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := strings.TrimSpace(string(b.buf))
+	if s == "" {
+		return "  (Chrome produced no stderr output)"
+	}
+	var sb strings.Builder
+	sb.WriteString("  chrome stderr (tail):\n")
+	for _, line := range strings.Split(s, "\n") {
+		sb.WriteString("    ")
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/go/cmd/sightmap/cmd_browser_launch_test.go
+++ b/go/cmd/sightmap/cmd_browser_launch_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+)
+
+func TestFinalChromeArgs(t *testing.T) {
+	base := []string{"--remote-debugging-port=9222", "--headless=new"}
+
+	// Non-root: no --no-sandbox; extra flags appended.
+	got := finalChromeArgs(base, 1000, []string{"--disable-gpu"})
+	if slices.Contains(got, "--no-sandbox") {
+		t.Error("non-root must not add --no-sandbox")
+	}
+	if !slices.Contains(got, "--disable-gpu") {
+		t.Error("caller --chrome-flag not appended")
+	}
+
+	// Root: --no-sandbox added automatically.
+	if got := finalChromeArgs(base, 0, nil); !slices.Contains(got, "--no-sandbox") {
+		t.Error("root (euid 0) must add --no-sandbox")
+	}
+
+	// Base must not be mutated.
+	if len(base) != 2 {
+		t.Errorf("base slice was mutated: %v", base)
+	}
+}
+
+func TestBoundedBufferTruncatesAndReports(t *testing.T) {
+	var b boundedBuffer
+	b.Write(bytes.Repeat([]byte("x"), chromeStderrCap+512))
+	if got := len(b.buf); got != chromeStderrCap {
+		t.Errorf("retained %d bytes, want cap %d", got, chromeStderrCap)
+	}
+
+	var empty boundedBuffer
+	if r := empty.tailReport(); r == "" {
+		t.Error("empty tailReport should still say something")
+	}
+
+	var withErr boundedBuffer
+	withErr.Write([]byte("Running as root without --no-sandbox is not supported\n"))
+	if r := withErr.tailReport(); !bytes.Contains([]byte(r), []byte("--no-sandbox")) {
+		t.Errorf("tailReport should surface the stderr line, got: %q", r)
+	}
+}

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -30,6 +31,9 @@ func runBrowserStart(args []string) error {
 	profileFlag := fset.String("profile", "", "Chrome user data dir (default: ~/.sightmap/profiles/default)")
 	headlessFlag := fset.Bool("headless", false, "Run headless")
 	waitFlag := fset.Float64("wait", 0, "Seconds to wait after navigation")
+	chromeBinaryFlag := fset.String("chrome-binary", "", "Path to a specific Chrome binary (overrides auto-detection)")
+	var chromeFlags stringSliceFlag
+	fset.Var(&chromeFlags, "chrome-flag", "Extra flag to pass to Chrome (repeatable), e.g. --chrome-flag=--no-sandbox")
 	if err := fset.Parse(args); err != nil {
 		return err
 	}
@@ -175,9 +179,13 @@ func runBrowserStart(args []string) error {
 	}
 
 	// ── Launch Chrome ─────────────────────────────────────────────────────────
-	chromePath, err := browser.FindChrome()
-	if err != nil {
-		return err
+	chromePath := *chromeBinaryFlag
+	if chromePath == "" {
+		found, findErr := browser.FindChrome()
+		if findErr != nil {
+			return findErr
+		}
+		chromePath = found
 	}
 
 	chromeArgs := []string{
@@ -210,7 +218,14 @@ func runBrowserStart(args []string) error {
 		)
 	}
 
+	// Root containers (the standard agent/CI env) need --no-sandbox or Chrome
+	// refuses to start; add it automatically. Caller --chrome-flag values append
+	// last so they can override.
+	chromeArgs = finalChromeArgs(chromeArgs, os.Geteuid(), chromeFlags)
+
+	var chromeStderr boundedBuffer
 	cmd := exec.Command(chromePath, chromeArgs...)
+	cmd.Stderr = &chromeStderr
 	setSysProcAttr(cmd) // platform-specific detach (defined in sysproc_*.go)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start: launch chrome: %w", err)
@@ -219,7 +234,10 @@ func runBrowserStart(args []string) error {
 	cdpAddr := fmt.Sprintf("127.0.0.1:%d", resolvedCDPPort)
 	if pollErr := pollCDPReady(cdpAddr); pollErr != nil {
 		cmd.Process.Kill()
-		return fmt.Errorf("start: chrome did not become ready: %w", pollErr)
+		_ = cmd.Wait() // let the stderr copy goroutine finish before reading the buffer
+		return fmt.Errorf("start: chrome did not become ready: %w\n"+
+			"  binary: %s\n  args:   %s\n%s",
+			pollErr, chromePath, strings.Join(chromeArgs, " "), chromeStderr.tailReport())
 	}
 
 	// Start the console/network collector against the now-ready session and


### PR DESCRIPTION
The "can't even start on Linux/CI/containers" wall — the environment most agents actually run in. Two focused commits.

## #44 — `FindChrome` on Linux/Windows

`FindChrome` only consulted the sightmap-managed Chrome for Testing (`~/.sightmap/browsers/`) on **macOS**; Linux and Windows just searched `PATH`. So the documented `browser install` → `browser start` flow failed on Linux with `no Chrome binary found in PATH`, even though `install` had just downloaded a managed Chrome. The managed-install check is hoisted to all platforms, and the no-Chrome errors now point at `browser install`. Refactored into `findChrome(goos, managed)` so per-OS resolution is unit-testable on any host (`TestFindChromeManagedPreferredPerOS`).

## #45 — root/container startup diagnosability

Running as root (the standard container/CI env) Chrome refuses to start (`Running as root without --no-sandbox is not supported`), but `browser start` surfaced only `timed out waiting for CDP` — Chrome's stderr was discarded and there was no flag passthrough. Now:

- `--no-sandbox` is added automatically when `euid == 0`.
- `--chrome-flag` (repeatable) and `--chrome-binary` let you override the launch.
- On the readiness timeout, the error reports the **resolved binary, the full arg list, and the tail of Chrome's stderr**.

`finalChromeArgs` and the bounded stderr buffer are unit-tested (`TestFinalChromeArgs`, `TestBoundedBufferTruncatesAndReports`).

## Testing

`go test ./...` green locally. The hermetic `browser-start-no-diagnostics` case (`requires: [linux]`, a fake `google-chrome` that prints to stderr and never opens CDP) skips on macOS but **runs on ubuntu CI** — it's flipped from `known_bug` to a guard here, so if the Linux stderr-surfacing were wrong, this PR's CI would go red. That's the safety net for the platform I can't run locally. (No container/Chrome download needed; end-to-end smoke deferred.)

`Closes #44, #45`.
