### PR TITLE
web: clarify two homepage copy lines

### DIFF
--- a/web/src/components/PitchSection.tsx
+++ b/web/src/components/PitchSection.tsx
@@ -4,7 +4,7 @@ export default function PitchSection() {
       <div className="container">
         <div className="section-label">The Problem</div>
         <p className="pitch-body">
-          Every agent working on your app starts from scratch. It greps source, guesses which components render each screen, misses quirks no source file records, and moves on <em>without leaving anything behind</em>.
+          Every agent working on your app starts from scratch. It greps source, guesses which components render each screen, misses the runtime quirks that no source file records, and moves on <em>without leaving anything behind</em>.
         </p>
         <p className="pitch-kicker">
           Agents record what they learn in a sightmap for the next agent to use.

--- a/web/src/components/PitchSection.tsx
+++ b/web/src/components/PitchSection.tsx
@@ -4,7 +4,7 @@ export default function PitchSection() {
       <div className="container">
         <div className="section-label">The Problem</div>
         <p className="pitch-body">
-          Every agent working on your app starts from scratch. It greps source, guesses which components render each screen, misses the runtime quirks that no source file records, and moves on <em>without leaving anything behind</em>.
+          Every agent working on your app starts from scratch. It greps source, guesses which components render each screen, stuggles with runtime quirks, and moves on <em>without leaving anything behind</em>.
         </p>
         <p className="pitch-kicker">
           Agents record what they learn in a sightmap for the next agent to use.

--- a/web/src/components/SpecSection.tsx
+++ b/web/src/components/SpecSection.tsx
@@ -329,7 +329,7 @@ Expected response fields:{'\n'}
         {/* -------------------- DIRECTORY CALLOUT -------------------- */}
         <div className="concept concept--last">
           <div className="concept-header">
-            <h3 className="concept-closer">Organize however.</h3>
+            <h3 className="concept-closer">Organize it your way.</h3>
           </div>
           <p className="concept-intro">
             Sightmap recursively loads and merges every <code>*.yaml</code> and <code>*.yml</code> file under <code>.sightmap/</code>. Split definitions by feature or view, or keep everything in one file.


### PR DESCRIPTION
Address feedback on the marketing site:

- "Organize however." reads as an incomplete sentence. Replaced with
  "Organize it your way."
- "misses quirks no source file records" --> Added the relative pronoun and a qualifier:
  "the runtime quirks"