### PR TITLE
sightmap: extract Matcher engine (Corpus becomes pure data)

### DIFF
--- a/.changeset/matcher-engine.md
+++ b/.changeset/matcher-engine.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+**Breaking:** split the matching engine out of `Corpus`. `Corpus` is now pure, serializable data; build a `Matcher` with `NewMatcher(corpus)` to match a live component tree. `Corpus.MatchTree` and `Corpus.Components` move to `Matcher.MatchTree` / `Matcher.Components` (the per-URL compiled-query cache now lives on the `Matcher`). Read-only corpus queries (`ComponentsForURL`, `ViewForURL`, `RequestsForURL`, `GlobalComponentNames`) stay on `Corpus`.

--- a/go/ARCHITECTURE.md
+++ b/go/ARCHITECTURE.md
@@ -75,9 +75,11 @@ These are the composed entrypoints external callers reach for. Signatures are
 indicative, not final.
 
 ```go
-// Load + compile a corpus once; share it for a whole run.
-corpus, err := sightmap.Load(dir)          // *sightmap.Corpus
-corpus.MatchTree(root, url)                 // matches
+// Load a corpus once (pure, serializable data); build a Matcher (the engine
+// that compiles + caches queries) to run it against live trees.
+corpus, err := sightmap.Load(dir)          // *sightmap.Corpus (pure data)
+m := sightmap.NewMatcher(corpus)           // *sightmap.Matcher (compiled-query cache)
+m.MatchTree(root, url)                      // matches
 corpus.ViewForURL(url)                      // *View
 
 // Attach to an already-running browser (own the lifecycle yourself),

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -167,7 +167,7 @@ func boundsByComponent(
 	if err != nil {
 		return nil, fmt.Errorf("bounds: load corpus: %w", err)
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("bounds: no sightmap components matched the current page (%s)", pageURL)
 	}

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -68,12 +68,13 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+	m := sightmap.NewMatcher(corpus)
+	matches := m.MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
 			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
 	}
-	components := sightmap.NewMatcher(corpus).Components(pageURL)
+	components := m.Components(pageURL)
 
 	// Extract properties only for nodes whose component name appears in the
 	// query — keeps the live extraction small and avoids the per-snapshot node

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -68,12 +68,12 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
 			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
 	}
-	components := corpus.Components(pageURL)
+	components := sightmap.NewMatcher(corpus).Components(pageURL)
 
 	// Extract properties only for nodes whose component name appears in the
 	// query — keeps the live extraction small and avoids the per-snapshot node

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -138,7 +138,7 @@ func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.Compone
 		return nil, nil, "", false
 	}
 	route = viewset.RouteOf(snapPath)
-	matches = corpus.MatchTree(root, route)
+	matches = sightmap.NewMatcher(corpus).MatchTree(root, route)
 	return root, matches, route, true
 }
 

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -54,7 +54,8 @@ func runGap(args []string) error {
 	if loadErr != nil {
 		return loadErr
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+	m := sightmap.NewMatcher(corpus)
+	matches := m.MatchTree(root, pageURL)
 
 	// ── Build parent map ─────────────────────────────────────────────────────
 	parentMap := coverage.BuildParentMap(root)
@@ -73,7 +74,7 @@ func runGap(args []string) error {
 		if scopeNode == nil {
 			// Component not found or not matched on page
 			// Check if it exists in the corpus
-			components := sightmap.NewMatcher(corpus).Components(pageURL)
+			components := m.Components(pageURL)
 			found := false
 			for _, comp := range components {
 				if comp.Name == *scopeFlag {

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runGap(args []string) error {
@@ -53,7 +54,7 @@ func runGap(args []string) error {
 	if loadErr != nil {
 		return loadErr
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 
 	// ── Build parent map ─────────────────────────────────────────────────────
 	parentMap := coverage.BuildParentMap(root)
@@ -72,7 +73,7 @@ func runGap(args []string) error {
 		if scopeNode == nil {
 			// Component not found or not matched on page
 			// Check if it exists in the corpus
-			components := corpus.Components(pageURL)
+			components := sightmap.NewMatcher(corpus).Components(pageURL)
 			found := false
 			for _, comp := range components {
 				if comp.Name == *scopeFlag {

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/render"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runInspect(args []string) error {
@@ -62,7 +63,7 @@ func runInspect(args []string) error {
 	if corpus, cErr := lf.loadCorpus(); cErr != nil {
 		fmt.Fprintf(os.Stderr, "inspect: load corpus: %v (continuing without component names)\n", cErr)
 	} else if corpus != nil {
-		inspectMatches = corpus.MatchTree(root, pageURL)
+		inspectMatches = sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	}
 
 	// ── Render ────────────────────────────────────────────────────────────────

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -357,7 +357,7 @@ func loadCompAnnotations(dir string) []compAnnotation {
 	if err != nil {
 		return nil
 	}
-	components := corpus.Components("")
+	components := sightmap.NewMatcher(corpus).Components("")
 
 	annotations := make([]compAnnotation, 0, len(components))
 	for _, comp := range components {

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -49,7 +49,7 @@ func runSuggest(args []string) error {
 		if corpus, cErr := lf.loadCorpus(); cErr != nil {
 			fmt.Fprintf(os.Stderr, "suggest: load corpus: %v (continuing without --exclude-known filtering)\n", cErr)
 		} else if corpus != nil {
-			for _, c := range corpus.Components("") {
+			for _, c := range sightmap.NewMatcher(corpus).Components("") {
 				knownSelectors = append(knownSelectors, c.Selectors...)
 			}
 		}
@@ -242,7 +242,7 @@ func buildSightmapMatchMapForSuggest(
 	if err != nil {
 		return nil, fmt.Errorf("load corpus (fallback): %v", err)
 	}
-	matches := corpus.MatchTree(root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
 	m := make(map[string]string)
 	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {
@@ -268,7 +268,7 @@ func buildSightmapMatchMap(treeFile string, smDir string, pageURL string) (map[s
 	if err != nil {
 		return nil, fmt.Errorf("load corpus: %v", err)
 	}
-	matches := corpus.MatchTree(&root, pageURL)
+	matches := sightmap.NewMatcher(corpus).MatchTree(&root, pageURL)
 	m := make(map[string]string)
 	comps.Walk(&root, func(n *comps.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -75,9 +75,10 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 	}
 	res.CorpusApplied = true
 
-	res.Matches = corpus.MatchTree(root, url)
+	m := sightmap.NewMatcher(corpus)
+	res.Matches = m.MatchTree(root, url)
 	res.View = corpus.ViewForURL(url)
-	res.Components = corpus.Components(url)
+	res.Components = m.Components(url)
 	res.GlobalNames = corpus.GlobalComponentNames()
 	res.Coverage = coverage.Score(root, res.Matches, coverage.Options{VisibleOnly: opts.VisibleOnly})
 

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -4,15 +4,14 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/sightmap/sightmap/go/match"
 )
 
-// Corpus is the parsed, $ref-expanded, hierarchy-flattened sightmap data, plus a
-// lazily-populated cache of compiled match queries. It is the single operational
-// handle callers hold: load one with Load (or a Loader), then MatchTree a live
-// component tree against it. Safe for concurrent use.
+// Corpus is the parsed, $ref-expanded, hierarchy-flattened sightmap data. It is
+// pure, serializable data: load one with Load (or a Loader) and read it with the
+// ComponentsForURL / ViewForURL / RequestsForURL queries. To match a live
+// component tree against it, build a Matcher with NewMatcher(corpus).
 type Corpus struct {
 	// Memory holds file-level memory entries from every corpus file, in
 	// file-path order. The spec activates these per source file ("applies
@@ -40,10 +39,6 @@ type Corpus struct {
 	// no longer visible in the flattened data (e.g. a circular $ref chain, which
 	// is expanded away). Validate surfaces these alongside its own checks.
 	loadDiagnostics []ValidationError
-
-	// mu guards the lazily-built compiled-query cache.
-	mu    sync.Mutex
-	cache map[string]*queryCacheEntry
 }
 
 // Access describes the reachability of a view for the reference capture account.

--- a/go/sightmap/corpus_match.go
+++ b/go/sightmap/corpus_match.go
@@ -1,78 +1,13 @@
 package sightmap
 
-import (
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
-)
-
-// Load parses the .sightmap/ corpus at dir and returns an operational Corpus.
-// It is shorthand for DirLoader(dir).Load(). Callers hold the returned *Corpus
-// for the life of a run; reloading is just another Load (the old Corpus is
-// discarded). For a long-lived process that needs to pick up on-disk edits, call
-// Load again and swap the handle.
+// Load parses the .sightmap/ corpus at dir and returns the parsed Corpus. It is
+// shorthand for DirLoader(dir).Load(). Callers hold the returned *Corpus for the
+// life of a run; reloading is just another Load (the old Corpus is discarded).
+// For a long-lived process that needs to pick up on-disk edits, call Load again
+// and swap the handle. To match a live tree against the corpus, wrap it in a
+// Matcher (see NewMatcher).
 func Load(dir string) (*Corpus, error) {
 	return DirLoader(dir).Load()
-}
-
-// queryCacheEntry stores the merged component list and compiled queries for one
-// page URL. Compilation is the expensive step, so it is cached per URL.
-type queryCacheEntry struct {
-	components []match.ComponentDef
-	queries    []match.MatchQuery
-}
-
-// entryFor returns the cached (or freshly compiled) queries for pageURL.
-func (c *Corpus) entryFor(pageURL string) *queryCacheEntry {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.cache == nil {
-		c.cache = make(map[string]*queryCacheEntry)
-	}
-	if e, ok := c.cache[pageURL]; ok {
-		return e
-	}
-	compList := c.ComponentsForURL(pageURL)
-	queries, _ := match.ParseQueries(compList)
-	e := &queryCacheEntry{components: compList, queries: queries}
-	c.cache[pageURL] = e
-	return e
-}
-
-// MatchTree applies the corpus to a pre-built component tree for pageURL: it
-// selects the matching view (falling back to global components), compiles the
-// queries if not already cached, then runs the NFA matcher over root. Returns
-// nil when root is nil or no queries apply.
-func (c *Corpus) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.ComponentMatch {
-	entry := c.entryFor(pageURL)
-	if root == nil || len(entry.queries) == 0 {
-		return nil
-	}
-
-	// Map component name → definition for memory resolution at match time.
-	byName := make(map[string]*match.ComponentDef, len(entry.components))
-	for i := range entry.components {
-		byName[entry.components[i].Name] = &entry.components[i]
-	}
-
-	result := make(map[*comps.ComponentNode]*match.ComponentMatch)
-	match.FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *match.MatchQuery) {
-		if _, already := result[node]; already {
-			return // first-match-wins
-		}
-		var memory []string
-		if def := byName[q.Name]; def != nil {
-			memory = def.Memory
-		}
-		result[node] = &match.ComponentMatch{Name: q.Name, Memory: memory}
-	})
-	return result
-}
-
-// Components returns the merged component list for pageURL (view components plus
-// non-colliding globals) — the compiled inventory, for tools that need the
-// definitions without a tree to match against. Cached alongside the queries.
-func (c *Corpus) Components(pageURL string) []match.ComponentDef {
-	return c.entryFor(pageURL).components
 }
 
 // GlobalComponentNames returns the set of component names declared at corpus

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -432,7 +432,7 @@ func TestMatchTreeEndToEnd(t *testing.T) {
 		},
 	}
 
-	matches := corpus.MatchTree(root, "https://example.com/search")
+	matches := sightmap.NewMatcher(corpus).MatchTree(root, "https://example.com/search")
 
 	// formNode → SearchForm
 	m := mustMatch(t, matches, formNode, "formNode")
@@ -492,7 +492,7 @@ func TestConcurrentSafety(t *testing.T) {
 			defer wg.Done()
 			// Use a few distinct URLs to exercise the multi-key cache path.
 			url := fmt.Sprintf("https://example.com/page/%d", i%5)
-			matches := corpus.MatchTree(root, url)
+			matches := sightmap.NewMatcher(corpus).MatchTree(root, url)
 			if _, ok := matches[buttonNode]; !ok {
 				errs[i] = fmt.Errorf("goroutine %d: button not matched", i)
 			}

--- a/go/sightmap/matcher.go
+++ b/go/sightmap/matcher.go
@@ -1,0 +1,87 @@
+package sightmap
+
+import (
+	"sync"
+
+	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/match"
+)
+
+// Matcher is the matching engine for a Corpus. It compiles the corpus's
+// component definitions into NFA queries — lazily, cached per page URL — and
+// runs them against a live component tree. The Corpus itself is pure data; build
+// a Matcher when you need to match against it.
+//
+// A Matcher holds a per-URL compiled-query cache and is safe for concurrent use.
+// Create one per Corpus and reuse it so the cache is shared across calls.
+type Matcher struct {
+	corpus *Corpus
+	mu     sync.Mutex
+	cache  map[string]*queryCacheEntry
+}
+
+// NewMatcher returns a Matcher bound to corpus.
+func NewMatcher(corpus *Corpus) *Matcher {
+	return &Matcher{corpus: corpus}
+}
+
+// queryCacheEntry stores the merged component list and compiled queries for one
+// page URL. Compilation is the expensive step, so it is cached per URL.
+type queryCacheEntry struct {
+	components []match.ComponentDef
+	queries    []match.MatchQuery
+}
+
+// entryFor returns the cached (or freshly compiled) queries for pageURL.
+func (m *Matcher) entryFor(pageURL string) *queryCacheEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cache == nil {
+		m.cache = make(map[string]*queryCacheEntry)
+	}
+	if e, ok := m.cache[pageURL]; ok {
+		return e
+	}
+	compList := m.corpus.ComponentsForURL(pageURL)
+	queries, _ := match.ParseQueries(compList)
+	e := &queryCacheEntry{components: compList, queries: queries}
+	m.cache[pageURL] = e
+	return e
+}
+
+// MatchTree applies the corpus to a pre-built component tree for pageURL: it
+// selects the matching view (falling back to global components), compiles the
+// queries if not already cached, then runs the NFA matcher over root. Returns
+// nil when root is nil or no queries apply.
+func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.ComponentMatch {
+	entry := m.entryFor(pageURL)
+	if root == nil || len(entry.queries) == 0 {
+		return nil
+	}
+
+	// Map component name → definition for memory resolution at match time.
+	byName := make(map[string]*match.ComponentDef, len(entry.components))
+	for i := range entry.components {
+		byName[entry.components[i].Name] = &entry.components[i]
+	}
+
+	result := make(map[*comps.ComponentNode]*match.ComponentMatch)
+	match.FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *match.MatchQuery) {
+		if _, already := result[node]; already {
+			return // first-match-wins
+		}
+		var memory []string
+		if def := byName[q.Name]; def != nil {
+			memory = def.Memory
+		}
+		result[node] = &match.ComponentMatch{Name: q.Name, Memory: memory}
+	})
+	return result
+}
+
+// Components returns the merged component list for pageURL (view components plus
+// non-colliding globals) — the compiled inventory, for tools that need the
+// definitions without a tree to match against. Cached alongside the queries.
+func (m *Matcher) Components(pageURL string) []match.ComponentDef {
+	return m.entryFor(pageURL).components
+}

--- a/go/viewset/novelty.go
+++ b/go/viewset/novelty.go
@@ -45,7 +45,7 @@ func SlotsForCapture(snapPath string, corpus *sightmap.Corpus) (Slots, bool) {
 	if json.Unmarshal(data, &root) != nil {
 		return Slots{}, false
 	}
-	matches := corpus.MatchTree(&root, RouteOf(snapPath))
+	matches := sightmap.NewMatcher(corpus).MatchTree(&root, RouteOf(snapPath))
 	cov := coverage.Score(&root, matches, coverage.Options{VisibleOnly: true})
 	return SlotsFromMatch(matches, cov.Orphans, cov.ParentMap), true
 }


### PR DESCRIPTION
## What

Extract the matching engine off `Corpus` into a new `Matcher`:

- `Corpus` is now **pure, serializable data** (no cache, no mutex).
- `NewMatcher(corpus)` holds the per-URL compiled-query cache; `MatchTree` / `Components` move onto it.
- Callers build a `Matcher` where they match (one per matching scope, so the cache is shared within a scope). No behavior change.

## Why

Completes the data-vs-engine split: `Corpus` is the wire/storage/serve form, `Matcher` is the engine. Precondition for later serving the `Corpus` wire directly.

## Scope

- **Left alone on purpose:** `cmd/sightmap` serve's `compiledSightmapJSON`. Replacing it changes the wire the browser extension consumes, so that's a separate coordinated client+server change — this PR is engine-only.

## Notes

- **Stacked on #162** (corpus wire format) → #161 (rename). Merge in order; bases retarget automatically.
- NOTE: changeset pending a semver call (breaking: `Corpus.MatchTree`/`Components` now live on `Matcher`).

Green locally: `go build ./...`, `go vet ./...`, full `go test ./...`.
