### PR TITLE
match: rename SightmapComponent/SightmapMatch -> ComponentDef/ComponentMatch

### DIFF
--- a/.changeset/def-rename.md
+++ b/.changeset/def-rename.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+**Breaking:** rename the rule-side corpus types to the `Def` convention — `match.SightmapComponent` → `match.ComponentDef` and `match.SightmapMatch` → `match.ComponentMatch`. A `ComponentDef` describes what to match; a `ComponentMatch` is the result of matching one. No behaviour change; callers update to the new names.

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -82,13 +82,13 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	for _, part := range q.Parts {
 		queryNames[part.Name] = true
 	}
-	relevant := make(map[*comps.ComponentNode]*match.SightmapMatch)
+	relevant := make(map[*comps.ComponentNode]*match.ComponentMatch)
 	for n, m := range matches {
 		if queryNames[m.Name] {
 			relevant[n] = m
 		}
 	}
-	compByName := make(map[string]match.SightmapComponent, len(components))
+	compByName := make(map[string]match.ComponentDef, len(components))
 	for _, c := range components {
 		compByName[c.Name] = c
 	}

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -124,7 +124,7 @@ func runCoverage(args []string) error {
 // can't be loaded, parsed, or matched. Shared by coverage/report/multi-coverage so
 // every reader matches a capture the same route-aware way instead of
 // each re-implementing the load/parse/match boilerplate.
-func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.SightmapMatch, route string, ok bool) {
+func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch, route string, ok bool) {
 	treeFile := snapPath + ".tree.json"
 	data, err := os.ReadFile(treeFile)
 	if err != nil {

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -58,7 +58,7 @@ func runInspect(args []string) error {
 	}
 
 	// ── Load sightmap (optional enrichment; warn but don't fail on a bad corpus) ──
-	var inspectMatches map[*comps.ComponentNode]*match.SightmapMatch
+	var inspectMatches map[*comps.ComponentNode]*match.ComponentMatch
 	if corpus, cErr := lf.loadCorpus(); cErr != nil {
 		fmt.Fprintf(os.Stderr, "inspect: load corpus: %v (continuing without component names)\n", cErr)
 	} else if corpus != nil {

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -272,7 +272,7 @@ func offlineSelectorCount(ctx context.Context, conn *browser.CDPConn, selector s
 	if err != nil {
 		return 0, err
 	}
-	defs := []match.SightmapComponent{{Name: "__probe__", Selectors: []string{selector}}}
+	defs := []match.ComponentDef{{Name: "__probe__", Selectors: []string{selector}}}
 	return len(match.ApplySightmap(root, defs)), nil
 }
 

--- a/go/cmd/sightmap/cmd_serve.go
+++ b/go/cmd/sightmap/cmd_serve.go
@@ -44,7 +44,7 @@ type compiledSightmapJSON struct {
 	ViewComponents map[string][]compiledComponent `json:"viewComponents"`
 }
 
-func normaliseComponent(c match.SightmapComponent) compiledComponent {
+func normaliseComponent(c match.ComponentDef) compiledComponent {
 	chain := c.ParentChain
 	if chain == nil {
 		chain = []string{} // always emit [], never null

--- a/go/cmd/sightmap/cmd_snapshot_json.go
+++ b/go/cmd/sightmap/cmd_snapshot_json.go
@@ -32,10 +32,10 @@ type annotatedNode struct {
 }
 
 // buildAnnotatedNode recursively constructs an annotatedNode tree by joining
-// each ComponentNode pointer with its SightmapMatch and any extracted props.
+// each ComponentNode pointer with its ComponentMatch and any extracted props.
 func buildAnnotatedNode(
 	node *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	propValues map[string]map[string]string, // nodeID → {propName → value}; may be nil
 ) *annotatedNode {
 	an := &annotatedNode{
@@ -88,14 +88,14 @@ func writeAnnotatedJSON(
 	root *comps.ComponentNode,
 	path string,
 	view *sightmap.View,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	propValues map[string]map[string]string,
 ) error {
 	if root == nil {
 		return nil
 	}
 	if matches == nil {
-		matches = map[*comps.ComponentNode]*match.SightmapMatch{}
+		matches = map[*comps.ComponentNode]*match.ComponentMatch{}
 	}
 
 	out := annotatedOutput{

--- a/go/cmd/sightmap/cmd_snapshot_json_test.go
+++ b/go/cmd/sightmap/cmd_snapshot_json_test.go
@@ -35,11 +35,11 @@ func TestWriteAnnotatedJSON_MatchedNode(t *testing.T) {
 		InViewport:    true,
 	}
 
-	sm := &match.SightmapMatch{
+	sm := &match.ComponentMatch{
 		Name:   "SiteLogoLink",
 		Memory: []string{"main navigation logo"},
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		node: sm,
 	}
 	propValues := map[string]map[string]string{
@@ -101,7 +101,7 @@ func TestWriteAnnotatedJSON_UnmatchedNode(t *testing.T) {
 
 	// node is NOT in the matches map
 	other := &comps.ComponentNode{Id: "99"}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		other: {Name: "SomeOtherComponent"},
 	}
 

--- a/go/compquery/compquery.go
+++ b/go/compquery/compquery.go
@@ -111,7 +111,7 @@ func (q *Query) String() string {
 // disambiguates.
 func Resolve(
 	root *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	props map[string]map[string]string,
 	q *Query,
 ) (*comps.ComponentNode, error) {
@@ -136,7 +136,7 @@ func Resolve(
 // (descendant semantics). Results are in document (pre-order) order.
 func FindCandidates(
 	root *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	props map[string]map[string]string,
 	q *Query,
 ) []*comps.ComponentNode {
@@ -171,7 +171,7 @@ func FindCandidates(
 func satisfies(
 	node *comps.ComponentNode,
 	part Part,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	props map[string]map[string]string,
 ) bool {
 	m := matches[node]
@@ -195,7 +195,7 @@ func satisfies(
 func subsequence(
 	prefix []Part,
 	ancestors []*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	props map[string]map[string]string,
 ) bool {
 	i := 0
@@ -213,7 +213,7 @@ func subsequence(
 func ambiguityError(
 	q *Query,
 	cands []*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	props map[string]map[string]string,
 ) error {
 	var b strings.Builder

--- a/go/compquery/compquery_test.go
+++ b/go/compquery/compquery_test.go
@@ -151,7 +151,7 @@ func TestPredicateMatch(t *testing.T) {
 //	└─ TileGroup
 //	    ├─ FulfillmentTileButton (t1) label=Pickup
 //	    └─ FulfillmentTileButton (t2) label=Delivery
-func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*match.SightmapMatch, map[string]map[string]string) {
+func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*match.ComponentMatch, map[string]map[string]string) {
 	u1 := &comps.ComponentNode{Id: "u1"}
 	p1 := &comps.ComponentNode{Id: "p1"}
 	loginForm := &comps.ComponentNode{Id: "m2", Children: []*comps.ComponentNode{u1, p1}}
@@ -163,7 +163,7 @@ func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*match.Sight
 
 	root := &comps.ComponentNode{Id: "root", Children: []*comps.ComponentNode{mainPanel, tileGroup}}
 
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		mainPanel: {Name: "MainPanel"},
 		loginForm: {Name: "LoginForm"},
 		u1:        {Name: "UserNameInput"},

--- a/go/coverage/coverage.go
+++ b/go/coverage/coverage.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Matches maps a component node to the sightmap rule it matched.
-type Matches = map[*comps.ComponentNode]*match.SightmapMatch
+type Matches = map[*comps.ComponentNode]*match.ComponentMatch
 
 // ParentMap maps each non-root node to its parent.
 type ParentMap = map[*comps.ComponentNode]*comps.ComponentNode

--- a/go/coverage/gaps_test.go
+++ b/go/coverage/gaps_test.go
@@ -38,7 +38,7 @@ func gapsFixture() (root, banner, image *comps.ComponentNode, parentMap map[*com
 
 func TestAnnotationGaps_FlaggedWhenNoContext(t *testing.T) {
 	root, _, image, pm := gapsFixture()
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{} // nothing matched
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{} // nothing matched
 
 	gaps := Gaps(root, matches, pm, true)
 	if len(gaps) != 1 {
@@ -59,7 +59,7 @@ func TestAnnotationGaps_FlaggedWhenNoContext(t *testing.T) {
 func TestAnnotationGaps_NotFlaggedWhenDirectlyMatched(t *testing.T) {
 	root, _, image, pm := gapsFixture()
 	// The content node itself is now captured by a component (T1).
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		image: {Name: "BannerImage"},
 	}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
@@ -70,7 +70,7 @@ func TestAnnotationGaps_NotFlaggedWhenDirectlyMatched(t *testing.T) {
 func TestAnnotationGaps_NotFlaggedWhenAncestorMatched(t *testing.T) {
 	root, banner, _, pm := gapsFixture()
 	// A matched ancestor gives the node component context → precision guard.
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		banner: {Name: "HeroBanner"},
 	}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
@@ -89,7 +89,7 @@ func TestAnnotationGaps_ShortAndEmptyNamesIgnored(t *testing.T) {
 		Children:  []*comps.ComponentNode{short, empty, symbols},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{}
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("want 0 gaps for short/empty/symbol names, got %d: %+v", len(gaps), gaps)
 	}
@@ -111,7 +111,7 @@ func TestAnnotationGaps_InteractiveSkipped(t *testing.T) {
 		Children:  []*comps.ComponentNode{link},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{}
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("want 0 gaps for interactive node, got %d: %+v", len(gaps), gaps)
 	}
@@ -131,7 +131,7 @@ func TestAnnotationGaps_VisibleOnly(t *testing.T) {
 		Children:  []*comps.ComponentNode{hidden},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{}
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{}
 
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("visibleOnly: want 0 gaps for hidden node, got %d", len(gaps))

--- a/go/match/class_selectors_test.go
+++ b/go/match/class_selectors_test.go
@@ -90,12 +90,12 @@ func TestClassAttrSelectors(t *testing.T) {
 				},
 			}
 
-			comp := match.SightmapComponent{
+			comp := match.ComponentDef{
 				Name:      "TestButton",
 				Selectors: []string{tt.selector},
 			}
 
-			matches := match.ApplySightmap(node, []match.SightmapComponent{comp})
+			matches := match.ApplySightmap(node, []match.ComponentDef{comp})
 			got := len(matches) > 0
 
 			if got != tt.want {

--- a/go/match/conflicts_test.go
+++ b/go/match/conflicts_test.go
@@ -12,7 +12,7 @@ func TestFindConflicts_NodeClaimedByTwoNames(t *testing.T) {
 	root := node("root", "div", nil,
 		nodeAttr("dlg", "div", map[string]string{"role": "dialog", "data-testid": "login"}),
 	)
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "AppDialog", Selectors: []string{`[role="dialog"]`}},
 		{Name: "LoginDialog", Selectors: []string{`[data-testid="login"]`}},
 	}
@@ -36,7 +36,7 @@ func TestFindConflicts_SameNameManyNodes(t *testing.T) {
 		node("c2", "div", []string{"card"}),
 		node("c3", "div", []string{"card"}),
 	)
-	defs := []match.SightmapComponent{{Name: "Card", Selectors: []string{".card"}}}
+	defs := []match.ComponentDef{{Name: "Card", Selectors: []string{".card"}}}
 	if c := match.FindConflicts(root, defs); len(c) != 0 {
 		t.Errorf("same name matching many nodes must not conflict, got %+v", c)
 	}
@@ -49,7 +49,7 @@ func TestFindConflicts_DistinctNodes(t *testing.T) {
 		node("a", "div", []string{"a"}),
 		node("b", "div", []string{"b"}),
 	)
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "A", Selectors: []string{".a"}},
 		{Name: "B", Selectors: []string{".b"}},
 	}

--- a/go/match/conformance_test.go
+++ b/go/match/conformance_test.go
@@ -35,7 +35,7 @@ func TestConformance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read sightmap: %v", err)
 			}
-			var defs []match.SightmapComponent
+			var defs []match.ComponentDef
 			if err := yaml.Unmarshal(smData, &defs); err != nil {
 				t.Fatalf("parse sightmap: %v", err)
 			}

--- a/go/match/has_test.go
+++ b/go/match/has_test.go
@@ -20,7 +20,7 @@ func TestHas_FormGroupScoping(t *testing.T) {
 		formGroup("protection", nodeAttr("rb", "input", map[string]string{"type": "radio"})),
 	)
 
-	defs := []match.SightmapComponent{{
+	defs := []match.ComponentDef{{
 		Name:      "AssemblyOption",
 		Selectors: []string{`[data-testid="form-group"]:has(input[type="checkbox"])`},
 	}}
@@ -37,7 +37,7 @@ func TestHas_DirectChildScoping(t *testing.T) {
 		node("hasDirect", "div", []string{"box"}, node("b1", "button", nil)),
 		node("hasNested", "div", []string{"box"}, node("", "span", nil, node("b2", "button", nil))),
 	)
-	defs := []match.SightmapComponent{{
+	defs := []match.ComponentDef{{
 		Name:      "BoxWithButton",
 		Selectors: []string{"div.box:has(> button)"},
 	}}

--- a/go/match/intermediate_test.go
+++ b/go/match/intermediate_test.go
@@ -63,7 +63,7 @@ func buildBreadcrumbTree() *comps.ComponentNode {
 // structural nodes sit between the Breadcrumb container and the link.
 func TestChildAnnotation_ThroughStructuralIntermediate(t *testing.T) {
 	root := buildBreadcrumbTree()
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "Breadcrumb", Selectors: []string{`[data-component^="breadcrumbs:Breadcrumbs"]`}},
 		// Flattened child selector: parent + " " + child
 		{Name: "BreadcrumbLink", Selectors: []string{`[data-component^="breadcrumbs:Breadcrumbs"] a`}},
@@ -107,7 +107,7 @@ func TestChildAnnotation_ThroughStructuralIntermediate(t *testing.T) {
 // claim a BreadcrumbLink node before the scoped match fires.
 func TestChildAnnotation_BroadGlobalDoesNotSteal(t *testing.T) {
 	root := buildBreadcrumbTree()
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		// FooterLink: broad global "a" selector — listed FIRST (lower index)
 		{Name: "FooterLink", Selectors: []string{`a`}},
 		// Breadcrumb + scoped child — listed AFTER FooterLink

--- a/go/match/matcher_test.go
+++ b/go/match/matcher_test.go
@@ -38,7 +38,7 @@ func nodeInvisible(id, tag string) *comps.ComponentNode {
 // ---------- helpers ----------------------------------------------------------
 
 // applyDefs is a shorthand: build defs, apply, return matched node IDs by name.
-func applyDefs(t *testing.T, root *comps.ComponentNode, defs []match.SightmapComponent) map[string][]string {
+func applyDefs(t *testing.T, root *comps.ComponentNode, defs []match.ComponentDef) map[string][]string {
 	t.Helper()
 	m := match.ApplySightmap(root, defs)
 	result := make(map[string][]string)
@@ -111,7 +111,7 @@ func makeTree() *comps.ComponentNode {
 
 func TestSingleTag(t *testing.T) {
 	root := makeTree()
-	defs := []match.SightmapComponent{{Name: "Nav", Selectors: []string{"nav"}}}
+	defs := []match.ComponentDef{{Name: "Nav", Selectors: []string{"nav"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Nav", "nav")
 }
@@ -119,7 +119,7 @@ func TestSingleTag(t *testing.T) {
 func TestDescendant_TwoLevels(t *testing.T) {
 	// nav.main-nav a.nav-link: anchor inside nav, bridging intermediate nodes.
 	root := makeTree()
-	defs := []match.SightmapComponent{{Name: "NavLink", Selectors: []string{"nav.main-nav a.nav-link"}}}
+	defs := []match.ComponentDef{{Name: "NavLink", Selectors: []string{"nav.main-nav a.nav-link"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "NavLink", "a1", "a2")
 }
@@ -127,7 +127,7 @@ func TestDescendant_TwoLevels(t *testing.T) {
 func TestDescendant_DeepNesting(t *testing.T) {
 	// div button: button anywhere inside a div, even deeply nested.
 	root := makeTree()
-	defs := []match.SightmapComponent{{Name: "Btn", Selectors: []string{"div button"}}}
+	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"div button"}}}
 	got := applyDefs(t, root, defs)
 	// root is div, so all buttons (btn1, btn2, btn3) are descendants.
 	assertIDs(t, got, "Btn", "btn1", "btn2", "btn3")
@@ -136,7 +136,7 @@ func TestDescendant_DeepNesting(t *testing.T) {
 func TestDirectChild_Matches(t *testing.T) {
 	// form.search > button.submit: button DIRECTLY under form.
 	root := makeTree()
-	defs := []match.SightmapComponent{{Name: "SubmitBtn", Selectors: []string{"form.search > button.submit"}}}
+	defs := []match.ComponentDef{{Name: "SubmitBtn", Selectors: []string{"form.search > button.submit"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "SubmitBtn", "btn3")
 }
@@ -144,7 +144,7 @@ func TestDirectChild_Matches(t *testing.T) {
 func TestDirectChild_DoesNotMatchGrandchild(t *testing.T) {
 	// form.search > button.submit should NOT match btn1/btn2 (inside section > div.container).
 	root := makeTree()
-	defs := []match.SightmapComponent{{Name: "DirectBtn", Selectors: []string{"div.container > button"}}}
+	defs := []match.ComponentDef{{Name: "DirectBtn", Selectors: []string{"div.container > button"}}}
 	got := applyDefs(t, root, defs)
 	// btn1 and btn2 are direct children of div.container
 	assertIDs(t, got, "DirectBtn", "btn1", "btn2")
@@ -172,7 +172,7 @@ func TestDirectChild_TwoHops(t *testing.T) {
 			},
 		},
 	}
-	defs := []match.SightmapComponent{{Name: "Link", Selectors: []string{"ul > li > a"}}}
+	defs := []match.ComponentDef{{Name: "Link", Selectors: []string{"ul > li > a"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Link", "a")
 }
@@ -192,7 +192,7 @@ func TestDirectChild_NotTwoLevelsDeep(t *testing.T) {
 			},
 		},
 	}
-	defs := []match.SightmapComponent{{Name: "Link", Selectors: []string{"ul > a"}}}
+	defs := []match.ComponentDef{{Name: "Link", Selectors: []string{"ul > a"}}}
 	got := applyDefs(t, root, defs)
 	assertNoMatch(t, got, "Link")
 }
@@ -200,7 +200,7 @@ func TestDirectChild_NotTwoLevelsDeep(t *testing.T) {
 func TestMultiQuery_SinglePass(t *testing.T) {
 	// Two definitions matched in one pass; verify no state leakage between them.
 	root := makeTree()
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "NavLink", Selectors: []string{"nav.main-nav a.nav-link"}},
 		{Name: "SearchInput", Selectors: []string{`input[type="email"]`}},
 	}
@@ -214,7 +214,7 @@ func TestFirstMatchWins(t *testing.T) {
 	root := node("root", "div", nil,
 		node("btn", "button", []string{"primary", "submit"}),
 	)
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "Primary", Selectors: []string{"button.primary"}},
 		{Name: "Submit", Selectors: []string{"button.submit"}},
 	}
@@ -230,7 +230,7 @@ func TestInvisibleNodesIncluded(t *testing.T) {
 		nodeInvisible("hidden", "button"),
 		node("visible", "button", nil),
 	)
-	defs := []match.SightmapComponent{{Name: "Btn", Selectors: []string{"button"}}}
+	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
 	got := applyDefs(t, root, defs)
 	// Both nodes should match, regardless of IsVisible.
 	assertIDs(t, got, "Btn", "hidden", "visible")
@@ -245,7 +245,7 @@ func TestNilSelectorNode_DoesNotMatchSpecificRule(t *testing.T) {
 			{Id: "child", Selector: &comps.SelectorPart{Tag: "button"}},
 		},
 	}
-	defs := []match.SightmapComponent{{Name: "Btn", Selectors: []string{"button"}}}
+	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
 	got := applyDefs(t, root, defs)
 	// Only "child" should match; "root" has no selector.
 	assertIDs(t, got, "Btn", "child")
@@ -256,7 +256,7 @@ func TestAttrSelector_Substring(t *testing.T) {
 		nodeAttr("n1", "div", map[string]string{"aria-label": "Search products"}),
 		nodeAttr("n2", "div", map[string]string{"aria-label": "Filter results"}),
 	)
-	defs := []match.SightmapComponent{{Name: "Search", Selectors: []string{`[aria-label*="Search"]`}}}
+	defs := []match.ComponentDef{{Name: "Search", Selectors: []string{`[aria-label*="Search"]`}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Search", "n1")
 }
@@ -266,7 +266,7 @@ func TestNotPseudo(t *testing.T) {
 		node("enabled", "button", []string{"primary"}),
 		node("disabled", "button", []string{"primary", "disabled"}),
 	)
-	defs := []match.SightmapComponent{{Name: "Active", Selectors: []string{"button:not(.disabled)"}}}
+	defs := []match.ComponentDef{{Name: "Active", Selectors: []string{"button:not(.disabled)"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Active", "enabled")
 }
@@ -278,7 +278,7 @@ func TestFramePrefixedIDs_Traversed(t *testing.T) {
 			node("1_5", "a", []string{"nav-link"}),
 		),
 	)
-	defs := []match.SightmapComponent{{Name: "NavLink", Selectors: []string{"nav a.nav-link"}}}
+	defs := []match.ComponentDef{{Name: "NavLink", Selectors: []string{"nav a.nav-link"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "NavLink", "1_5")
 }
@@ -298,7 +298,7 @@ func TestMobileSyntheticSelector(t *testing.T) {
 			},
 		},
 	}
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "AddToCart", Selectors: []string{`UIButton[label="Add to Cart"]`}},
 	}
 	got := applyDefs(t, root, defs)
@@ -306,7 +306,7 @@ func TestMobileSyntheticSelector(t *testing.T) {
 }
 
 func TestParseQueries_InvalidSelectorSkipped(t *testing.T) {
-	defs := []match.SightmapComponent{
+	defs := []match.ComponentDef{
 		{Name: "Valid", Selectors: []string{"button"}},
 		{Name: "Invalid", Selectors: []string{":hover"}}, // unsupported pseudo
 	}
@@ -320,7 +320,7 @@ func TestParseQueries_InvalidSelectorSkipped(t *testing.T) {
 }
 
 func TestApplySightmap_NilRoot(t *testing.T) {
-	defs := []match.SightmapComponent{{Name: "X", Selectors: []string{"div"}}}
+	defs := []match.ComponentDef{{Name: "X", Selectors: []string{"div"}}}
 	result := match.ApplySightmap(nil, defs)
 	if result != nil {
 		t.Errorf("expected nil for nil root, got %v", result)

--- a/go/match/sightmap.go
+++ b/go/match/sightmap.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sightmap/sightmap/go/sel"
 )
 
-// SightmapComponent is a single flattened sightmap component definition.
+// ComponentDef is a single flattened sightmap component definition.
 // Hierarchical YAML selectors should be pre-flattened by the caller into
 // compound descendant selectors before calling ParseQueries.
-type SightmapComponent struct {
+type ComponentDef struct {
 	Name        string     `json:"name"`
 	Selectors   []string   `json:"selectors"`
 	Source      string     `json:"source,omitempty"`
@@ -28,18 +28,18 @@ type Property struct {
 	Transform string `json:"transform"` // optional post-processing
 }
 
-// SightmapMatch records which component definition matched a node.
-type SightmapMatch struct {
+// ComponentMatch records which component definition matched a node.
+type ComponentMatch struct {
 	Name   string
 	Memory []string
 	Tags   []string
 }
 
-// ParseQueries parses SightmapComponent definitions into MatchQuery values.
+// ParseQueries parses ComponentDef definitions into MatchQuery values.
 // Each selector string in each component becomes a separate MatchQuery.
 // Invalid selectors are skipped; their errors are returned alongside the
 // valid queries (non-fatal).
-func ParseQueries(defs []SightmapComponent) ([]MatchQuery, []error) {
+func ParseQueries(defs []ComponentDef) ([]MatchQuery, []error) {
 	var queries []MatchQuery
 	var errs []error
 
@@ -62,12 +62,12 @@ func ParseQueries(defs []SightmapComponent) ([]MatchQuery, []error) {
 }
 
 // ApplySightmap runs the NFA against root and returns a map from matched
-// ComponentNode to the SightmapMatch that claimed it. First-match-wins: when
+// ComponentNode to the ComponentMatch that claimed it. First-match-wins: when
 // multiple definitions match the same node, the one earliest in defs order
 // (and earliest selector within that definition) takes precedence.
 //
 // Returns nil if defs is empty or root is nil.
-func ApplySightmap(root *comps.ComponentNode, defs []SightmapComponent) map[*comps.ComponentNode]*SightmapMatch {
+func ApplySightmap(root *comps.ComponentNode, defs []ComponentDef) map[*comps.ComponentNode]*ComponentMatch {
 	if root == nil || len(defs) == 0 {
 		return nil
 	}
@@ -77,14 +77,14 @@ func ApplySightmap(root *comps.ComponentNode, defs []SightmapComponent) map[*com
 		return nil
 	}
 
-	// Build a lookup from query name → SightmapMatch so we can resolve the
+	// Build a lookup from query name → ComponentMatch so we can resolve the
 	// component definition at match time.
-	defByName := make(map[string]*SightmapComponent, len(defs))
+	defByName := make(map[string]*ComponentDef, len(defs))
 	for i := range defs {
 		defByName[defs[i].Name] = &defs[i]
 	}
 
-	result := make(map[*comps.ComponentNode]*SightmapMatch)
+	result := make(map[*comps.ComponentNode]*ComponentMatch)
 
 	FindAllMatches(root, queries, func(node *comps.ComponentNode, q *MatchQuery) {
 		// First-match-wins: skip if already claimed.
@@ -92,7 +92,7 @@ func ApplySightmap(root *comps.ComponentNode, defs []SightmapComponent) map[*com
 			return
 		}
 		def := defByName[q.Name]
-		result[node] = &SightmapMatch{
+		result[node] = &ComponentMatch{
 			Name:   q.Name,
 			Memory: def.Memory,
 			Tags:   def.Tags,
@@ -116,7 +116,7 @@ type Conflict struct {
 // normal and never reported; a single node claimed by several names is the
 // ambiguity, since ApplySightmap keeps only the first. It reuses the same
 // traversal as ApplySightmap, so it sees exactly the same matches.
-func FindConflicts(root *comps.ComponentNode, defs []SightmapComponent) []Conflict {
+func FindConflicts(root *comps.ComponentNode, defs []ComponentDef) []Conflict {
 	if root == nil || len(defs) == 0 {
 		return nil
 	}

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -18,9 +18,9 @@ import (
 type Result struct {
 	Root        *comps.ComponentNode
 	URL         string
-	Matches     map[*comps.ComponentNode]*match.SightmapMatch
+	Matches     map[*comps.ComponentNode]*match.ComponentMatch
 	View        *sightmap.View
-	Components  []match.SightmapComponent
+	Components  []match.ComponentDef
 	GlobalNames map[string]bool
 	Props       map[string]map[string]string
 	Coverage    coverage.Result
@@ -88,7 +88,7 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 	res.ComponentConflicts = match.FindConflicts(root, res.Components)
 
 	if opts.ExtractProps && len(res.Matches) > 0 && len(res.Components) > 0 {
-		compByName := make(map[string]match.SightmapComponent, len(res.Components))
+		compByName := make(map[string]match.ComponentDef, len(res.Components))
 		for _, c := range res.Components {
 			compByName[c.Name] = c
 		}

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -19,8 +19,8 @@ import (
 func ExtractProperties(
 	ctx context.Context,
 	conn *browser.CDPConn,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
-	compByName map[string]match.SightmapComponent,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	compByName map[string]match.ComponentDef,
 ) map[string]map[string]string {
 	type specProp struct {
 		Name      string `json:"name"`

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -110,7 +110,7 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 
 // writeGuide prints the [Guide] section: component names and match counts,
 // sorted by count descending then name ascending.
-func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.SightmapMatch) {
+func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.ComponentMatch) {
 	counts := make(map[string]int)
 	for _, m := range matches {
 		if m != nil {
@@ -158,8 +158,8 @@ func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.SightmapMat
 // excluded from the page-check since they match on any page.
 func writeZeroMatchWarnings(
 	w io.Writer,
-	viewComponents []match.SightmapComponent,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	viewComponents []match.ComponentDef,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	view *sightmap.View,
 	globalNames map[string]bool,
 ) {
@@ -342,7 +342,7 @@ func WriteT2Trace(
 	w io.Writer,
 	t2clusters map[*comps.ComponentNode]int,
 	t2children map[*comps.ComponentNode][]*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	view *sightmap.View,
 ) {
 	const minT2Count = 2 // ≥2 children required (single-child = simple wrapper)
@@ -423,7 +423,7 @@ func WriteT2Trace(
 // route (the topwork wizard returning the Dashboard). globalNames excludes
 // shared components (Header, TopworkApp, etc.) that match any page and would
 // suppress the warning spuriously. Pass nil to skip the exclusion.
-func CheckRootComponents(w io.Writer, viewComponents []match.SightmapComponent, globalNames map[string]bool, counts map[string]int, viewName string) {
+func CheckRootComponents(w io.Writer, viewComponents []match.ComponentDef, globalNames map[string]bool, counts map[string]int, viewName string) {
 	var topNames []string
 	for _, comp := range viewComponents {
 		if comp.Name == "" || len(comp.Selectors) == 0 || len(comp.ParentChain) > 0 {

--- a/go/observe/t2trace_test.go
+++ b/go/observe/t2trace_test.go
@@ -28,12 +28,12 @@ func TestWriteT2Trace_Basic(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		parent: {Name: "AppSidebar"},
 	}
 	view := &sightmap.View{
 		Name: "Home",
-		Components: []match.SightmapComponent{
+		Components: []match.ComponentDef{
 			{Name: "AppSidebar"},
 		},
 	}
@@ -76,11 +76,11 @@ func TestWriteT2Trace_SingleChildSuppressed(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: {child},
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		parent: {Name: "NavFooter"},
 	}
 	view := &sightmap.View{
-		Components: []match.SightmapComponent{
+		Components: []match.ComponentDef{
 			{Name: "NavFooter"},
 		},
 	}
@@ -113,11 +113,11 @@ func TestWriteT2Trace_MemoryNoteSuppressed(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		parent: {Name: "AppContent"},
 	}
 	view := &sightmap.View{
-		Components: []match.SightmapComponent{
+		Components: []match.ComponentDef{
 			{
 				Name:   "AppContent",
 				Memory: []string{"Investigated. All children use volatile classes."},
@@ -167,11 +167,11 @@ func TestWriteT2Trace_Truncation(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		parent: {Name: "ProductGrid"},
 	}
 	view := &sightmap.View{
-		Components: []match.SightmapComponent{
+		Components: []match.ComponentDef{
 			{Name: "ProductGrid"},
 		},
 	}

--- a/go/render/inspect.go
+++ b/go/render/inspect.go
@@ -22,7 +22,7 @@ type InspectNode struct {
 	IsVisible     bool
 	IsIgnored     bool
 	IsInteractive bool
-	Match         *match.SightmapMatch // non-nil when a sightmap definition matched
+	Match         *match.ComponentMatch // non-nil when a sightmap definition matched
 	Children      []*InspectNode
 	Original      *comps.ComponentNode
 }
@@ -45,14 +45,14 @@ type InspectOpts struct {
 // Inspect builds an unfiltered InspectNode tree from a raw ComponentNode tree.
 // Every node is preserved — hidden, ignored, and structural nodes all appear.
 // If matches is non-nil, matched nodes have their Match field populated.
-func Inspect(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.SightmapMatch) *InspectNode {
+func Inspect(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *InspectNode {
 	if root == nil {
 		return nil
 	}
 	return buildInspectNode(root, matches)
 }
 
-func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.SightmapMatch) *InspectNode {
+func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *InspectNode {
 	tag := ""
 	if node.Selector != nil && node.Selector.Tag != "" {
 		tag = node.Selector.Tag

--- a/go/render/inspect_test.go
+++ b/go/render/inspect_test.go
@@ -48,7 +48,7 @@ func TestInspect_NoFilteringVsFilter(t *testing.T) {
 // TestInspect_MatchAnnotation verifies that match is propagated onto InspectNode.
 func TestInspect_MatchAnnotation(t *testing.T) {
 	btn := node("1", "button", "OK", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		btn: {Name: "SubmitBtn"},
 	}
 
@@ -192,7 +192,7 @@ func TestFormatInspect_Selectors_ShowsAll(t *testing.T) {
 // TestFormatInspect_MatchAnnotation verifies ★Name is shown for matched nodes.
 func TestFormatInspect_MatchAnnotation(t *testing.T) {
 	btn := node("3", "button", "Shop", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		btn: {Name: "ShopButton"},
 	}
 	in := Inspect(btn, matches)

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -13,10 +13,10 @@ import (
 // Comp is a filtered, display-ready component node produced by Filter().
 type Comp struct {
 	Id       string
-	Role     string               // display role: AX role (interactive) or match name (structural)
-	Name     string               // accessible name; may be collapsed from StaticText children
-	Value    string               // form field value
-	Match    *match.SightmapMatch // non-nil when matched by a sightmap definition
+	Role     string                // display role: AX role (interactive) or match name (structural)
+	Name     string                // accessible name; may be collapsed from StaticText children
+	Value    string                // form field value
+	Match    *match.ComponentMatch // non-nil when matched by a sightmap definition
 	Children []*Comp
 	Original *comps.ComponentNode // original raw node; .Role has the unmodified AX role
 }
@@ -50,7 +50,7 @@ type FormatOpts struct {
 // StaticText child is collapsed into the parent's Name.
 //
 // If matches is nil or empty, no sightmap annotations are applied.
-func Filter(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.SightmapMatch) *Comp {
+func Filter(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *Comp {
 	if root == nil {
 		return nil
 	}
@@ -216,7 +216,7 @@ func decide(node *comps.ComponentNode, matched bool) disposition {
 	return keepNode
 }
 
-func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.SightmapMatch) []*Comp {
+func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) []*Comp {
 	m := matches[node]
 	matched := m != nil
 
@@ -277,7 +277,7 @@ func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.
 	}}
 }
 
-func convertChildren(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.SightmapMatch) []*Comp {
+func convertChildren(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) []*Comp {
 	var out []*Comp
 	for _, ch := range node.Children {
 		out = append(out, convert(ch, matches)...)

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -215,7 +215,7 @@ func TestFilter_MergeAdjacentStaticText_Mixed(t *testing.T) {
 
 func TestFilter_MatchProtectsFromTransparency(t *testing.T) {
 	div := node("1", "none", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		div: {Name: "ProductCard"},
 	}
 	comp := Filter(div, matches)
@@ -234,7 +234,7 @@ func TestFilter_MatchedLinkRoleReplaced(t *testing.T) {
 	// Mirrors the canonical extractor's DisplayRole(): match name always replaces AX role,
 	// even for interactive roles like "link". No ★ annotation.
 	a := node("1", "link", "Home", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "NavLink"},
 	}
 	comp := Filter(a, matches)
@@ -251,7 +251,7 @@ func TestFilter_MatchedLinkRoleReplaced(t *testing.T) {
 
 func TestFilter_StructuralRoleReplacedByMatchName(t *testing.T) {
 	nav := node("1", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		nav: {Name: "GlobalNav"},
 	}
 	comp := Filter(nav, matches)
@@ -291,7 +291,7 @@ func TestFilter_Value_Preserved(t *testing.T) {
 
 func TestFilter_EmptyMatches(t *testing.T) {
 	root := node("1", "button", "OK", true, true, false)
-	comp := Filter(root, map[*comps.ComponentNode]*match.SightmapMatch{})
+	comp := Filter(root, map[*comps.ComponentNode]*match.ComponentMatch{})
 	if comp == nil {
 		t.Fatal("expected non-nil comp")
 	}
@@ -325,7 +325,7 @@ func TestFormat_NilComp(t *testing.T) {
 
 func TestFormat_WithMatchAnnotation_Interactive(t *testing.T) {
 	a := node("1", "link", "Home", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "NavLink"},
 	}
 	comp := Filter(a, matches)
@@ -341,7 +341,7 @@ func TestFormat_WithMatchAnnotation_Interactive(t *testing.T) {
 
 func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 	nav := node("1", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		nav: {Name: "GlobalNav"},
 	}
 	comp := Filter(nav, matches)
@@ -356,7 +356,7 @@ func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 
 func TestFormat_WithPropValues(t *testing.T) {
 	a := node("1", "link", "Garden Center", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "CategoryTile"},
 	}
 	comp := Filter(a, matches)
@@ -376,7 +376,7 @@ func TestFormat_WithPropValues(t *testing.T) {
 
 func TestFormat_WithPropValues_SortedKeys(t *testing.T) {
 	a := node("1", "link", "Item", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "Tile"},
 	}
 	comp := Filter(a, matches)
@@ -598,7 +598,7 @@ func TestFilter_MultipleChildren_ParentNameKept(t *testing.T) {
 func TestFormat_Bracket_NoPropsNoName(t *testing.T) {
 	// Matched structural node with no text and no props → bare [CompName]
 	nav := node("42", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		nav: {Name: "SiteHeader"},
 	}
 	comp := Filter(nav, matches)
@@ -613,7 +613,7 @@ func TestFormat_Bracket_NoPropsNoName(t *testing.T) {
 func TestFormat_Bracket_NameKept_NoProps(t *testing.T) {
 	// Matched node, name present, no props → name shown last inside brackets
 	a := node("7", "link", "Shop Now", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "BannerLink"},
 	}
 	comp := Filter(a, matches)
@@ -628,7 +628,7 @@ func TestFormat_Bracket_NameKept_NoProps(t *testing.T) {
 func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 	// Rule A: name exactly matches a prop value → name omitted
 	a := node("3", "link", "Explore", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "DesktopNavLink"},
 	}
 	comp := Filter(a, matches)
@@ -647,7 +647,7 @@ func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 func TestFormat_RuleA_NameKept_CaseDiffers(t *testing.T) {
 	// Rule A is exact — case difference means name is kept last
 	a := node("5", "link", "FRI Aug 21 7:00pm", true, true, false)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		a: {Name: "ShowDateRow"},
 	}
 	comp := Filter(a, matches)
@@ -671,7 +671,7 @@ func TestFormat_RuleB_StaticTextSuppressed(t *testing.T) {
 	btn := node("3", "button", "Open menu", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
 	// generic with name "foo bar" is kept (name != "")
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		parent: {Name: "NavItem"},
 	}
 	comp := Filter(parent, matches)
@@ -700,7 +700,7 @@ func TestFormat_RuleB_StaticTextKept_NoMatch(t *testing.T) {
 	st := node("2", "StaticText", "other text", true, false, false)
 	btn := node("3", "button", "OK", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		parent: {Name: "MyComp"},
 	}
 	comp := Filter(parent, matches)
@@ -724,7 +724,7 @@ func TestFormat_ValueFallback_InBrackets(t *testing.T) {
 		Id: "7", Role: "textbox", Name: "Search", Value: "query text",
 		IsVisible: true, IsInteractive: true,
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		n: {Name: "SearchInput"},
 	}
 	comp := Filter(n, matches)
@@ -744,7 +744,7 @@ func TestFormat_ValueOverride_SightmapWins(t *testing.T) {
 		Id: "8", Role: "textbox", Name: "Dropdown", Value: "AX value",
 		IsVisible: true, IsInteractive: true,
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		n: {Name: "CustomSelect"},
 	}
 	comp := Filter(n, matches)
@@ -804,7 +804,7 @@ func TestFormat_Selectors_AfterBracket(t *testing.T) {
 			Attrs: map[string]string{"data-testid": "home-link"},
 		},
 	}
-	matches := map[*comps.ComponentNode]*match.SightmapMatch{
+	matches := map[*comps.ComponentNode]*match.ComponentMatch{
 		n: {Name: "HomeLink"},
 	}
 	comp := Filter(n, matches)

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -24,7 +24,7 @@ type Corpus struct {
 
 	// GlobalComponents is the flat list of globally-defined components
 	// (from components.yaml), with children already flattened.
-	GlobalComponents []match.SightmapComponent
+	GlobalComponents []match.ComponentDef
 
 	// Views contains per-route component lists, with $refs expanded and
 	// children flattened.
@@ -59,7 +59,7 @@ type View struct {
 	Name       string
 	Route      string
 	Memory     []string
-	Components []match.SightmapComponent
+	Components []match.ComponentDef
 	Stability  string     // "" (default/active), "stub", or "deferred"
 	Access     Access     // reachability for the reference capture account
 	URL        string     // Representative URL for this view
@@ -109,7 +109,7 @@ func (v *View) SnapBasename() string {
 // ComponentsForURL returns the merged flat component list for a given URL:
 // view components first, then global components that don't collide on name.
 // Returns GlobalComponents only if no view matches.
-func (c *Corpus) ComponentsForURL(pageURL string) []match.SightmapComponent {
+func (c *Corpus) ComponentsForURL(pageURL string) []match.ComponentDef {
 	v := c.ViewForURL(pageURL)
 	if v == nil {
 		return c.GlobalComponents
@@ -121,7 +121,7 @@ func (c *Corpus) ComponentsForURL(pageURL string) []match.SightmapComponent {
 		viewNames[vc.Name] = true
 	}
 
-	result := make([]match.SightmapComponent, 0, len(v.Components)+len(c.GlobalComponents))
+	result := make([]match.ComponentDef, 0, len(v.Components)+len(c.GlobalComponents))
 	result = append(result, v.Components...)
 	for _, gc := range c.GlobalComponents {
 		if !viewNames[gc.Name] {
@@ -137,10 +137,10 @@ func (c *Corpus) ComponentsForURL(pageURL string) []match.SightmapComponent {
 // (global list first, then views in corpus order) wins. Route is not considered — this is
 // for a whole-corpus consumer (a linter, a coverage report, an upload payload builder), not
 // a per-page match; use ComponentsForURL for a single page's applicable list.
-func (c *Corpus) AllComponents() []match.SightmapComponent {
+func (c *Corpus) AllComponents() []match.ComponentDef {
 	seen := make(map[string]bool)
-	var out []match.SightmapComponent
-	add := func(comp match.SightmapComponent) {
+	var out []match.ComponentDef
+	add := func(comp match.ComponentDef) {
 		if comp.Name == "" || seen[comp.Name] {
 			return
 		}

--- a/go/sightmap/corpus_match.go
+++ b/go/sightmap/corpus_match.go
@@ -17,7 +17,7 @@ func Load(dir string) (*Corpus, error) {
 // queryCacheEntry stores the merged component list and compiled queries for one
 // page URL. Compilation is the expensive step, so it is cached per URL.
 type queryCacheEntry struct {
-	components []match.SightmapComponent
+	components []match.ComponentDef
 	queries    []match.MatchQuery
 }
 
@@ -42,19 +42,19 @@ func (c *Corpus) entryFor(pageURL string) *queryCacheEntry {
 // selects the matching view (falling back to global components), compiles the
 // queries if not already cached, then runs the NFA matcher over root. Returns
 // nil when root is nil or no queries apply.
-func (c *Corpus) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.SightmapMatch {
+func (c *Corpus) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.ComponentMatch {
 	entry := c.entryFor(pageURL)
 	if root == nil || len(entry.queries) == 0 {
 		return nil
 	}
 
 	// Map component name → definition for memory resolution at match time.
-	byName := make(map[string]*match.SightmapComponent, len(entry.components))
+	byName := make(map[string]*match.ComponentDef, len(entry.components))
 	for i := range entry.components {
 		byName[entry.components[i].Name] = &entry.components[i]
 	}
 
-	result := make(map[*comps.ComponentNode]*match.SightmapMatch)
+	result := make(map[*comps.ComponentNode]*match.ComponentMatch)
 	match.FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *match.MatchQuery) {
 		if _, already := result[node]; already {
 			return // first-match-wins
@@ -63,7 +63,7 @@ func (c *Corpus) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps
 		if def := byName[q.Name]; def != nil {
 			memory = def.Memory
 		}
-		result[node] = &match.SightmapMatch{Name: q.Name, Memory: memory}
+		result[node] = &match.ComponentMatch{Name: q.Name, Memory: memory}
 	})
 	return result
 }
@@ -71,7 +71,7 @@ func (c *Corpus) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps
 // Components returns the merged component list for pageURL (view components plus
 // non-colliding globals) — the compiled inventory, for tools that need the
 // definitions without a tree to match against. Cached alongside the queries.
-func (c *Corpus) Components(pageURL string) []match.SightmapComponent {
+func (c *Corpus) Components(pageURL string) []match.ComponentDef {
 	return c.entryFor(pageURL).components
 }
 

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -275,17 +275,17 @@ views:
 
 func TestRouteMatching(t *testing.T) {
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.SightmapComponent{
+		GlobalComponents: []match.ComponentDef{
 			{Name: "Global", Selectors: []string{"body"}},
 		},
 		Views: []sightmap.View{
-			{Name: "B", Route: "/b/**", Components: []match.SightmapComponent{
+			{Name: "B", Route: "/b/**", Components: []match.ComponentDef{
 				{Name: "BComp", Selectors: []string{".b"}},
 			}},
-			{Name: "Product", Route: "/product/*", Components: []match.SightmapComponent{
+			{Name: "Product", Route: "/product/*", Components: []match.ComponentDef{
 				{Name: "PComp", Selectors: []string{".p"}},
 			}},
-			{Name: "Home", Route: "/", Components: []match.SightmapComponent{
+			{Name: "Home", Route: "/", Components: []match.ComponentDef{
 				{Name: "HomeComp", Selectors: []string{".home"}},
 			}},
 		},
@@ -329,15 +329,15 @@ func TestRouteMatching(t *testing.T) {
 // ---- 5. ComponentsForURL merging --------------------------------------------
 
 func TestComponentsForURL(t *testing.T) {
-	globalA := match.SightmapComponent{Name: "A", Selectors: []string{"#a"}}
-	globalB := match.SightmapComponent{Name: "B", Selectors: []string{"#b-global"}}
-	viewB := match.SightmapComponent{Name: "B", Selectors: []string{"#b-view"}}
-	viewC := match.SightmapComponent{Name: "C", Selectors: []string{"#c"}}
+	globalA := match.ComponentDef{Name: "A", Selectors: []string{"#a"}}
+	globalB := match.ComponentDef{Name: "B", Selectors: []string{"#b-global"}}
+	viewB := match.ComponentDef{Name: "B", Selectors: []string{"#b-view"}}
+	viewC := match.ComponentDef{Name: "C", Selectors: []string{"#c"}}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.SightmapComponent{globalA, globalB},
+		GlobalComponents: []match.ComponentDef{globalA, globalB},
 		Views: []sightmap.View{
-			{Route: "/page", Components: []match.SightmapComponent{viewB, viewC}},
+			{Route: "/page", Components: []match.ComponentDef{viewB, viewC}},
 		},
 	}
 
@@ -373,15 +373,15 @@ func TestComponentsForURL(t *testing.T) {
 }
 
 func TestAllComponents(t *testing.T) {
-	globalA := match.SightmapComponent{Name: "A", Selectors: []string{"#a"}}
-	globalB := match.SightmapComponent{Name: "B", Selectors: []string{"#b-global"}}
-	viewB := match.SightmapComponent{Name: "B", Selectors: []string{"#b-view"}} // $ref-expanded global, same name
-	viewC := match.SightmapComponent{Name: "C", Selectors: []string{"#c"}}
+	globalA := match.ComponentDef{Name: "A", Selectors: []string{"#a"}}
+	globalB := match.ComponentDef{Name: "B", Selectors: []string{"#b-global"}}
+	viewB := match.ComponentDef{Name: "B", Selectors: []string{"#b-view"}} // $ref-expanded global, same name
+	viewC := match.ComponentDef{Name: "C", Selectors: []string{"#c"}}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.SightmapComponent{globalA, globalB},
+		GlobalComponents: []match.ComponentDef{globalA, globalB},
 		Views: []sightmap.View{
-			{Route: "/page", Components: []match.SightmapComponent{viewB, viewC}},
+			{Route: "/page", Components: []match.ComponentDef{viewB, viewC}},
 		},
 	}
 
@@ -425,7 +425,7 @@ func TestMatchTreeEndToEnd(t *testing.T) {
 	}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.SightmapComponent{
+		GlobalComponents: []match.ComponentDef{
 			{Name: "SearchForm", Selectors: []string{"form#search-form"}, Memory: []string{"search form hint"}},
 			{Name: "SearchInput", Selectors: []string{"form#search-form input"}},
 			{Name: "SearchSubmit", Selectors: []string{"form#search-form button"}, Memory: []string{"submit hint"}},
@@ -477,7 +477,7 @@ func TestConcurrentSafety(t *testing.T) {
 	}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.SightmapComponent{
+		GlobalComponents: []match.ComponentDef{
 			{Name: "Button", Selectors: []string{"button"}},
 		},
 	}
@@ -519,15 +519,15 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-func indexByName(cs []match.SightmapComponent) map[string]match.SightmapComponent {
-	m := make(map[string]match.SightmapComponent, len(cs))
+func indexByName(cs []match.ComponentDef) map[string]match.ComponentDef {
+	m := make(map[string]match.ComponentDef, len(cs))
 	for _, c := range cs {
 		m[c.Name] = c
 	}
 	return m
 }
 
-func compNames(cs []match.SightmapComponent) []string {
+func compNames(cs []match.ComponentDef) []string {
 	names := make([]string, len(cs))
 	for i, c := range cs {
 		names[i] = c.Name
@@ -547,7 +547,7 @@ func equalSels(a, b []string) bool {
 	return true
 }
 
-func hasComp(cs []match.SightmapComponent, name string) bool {
+func hasComp(cs []match.ComponentDef, name string) bool {
 	for _, c := range cs {
 		if c.Name == name {
 			return true
@@ -556,7 +556,7 @@ func hasComp(cs []match.SightmapComponent, name string) bool {
 	return false
 }
 
-func mustGet(t *testing.T, m map[string]match.SightmapComponent, name string) match.SightmapComponent {
+func mustGet(t *testing.T, m map[string]match.ComponentDef, name string) match.ComponentDef {
 	t.Helper()
 	c, ok := m[name]
 	if !ok {
@@ -573,10 +573,10 @@ func mustGet(t *testing.T, m map[string]match.SightmapComponent, name string) ma
 
 func mustMatch(
 	t *testing.T,
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	node *comps.ComponentNode,
 	label string,
-) *match.SightmapMatch {
+) *match.ComponentMatch {
 	t.Helper()
 	m, ok := matches[node]
 	if !ok {

--- a/go/sightmap/lint.go
+++ b/go/sightmap/lint.go
@@ -243,14 +243,14 @@ func LintWithCounts(c *Corpus, counts map[string]int) []LintWarning {
 
 // lintComponent runs per-component lint rules.
 // global controls whether rules restricted to global scope are applied.
-func lintComponent(comp match.SightmapComponent, global bool) []LintWarning {
+func lintComponent(comp match.ComponentDef, global bool) []LintWarning {
 	return lintComponentWithCounts(comp, global, nil)
 }
 
 // lintComponentWithCounts is the full implementation of per-component lint
 // rules. counts (component name → match count) optionally augments the
 // multi-instance-no-property warning; pass nil to use static heuristics only.
-func lintComponentWithCounts(comp match.SightmapComponent, global bool, counts map[string]int) []LintWarning {
+func lintComponentWithCounts(comp match.ComponentDef, global bool, counts map[string]int) []LintWarning {
 	var warnings []LintWarning
 
 	name := comp.Name

--- a/go/sightmap/lint_snapshot_test.go
+++ b/go/sightmap/lint_snapshot_test.go
@@ -12,7 +12,7 @@ import (
 // multi-instance-no-property under static heuristics:
 // a bare generic button with a utility class and no properties.
 func broadComp(name string) *sightmap.Corpus {
-	return corpusFrom([]match.SightmapComponent{
+	return corpusFrom([]match.ComponentDef{
 		{Name: name, Selectors: []string{"button.btn-action"}},
 	}, nil)
 }
@@ -112,7 +112,7 @@ func TestLintSnapshot_EmptyCountsMap(t *testing.T) {
 // TestLintSnapshot_UnrelatedComponentsUnaffected verifies that a count entry
 // for one component does not affect warnings for a different component.
 func TestLintSnapshot_UnrelatedComponentsUnaffected(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "AddToCart", Selectors: []string{"button.btn-action"}},
 		{Name: "QuickBuy", Selectors: []string{"button.btn-quick"}},
 	}, nil)

--- a/go/sightmap/lint_stability_test.go
+++ b/go/sightmap/lint_stability_test.go
@@ -10,12 +10,12 @@ import (
 func TestLint_StabilitySuppression(t *testing.T) {
 	tests := []struct {
 		name     string
-		comp     match.SightmapComponent
+		comp     match.ComponentDef
 		wantRule string // empty if no warning expected
 	}{
 		{
 			name: "unstable suppresses multi-instance warning",
-			comp: match.SightmapComponent{
+			comp: match.ComponentDef{
 				Name:       "VolatileButton",
 				Selectors:  []string{"button.css-module-xyz"},
 				Stability:  "unstable",
@@ -25,7 +25,7 @@ func TestLint_StabilitySuppression(t *testing.T) {
 		},
 		{
 			name: "uncertain does not suppress multi-instance warning",
-			comp: match.SightmapComponent{
+			comp: match.ComponentDef{
 				Name:       "UncertainButton",
 				Selectors:  []string{"button.btn-primary"},
 				Stability:  "uncertain",
@@ -35,7 +35,7 @@ func TestLint_StabilitySuppression(t *testing.T) {
 		},
 		{
 			name: "no stability triggers warning",
-			comp: match.SightmapComponent{
+			comp: match.ComponentDef{
 				Name:       "GenericButton",
 				Selectors:  []string{"button.btn"},
 				Stability:  "",
@@ -47,7 +47,7 @@ func TestLint_StabilitySuppression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := corpusFrom([]match.SightmapComponent{tt.comp}, nil)
+			c := corpusFrom([]match.ComponentDef{tt.comp}, nil)
 			warnings := sightmap.Lint(c)
 
 			foundRule := ""

--- a/go/sightmap/lint_test.go
+++ b/go/sightmap/lint_test.go
@@ -19,7 +19,7 @@ func hasRule(ws []sightmap.LintWarning, rule string) bool {
 
 func TestLint_NameCase(t *testing.T) {
 	// ".nav-link" is a class selector — won't trigger broad-tag-selector.
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "navLink", Selectors: []string{".nav-link"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -32,7 +32,7 @@ func TestLint_NameCase(t *testing.T) {
 }
 
 func TestLint_BroadTagGlobal(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "Button", Selectors: []string{"button"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -52,7 +52,7 @@ func TestLint_BroadTagInView(t *testing.T) {
 		{
 			Name:  "Page",
 			Route: "/",
-			Components: []match.SightmapComponent{
+			Components: []match.ComponentDef{
 				{Name: "Button", Selectors: []string{"button"}},
 			},
 		},
@@ -70,7 +70,7 @@ func TestLint_BroadTagInView(t *testing.T) {
 }
 
 func TestLint_IdHash(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "Root", Selectors: []string{"div#root-12345"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -83,7 +83,7 @@ func TestLint_IdHash(t *testing.T) {
 }
 
 func TestLint_DeepNesting(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "Input", Selectors: []string{"form div section input"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -100,7 +100,7 @@ func TestLint_CommaInSelector(t *testing.T) {
 	// "a, button" contains a comma that should have been split by the loader.
 	// It also fails ParseSightmapSelector (comma stops the parse), so we
 	// expect both a "validation" warning and a "comma-in-selector" warning.
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "Link", Selectors: []string{"a, button"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -112,7 +112,7 @@ func TestLint_CommaInSelector(t *testing.T) {
 func TestLint_ValidationErrors(t *testing.T) {
 	// A component with an empty name is a validation error; Lint should
 	// surface it as a warning with Rule="validation".
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "", Selectors: []string{"div"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -127,7 +127,7 @@ func TestLint_ValidationErrors(t *testing.T) {
 func TestLint_DeepNestingFalsePositive(t *testing.T) {
 	// Selector with spaces INSIDE a quoted attribute value should NOT trigger
 	// deep-nesting — only 2 real selector parts (1 combinator).
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "LogoLink", Selectors: []string{`#nav-header a[aria-label="Link to homepage"]`}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -140,7 +140,7 @@ func TestLint_DeepNestingFalsePositive(t *testing.T) {
 
 func TestLint_CommaInIsNotFlagged(t *testing.T) {
 	// A comma inside :is() is valid and must NOT trigger comma-in-selector.
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "Content", Selectors: []string{`:is([data-testid="main"], [data-testid="top"]) [data-testid="foo"]`}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -154,12 +154,12 @@ func TestLint_CommaInIsNotFlagged(t *testing.T) {
 func TestLint_NoDuplicateWarnings(t *testing.T) {
 	// A global component referenced via $ref in two views should produce
 	// at most one warning per (rule, component, selector) triplet.
-	global := match.SightmapComponent{Name: "Button", Selectors: []string{"button"}}
+	global := match.ComponentDef{Name: "Button", Selectors: []string{"button"}}
 	c := corpusFrom(
-		[]match.SightmapComponent{global},
+		[]match.ComponentDef{global},
 		[]sightmap.View{
-			{Name: "PageA", Route: "/a", Components: []match.SightmapComponent{global}},
-			{Name: "PageB", Route: "/b", Components: []match.SightmapComponent{global}},
+			{Name: "PageA", Route: "/a", Components: []match.ComponentDef{global}},
+			{Name: "PageB", Route: "/b", Components: []match.ComponentDef{global}},
 		},
 	)
 	warnings := sightmap.Lint(c)
@@ -178,14 +178,14 @@ func TestLint_NoDuplicateWarnings(t *testing.T) {
 func TestLint_Clean(t *testing.T) {
 	// nav.navbar: has a class, so it is not a bare-tag selector.
 	c := corpusFrom(
-		[]match.SightmapComponent{
+		[]match.ComponentDef{
 			{Name: "NavBar", Selectors: []string{"nav.navbar"}},
 		},
 		[]sightmap.View{
 			{
 				Name:       "Home",
 				Route:      "/",
-				Components: []match.SightmapComponent{{Name: "Hero", Selectors: []string{".hero"}}},
+				Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 			},
 		},
 	)
@@ -198,7 +198,7 @@ func TestLint_Clean(t *testing.T) {
 // TestLint_MultiInstanceNoProperty tests that components with broad selectors
 // and no properties trigger the multi-instance-no-property warning.
 func TestLint_MultiInstanceNoProperty_Button(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "DeleteButton", Selectors: []string{"button.btn-danger"}},
 	}, nil)
 
@@ -216,7 +216,7 @@ func TestLint_MultiInstanceNoProperty_Button(t *testing.T) {
 }
 
 func TestLint_MultiInstanceNoProperty_Card(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "ProductCard", Selectors: []string{`[data-component="product-card"]`}},
 	}, nil)
 
@@ -228,7 +228,7 @@ func TestLint_MultiInstanceNoProperty_Card(t *testing.T) {
 }
 
 func TestLint_MultiInstanceWithProperties_NoWarn(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{
 			Name:      "ProductCard",
 			Selectors: []string{`[data-component="product-card"]`},
@@ -249,7 +249,7 @@ func TestLint_MultiInstanceWithProperties_NoWarn(t *testing.T) {
 
 func TestLint_Singleton_NoWarn(t *testing.T) {
 	// Singletons like SiteHeader should not warn even without properties
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "SiteHeader", Selectors: []string{`header[role="banner"]`}},
 	}, nil)
 
@@ -264,7 +264,7 @@ func TestLint_Singleton_NoWarn(t *testing.T) {
 
 func TestLint_UniqueSelector_NoWarn(t *testing.T) {
 	// Selectors with data-testid are unique and should not warn
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "SubmitButton", Selectors: []string{`button[data-testid="submit-form"]`}},
 	}, nil)
 
@@ -290,7 +290,7 @@ func TestLint_ColonAnchoredDataComponent_NoWarn(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := corpusFrom([]match.SightmapComponent{
+			c := corpusFrom([]match.ComponentDef{
 				{Name: "TheComp", Selectors: []string{tc.sel}},
 			}, nil)
 			for _, w := range sightmap.Lint(c) {
@@ -302,7 +302,7 @@ func TestLint_ColonAnchoredDataComponent_NoWarn(t *testing.T) {
 	}
 
 	// ^= prefix is still broad and SHOULD warn
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "TheComp", Selectors: []string{`[data-component^="product-details:ProductDetails"]`}},
 	}, nil)
 	hasWarn := false
@@ -318,7 +318,7 @@ func TestLint_ColonAnchoredDataComponent_NoWarn(t *testing.T) {
 
 func TestLint_UniqueIdSelector_NoWarn(t *testing.T) {
 	// Selectors with #id are unique and should not warn
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "MainNav", Selectors: []string{"#main-navigation"}},
 	}, nil)
 
@@ -341,7 +341,7 @@ func TestLint_ChildRepeatsParent_Warns(t *testing.T) {
 		{
 			Name:  "DashboardPage",
 			Route: "/dashboard",
-			Components: []match.SightmapComponent{
+			Components: []match.ComponentDef{
 				{
 					Name:        "FreelancerCard",
 					Selectors:   []string{".dashboard .dashboard .freelancer-card"},
@@ -362,7 +362,7 @@ func TestLint_ChildRepeatsParent_MultiClass(t *testing.T) {
 		{
 			Name:  "Page",
 			Route: "/",
-			Components: []match.SightmapComponent{
+			Components: []match.ComponentDef{
 				{
 					Name:        "HelpLink",
 					Selectors:   []string{".help-card .help-card a"},
@@ -383,7 +383,7 @@ func TestLint_ChildRepeatsParent_NoWarnCorrect(t *testing.T) {
 		{
 			Name:  "DashboardPage",
 			Route: "/dashboard",
-			Components: []match.SightmapComponent{
+			Components: []match.ComponentDef{
 				{
 					Name:        "FreelancerCard",
 					Selectors:   []string{".freelancer-card"},
@@ -403,7 +403,7 @@ func TestLint_ChildRepeatsParent_NoWarnCorrect(t *testing.T) {
 func TestLint_ChildRepeatsParent_NoWarnGlobal(t *testing.T) {
 	// A top-level global component with a multi-class selector like ".x .x" must
 	// NOT trigger child-repeats-parent — the rule is gated on ParentChain.
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{
 			Name:        "WeirdGlobal",
 			Selectors:   []string{".nav .nav"},
@@ -424,7 +424,7 @@ func TestLint_ChildComponent_NoWarn(t *testing.T) {
 		{
 			Name:  "ProductPage",
 			Route: "/product",
-			Components: []match.SightmapComponent{
+			Components: []match.ComponentDef{
 				{
 					Name:      "ProductGrid",
 					Selectors: []string{`[data-testid="product-grid"]`},

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -329,9 +329,9 @@ func (ctx *flattenCtx) recordCircular(chain []string) {
 }
 
 // flattenAll flattens a slice of rawComponents into a flat list of
-// SightmapComponents with compound descendant selectors.
-func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.SightmapComponent {
-	var result []match.SightmapComponent
+// ComponentDefs with compound descendant selectors.
+func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.ComponentDef {
+	var result []match.ComponentDef
 	for _, rc := range rcs {
 		result = append(result, flattenOne(rc, nil, ctx, nil, nil)...)
 	}
@@ -342,11 +342,11 @@ func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.SightmapComponent {
 // parentSels holds the already-computed selectors of the nearest ancestor;
 // they are prepended (with a space) to every alternative in this component's
 // selector. parentChain is the slice of ancestor component names (root-first)
-// carried through recursion and stored on each SightmapComponent so the
+// carried through recursion and stored on each ComponentDef so the
 // extension can scope child selectors to their parent's DOM subtree.
 // refStack is the chain of $ref names currently being expanded; it guards
 // against circular references, which would otherwise recurse forever.
-func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentChain []string, refStack []string) []match.SightmapComponent {
+func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentChain []string, refStack []string) []match.ComponentDef {
 	// Expand $ref: replace the placeholder with a deep copy of the named global.
 	if rc.Ref != "" {
 		for _, prev := range refStack {
@@ -414,7 +414,7 @@ func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentCha
 		}
 	}
 
-	result := []match.SightmapComponent{{
+	result := []match.ComponentDef{{
 		Name:        rc.Name,
 		Selectors:   mySels,
 		Source:      rc.Source,

--- a/go/sightmap/loader_stability_test.go
+++ b/go/sightmap/loader_stability_test.go
@@ -12,7 +12,7 @@ func TestLoader_ComponentStability(t *testing.T) {
 	tests := []struct {
 		name     string
 		yaml     string
-		wantComp match.SightmapComponent
+		wantComp match.ComponentDef
 	}{
 		{
 			name: "omitted defaults to empty",
@@ -21,7 +21,7 @@ components:
   - name: TestComponent
     selector: button
 `,
-			wantComp: match.SightmapComponent{
+			wantComp: match.ComponentDef{
 				Name:       "TestComponent",
 				Selectors:  []string{"button"},
 				Stability:  "",
@@ -36,7 +36,7 @@ components:
     selector: '[data-testid="sheet"]'
     stability: uncertain
 `,
-			wantComp: match.SightmapComponent{
+			wantComp: match.ComponentDef{
 				Name:       "UncertainComponent",
 				Selectors:  []string{`[data-testid="sheet"]`},
 				Stability:  "uncertain",
@@ -53,7 +53,7 @@ components:
     memory:
       - Selector uses volatile CSS module class names
 `,
-			wantComp: match.SightmapComponent{
+			wantComp: match.ComponentDef{
 				Name:      "UnstableComponent",
 				Selectors: []string{".css-module-class"},
 				Stability: "unstable",
@@ -108,7 +108,7 @@ views:
 				Name:       "HomePage",
 				Route:      "/",
 				Stability:  "",
-				Components: []match.SightmapComponent{},
+				Components: []match.ComponentDef{},
 			},
 		},
 		{
@@ -124,7 +124,7 @@ views:
 				Name:       "LegacyCMSPage",
 				Route:      "/legacy/**",
 				Stability:  "stub",
-				Components: []match.SightmapComponent{},
+				Components: []match.ComponentDef{},
 			},
 		},
 		{
@@ -140,7 +140,7 @@ views:
 				Name:       "AdminPanel",
 				Route:      "/admin/**",
 				Stability:  "deferred",
-				Components: []match.SightmapComponent{},
+				Components: []match.ComponentDef{},
 			},
 		},
 	}
@@ -200,7 +200,7 @@ components:
 	}
 
 	// Find each component by name
-	var parent, child *match.SightmapComponent
+	var parent, child *match.ComponentDef
 	for i := range corpus.GlobalComponents {
 		if corpus.GlobalComponents[i].Name == "ParentComponent" {
 			parent = &corpus.GlobalComponents[i]

--- a/go/sightmap/loader_test.go
+++ b/go/sightmap/loader_test.go
@@ -33,7 +33,7 @@ func TestLoadDir_FileLevelMemoryAccumulatesInPathOrder(t *testing.T) {
 	}
 }
 
-// A component's tags: and source: flatten onto its match.SightmapComponent, and neither
+// A component's tags: and source: flatten onto its match.ComponentDef, and neither
 // is inherited by children — matching Memory/Properties/Stability's existing convention
 // (only the selector prefix cascades to a child).
 func TestLoadDir_ComponentTagsAndSourceDoNotInheritToChildren(t *testing.T) {

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -212,7 +212,7 @@ func viewLocList(vs []View) string {
 // seen maps component name → sorted-selector fingerprint so that the same
 // name is only flagged as a duplicate when the selector set is also identical.
 // Same name + different selectors = intentional child-component reuse = OK.
-func validateComponent(comp match.SightmapComponent, seen map[string]string) []ValidationError {
+func validateComponent(comp match.ComponentDef, seen map[string]string) []ValidationError {
 	var errs []ValidationError
 
 	// empty-name: no further named checks are possible.

--- a/go/sightmap/validate_test.go
+++ b/go/sightmap/validate_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 // corpusFrom is a convenience constructor for test corpora.
-func corpusFrom(globals []match.SightmapComponent, views []sightmap.View) *sightmap.Corpus {
+func corpusFrom(globals []match.ComponentDef, views []sightmap.View) *sightmap.Corpus {
 	return &sightmap.Corpus{GlobalComponents: globals, Views: views}
 }
 
 func TestValidate_EmptyName(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "", Selectors: []string{"div"}},
 	}, nil)
 	errs := sightmap.Validate(c)
@@ -26,7 +26,7 @@ func TestValidate_EmptyName(t *testing.T) {
 }
 
 func TestValidate_NoSelector(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "NavBar", Selectors: nil},
 	}, nil)
 	errs := sightmap.Validate(c)
@@ -39,7 +39,7 @@ func TestValidate_NoSelector(t *testing.T) {
 }
 
 func TestValidate_BadSelector(t *testing.T) {
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "NavBar", Selectors: []string{":hover"}},
 	}, nil)
 	errs := sightmap.Validate(c)
@@ -56,7 +56,7 @@ func TestValidate_BadSelector(t *testing.T) {
 
 func TestValidate_DuplicateNameGlobal(t *testing.T) {
 	// True duplicate: same name AND same selector — should error.
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "NavBar", Selectors: []string{"nav"}},
 		{Name: "NavBar", Selectors: []string{"nav"}},
 	}, nil)
@@ -75,7 +75,7 @@ func TestValidate_DuplicateNameInView(t *testing.T) {
 		{
 			Name:  "Home",
 			Route: "/",
-			Components: []match.SightmapComponent{
+			Components: []match.ComponentDef{
 				{Name: "Hero", Selectors: []string{".hero"}},
 				{Name: "Hero", Selectors: []string{".hero"}},
 			},
@@ -93,7 +93,7 @@ func TestValidate_DuplicateNameInView(t *testing.T) {
 func TestValidate_SameNameDifferentSelector_OK(t *testing.T) {
 	// Intentional reuse: same child name under different parent components
 	// (e.g. CarouselScrollButton under multiple carousels). Must NOT error.
-	c := corpusFrom([]match.SightmapComponent{
+	c := corpusFrom([]match.ComponentDef{
 		{Name: "ScrollBtn", Selectors: []string{"[data-testid='carousel-a'] button"}},
 		{Name: "ScrollBtn", Selectors: []string{"[data-testid='carousel-b'] button"}},
 		{Name: "ScrollBtn", Selectors: []string{"[data-testid='carousel-c'] button"}},
@@ -109,7 +109,7 @@ func TestValidate_MissingRoute(t *testing.T) {
 		{
 			Name:       "Home",
 			Route:      "",
-			Components: []match.SightmapComponent{{Name: "Hero", Selectors: []string{".hero"}}},
+			Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 		},
 	})
 	errs := sightmap.Validate(c)
@@ -123,14 +123,14 @@ func TestValidate_MissingRoute(t *testing.T) {
 
 func TestValidate_Clean(t *testing.T) {
 	c := corpusFrom(
-		[]match.SightmapComponent{
+		[]match.ComponentDef{
 			{Name: "NavBar", Selectors: []string{"nav"}},
 		},
 		[]sightmap.View{
 			{
 				Name:       "Home",
 				Route:      "/",
-				Components: []match.SightmapComponent{{Name: "Hero", Selectors: []string{".hero"}}},
+				Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 			},
 		},
 	)

--- a/go/viewset/novelty.go
+++ b/go/viewset/novelty.go
@@ -16,7 +16,7 @@ import (
 // by the offline path (SlotsForCapture) and the live capture path (the capture
 // command) so both gate on the same notion of "new".
 func SlotsFromMatch(
-	matches map[*comps.ComponentNode]*match.SightmapMatch,
+	matches map[*comps.ComponentNode]*match.ComponentMatch,
 	orphans []*comps.ComponentNode,
 	parentMap coverage.ParentMap,
 ) Slots {


### PR DESCRIPTION
## What

Rename the rule-side corpus types to the `Def` convention:

- `match.SightmapComponent` → `match.ComponentDef`
- `match.SightmapMatch` → `match.ComponentMatch`

Pure mechanical rename across the module (~39 files, 217/217); **no behavior change**. Done as a word-boundary rewrite, so the domain `buildSightmapMatchMap*` helpers (which build node→name maps, not the type) are intentionally left alone.

## Why

Establishes the vocabulary for the corpus/runtime data model: a `ComponentDef` *matches* a `Component`; a `RequestDef` classifies a `Request`. Per-entity result names (`ComponentMatch`) avoid a generic `match.Match` stutter, and we deliberately don't pre-create `ViewMatch`/`RequestMatch` (view/request matching return their defs directly). Observed log/exception types stay out of `match` — that Family A/B boundary keeps the package bounded.

## Breaking

`match.SightmapComponent` / `SightmapMatch` are exported and consumed downstream (FullStory/lidar). Consumers pick this up on their next dep bump.

## Notes

- NOTE: changeset intentionally omitted pending a semver-bump call (breaking rename).
- First of a two-PR stack; the corpus-wire PR builds on this branch.

Green locally: `go build ./...`, `go vet ./...`, full `go test ./...`.
