### PR TITLE
sightmap: model requests + RequestsForURL, JSON wire tags, stable pre-order

### DIFF
--- a/.changeset/matcher-engine.md
+++ b/.changeset/matcher-engine.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+**Breaking:** split the matching engine out of `Corpus`. `Corpus` is now pure, serializable data; build a `Matcher` with `NewMatcher(corpus)` to match a live component tree. `Corpus.MatchTree` and `Corpus.Components` move to `Matcher.MatchTree` / `Matcher.Components` (the per-URL compiled-query cache now lives on the `Matcher`). Read-only corpus queries (`ComponentsForURL`, `ViewForURL`, `RequestsForURL`, `GlobalComponentNames`) stay on `Corpus`.

--- a/.changeset/requests-wire.md
+++ b/.changeset/requests-wire.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Model `requests:` in the corpus and make it serializable to a stable wire form:
+
+- Global and view-scoped API request definitions (`RequestDef` / `Payload` / `Field`) are now parsed into the corpus — previously `requests:` was known to the schema but silently dropped.
+- New `Corpus.RequestsForURL(url, method)` returns every request whose route glob (and optional method) matches the observed request — "all matches apply", per the spec. Reuses the existing route matcher (`:param`, trailing-slash, `**`).
+- `Corpus`, `View`, and `RequestDef` now carry JSON tags, so a corpus serializes to a lean wire form (`memory` / `globals` / `views` / `requests`); authoring-only `View` fields (`url` / `access` / `snapshots` / `sourceFile` / `stability`) are excluded. The flattened list is emitted in a stable pre-order (lexical file order, then declaration-order depth-first), locked by a test, so the wire form is reproducible.

--- a/go/ARCHITECTURE.md
+++ b/go/ARCHITECTURE.md
@@ -75,9 +75,11 @@ These are the composed entrypoints external callers reach for. Signatures are
 indicative, not final.
 
 ```go
-// Load + compile a corpus once; share it for a whole run.
-corpus, err := sightmap.Load(dir)          // *sightmap.Corpus
-corpus.MatchTree(root, url)                 // matches
+// Load a corpus once (pure, serializable data); build a Matcher (the engine
+// that compiles + caches queries) to run it against live trees.
+corpus, err := sightmap.Load(dir)          // *sightmap.Corpus (pure data)
+m := sightmap.NewMatcher(corpus)           // *sightmap.Matcher (compiled-query cache)
+m.MatchTree(root, url)                      // matches
 corpus.ViewForURL(url)                      // *View
 
 // Attach to an already-running browser (own the lifecycle yourself),

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -167,7 +167,7 @@ func boundsByComponent(
 	if err != nil {
 		return nil, fmt.Errorf("bounds: load corpus: %w", err)
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("bounds: no sightmap components matched the current page (%s)", pageURL)
 	}

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -68,12 +68,13 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+	m := sightmap.NewMatcher(corpus)
+	matches := m.MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
 			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
 	}
-	components := sightmap.NewMatcher(corpus).Components(pageURL)
+	components := m.Components(pageURL)
 
 	// Extract properties only for nodes whose component name appears in the
 	// query — keeps the live extraction small and avoids the per-snapshot node

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -68,12 +68,12 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
 			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
 	}
-	components := corpus.Components(pageURL)
+	components := sightmap.NewMatcher(corpus).Components(pageURL)
 
 	// Extract properties only for nodes whose component name appears in the
 	// query — keeps the live extraction small and avoids the per-snapshot node

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -138,7 +138,7 @@ func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.Compone
 		return nil, nil, "", false
 	}
 	route = viewset.RouteOf(snapPath)
-	matches = corpus.MatchTree(root, route)
+	matches = sightmap.NewMatcher(corpus).MatchTree(root, route)
 	return root, matches, route, true
 }
 

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -54,7 +54,8 @@ func runGap(args []string) error {
 	if loadErr != nil {
 		return loadErr
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+	m := sightmap.NewMatcher(corpus)
+	matches := m.MatchTree(root, pageURL)
 
 	// ── Build parent map ─────────────────────────────────────────────────────
 	parentMap := coverage.BuildParentMap(root)
@@ -73,7 +74,7 @@ func runGap(args []string) error {
 		if scopeNode == nil {
 			// Component not found or not matched on page
 			// Check if it exists in the corpus
-			components := sightmap.NewMatcher(corpus).Components(pageURL)
+			components := m.Components(pageURL)
 			found := false
 			for _, comp := range components {
 				if comp.Name == *scopeFlag {

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runGap(args []string) error {
@@ -53,7 +54,7 @@ func runGap(args []string) error {
 	if loadErr != nil {
 		return loadErr
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 
 	// ── Build parent map ─────────────────────────────────────────────────────
 	parentMap := coverage.BuildParentMap(root)
@@ -72,7 +73,7 @@ func runGap(args []string) error {
 		if scopeNode == nil {
 			// Component not found or not matched on page
 			// Check if it exists in the corpus
-			components := corpus.Components(pageURL)
+			components := sightmap.NewMatcher(corpus).Components(pageURL)
 			found := false
 			for _, comp := range components {
 				if comp.Name == *scopeFlag {

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/render"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runInspect(args []string) error {
@@ -62,7 +63,7 @@ func runInspect(args []string) error {
 	if corpus, cErr := lf.loadCorpus(); cErr != nil {
 		fmt.Fprintf(os.Stderr, "inspect: load corpus: %v (continuing without component names)\n", cErr)
 	} else if corpus != nil {
-		inspectMatches = corpus.MatchTree(root, pageURL)
+		inspectMatches = sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	}
 
 	// ── Render ────────────────────────────────────────────────────────────────

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -357,7 +357,7 @@ func loadCompAnnotations(dir string) []compAnnotation {
 	if err != nil {
 		return nil
 	}
-	components := corpus.Components("")
+	components := sightmap.NewMatcher(corpus).Components("")
 
 	annotations := make([]compAnnotation, 0, len(components))
 	for _, comp := range components {

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -49,7 +49,7 @@ func runSuggest(args []string) error {
 		if corpus, cErr := lf.loadCorpus(); cErr != nil {
 			fmt.Fprintf(os.Stderr, "suggest: load corpus: %v (continuing without --exclude-known filtering)\n", cErr)
 		} else if corpus != nil {
-			for _, c := range corpus.Components("") {
+			for _, c := range sightmap.NewMatcher(corpus).Components("") {
 				knownSelectors = append(knownSelectors, c.Selectors...)
 			}
 		}
@@ -242,7 +242,7 @@ func buildSightmapMatchMapForSuggest(
 	if err != nil {
 		return nil, fmt.Errorf("load corpus (fallback): %v", err)
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	m := make(map[string]string)
 	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {
@@ -268,7 +268,7 @@ func buildSightmapMatchMap(treeFile string, smDir string, pageURL string) (map[s
 	if err != nil {
 		return nil, fmt.Errorf("load corpus: %v", err)
 	}
-	matches := corpus.MatchTree(&root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(&root, pageURL)
 	m := make(map[string]string)
 	comps.Walk(&root, func(n *comps.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -75,9 +75,10 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 	}
 	res.CorpusApplied = true
 
-	res.Matches = corpus.MatchTree(root, url)
+	m := sightmap.NewMatcher(corpus)
+	res.Matches = m.MatchTree(root, url)
 	res.View = corpus.ViewForURL(url)
-	res.Components = corpus.Components(url)
+	res.Components = m.Components(url)
 	res.GlobalNames = corpus.GlobalComponentNames()
 	res.Coverage = coverage.Score(root, res.Matches, coverage.Options{VisibleOnly: opts.VisibleOnly})
 

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -4,15 +4,14 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/sightmap/sightmap/go/match"
 )
 
-// Corpus is the parsed, $ref-expanded, hierarchy-flattened sightmap data, plus a
-// lazily-populated cache of compiled match queries. It is the single operational
-// handle callers hold: load one with Load (or a Loader), then MatchTree a live
-// component tree against it. Safe for concurrent use.
+// Corpus is the parsed, $ref-expanded, hierarchy-flattened sightmap data. It is
+// pure, serializable data: load one with Load (or a Loader) and read it with the
+// ComponentsForURL / ViewForURL / RequestsForURL queries. To match a live
+// component tree against it, build a Matcher with NewMatcher(corpus).
 type Corpus struct {
 	// Memory holds file-level memory entries from every corpus file, in
 	// file-path order. The spec activates these per source file ("applies
@@ -40,10 +39,6 @@ type Corpus struct {
 	// no longer visible in the flattened data (e.g. a circular $ref chain, which
 	// is expanded away). Validate surfaces these alongside its own checks.
 	loadDiagnostics []ValidationError
-
-	// mu guards the lazily-built compiled-query cache.
-	mu    sync.Mutex
-	cache map[string]*queryCacheEntry
 }
 
 // Access describes the reachability of a view for the reference capture account.

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -20,15 +20,21 @@ type Corpus struct {
 	// which flattened component or view came from which file, so entries
 	// are concatenated corpus-wide instead of scoped to their file's
 	// definitions. Tighten this if per-file activation is ever needed.
-	Memory []string
+	Memory []string `json:"memory,omitempty"`
 
 	// GlobalComponents is the flat list of globally-defined components
 	// (from components.yaml), with children already flattened.
-	GlobalComponents []match.ComponentDef
+	GlobalComponents []match.ComponentDef `json:"globals,omitempty"`
 
 	// Views contains per-route component lists, with $refs expanded and
 	// children flattened.
-	Views []View
+	Views []View `json:"views,omitempty"`
+
+	// Requests is the flat list of globally-defined API request definitions
+	// (from a file-root `requests:` list). View-scoped requests live on each
+	// View instead. Match against an observed network request via
+	// RequestsForURL.
+	Requests []RequestDef `json:"requests,omitempty"`
 
 	// loadDiagnostics holds structural problems detected while loading that are
 	// no longer visible in the flattened data (e.g. a circular $ref chain, which
@@ -56,15 +62,18 @@ func (a Access) IsOpen() bool {
 
 // View is a per-URL-pattern view definition from the sightmap corpus.
 type View struct {
-	Name       string
-	Route      string
-	Memory     []string
-	Components []match.ComponentDef
-	Stability  string     // "" (default/active), "stub", or "deferred"
-	Access     Access     // reachability for the reference capture account
-	URL        string     // Representative URL for this view
-	Snapshots  []Snapshot // List of snapshots for this view
-	SourceFile string     // Source YAML filename (without .yaml extension)
+	Name       string               `json:"name"`
+	Route      string               `json:"route,omitempty"`
+	Memory     []string             `json:"memory,omitempty"`
+	Components []match.ComponentDef `json:"components,omitempty"`
+	Requests   []RequestDef         `json:"requests,omitempty"` // view-scoped API request definitions
+
+	// Authoring/tooling fields — kept out of the serialized wire form.
+	Stability  string     `json:"-"` // "" (default/active), "stub", or "deferred"
+	Access     Access     `json:"-"` // reachability for the reference capture account
+	URL        string     `json:"-"` // Representative URL for this view
+	Snapshots  []Snapshot `json:"-"` // List of snapshots for this view
+	SourceFile string     `json:"-"` // Source YAML filename (without .yaml extension)
 }
 
 // ViewByName returns a pointer to the first View with the given name, or nil.

--- a/go/sightmap/corpus_match.go
+++ b/go/sightmap/corpus_match.go
@@ -1,78 +1,13 @@
 package sightmap
 
-import (
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
-)
-
-// Load parses the .sightmap/ corpus at dir and returns an operational Corpus.
-// It is shorthand for DirLoader(dir).Load(). Callers hold the returned *Corpus
-// for the life of a run; reloading is just another Load (the old Corpus is
-// discarded). For a long-lived process that needs to pick up on-disk edits, call
-// Load again and swap the handle.
+// Load parses the .sightmap/ corpus at dir and returns the parsed Corpus. It is
+// shorthand for DirLoader(dir).Load(). Callers hold the returned *Corpus for the
+// life of a run; reloading is just another Load (the old Corpus is discarded).
+// For a long-lived process that needs to pick up on-disk edits, call Load again
+// and swap the handle. To match a live tree against the corpus, wrap it in a
+// Matcher (see NewMatcher).
 func Load(dir string) (*Corpus, error) {
 	return DirLoader(dir).Load()
-}
-
-// queryCacheEntry stores the merged component list and compiled queries for one
-// page URL. Compilation is the expensive step, so it is cached per URL.
-type queryCacheEntry struct {
-	components []match.ComponentDef
-	queries    []match.MatchQuery
-}
-
-// entryFor returns the cached (or freshly compiled) queries for pageURL.
-func (c *Corpus) entryFor(pageURL string) *queryCacheEntry {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.cache == nil {
-		c.cache = make(map[string]*queryCacheEntry)
-	}
-	if e, ok := c.cache[pageURL]; ok {
-		return e
-	}
-	compList := c.ComponentsForURL(pageURL)
-	queries, _ := match.ParseQueries(compList)
-	e := &queryCacheEntry{components: compList, queries: queries}
-	c.cache[pageURL] = e
-	return e
-}
-
-// MatchTree applies the corpus to a pre-built component tree for pageURL: it
-// selects the matching view (falling back to global components), compiles the
-// queries if not already cached, then runs the NFA matcher over root. Returns
-// nil when root is nil or no queries apply.
-func (c *Corpus) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.ComponentMatch {
-	entry := c.entryFor(pageURL)
-	if root == nil || len(entry.queries) == 0 {
-		return nil
-	}
-
-	// Map component name → definition for memory resolution at match time.
-	byName := make(map[string]*match.ComponentDef, len(entry.components))
-	for i := range entry.components {
-		byName[entry.components[i].Name] = &entry.components[i]
-	}
-
-	result := make(map[*comps.ComponentNode]*match.ComponentMatch)
-	match.FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *match.MatchQuery) {
-		if _, already := result[node]; already {
-			return // first-match-wins
-		}
-		var memory []string
-		if def := byName[q.Name]; def != nil {
-			memory = def.Memory
-		}
-		result[node] = &match.ComponentMatch{Name: q.Name, Memory: memory}
-	})
-	return result
-}
-
-// Components returns the merged component list for pageURL (view components plus
-// non-colliding globals) — the compiled inventory, for tools that need the
-// definitions without a tree to match against. Cached alongside the queries.
-func (c *Corpus) Components(pageURL string) []match.ComponentDef {
-	return c.entryFor(pageURL).components
 }
 
 // GlobalComponentNames returns the set of component names declared at corpus

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -432,7 +432,7 @@ func TestMatchTreeEndToEnd(t *testing.T) {
 		},
 	}
 
-	matches := corpus.MatchTree(root, "https://example.com/search")
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, "https://example.com/search")
 
 	// formNode → SearchForm
 	m := mustMatch(t, matches, formNode, "formNode")
@@ -492,7 +492,7 @@ func TestConcurrentSafety(t *testing.T) {
 			defer wg.Done()
 			// Use a few distinct URLs to exercise the multi-key cache path.
 			url := fmt.Sprintf("https://example.com/page/%d", i%5)
-			matches := corpus.MatchTree(root, url)
+			matches := sightmap.NewMatcher(corpus).MatchTree(root, url)
 			if _, ok := matches[buttonNode]; !ok {
 				errs[i] = fmt.Errorf("goroutine %d: button not matched", i)
 			}

--- a/go/sightmap/corpus_wire_test.go
+++ b/go/sightmap/corpus_wire_test.go
@@ -1,0 +1,71 @@
+package sightmap_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// A Corpus serializes to the lean wire form (memory/globals/views/requests),
+// with view authoring fields (url/access/snapshots/sourceFile/stability)
+// excluded, and round-trips its wire fields without loss.
+func TestCorpusWireRoundTrip(t *testing.T) {
+	orig := &sightmap.Corpus{
+		Memory:           []string{"file note"},
+		GlobalComponents: []match.ComponentDef{{Name: "Nav", Selectors: []string{"nav"}}},
+		Requests: []sightmap.RequestDef{
+			{Name: "Search", Route: "/api/search", Method: "POST",
+				Request: &sightmap.Payload{Fields: []sightmap.Field{{Name: "q", Type: "string"}}}},
+		},
+		Views: []sightmap.View{{
+			Name:       "Home",
+			Route:      "/",
+			Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
+			Requests:   []sightmap.RequestDef{{Name: "Ping", Route: "/api/ping"}},
+			// Authoring fields that must NOT appear on the wire:
+			URL:        "https://x.test/",
+			SourceFile: "homefile",
+			Stability:  "stub",
+			Access:     sightmap.Access{Status: "blocked", Reason: "admin"},
+			Snapshots:  []sightmap.Snapshot{{Name: "base"}},
+		}},
+	}
+
+	blob, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(blob)
+
+	for _, want := range []string{`"memory"`, `"globals"`, `"views"`, `"requests"`, `"route":"/api/search"`, `"method":"POST"`, `"fields"`} {
+		if !strings.Contains(js, want) {
+			t.Errorf("wire JSON missing %s:\n%s", want, js)
+		}
+	}
+	for _, bad := range []string{`"url"`, `"sourceFile"`, `"access"`, `"snapshots"`, `"stability"`, `"reason"`, `"blocked"`, `"homefile"`} {
+		if strings.Contains(js, bad) {
+			t.Errorf("wire JSON should not contain authoring token %s:\n%s", bad, js)
+		}
+	}
+
+	var back sightmap.Corpus
+	if err := json.Unmarshal(blob, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.Views) != 1 || back.Views[0].Name != "Home" || back.Views[0].Route != "/" {
+		t.Fatalf("view did not round-trip: %+v", back.Views)
+	}
+	if len(back.Views[0].Requests) != 1 || back.Views[0].Requests[0].Name != "Ping" {
+		t.Errorf("view requests did not round-trip: %+v", back.Views[0].Requests)
+	}
+	if len(back.Requests) != 1 || back.Requests[0].Method != "POST" ||
+		back.Requests[0].Request == nil || len(back.Requests[0].Request.Fields) != 1 {
+		t.Errorf("global request did not round-trip: %+v", back.Requests)
+	}
+	if back.Views[0].URL != "" || back.Views[0].Stability != "" || back.Views[0].SourceFile != "" {
+		t.Errorf("authoring fields should be empty after a wire round-trip: %+v", back.Views[0])
+	}
+}

--- a/go/sightmap/flatten_order_test.go
+++ b/go/sightmap/flatten_order_test.go
@@ -1,0 +1,54 @@
+package sightmap
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// The flattened corpus is emitted in a stable, deterministic order: corpus files
+// in lexical path order, components in declaration order, and each parent
+// immediately before its flattened children (pre-order). That ordering underpins
+// a reproducible wire form, so lock it against accidental reordering.
+func TestLoadDir_DeterministicPreOrder(t *testing.T) {
+	dir := t.TempDir()
+	// Lexical filenames: a-comps sorts before b-comps.
+	if err := os.WriteFile(filepath.Join(dir, "a-comps.yaml"), []byte(`
+version: 1
+components:
+  - name: Alpha
+    selector: .a
+    children:
+      - name: AlphaOne
+        selector: .a1
+      - name: AlphaTwo
+        selector: .a2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b-comps.yaml"), []byte(`
+version: 1
+components:
+  - name: Beta
+    selector: .b
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	corpus, err := loadDir(dir)
+	if err != nil {
+		t.Fatalf("loadDir: %v", err)
+	}
+
+	var got []string
+	for _, c := range corpus.GlobalComponents {
+		got = append(got, c.Name)
+	}
+	// a-comps before b-comps (file order); Alpha before its children (pre-order);
+	// AlphaOne before AlphaTwo (declaration order).
+	want := []string{"Alpha", "AlphaOne", "AlphaTwo", "Beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("flatten order = %v, want %v", got, want)
+	}
+}

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -44,6 +44,7 @@ type rawFile struct {
 	Memory     []string       `yaml:"memory"`
 	Components []rawComponent `yaml:"components"`
 	Views      []rawView      `yaml:"views"`
+	Requests   []rawRequest   `yaml:"requests"`
 	URL        string         `yaml:"url"`
 	Snapshots  []rawSnapshot  `yaml:"snapshots"`
 }
@@ -61,6 +62,7 @@ type rawView struct {
 	Description string         `yaml:"description"`
 	Memory      []string       `yaml:"memory"`
 	Components  []rawComponent `yaml:"components"`
+	Requests    []rawRequest   `yaml:"requests"`
 	Stability   string         `yaml:"stability"`
 	Access      *rawAccess     `yaml:"access"`
 }
@@ -74,6 +76,28 @@ type rawProperty struct {
 	Name      string `yaml:"name"`
 	Extract   string `yaml:"extract"`
 	Transform string `yaml:"transform"`
+}
+
+type rawRequest struct {
+	Name        string      `yaml:"name"`
+	Route       string      `yaml:"route"`
+	Method      string      `yaml:"method"`
+	Description string      `yaml:"description"`
+	Source      string      `yaml:"source"`
+	Request     *rawPayload `yaml:"request"`
+	Response    *rawPayload `yaml:"response"`
+	Headers     []string    `yaml:"headers"`
+	Memory      []string    `yaml:"memory"`
+}
+
+type rawPayload struct {
+	Fields []rawField `yaml:"fields"`
+}
+
+type rawField struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
 }
 
 type rawComponent struct {
@@ -139,6 +163,7 @@ func loadDir(path string) (*Corpus, error) {
 
 	var memory []string
 	var globalRaws []rawComponent
+	var globalRequestRaws []rawRequest
 	type viewFileWithPath struct {
 		rf   rawFile
 		path string
@@ -163,6 +188,9 @@ func loadDir(path string) (*Corpus, error) {
 		memory = append(memory, rf.Memory...)
 		if len(rf.Components) > 0 {
 			globalRaws = append(globalRaws, rf.Components...)
+		}
+		if len(rf.Requests) > 0 {
+			globalRequestRaws = append(globalRequestRaws, rf.Requests...)
 		}
 		if len(rf.Views) > 0 {
 			viewFiles = append(viewFiles, viewFileWithPath{rf: rf, path: p})
@@ -189,6 +217,10 @@ func loadDir(path string) (*Corpus, error) {
 
 	// Flatten global components (hierarchy → compound descendant selectors).
 	globalComps := flattenAll(globalRaws, ctx)
+
+	// Global (file-root) request definitions. Requests are flat — no $ref,
+	// hierarchy, or selector cascade — so they convert directly.
+	globalRequests := toRequestDefs(globalRequestRaws, ctx)
 
 	// Build views, expanding $refs and flattening each view's component list.
 	var views []View
@@ -223,6 +255,7 @@ func loadDir(path string) (*Corpus, error) {
 				Route:      rv.Route,
 				Memory:     rv.Memory,
 				Components: flattenAll(rv.Components, ctx),
+				Requests:   toRequestDefs(rv.Requests, ctx),
 				Stability:  rv.Stability,
 				Access:     access,
 				URL:        viewURL,
@@ -236,6 +269,7 @@ func loadDir(path string) (*Corpus, error) {
 		Memory:           memory,
 		GlobalComponents: globalComps,
 		Views:            views,
+		Requests:         globalRequests,
 		loadDiagnostics:  append(ctx.diagnostics, fieldDiags...),
 	}, nil
 }
@@ -252,6 +286,59 @@ func rawPropsToMatch(rps []rawProperty) []match.Property {
 		ps[i] = match.Property{Name: rp.Name, Extract: rp.Extract, Transform: rp.Transform}
 	}
 	return ps
+}
+
+// toRequestDefs converts raw request definitions into RequestDefs. A request
+// missing its required name or route is dropped with a diagnostic (the schema
+// requires both), mirroring how flattenOne surfaces missing component fields.
+func toRequestDefs(rrs []rawRequest, ctx *flattenCtx) []RequestDef {
+	if len(rrs) == 0 {
+		return nil
+	}
+	out := make([]RequestDef, 0, len(rrs))
+	for _, rr := range rrs {
+		if rr.Name == "" {
+			ctx.addDiag("request-missing-name\x00"+rr.Route, ValidationError{
+				Code:     "missing-name",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("request is missing a name (route %q)", rr.Route),
+			})
+			continue
+		}
+		if rr.Route == "" {
+			ctx.addDiag("request-missing-route\x00"+rr.Name, ValidationError{
+				Component: rr.Name,
+				Code:      "missing-route",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("request %q is missing a route", rr.Name),
+			})
+			continue
+		}
+		out = append(out, RequestDef{
+			Name:        rr.Name,
+			Route:       rr.Route,
+			Method:      rr.Method,
+			Description: rr.Description,
+			Source:      rr.Source,
+			Request:     toPayload(rr.Request),
+			Response:    toPayload(rr.Response),
+			Headers:     rr.Headers,
+			Memory:      rr.Memory,
+		})
+	}
+	return out
+}
+
+// toPayload converts an optional raw payload (request or response body shape).
+func toPayload(rp *rawPayload) *Payload {
+	if rp == nil {
+		return nil
+	}
+	p := &Payload{}
+	for _, rf := range rp.Fields {
+		p.Fields = append(p.Fields, Field{Name: rf.Name, Type: rf.Type, Description: rf.Description})
+	}
+	return p
 }
 
 // globalNameCollisions warns when two or more top-level global components share a
@@ -329,7 +416,10 @@ func (ctx *flattenCtx) recordCircular(chain []string) {
 }
 
 // flattenAll flattens a slice of rawComponents into a flat list of
-// ComponentDefs with compound descendant selectors.
+// ComponentDefs with compound descendant selectors. Order is deterministic and
+// stable: components in declaration order, each parent immediately before its
+// flattened children (pre-order). Combined with loadDir's lexical file walk this
+// gives the corpus a reproducible flattened/wire ordering.
 func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.ComponentDef {
 	var result []match.ComponentDef
 	for _, rc := range rcs {

--- a/go/sightmap/matcher.go
+++ b/go/sightmap/matcher.go
@@ -1,0 +1,87 @@
+package sightmap
+
+import (
+	"sync"
+
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/match"
+)
+
+// Matcher is the matching engine for a Corpus. It compiles the corpus's
+// component definitions into NFA queries — lazily, cached per page URL — and
+// runs them against a live component tree. The Corpus itself is pure data; build
+// a Matcher when you need to match against it.
+//
+// A Matcher holds a per-URL compiled-query cache and is safe for concurrent use.
+// Create one per Corpus and reuse it so the cache is shared across calls.
+type Matcher struct {
+	corpus *Corpus
+	mu     sync.Mutex
+	cache  map[string]*queryCacheEntry
+}
+
+// NewMatcher returns a Matcher bound to corpus.
+func NewMatcher(corpus *Corpus) *Matcher {
+	return &Matcher{corpus: corpus}
+}
+
+// queryCacheEntry stores the merged component list and compiled queries for one
+// page URL. Compilation is the expensive step, so it is cached per URL.
+type queryCacheEntry struct {
+	components []match.ComponentDef
+	queries    []match.MatchQuery
+}
+
+// entryFor returns the cached (or freshly compiled) queries for pageURL.
+func (m *Matcher) entryFor(pageURL string) *queryCacheEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cache == nil {
+		m.cache = make(map[string]*queryCacheEntry)
+	}
+	if e, ok := m.cache[pageURL]; ok {
+		return e
+	}
+	compList := m.corpus.ComponentsForURL(pageURL)
+	queries, _ := match.ParseQueries(compList)
+	e := &queryCacheEntry{components: compList, queries: queries}
+	m.cache[pageURL] = e
+	return e
+}
+
+// MatchTree applies the corpus to a pre-built component tree for pageURL: it
+// selects the matching view (falling back to global components), compiles the
+// queries if not already cached, then runs the NFA matcher over root. Returns
+// nil when root is nil or no queries apply.
+func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.ComponentMatch {
+	entry := m.entryFor(pageURL)
+	if root == nil || len(entry.queries) == 0 {
+		return nil
+	}
+
+	// Map component name → definition for memory resolution at match time.
+	byName := make(map[string]*match.ComponentDef, len(entry.components))
+	for i := range entry.components {
+		byName[entry.components[i].Name] = &entry.components[i]
+	}
+
+	result := make(map[*comps.ComponentNode]*match.ComponentMatch)
+	match.FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *match.MatchQuery) {
+		if _, already := result[node]; already {
+			return // first-match-wins
+		}
+		var memory []string
+		if def := byName[q.Name]; def != nil {
+			memory = def.Memory
+		}
+		result[node] = &match.ComponentMatch{Name: q.Name, Memory: memory}
+	})
+	return result
+}
+
+// Components returns the merged component list for pageURL (view components plus
+// non-colliding globals) — the compiled inventory, for tools that need the
+// definitions without a tree to match against. Cached alongside the queries.
+func (m *Matcher) Components(pageURL string) []match.ComponentDef {
+	return m.entryFor(pageURL).components
+}

--- a/go/sightmap/request.go
+++ b/go/sightmap/request.go
@@ -1,0 +1,80 @@
+package sightmap
+
+import (
+	"net/url"
+	"strings"
+)
+
+// RequestDef is a named API endpoint from the sightmap corpus. It classifies an
+// observed network request by matching that request's route (a glob pattern)
+// and optional method. Requests may be declared globally (a file-root
+// `requests:` list) or scoped to a view; either way they are matched by their
+// own route against the observed request URL, not by the page's view.
+//
+// Per the spec, request matching is "all matches apply": every RequestDef whose
+// route (and optional method) matches contributes to the enriched output —
+// there is no single winner, unlike view matching (most-specific-wins).
+//
+// It is named on the rule side of the corpus (a RequestDef classifies an
+// observed request) so the Request/Response payload fields read naturally; the
+// sibling View / component definition types are regularized onto the same
+// convention separately.
+type RequestDef struct {
+	Name        string   `json:"name"`
+	Route       string   `json:"route,omitempty"`  // glob pattern; express-style ":param" segments match one segment
+	Method      string   `json:"method,omitempty"` // optional HTTP method filter; "" matches any method
+	Description string   `json:"description,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	Request     *Payload `json:"request,omitempty"`  // expected request payload shape
+	Response    *Payload `json:"response,omitempty"` // expected response payload shape
+	Headers     []string `json:"headers,omitempty"`  // notable header names to highlight
+	Memory      []string `json:"memory,omitempty"`   // request-level memory entries
+}
+
+// Payload is the expected shape of a request or response body. The field list
+// is advisory and not exhaustive — extra fields on the wire are not rejected.
+type Payload struct {
+	Fields []Field `json:"fields,omitempty"`
+}
+
+// Field is one expected field in a Payload. Type and Description are free-text.
+type Field struct {
+	Name        string `json:"name"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// RequestsForURL returns every RequestDef whose route matches requestURL and
+// whose method matches. An empty RequestDef.Method matches any method; an empty
+// method argument matches any RequestDef. requestURL is the observed network
+// request's URL (the API endpoint being called), NOT the page URL; its query
+// string and fragment are ignored and trailing slashes are normalized away.
+//
+// Global requests are returned first (corpus-file order), then view-scoped
+// requests in view-declaration order. All matches apply — there is no winner.
+func (c *Corpus) RequestsForURL(requestURL, method string) []RequestDef {
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return nil
+	}
+	path := normalizeRoutePath(u.Path)
+
+	var out []RequestDef
+	appendMatches := func(defs []RequestDef) {
+		for _, rd := range defs {
+			if !MatchRoute(rd.Route, path) {
+				continue
+			}
+			if rd.Method != "" && method != "" && !strings.EqualFold(rd.Method, method) {
+				continue
+			}
+			out = append(out, rd)
+		}
+	}
+
+	appendMatches(c.Requests)
+	for i := range c.Views {
+		appendMatches(c.Views[i].Requests)
+	}
+	return out
+}

--- a/go/sightmap/request_load_test.go
+++ b/go/sightmap/request_load_test.go
@@ -1,0 +1,72 @@
+package sightmap
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// requests: is parsed at the file root (global) and inside a view (view-scoped),
+// including the nested request/response payload fields and headers.
+func TestLoadDir_Requests(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+version: 1
+requests:
+  - name: SearchFlights
+    route: /api/flights/search
+    method: POST
+    request:
+      fields:
+        - name: origin
+          type: string
+    response:
+      fields:
+        - name: results
+          type: array
+    headers: [x-request-id]
+    memory:
+      - rate limited to 10/min
+views:
+  - name: Admin
+    route: /admin
+    requests:
+      - name: AdminPing
+        route: /api/admin/ping
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	corpus, err := loadDir(dir)
+	if err != nil {
+		t.Fatalf("loadDir: %v", err)
+	}
+
+	if len(corpus.Requests) != 1 {
+		t.Fatalf("want 1 global request, got %d: %+v", len(corpus.Requests), corpus.Requests)
+	}
+	r := corpus.Requests[0]
+	if r.Name != "SearchFlights" || r.Route != "/api/flights/search" || r.Method != "POST" {
+		t.Errorf("global request = %+v, want SearchFlights POST /api/flights/search", r)
+	}
+	if r.Request == nil || len(r.Request.Fields) != 1 ||
+		r.Request.Fields[0].Name != "origin" || r.Request.Fields[0].Type != "string" {
+		t.Errorf("request payload = %+v, want one field origin:string", r.Request)
+	}
+	if r.Response == nil || len(r.Response.Fields) != 1 || r.Response.Fields[0].Name != "results" {
+		t.Errorf("response payload = %+v, want one field results", r.Response)
+	}
+	if !reflect.DeepEqual(r.Headers, []string{"x-request-id"}) {
+		t.Errorf("headers = %v, want [x-request-id]", r.Headers)
+	}
+	if !reflect.DeepEqual(r.Memory, []string{"rate limited to 10/min"}) {
+		t.Errorf("memory = %v, want [rate limited to 10/min]", r.Memory)
+	}
+
+	if len(corpus.Views) != 1 || len(corpus.Views[0].Requests) != 1 ||
+		corpus.Views[0].Requests[0].Name != "AdminPing" {
+		t.Errorf("view requests = %+v, want one AdminPing", corpus.Views)
+	}
+}

--- a/go/sightmap/request_test.go
+++ b/go/sightmap/request_test.go
@@ -1,0 +1,62 @@
+package sightmap_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func reqNames(defs []sightmap.RequestDef) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+	return names
+}
+
+func TestRequestsForURL(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{
+			{Name: "SearchFlights", Route: "/api/flights/search", Method: "POST"},
+			{Name: "AnyFlights", Route: "/api/flights/**"}, // no method -> any method
+			{Name: "GetUser", Route: "/api/users/:id", Method: "GET"},
+		},
+		Views: []sightmap.View{
+			{Name: "Admin", Route: "/admin", Requests: []sightmap.RequestDef{
+				{Name: "AdminPing", Route: "/api/flights/search", Method: "GET"},
+			}},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		url, method string
+		want        []string
+	}{
+		// All matches apply: the exact-route POST and the globstar both fire;
+		// globals come before view-scoped defs.
+		{"exact + globstar", "https://x.test/api/flights/search", "POST", []string{"SearchFlights", "AnyFlights"}},
+		// GET excludes the POST-only def but keeps the method-less globstar and
+		// the view-scoped GET def.
+		{"method filter", "https://x.test/api/flights/search", "GET", []string{"AnyFlights", "AdminPing"}},
+		// An empty method argument matches every route hit regardless of method.
+		{"any method", "https://x.test/api/flights/search", "", []string{"SearchFlights", "AnyFlights", "AdminPing"}},
+		{"param segment", "https://x.test/api/users/42", "GET", []string{"GetUser"}},
+		{"param is one segment only", "https://x.test/api/users/42/orders", "GET", nil},
+		{"query/fragment/trailing-slash ignored", "https://x.test/api/flights/search/?q=1#f", "POST", []string{"SearchFlights", "AnyFlights"}},
+		{"method match is case-insensitive", "https://x.test/api/flights/search", "post", []string{"SearchFlights", "AnyFlights"}},
+		{"no route match", "https://x.test/nope", "GET", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reqNames(corpus.RequestsForURL(tc.url, tc.method))
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("RequestsForURL(%q, %q) = %v, want %v", tc.url, tc.method, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/viewset/novelty.go
+++ b/go/viewset/novelty.go
@@ -45,7 +45,7 @@ func SlotsForCapture(snapPath string, corpus *sightmap.Corpus) (Slots, bool) {
 	if json.Unmarshal(data, &root) != nil {
 		return Slots{}, false
 	}
-	matches := corpus.MatchTree(&root, RouteOf(snapPath))
+	matches := sightmap.NewMatcher(corpus).MatchTree(&root, RouteOf(snapPath))
 	cov := coverage.Score(&root, matches, coverage.Options{VisibleOnly: true})
 	return SlotsFromMatch(matches, cov.Orphans, cov.ParentMap), true
 }


### PR DESCRIPTION
## What

Make the corpus a deterministic, serializable, requests-aware wire form:

- **Model `requests:`** — global + view-scoped `RequestDef`/`Payload`/`Field` on `Corpus`/`View`, parsed by the loader (with `missing-name`/`missing-route` diagnostics for parity with components).
- **`Corpus.RequestsForURL(url, method)`** — route glob + optional method, "all matches apply" per spec; reuses the existing route matcher (`:param`, trailing-slash, `**` all handled).
- **JSON wire tags** on `Corpus`/`View`/`RequestDef` — serializes to the lean wire (`memory`/`globals`/`views`/`requests`); authoring-only `View` fields (`url`/`access`/`snapshots`/`sourceFile`/`stability`) are `json:"-"`.
- **Stable pre-order** — the flatten is already deterministic (lexical file order + DFS declaration order); locked with a regression test so the wire form stays reproducible.

Closes #47 (`requests:` were known to the schema + unknown-field checker but never modeled or consumed).

## Why

Unblocks downstream network-signal enrichment (semantic names on network requests) and gives the corpus a reproducible wire/storage/serve form.

## Notes

- **Stacked on #161** (the `Def` rename) — merge that first; GitHub retargets this base to `main` automatically.
- NOTE: changeset intentionally omitted pending a semver-bump call (additive: new `RequestsForURL` API + wire tags).

Green locally: `go build ./...`, `go vet ./...`, full `go test ./...`.
