### PR TITLE
sightmap: split observed Element identity from the SelectorPart pattern

### DIFF
--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -448,8 +448,8 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 	return data, nil
 }
 
-// selectorString builds a simple CSS selector string from a *comps.SelectorPart.
-func selectorString(s *comps.SelectorPart) string {
+// selectorString builds a simple CSS selector string from an observed Element.
+func selectorString(s *comps.Element) string {
 	if s == nil {
 		return ""
 	}
@@ -619,7 +619,7 @@ func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, 
 		// fall through to the bounds/selector paths below.
 	}
 	if node.Bounds == nil {
-		sel := selectorString(node.Selector)
+		sel := selectorString(node.Element)
 		if sel == "" {
 			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
@@ -805,7 +805,7 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 // (e.g. a bare numeric probe ID) degrades silently to the bounds path rather
 // than surfacing as an EvalJSON JS exception.
 func ScrollIntoView(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error {
-	if sel := selectorString(node.Selector); sel != "" {
+	if sel := selectorString(node.Element); sel != "" {
 		script := fmt.Sprintf(
 			`try{const el=document.querySelector(%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,
 			sel,

--- a/go/browser/actions_test.go
+++ b/go/browser/actions_test.go
@@ -346,8 +346,8 @@ func TestClick_NoBounds(t *testing.T) {
 	})
 
 	node := &comps.ComponentNode{
-		Id:       "test",
-		Selector: &comps.SelectorPart{Tag: "button", Id: "submit"},
+		Id:      "test",
+		Element: &comps.Element{Tag: "button", Id: "submit"},
 	}
 	if _, _, err := Click(context.Background(), conn, node); err != nil {
 		t.Fatal(err)

--- a/go/cmd/sightmap/cmd_sel_check.go
+++ b/go/cmd/sightmap/cmd_sel_check.go
@@ -119,9 +119,9 @@ func runSelCheckOut(args []string, out io.Writer) error {
 			name = string([]rune(name)[:50])
 		}
 		fmt.Fprintf(out, "\n  node %s  %-8s%q\n", node.Id, node.Role, name)
-		if node.Selector != nil && len(node.Selector.Attrs) > 0 {
+		if node.Element != nil && len(node.Element.Attrs) > 0 {
 			for _, key := range interestingAttrs {
-				if val, ok := node.Selector.Attrs[key]; ok {
+				if val, ok := node.Element.Attrs[key]; ok {
 					fmt.Fprintf(out, "    %s: %s\n", key, val)
 				}
 			}

--- a/go/cmd/sightmap/cmd_sel_check_test.go
+++ b/go/cmd/sightmap/cmd_sel_check_test.go
@@ -28,7 +28,7 @@ const selCheckFixtureJSON = `{
       "id": "10",
       "role": "none",
       "name": "",
-      "selector": {
+      "element": {
         "tag": "div",
         "attrs": {"data-component": "product-details:ProductDetails:v9.32.1"}
       },
@@ -40,7 +40,7 @@ const selCheckFixtureJSON = `{
       "id": "20",
       "role": "button",
       "name": "Add to Cart",
-      "selector": {
+      "element": {
         "tag": "button",
         "attrs": {"data-testid": "add-to-cart"}
       },
@@ -52,7 +52,7 @@ const selCheckFixtureJSON = `{
       "id": "30",
       "role": "none",
       "name": "",
-      "selector": {
+      "element": {
         "tag": "div",
         "attrs": {"data-component": "product-details:ProductDetails:v9.32.1"}
       },
@@ -63,7 +63,7 @@ const selCheckFixtureJSON = `{
           "id": "31",
           "role": "generic",
           "name": "Product Title Here",
-          "selector": {
+          "element": {
             "tag": "h1",
             "attrs": {"data-component": "product-details:ProductTitle:v1"}
           },

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -377,9 +377,9 @@ func loadCompAnnotations(dir string) []compAnnotation {
 }
 
 // findCompAnnotation returns the name of the first component whose first
-// SelectorPart matches the parent node, or "" if none match.
+// pattern matches the parent node, or "" if none match.
 func findCompAnnotation(annotations []compAnnotation, p parentInfo) string {
-	node := &comps.SelectorPart{
+	node := &comps.Element{
 		Tag:     p.Tag,
 		Id:      p.Id,
 		Classes: p.Cls,

--- a/go/cmd/sightmap/cmd_snapshot_json.go
+++ b/go/cmd/sightmap/cmd_snapshot_json.go
@@ -13,17 +13,17 @@ import (
 // It adds component name, memory notes, and extracted prop values from the
 // sightmap corpus, omitting those fields when the node is unmatched.
 type annotatedNode struct {
-	ID            string              `json:"id"`
-	Role          string              `json:"role"`
-	Name          string              `json:"name,omitempty"`
-	Value         string              `json:"value,omitempty"`
-	Selector      *comps.SelectorPart `json:"selector,omitempty"`
-	Bounds        *comps.Bounds       `json:"bounds,omitempty"`
-	IsVisible     bool                `json:"isVisible"`
-	IsInteractive bool                `json:"isInteractive"`
-	InViewport    bool                `json:"inViewport"`
-	IsIgnored     bool                `json:"isIgnored,omitempty"`
-	NthChild      int                 `json:"nthChild,omitempty"`
+	ID            string         `json:"id"`
+	Role          string         `json:"role"`
+	Name          string         `json:"name,omitempty"`
+	Value         string         `json:"value,omitempty"`
+	Element       *comps.Element `json:"element,omitempty"`
+	Bounds        *comps.Bounds  `json:"bounds,omitempty"`
+	IsVisible     bool           `json:"isVisible"`
+	IsInteractive bool           `json:"isInteractive"`
+	InViewport    bool           `json:"inViewport"`
+	IsIgnored     bool           `json:"isIgnored,omitempty"`
+	NthChild      int            `json:"nthChild,omitempty"`
 	// sightmap-added fields — omitted when the node is unmatched or has no props
 	Component string            `json:"component,omitempty"`
 	Memory    []string          `json:"memory,omitempty"`
@@ -43,7 +43,7 @@ func buildAnnotatedNode(
 		Role:          node.Role,
 		Name:          node.Name,
 		Value:         node.Value,
-		Selector:      node.Selector,
+		Element:       node.Element,
 		Bounds:        node.Bounds,
 		IsVisible:     node.IsVisible,
 		IsInteractive: node.IsInteractive,

--- a/go/comps/component.go
+++ b/go/comps/component.go
@@ -46,6 +46,18 @@ type HasRelative struct {
 	Combinators []string        `json:"combinators"`
 }
 
+// Element is the observed identity of one DOM element (or a synthetic identity
+// for native mobile): the concrete tag/id/classes/attrs a live node presents. It
+// is the SUBJECT that a SelectorPart pattern is matched against. Unlike
+// SelectorPart it carries no matching operators or logical/relational pseudos
+// (AttrOps/Not/Is/Has) — an observed element has facts, not predicates.
+type Element struct {
+	Tag     string            `json:"tag,omitempty"`
+	Id      string            `json:"id,omitempty"`
+	Classes []string          `json:"classes,omitempty"`
+	Attrs   map[string]string `json:"attrs,omitempty"`
+}
+
 // Bounds holds the bounding box of a component in viewport coordinates.
 type Bounds struct {
 	X      int `json:"x"`
@@ -81,9 +93,11 @@ type ComponentNode struct {
 	// Properties holds additional A11Y properties (aria-* and others). (post-merge)
 	Properties map[string]string `json:"properties,omitempty"`
 
-	// Selector is the structured CSS identity of the underlying DOM element. (pre-merge)
-	// Nil for nodes that have no corresponding DOM element (e.g. virtual nodes).
-	Selector *SelectorPart `json:"selector,omitempty"`
+	// Element is the observed identity of the underlying DOM element — its
+	// tag/id/classes/attrs. (pre-merge) Nil for nodes that have no corresponding
+	// DOM element (e.g. virtual nodes). It is matched against SelectorPart
+	// patterns; see package sel.
+	Element *Element `json:"element,omitempty"`
 
 	// Bounds is the viewport bounding box. (pre-merge)
 	Bounds *Bounds `json:"bounds,omitempty"`

--- a/go/comps/component_test.go
+++ b/go/comps/component_test.go
@@ -107,7 +107,7 @@ func TestUnmarshalJSON_FullSnapshot(t *testing.T) {
 		"name": "Submit",
 		"value": "",
 		"properties": {"aria-label": "Submit form"},
-		"selector": {
+		"element": {
 			"tag": "button",
 			"classes": ["btn", "btn-primary"]
 		},
@@ -155,7 +155,7 @@ func TestUnmarshalJSON_FullSnapshot(t *testing.T) {
 func TestUnmarshalJSON_SelectorPart(t *testing.T) {
 	jsonData := `{
 		"role": "button",
-		"selector": {
+		"element": {
 			"tag": "button",
 			"classes": ["btn", "btn-primary"],
 			"attrs": {"data-testid": "submit-btn"}
@@ -167,17 +167,17 @@ func TestUnmarshalJSON_SelectorPart(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	if node.Selector == nil {
+	if node.Element == nil {
 		t.Fatal("Selector = nil, want non-nil")
 	}
-	if node.Selector.Tag != "button" {
-		t.Errorf("Selector.Tag = %q, want %q", node.Selector.Tag, "button")
+	if node.Element.Tag != "button" {
+		t.Errorf("Selector.Tag = %q, want %q", node.Element.Tag, "button")
 	}
-	if len(node.Selector.Classes) != 2 {
-		t.Errorf("len(Selector.Classes) = %d, want 2", len(node.Selector.Classes))
+	if len(node.Element.Classes) != 2 {
+		t.Errorf("len(Selector.Classes) = %d, want 2", len(node.Element.Classes))
 	}
-	if node.Selector.Attrs["data-testid"] != "submit-btn" {
-		t.Errorf("Selector.Attrs[data-testid] = %q, want %q", node.Selector.Attrs["data-testid"], "submit-btn")
+	if node.Element.Attrs["data-testid"] != "submit-btn" {
+		t.Errorf("Selector.Attrs[data-testid] = %q, want %q", node.Element.Attrs["data-testid"], "submit-btn")
 	}
 }
 

--- a/go/conformance/component-schema.md
+++ b/go/conformance/component-schema.md
@@ -73,7 +73,7 @@ Viewport bounding box in pixels.
 | Name | string | `name` | post-merge | Computed accessible name (NOT raw `textContent`). |
 | Value | string | `value` | post-merge | Current value for form controls. |
 | Properties | map[string]string | `properties` | post-merge | Additional A11Y properties (`aria-*` etc.). |
-| Selector | \*SelectorPart | `selector` | pre-merge | Structured CSS identity. Nil for virtual nodes. |
+| Element | \*Element | `element` | pre-merge | Observed element identity (tag/id/classes/attrs). Nil for virtual nodes. Matched against `SelectorPart` patterns. |
 | Bounds | \*Bounds | `bounds` | pre-merge | Viewport bounding box. |
 | IsVisible | bool | `isVisible` | pre-merge | Effective visibility, computed in-browser via `Element.checkVisibility` — false when the element or any ancestor is hidden (`display:none`, `visibility:hidden`, `opacity:0`, `content-visibility`). |
 | IsInteractive | bool | `isInteractive` | pre-merge | Element is actionable per probe heuristics. |
@@ -82,7 +82,21 @@ Viewport bounding box in pixels.
 | NthChild | int | `nthChild` | pre-merge | 1-based position among parent's children. |
 | Children | []\*ComponentNode | `children` | pre-merge | Direct children in document order. |
 
-`omitempty` applies to: `Properties`, `Selector`, `Bounds`, `Children`.
+`omitempty` applies to: `Properties`, `Element`, `Bounds`, `Children`.
+
+### Element
+
+The observed identity of a node's underlying element — the concrete facts a live
+DOM (or native) element presents. It is the *subject* a `SelectorPart` pattern is
+matched against, and carries no matching operators or pseudo-classes
+(`AttrOps`/`Not`/`Is`/`Has`) — those live only on the pattern side.
+
+| Field | Type | JSON key |
+|---|---|---|
+| Tag | string | `tag` |
+| Id | string | `id` |
+| Classes | []string | `classes` |
+| Attrs | map[string]string | `attrs` |
 Boolean fields and `NthChild` are always present (zero value is meaningful).
 
 ### Phase notes
@@ -102,12 +116,11 @@ Boolean fields and `NthChild` are always present (zero value is meaningful).
   "name": "Add to cart",
   "value": "",
   "properties": { "aria-pressed": "false" },
-  "selector": {
+  "element": {
     "tag": "button",
     "id": "add-btn",
     "classes": ["primary", "action"],
-    "attrs": { "data-testid": "add-to-cart" },
-    "not": { "classes": ["disabled"] }
+    "attrs": { "data-testid": "add-to-cart" }
   },
   "bounds": { "x": 10, "y": 20, "width": 120, "height": 40 },
   "isVisible": true,

--- a/go/conformance/fixtures/001-simple-tag/component-tree.json
+++ b/go/conformance/fixtures/001-simple-tag/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "btn1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "button"}
+      "element": {"tag": "button"}
     }
   ]
 }

--- a/go/conformance/fixtures/002-class-selector/component-tree.json
+++ b/go/conformance/fixtures/002-class-selector/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "pc1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "div", "classes": ["product-card"]},
+      "element": {"tag": "div", "classes": ["product-card"]},
       "children": [
         {
           "id": "pc2",
@@ -32,7 +32,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 1,
-          "selector": {"tag": "div"},
+          "element": {"tag": "div"},
           "children": [
             {
               "id": "pc3",
@@ -44,7 +44,7 @@
               "inViewport": true,
               "isIgnored": false,
               "nthChild": 1,
-              "selector": {"tag": "div", "classes": ["product-card", "featured"]}
+              "element": {"tag": "div", "classes": ["product-card", "featured"]}
             }
           ]
         }

--- a/go/conformance/fixtures/003-attribute-selectors/component-tree.json
+++ b/go/conformance/fixtures/003-attribute-selectors/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "inp1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "input", "attrs": {"type": "email"}}
+      "element": {"tag": "input", "attrs": {"type": "email"}}
     },
     {
       "id": "inp2",
@@ -32,7 +32,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": {"tag": "input", "attrs": {"type": "text"}}
+      "element": {"tag": "input", "attrs": {"type": "text"}}
     },
     {
       "id": "a1",
@@ -44,7 +44,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 3,
-      "selector": {"tag": "a", "attrs": {"href": "https://example.com"}}
+      "element": {"tag": "a", "attrs": {"href": "https://example.com"}}
     },
     {
       "id": "d1",
@@ -56,7 +56,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 4,
-      "selector": {"tag": "div", "attrs": {"aria-label": "Search products"}}
+      "element": {"tag": "div", "attrs": {"aria-label": "Search products"}}
     },
     {
       "id": "s1",
@@ -68,7 +68,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 5,
-      "selector": {"tag": "span", "attrs": {"class": "active btn"}}
+      "element": {"tag": "span", "attrs": {"class": "active btn"}}
     },
     {
       "id": "d2",
@@ -80,7 +80,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 6,
-      "selector": {"tag": "div", "attrs": {"lang": "en-US"}}
+      "element": {"tag": "div", "attrs": {"lang": "en-US"}}
     },
     {
       "id": "inp3",
@@ -92,7 +92,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 7,
-      "selector": {
+      "element": {
         "tag": "input",
         "attrs": {"disabled": ""},
         "attrOps": {"disabled": "[]"}

--- a/go/conformance/fixtures/004-descendant/component-tree.json
+++ b/go/conformance/fixtures/004-descendant/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "nav",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "nav", "classes": ["main-nav"]},
+      "element": {"tag": "nav", "classes": ["main-nav"]},
       "children": [
         {
           "id": "ul",
@@ -32,7 +32,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 1,
-          "selector": {"tag": "ul"},
+          "element": {"tag": "ul"},
           "children": [
             {
               "id": "li1",
@@ -44,7 +44,7 @@
               "inViewport": true,
               "isIgnored": false,
               "nthChild": 1,
-              "selector": {"tag": "li"},
+              "element": {"tag": "li"},
               "children": [
                 {
                   "id": "a1",
@@ -56,7 +56,7 @@
                   "inViewport": true,
                   "isIgnored": false,
                   "nthChild": 1,
-                  "selector": {"tag": "a", "classes": ["nav-link"]}
+                  "element": {"tag": "a", "classes": ["nav-link"]}
                 }
               ]
             },
@@ -70,7 +70,7 @@
               "inViewport": true,
               "isIgnored": false,
               "nthChild": 2,
-              "selector": {"tag": "li"},
+              "element": {"tag": "li"},
               "children": [
                 {
                   "id": "a2",
@@ -82,7 +82,7 @@
                   "inViewport": true,
                   "isIgnored": false,
                   "nthChild": 1,
-                  "selector": {"tag": "a", "classes": ["nav-link"]}
+                  "element": {"tag": "a", "classes": ["nav-link"]}
                 }
               ]
             }

--- a/go/conformance/fixtures/005-direct-child/component-tree.json
+++ b/go/conformance/fixtures/005-direct-child/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "form", "classes": ["search"]},
+  "element": {"tag": "form", "classes": ["search"]},
   "children": [
     {
       "id": "inp1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "input", "attrs": {"type": "email"}}
+      "element": {"tag": "input", "attrs": {"type": "email"}}
     },
     {
       "id": "div1",
@@ -32,7 +32,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": {"tag": "div"},
+      "element": {"tag": "div"},
       "children": [
         {
           "id": "inp2",
@@ -44,7 +44,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 1,
-          "selector": {"tag": "input", "attrs": {"type": "email"}}
+          "element": {"tag": "input", "attrs": {"type": "email"}}
         }
       ]
     }

--- a/go/conformance/fixtures/006-not-pseudo/component-tree.json
+++ b/go/conformance/fixtures/006-not-pseudo/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": { "tag": "section" },
+  "element": { "tag": "section" },
   "children": [
     {
       "id": "btn1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": { "tag": "button", "classes": ["primary"] }
+      "element": { "tag": "button", "classes": ["primary"] }
     },
     {
       "id": "btn2",
@@ -32,7 +32,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": { "tag": "button", "classes": ["primary", "disabled"] }
+      "element": { "tag": "button", "classes": ["primary", "disabled"] }
     },
     {
       "id": "d1",
@@ -44,7 +44,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 3,
-      "selector": { "tag": "div" }
+      "element": { "tag": "div" }
     },
     {
       "id": "d2",
@@ -56,7 +56,7 @@
       "inViewport": false,
       "isIgnored": false,
       "nthChild": 4,
-      "selector": {
+      "element": {
         "tag": "div",
         "attrs": { "hidden": "" },
         "attrOps": { "hidden": "[]" }

--- a/go/conformance/fixtures/007-multi-query/component-tree.json
+++ b/go/conformance/fixtures/007-multi-query/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "nav",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "nav"},
+      "element": {"tag": "nav"},
       "children": [
         {
           "id": "a1",
@@ -32,7 +32,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 1,
-          "selector": {"tag": "a", "classes": ["nav-link"]}
+          "element": {"tag": "a", "classes": ["nav-link"]}
         }
       ]
     },
@@ -46,7 +46,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": {"tag": "form", "classes": ["search"]},
+      "element": {"tag": "form", "classes": ["search"]},
       "children": [
         {
           "id": "inp1",
@@ -58,7 +58,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 1,
-          "selector": {"tag": "input", "attrs": {"type": "email"}}
+          "element": {"tag": "input", "attrs": {"type": "email"}}
         }
       ]
     }

--- a/go/conformance/fixtures/008-first-match-wins/component-tree.json
+++ b/go/conformance/fixtures/008-first-match-wins/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "btn",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "button", "classes": ["primary", "submit"]}
+      "element": {"tag": "button", "classes": ["primary", "submit"]}
     }
   ]
 }

--- a/go/conformance/fixtures/009-invisible-included/component-tree.json
+++ b/go/conformance/fixtures/009-invisible-included/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "btn1",
@@ -20,7 +20,7 @@
       "inViewport": false,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "button"}
+      "element": {"tag": "button"}
     },
     {
       "id": "btn2",
@@ -32,7 +32,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": {"tag": "button"}
+      "element": {"tag": "button"}
     }
   ]
 }

--- a/go/conformance/fixtures/010-iframe-prefix/component-tree.json
+++ b/go/conformance/fixtures/010-iframe-prefix/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "1_nav",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "nav"},
+      "element": {"tag": "nav"},
       "children": [
         {
           "id": "1_5",
@@ -32,7 +32,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 1,
-          "selector": {"tag": "a", "classes": ["nav-link"]}
+          "element": {"tag": "a", "classes": ["nav-link"]}
         },
         {
           "id": "1_6",
@@ -44,7 +44,7 @@
           "inViewport": true,
           "isIgnored": false,
           "nthChild": 2,
-          "selector": {"tag": "a", "classes": ["nav-link"]}
+          "element": {"tag": "a", "classes": ["nav-link"]}
         }
       ]
     }

--- a/go/conformance/fixtures/011-native-mobile-synthetic/component-tree.json
+++ b/go/conformance/fixtures/011-native-mobile-synthetic/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "UIView"},
+  "element": {"tag": "UIView"},
   "children": [
     {
       "id": "btn1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "UIButton", "attrs": {"label": "Add to Cart"}}
+      "element": {"tag": "UIButton", "attrs": {"label": "Add to Cart"}}
     },
     {
       "id": "btn2",
@@ -32,7 +32,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": {"tag": "UIButton", "attrs": {"label": "Remove"}}
+      "element": {"tag": "UIButton", "attrs": {"label": "Remove"}}
     }
   ]
 }

--- a/go/conformance/fixtures/012-id-class-field-attrs/component-tree.json
+++ b/go/conformance/fixtures/012-id-class-field-attrs/component-tree.json
@@ -8,7 +8,7 @@
   "inViewport": true,
   "isIgnored": false,
   "nthChild": 1,
-  "selector": {"tag": "div"},
+  "element": {"tag": "div"},
   "children": [
     {
       "id": "row1",
@@ -20,7 +20,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 1,
-      "selector": {"tag": "div", "id": "issue_9f1c"}
+      "element": {"tag": "div", "id": "issue_9f1c"}
     },
     {
       "id": "row2",
@@ -32,7 +32,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 2,
-      "selector": {"tag": "div", "id": "cycle_42"}
+      "element": {"tag": "div", "id": "cycle_42"}
     },
     {
       "id": "icon1",
@@ -44,7 +44,7 @@
       "inViewport": true,
       "isIgnored": false,
       "nthChild": 3,
-      "selector": {"tag": "svg", "classes": ["lucide", "lucide-check"]}
+      "element": {"tag": "svg", "classes": ["lucide", "lucide-check"]}
     }
   ]
 }

--- a/go/coverage/anchor.go
+++ b/go/coverage/anchor.go
@@ -17,8 +17,8 @@ import (
 func NearestDataAttrAncestor(node *comps.ComponentNode, parentMap ParentMap) *comps.ComponentNode {
 	curr := parentMap[node]
 	for curr != nil {
-		if curr.Selector != nil {
-			a := curr.Selector.Attrs
+		if curr.Element != nil {
+			a := curr.Element.Attrs
 			if a["data-testid"] != "" || a["data-component"] != "" {
 				return curr
 			}
@@ -31,21 +31,21 @@ func NearestDataAttrAncestor(node *comps.ComponentNode, parentMap ParentMap) *co
 // DataAttrSelector formats an ancestor node for an "inside:" display line.
 // Prefers data-testid, then data-component, then falls back to tag#id.cls.
 func DataAttrSelector(node *comps.ComponentNode) string {
-	if node.Selector == nil {
+	if node.Element == nil {
 		return node.Role
 	}
-	tag := node.Selector.Tag
+	tag := node.Element.Tag
 	if tag == "" {
 		tag = node.Role
 	}
-	a := node.Selector.Attrs
+	a := node.Element.Attrs
 	if dt := a["data-testid"]; dt != "" {
 		return fmt.Sprintf(`%s[data-testid="%s"]`, tag, dt)
 	}
 	if dc := a["data-component"]; dc != "" {
 		return fmt.Sprintf(`%s[data-component^="%s"]`, tag, dc)
 	}
-	return SelectorString(node.Selector)
+	return SelectorString(node.Element)
 }
 
 // OrphanSlotKey is the cross-capture STRUCTURAL identity of an uncovered
@@ -71,8 +71,8 @@ func OrphanSlotKey(node *comps.ComponentNode, parentMap ParentMap) string {
 // "" when there is no stable ancestor to anchor on.
 func ArrowHint(node *comps.ComponentNode, parentMap ParentMap) string {
 	nodeTag := ""
-	if node.Selector != nil {
-		nodeTag = node.Selector.Tag
+	if node.Element != nil {
+		nodeTag = node.Element.Tag
 	}
 	if nodeTag == "" {
 		nodeTag = node.Role
@@ -82,22 +82,22 @@ func ArrowHint(node *comps.ComponentNode, parentMap ParentMap) string {
 	}
 
 	anc := NearestDataAttrAncestor(node, parentMap)
-	if anc == nil || anc.Selector == nil {
+	if anc == nil || anc.Element == nil {
 		return ""
 	}
-	a := anc.Selector.Attrs
+	a := anc.Element.Attrs
 	if dt := a["data-testid"]; dt != "" {
 		return fmt.Sprintf(`[data-testid="%s"] %s`, dt, nodeTag)
 	}
 	if dc := a["data-component"]; dc != "" {
 		return fmt.Sprintf(`[data-component^="%s"] %s`, dc, nodeTag)
 	}
-	return SelectorString(anc.Selector) + " " + nodeTag
+	return SelectorString(anc.Element) + " " + nodeTag
 }
 
-// SelectorString formats a SelectorPart as tag[#id][.cls1.cls2]. Attributes are
-// not included; they appear only in the trace/anchor displays above.
-func SelectorString(s *comps.SelectorPart) string {
+// SelectorString formats an observed Element as tag[#id][.cls1.cls2]. Attributes
+// are not included; they appear only in the trace/anchor displays above.
+func SelectorString(s *comps.Element) string {
 	if s == nil {
 		return ""
 	}

--- a/go/coverage/gaps_test.go
+++ b/go/coverage/gaps_test.go
@@ -24,7 +24,7 @@ func gapsFixture() (root, banner, image *comps.ComponentNode, parentMap map[*com
 		Id:        "banner",
 		Role:      "generic",
 		IsVisible: true,
-		Selector:  &comps.SelectorPart{Tag: "div", Attrs: map[string]string{"data-testid": "hero"}},
+		Element:   &comps.Element{Tag: "div", Attrs: map[string]string{"data-testid": "hero"}},
 		Children:  []*comps.ComponentNode{image},
 	}
 	root = &comps.ComponentNode{

--- a/go/extract/build.go
+++ b/go/extract/build.go
@@ -101,7 +101,7 @@ func walkDOMNode(
 	}
 
 	// Parse the CSS selector string; fall back to TagName on error.
-	sp := selectorPartFor(pc)
+	el := elementFor(pc)
 
 	// Merge A11Y data.
 	a11yNode := a11yByID[node.BackendNodeID]
@@ -113,7 +113,7 @@ func walkDOMNode(
 		Name:          name,
 		Value:         value,
 		Properties:    props,
-		Selector:      sp,
+		Element:       el,
 		Bounds:        pc.Bounds,
 		IsVisible:     pc.IsVisible,
 		IsInteractive: pc.IsInteractive,
@@ -126,33 +126,34 @@ func walkDOMNode(
 	return compNode, nil
 }
 
-// selectorPartFor parses ProbeComponent.Selector with sel.ParseSightmapSelector.
-// If parsing succeeds it returns the last (most-specific) part. On any error it
-// falls back to a SelectorPart with Tag = strings.ToLower(pc.TagName).
+// elementFor parses ProbeComponent.Selector with sel.ParseSightmapSelector and
+// projects the last (most-specific) compound into an observed Element. On any
+// error it falls back to an Element with Tag = strings.ToLower(pc.TagName).
 //
-// The returned SelectorPart has its Classes duplicated into Attrs["class"] to
-// support attribute selectors like [class*="partial"], [class^="prefix-"], etc.
-func selectorPartFor(pc *ProbeComponent) *comps.SelectorPart {
-	var sp *comps.SelectorPart
+// The returned Element has its Classes duplicated into Attrs["class"] to support
+// attribute selectors like [class*="partial"], [class^="prefix-"], etc.
+func elementFor(pc *ProbeComponent) *comps.Element {
+	var el *comps.Element
 	if pc.Selector != "" {
 		parsed, err := sel.ParseSightmapSelector(pc.Selector)
 		if err == nil && len(parsed.Parts) > 0 {
-			sp = parsed.Parts[len(parsed.Parts)-1]
+			p := parsed.Parts[len(parsed.Parts)-1]
+			el = &comps.Element{Tag: p.Tag, Id: p.Id, Classes: p.Classes, Attrs: p.Attrs}
 		}
 	}
-	if sp == nil {
-		sp = &comps.SelectorPart{Tag: strings.ToLower(pc.TagName)}
+	if el == nil {
+		el = &comps.Element{Tag: strings.ToLower(pc.TagName)}
 	}
 
 	// Duplicate classes into Attrs["class"] for attribute selector support.
-	if len(sp.Classes) > 0 {
-		if sp.Attrs == nil {
-			sp.Attrs = make(map[string]string)
+	if len(el.Classes) > 0 {
+		if el.Attrs == nil {
+			el.Attrs = make(map[string]string)
 		}
-		sp.Attrs["class"] = strings.Join(sp.Classes, " ")
+		el.Attrs["class"] = strings.Join(el.Classes, " ")
 	}
 
-	return sp
+	return el
 }
 
 // mergeA11Y derives role/name/value/ignored/properties from the A11Y tree.

--- a/go/extract/build_test.go
+++ b/go/extract/build_test.go
@@ -64,11 +64,11 @@ func TestMinimalTree(t *testing.T) {
 	if root.Name != "Submit" {
 		t.Errorf("Name = %q, want %q", root.Name, "Submit")
 	}
-	if root.Selector == nil {
+	if root.Element == nil {
 		t.Fatal("Selector is nil")
 	}
-	if root.Selector.Tag != "button" {
-		t.Errorf("Selector.Tag = %q, want %q", root.Selector.Tag, "button")
+	if root.Element.Tag != "button" {
+		t.Errorf("Selector.Tag = %q, want %q", root.Element.Tag, "button")
 	}
 }
 
@@ -250,14 +250,14 @@ func TestSelectorParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildTree error: %v", err)
 	}
-	if root.Selector == nil {
+	if root.Element == nil {
 		t.Fatal("Selector is nil")
 	}
-	if root.Selector.Tag != "button" {
-		t.Errorf("Selector.Tag = %q, want %q", root.Selector.Tag, "button")
+	if root.Element.Tag != "button" {
+		t.Errorf("Selector.Tag = %q, want %q", root.Element.Tag, "button")
 	}
-	if len(root.Selector.Classes) != 1 || root.Selector.Classes[0] != "primary" {
-		t.Errorf("Selector.Classes = %v, want [primary]", root.Selector.Classes)
+	if len(root.Element.Classes) != 1 || root.Element.Classes[0] != "primary" {
+		t.Errorf("Selector.Classes = %v, want [primary]", root.Element.Classes)
 	}
 }
 
@@ -276,15 +276,15 @@ func TestSelectorFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildTree error: %v", err)
 	}
-	if root.Selector == nil {
+	if root.Element == nil {
 		t.Fatal("Selector is nil")
 	}
-	if root.Selector.Tag != "span" {
-		t.Errorf("Selector.Tag = %q, want %q", root.Selector.Tag, "span")
+	if root.Element.Tag != "span" {
+		t.Errorf("Selector.Tag = %q, want %q", root.Element.Tag, "span")
 	}
 	// No classes should be set from the invalid selector.
-	if len(root.Selector.Classes) != 0 {
-		t.Errorf("Selector.Classes = %v, want []", root.Selector.Classes)
+	if len(root.Element.Classes) != 0 {
+		t.Errorf("Selector.Classes = %v, want []", root.Element.Classes)
 	}
 }
 
@@ -303,23 +303,23 @@ func TestClassAttrDuplication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildTree error: %v", err)
 	}
-	if root.Selector == nil {
+	if root.Element == nil {
 		t.Fatal("Selector is nil")
 	}
 
 	// Classes should be parsed
-	if len(root.Selector.Classes) != 2 {
-		t.Errorf("Selector.Classes len = %d, want 2", len(root.Selector.Classes))
+	if len(root.Element.Classes) != 2 {
+		t.Errorf("Selector.Classes len = %d, want 2", len(root.Element.Classes))
 	}
-	if root.Selector.Classes[0] != "btn" || root.Selector.Classes[1] != "btn-primary" {
-		t.Errorf("Selector.Classes = %v, want [btn, btn-primary]", root.Selector.Classes)
+	if root.Element.Classes[0] != "btn" || root.Element.Classes[1] != "btn-primary" {
+		t.Errorf("Selector.Classes = %v, want [btn, btn-primary]", root.Element.Classes)
 	}
 
 	// Classes should also be in Attrs["class"]
-	if root.Selector.Attrs == nil {
+	if root.Element.Attrs == nil {
 		t.Fatal("Selector.Attrs is nil")
 	}
-	classAttr, ok := root.Selector.Attrs["class"]
+	classAttr, ok := root.Element.Attrs["class"]
 	if !ok {
 		t.Fatal("Selector.Attrs[\"class\"] not found")
 	}

--- a/go/match/class_selectors_test.go
+++ b/go/match/class_selectors_test.go
@@ -83,7 +83,7 @@ func TestClassAttrSelectors(t *testing.T) {
 			node := &comps.ComponentNode{
 				Id:   "test-node",
 				Role: "button",
-				Selector: &comps.SelectorPart{
+				Element: &comps.Element{
 					Tag:     "button",
 					Classes: tt.classes,
 					Attrs:   map[string]string{"class": strings.Join(tt.classes, " ")},

--- a/go/match/intermediate_test.go
+++ b/go/match/intermediate_test.go
@@ -19,34 +19,34 @@ import (
 //	      a (link — BreadcrumbLink target)
 func buildBreadcrumbTree() *comps.ComponentNode {
 	return &comps.ComponentNode{
-		Id:       "page",
-		Selector: &comps.SelectorPart{Tag: "div"},
+		Id:      "page",
+		Element: &comps.Element{Tag: "div"},
 		Children: []*comps.ComponentNode{
 			{
 				Id:   "breadcrumb",
 				Role: "navigation",
-				Selector: &comps.SelectorPart{
+				Element: &comps.Element{
 					Tag:   "nav",
 					Attrs: map[string]string{"data-component": "breadcrumbs:Breadcrumbs:v14.0.1"},
 				},
 				Children: []*comps.ComponentNode{
 					{
-						Id:       "list",
-						Role:     "list",
-						Selector: &comps.SelectorPart{Tag: "ol"},
+						Id:      "list",
+						Role:    "list",
+						Element: &comps.Element{Tag: "ol"},
 						Children: []*comps.ComponentNode{
 							{
 								Id:        "listitem",
 								Role:      "listitem",
 								IsIgnored: false,
-								Selector:  &comps.SelectorPart{Tag: "li"},
+								Element:   &comps.Element{Tag: "li"},
 								Children: []*comps.ComponentNode{
 									{
 										Id:            "link",
 										Role:          "link",
 										IsInteractive: true,
 										IsVisible:     true,
-										Selector:      &comps.SelectorPart{Tag: "a"},
+										Element:       &comps.Element{Tag: "a"},
 									},
 								},
 							},

--- a/go/match/matcher_test.go
+++ b/go/match/matcher_test.go
@@ -13,7 +13,7 @@ import (
 func node(id, tag string, classes []string, children ...*comps.ComponentNode) *comps.ComponentNode {
 	return &comps.ComponentNode{
 		Id:        id,
-		Selector:  &comps.SelectorPart{Tag: tag, Classes: classes},
+		Element:   &comps.Element{Tag: tag, Classes: classes},
 		IsVisible: true,
 		Children:  children,
 	}
@@ -22,7 +22,7 @@ func node(id, tag string, classes []string, children ...*comps.ComponentNode) *c
 func nodeAttr(id, tag string, attrs map[string]string, children ...*comps.ComponentNode) *comps.ComponentNode {
 	return &comps.ComponentNode{
 		Id:       id,
-		Selector: &comps.SelectorPart{Tag: tag, Attrs: attrs},
+		Element:  &comps.Element{Tag: tag, Attrs: attrs},
 		Children: children,
 	}
 }
@@ -31,7 +31,7 @@ func nodeInvisible(id, tag string) *comps.ComponentNode {
 	return &comps.ComponentNode{
 		Id:        id,
 		IsVisible: false,
-		Selector:  &comps.SelectorPart{Tag: tag},
+		Element:   &comps.Element{Tag: tag},
 	}
 }
 
@@ -160,14 +160,14 @@ func TestDirectChild_DoesNotMatchGrandchild(t *testing.T) {
 func TestDirectChild_TwoHops(t *testing.T) {
 	// A > B > C chain.
 	root := &comps.ComponentNode{
-		Id:       "r",
-		Selector: &comps.SelectorPart{Tag: "ul"},
+		Id:      "r",
+		Element: &comps.Element{Tag: "ul"},
 		Children: []*comps.ComponentNode{
 			{
-				Id:       "li",
-				Selector: &comps.SelectorPart{Tag: "li"},
+				Id:      "li",
+				Element: &comps.Element{Tag: "li"},
 				Children: []*comps.ComponentNode{
-					{Id: "a", Selector: &comps.SelectorPart{Tag: "a"}},
+					{Id: "a", Element: &comps.Element{Tag: "a"}},
 				},
 			},
 		},
@@ -180,14 +180,14 @@ func TestDirectChild_TwoHops(t *testing.T) {
 func TestDirectChild_NotTwoLevelsDeep(t *testing.T) {
 	// ul > a should NOT match a inside li (two levels deep).
 	root := &comps.ComponentNode{
-		Id:       "r",
-		Selector: &comps.SelectorPart{Tag: "ul"},
+		Id:      "r",
+		Element: &comps.Element{Tag: "ul"},
 		Children: []*comps.ComponentNode{
 			{
-				Id:       "li",
-				Selector: &comps.SelectorPart{Tag: "li"},
+				Id:      "li",
+				Element: &comps.Element{Tag: "li"},
 				Children: []*comps.ComponentNode{
-					{Id: "a", Selector: &comps.SelectorPart{Tag: "a"}},
+					{Id: "a", Element: &comps.Element{Tag: "a"}},
 				},
 			},
 		},
@@ -239,10 +239,10 @@ func TestInvisibleNodesIncluded(t *testing.T) {
 func TestNilSelectorNode_DoesNotMatchSpecificRule(t *testing.T) {
 	// A node with nil Selector cannot satisfy a specific selector rule.
 	root := &comps.ComponentNode{
-		Id:       "root",
-		Selector: nil,
+		Id:      "root",
+		Element: nil,
 		Children: []*comps.ComponentNode{
-			{Id: "child", Selector: &comps.SelectorPart{Tag: "button"}},
+			{Id: "child", Element: &comps.Element{Tag: "button"}},
 		},
 	}
 	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
@@ -286,12 +286,12 @@ func TestFramePrefixedIDs_Traversed(t *testing.T) {
 func TestMobileSyntheticSelector(t *testing.T) {
 	// Native mobile component with synthetic selectors.
 	root := &comps.ComponentNode{
-		Id:       "screen",
-		Selector: &comps.SelectorPart{Tag: "UIView"},
+		Id:      "screen",
+		Element: &comps.Element{Tag: "UIView"},
 		Children: []*comps.ComponentNode{
 			{
 				Id: "btn",
-				Selector: &comps.SelectorPart{
+				Element: &comps.Element{
 					Tag:   "UIButton",
 					Attrs: map[string]string{"label": "Add to Cart"},
 				},

--- a/go/render/inspect.go
+++ b/go/render/inspect.go
@@ -15,10 +15,10 @@ import (
 // every node from the raw component tree and shows full selector details.
 type InspectNode struct {
 	Id            string
-	Tag           string              // element tag (from Selector.Tag or Role fallback)
-	Selector      *comps.SelectorPart // full selector from probe.js
-	Role          string              // AX role (informational)
-	Name          string              // AX accessible name (shown when non-empty)
+	Tag           string         // element tag (from Element.Tag or Role fallback)
+	Element       *comps.Element // observed element identity from probe.js
+	Role          string         // AX role (informational)
+	Name          string         // AX accessible name (shown when non-empty)
 	IsVisible     bool
 	IsIgnored     bool
 	IsInteractive bool
@@ -54,8 +54,8 @@ func Inspect(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.
 
 func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *InspectNode {
 	tag := ""
-	if node.Selector != nil && node.Selector.Tag != "" {
-		tag = node.Selector.Tag
+	if node.Element != nil && node.Element.Tag != "" {
+		tag = node.Element.Tag
 	} else {
 		tag = node.Role
 	}
@@ -63,7 +63,7 @@ func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNod
 	n := &InspectNode{
 		Id:            node.Id,
 		Tag:           tag,
-		Selector:      node.Selector,
+		Element:       node.Element,
 		Role:          node.Role,
 		Name:          node.Name,
 		IsVisible:     node.IsVisible,
@@ -115,7 +115,7 @@ func (n *InspectNode) formatInspectNode(w io.Writer, indent string, depth int, o
 	}
 
 	// Selector display: tag#id[.classes][attrs]
-	line.WriteString(inspectSelectorDisplay(n.Selector, n.Tag, opts))
+	line.WriteString(inspectSelectorDisplay(n.Element, n.Tag, opts))
 
 	// Accessible name (shown when non-empty; helps identify interactive elements)
 	if n.Name != "" {
@@ -149,7 +149,7 @@ func (n *InspectNode) formatInspectNode(w io.Writer, indent string, depth int, o
 // Default (no flags): tag#id [data-*] [aria-*] [role] [type] [href] [name] [for] [action] [src] [placeholder]
 // --classes:          also prepends .class1.class2
 // --selectors:        shows ALL attributes (complete probe.js output)
-func inspectSelectorDisplay(sel *comps.SelectorPart, tag string, opts InspectOpts) string {
+func inspectSelectorDisplay(sel *comps.Element, tag string, opts InspectOpts) string {
 	if sel == nil {
 		return tag
 	}

--- a/go/render/inspect_test.go
+++ b/go/render/inspect_test.go
@@ -88,7 +88,7 @@ func TestFormatInspect_Basic(t *testing.T) {
 func TestFormatInspect_WithSelector(t *testing.T) {
 	n := &comps.ComponentNode{
 		Id: "7", Role: "button", Name: "Add", IsVisible: true, IsInteractive: true,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag:   "button",
 			Id:    "add-btn",
 			Attrs: map[string]string{"data-testid": "add-to-cart"},
@@ -137,7 +137,7 @@ func TestFormatInspect_Ignored(t *testing.T) {
 func TestFormatInspect_Classes(t *testing.T) {
 	n := &comps.ComponentNode{
 		Id: "1", Role: "div", IsVisible: true,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag:     "div",
 			Classes: []string{"btn", "btn-primary"},
 		},
@@ -164,7 +164,7 @@ func TestFormatInspect_Classes(t *testing.T) {
 func TestFormatInspect_Selectors_ShowsAll(t *testing.T) {
 	n := &comps.ComponentNode{
 		Id: "1", Role: "input", IsVisible: true, IsInteractive: true,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag: "input",
 			Attrs: map[string]string{
 				"data-testid": "search",

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -134,8 +134,8 @@ func (c *Comp) formatNode(w io.Writer, indent string, depth int, opts FormatOpts
 	}
 
 	// Selector hint (opt-in) — appended after closing bracket for matched nodes.
-	if opts.Selectors && c.Original != nil && c.Original.Selector != nil {
-		if hint := selectorHint(c.Original.Selector); hint != "" {
+	if opts.Selectors && c.Original != nil && c.Original.Element != nil {
+		if hint := selectorHint(c.Original.Element); hint != "" {
 			fmt.Fprintf(&line, " <%s>", hint)
 		}
 	}
@@ -171,8 +171,8 @@ const (
 
 func decide(node *comps.ComponentNode, matched bool) disposition {
 	// Drop non-semantic embedded resources.
-	if node.Selector != nil {
-		switch strings.ToLower(node.Selector.Tag) {
+	if node.Element != nil {
+		switch strings.ToLower(node.Element.Tag) {
 		case "style", "script", "noscript":
 			return dropNode
 		}
@@ -398,7 +398,7 @@ func truncate(s string, maxRunes int) string {
 
 // selectorHint builds a compact selector string showing only tag, #id,
 // [data-testid], and [data-component] — no CSS classes.
-func selectorHint(sel *comps.SelectorPart) string {
+func selectorHint(sel *comps.Element) string {
 	if sel == nil {
 		return ""
 	}

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -21,7 +21,7 @@ func node(id, role, name string, visible, interactive, ignored bool, children ..
 // nodeWithTag builds a ComponentNode with a Selector tag set.
 func nodeWithTag(id, role, name, tag string, visible, interactive, ignored bool, children ...*comps.ComponentNode) *comps.ComponentNode {
 	n := node(id, role, name, visible, interactive, ignored, children...)
-	n.Selector = &comps.SelectorPart{Tag: tag}
+	n.Element = &comps.Element{Tag: tag}
 	return n
 }
 
@@ -412,7 +412,7 @@ func TestFormat_Nested(t *testing.T) {
 func TestFormat_Selectors(t *testing.T) {
 	n := &comps.ComponentNode{
 		Id: "1", Role: "button", Name: "Add", IsVisible: true, IsInteractive: true,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag:   "button",
 			Attrs: map[string]string{"data-testid": "add-btn"},
 		},
@@ -435,7 +435,7 @@ func TestFormat_Selectors(t *testing.T) {
 func TestFormat_Selectors_NoClasses(t *testing.T) {
 	n := &comps.ComponentNode{
 		Id: "1", Role: "button", Name: "Add", IsVisible: true, IsInteractive: true,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag:     "button",
 			Classes: []string{"btn", "btn-primary"},
 			Id:      "submit-btn",
@@ -456,7 +456,7 @@ func TestFormat_Selectors_NoClasses(t *testing.T) {
 func TestFormat_Selectors_DataComponent(t *testing.T) {
 	n := &comps.ComponentNode{
 		Id: "1", Role: "generic", Name: "Canvas", IsVisible: true, IsInteractive: false,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag:   "div",
 			Attrs: map[string]string{"data-component": "LayoutCanvas"},
 		},
@@ -799,7 +799,7 @@ func TestFormat_Selectors_AfterBracket(t *testing.T) {
 	// --selectors hint appears AFTER the closing bracket for matched nodes.
 	n := &comps.ComponentNode{
 		Id: "5", Role: "link", Name: "Home", IsVisible: true, IsInteractive: true,
-		Selector: &comps.SelectorPart{
+		Element: &comps.Element{
 			Tag:   "a",
 			Attrs: map[string]string{"data-testid": "home-link"},
 		},
@@ -832,7 +832,7 @@ func TestSelectorHint_Empty(t *testing.T) {
 }
 
 func TestSelectorHint_TagOnly(t *testing.T) {
-	sel := &comps.SelectorPart{Tag: "div"}
+	sel := &comps.Element{Tag: "div"}
 	got := selectorHint(sel)
 	if got != "div" {
 		t.Errorf("expected 'div', got %q", got)
@@ -840,7 +840,7 @@ func TestSelectorHint_TagOnly(t *testing.T) {
 }
 
 func TestSelectorHint_TagAndId(t *testing.T) {
-	sel := &comps.SelectorPart{Tag: "nav", Id: "main-nav"}
+	sel := &comps.Element{Tag: "nav", Id: "main-nav"}
 	got := selectorHint(sel)
 	if got != "nav#main-nav" {
 		t.Errorf("expected 'nav#main-nav', got %q", got)
@@ -848,7 +848,7 @@ func TestSelectorHint_TagAndId(t *testing.T) {
 }
 
 func TestSelectorHint_NoClasses(t *testing.T) {
-	sel := &comps.SelectorPart{
+	sel := &comps.Element{
 		Tag:     "button",
 		Classes: []string{"foo", "bar"},
 	}

--- a/go/sel/match.go
+++ b/go/sel/match.go
@@ -15,11 +15,11 @@ func MatchesNode(node *comps.ComponentNode, rule *comps.SelectorPart) bool {
 	if rule == nil {
 		return true
 	}
-	nodeSel := node.Selector
-	if nodeSel == nil {
-		nodeSel = &comps.SelectorPart{}
+	el := node.Element
+	if el == nil {
+		el = &comps.Element{}
 	}
-	if !Matches(nodeSel, rule) {
+	if !Matches(el, rule) {
 		return false
 	}
 	// :has() — each entry is AND-ed; within an entry, alternatives are OR-ed.
@@ -71,25 +71,25 @@ func relMatches(anchor *comps.ComponentNode, parts []*comps.SelectorPart, combs 
 // Matches reports whether node satisfies rule. It checks tag, id, classes,
 // attribute operators, :not(), and :is()/:where(). It does NOT evaluate :has()
 // (which needs tree context — use MatchesNode for that). A nil rule matches
-// everything.
-func Matches(node, rule *comps.SelectorPart) bool {
+// everything. el is the observed element's identity (the subject).
+func Matches(el *comps.Element, rule *comps.SelectorPart) bool {
 	if rule == nil {
 		return true
 	}
 
 	// Tag match (case-insensitive for HTML; case-sensitive for synthetic mobile).
-	if rule.Tag != "" && !strings.EqualFold(node.Tag, rule.Tag) {
+	if rule.Tag != "" && !strings.EqualFold(el.Tag, rule.Tag) {
 		return false
 	}
 
 	// ID match.
-	if rule.Id != "" && node.Id != rule.Id {
+	if rule.Id != "" && el.Id != rule.Id {
 		return false
 	}
 
-	// Class match: every class in rule.Classes must appear in node.Classes.
+	// Class match: every class in rule.Classes must appear in el.Classes.
 	if len(rule.Classes) > 0 {
-		nodeClasses := sliceToSet(node.Classes)
+		nodeClasses := sliceToSet(el.Classes)
 		for _, cls := range rule.Classes {
 			if !nodeClasses[cls] {
 				return false
@@ -106,7 +106,7 @@ func Matches(node, rule *comps.SelectorPart) bool {
 			}
 		}
 
-		nodeVal, present := effectiveAttrValue(node, key)
+		nodeVal, present := effectiveAttrValue(el, key)
 		if !present {
 			// Attribute not present on node — only "[]" (presence-only) would
 			// logically not care, but absence means presence check fails too.
@@ -119,7 +119,7 @@ func Matches(node, rule *comps.SelectorPart) bool {
 	}
 
 	// :not() check.
-	if rule.Not != nil && Matches(node, rule.Not) {
+	if rule.Not != nil && Matches(el, rule.Not) {
 		return false
 	}
 
@@ -127,7 +127,7 @@ func Matches(node, rule *comps.SelectorPart) bool {
 	if len(rule.Is) > 0 {
 		anyMatch := false
 		for _, alt := range rule.Is {
-			if Matches(node, alt) {
+			if Matches(el, alt) {
 				anyMatch = true
 				break
 			}
@@ -140,24 +140,24 @@ func Matches(node, rule *comps.SelectorPart) bool {
 	return true
 }
 
-// effectiveAttrValue resolves an attribute value on a node's SelectorPart for
+// effectiveAttrValue resolves an attribute value on an observed Element for
 // matching. id and class live in dedicated fields (Id, Classes) — not always in
 // Attrs — so attribute selectors like [id^="issue_"] or [class*="card"] must see
 // them there to match offline the way the browser matches them live. Attrs is
 // consulted first (it wins when populated); id/class then fall back to their
 // dedicated fields. All other attributes come straight from Attrs.
-func effectiveAttrValue(node *comps.SelectorPart, key string) (string, bool) {
-	if v, ok := node.Attrs[key]; ok {
+func effectiveAttrValue(el *comps.Element, key string) (string, bool) {
+	if v, ok := el.Attrs[key]; ok {
 		return v, true
 	}
 	switch key {
 	case "id":
-		if node.Id != "" {
-			return node.Id, true
+		if el.Id != "" {
+			return el.Id, true
 		}
 	case "class":
-		if len(node.Classes) > 0 {
-			return strings.Join(node.Classes, " "), true
+		if len(el.Classes) > 0 {
+			return strings.Join(el.Classes, " "), true
 		}
 	}
 	return "", false

--- a/go/sel/match_has_test.go
+++ b/go/sel/match_has_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/sightmap/sightmap/go/sel"
 )
 
-// cn builds a ComponentNode with the given selector part and children.
-func cn(part *comps.SelectorPart, children ...*comps.ComponentNode) *comps.ComponentNode {
-	return &comps.ComponentNode{Selector: part, Children: children}
+// cn builds a ComponentNode with the given observed element identity and children.
+func cn(el *comps.Element, children ...*comps.ComponentNode) *comps.ComponentNode {
+	return &comps.ComponentNode{Element: el, Children: children}
 }
 
 // mustLastPart parses a selector and returns its final (target) part.

--- a/go/sel/parse_test.go
+++ b/go/sel/parse_test.go
@@ -402,9 +402,9 @@ func TestParse_MultipleAttributes(t *testing.T) {
 	}
 }
 
-// nodeWith builds a minimal SelectorPart for testing Matches.
-func nodeWith(tag, id string, classes []string, attrs map[string]string) *comps.SelectorPart {
-	return &comps.SelectorPart{
+// nodeWith builds a minimal observed Element for testing Matches.
+func nodeWith(tag, id string, classes []string, attrs map[string]string) *comps.Element {
+	return &comps.Element{
 		Tag:     tag,
 		Id:      id,
 		Classes: classes,

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -407,16 +407,16 @@ func TestAllComponents(t *testing.T) {
 func TestMatchTreeEndToEnd(t *testing.T) {
 	// Tree: root → form#search → {input, button}
 	inputNode := &comps.ComponentNode{
-		Id:       "input",
-		Selector: &comps.SelectorPart{Tag: "input"},
+		Id:      "input",
+		Element: &comps.Element{Tag: "input"},
 	}
 	buttonNode := &comps.ComponentNode{
-		Id:       "button",
-		Selector: &comps.SelectorPart{Tag: "button"},
+		Id:      "button",
+		Element: &comps.Element{Tag: "button"},
 	}
 	formNode := &comps.ComponentNode{
 		Id:       "form",
-		Selector: &comps.SelectorPart{Tag: "form", Id: "search-form"},
+		Element:  &comps.Element{Tag: "form", Id: "search-form"},
 		Children: []*comps.ComponentNode{inputNode, buttonNode},
 	}
 	root := &comps.ComponentNode{
@@ -468,8 +468,8 @@ func TestMatchTreeEndToEnd(t *testing.T) {
 
 func TestConcurrentSafety(t *testing.T) {
 	buttonNode := &comps.ComponentNode{
-		Id:       "btn",
-		Selector: &comps.SelectorPart{Tag: "button"},
+		Id:      "btn",
+		Element: &comps.Element{Tag: "button"},
 	}
 	root := &comps.ComponentNode{
 		Id:       "root",

--- a/go/testdata/fixtures/exhausted-t2.snap.tree.json
+++ b/go/testdata/fixtures/exhausted-t2.snap.tree.json
@@ -3,7 +3,7 @@
   "children": [
     {
       "role": "main",
-      "selector": {
+      "element": {
         "tag": "main",
         "classes": ["app-content"]
       },

--- a/go/testdata/fixtures/large-t2.snap.tree.json
+++ b/go/testdata/fixtures/large-t2.snap.tree.json
@@ -3,7 +3,7 @@
   "children": [
     {
       "role": "region",
-      "selector": {
+      "element": {
         "tag": "div",
         "classes": ["product-grid"]
       },

--- a/go/testdata/fixtures/multi-child-t2.snap.tree.json
+++ b/go/testdata/fixtures/multi-child-t2.snap.tree.json
@@ -3,7 +3,7 @@
   "children": [
     {
       "role": "complementary",
-      "selector": {
+      "element": {
         "tag": "div",
         "classes": ["sidebar"]
       },


### PR DESCRIPTION
First structural slice of the library restructuring for downstream consumers
(#189): split the observed **element identity** from the **selector pattern**.

`ComponentNode.Selector` was doing double duty — the observed identity of a DOM
element (its `tag`/`id`/`classes`/`attrs`) *and* a matching pattern, carrying
predicate-only fields (`AttrOps`/`Not`/`Is`/`Has`) that are meaningless on a real
observed element. This introduces `comps.Element` for the observed *subject* and
matches it against `SelectorPart` *patterns*, so the matcher signature is honest
(`Matches(el *Element, rule *SelectorPart)`) and an observed element structurally
can't hold a `:not()`.

## Changes

- **`comps`**: add `Element{Tag,Id,Classes,Attrs}`; `ComponentNode.Selector`
  (`*SelectorPart`, json `selector`) → `Element` (`*Element`, json `element`).
- **`sel`**: `Matches(el *Element, rule *SelectorPart)`; `effectiveAttrValue`
  over `Element`; `MatchesNode` reads `node.Element`.
- **`extract`**: `elementFor` projects the parsed compound into an `Element`.
- **`render` / `coverage` / `browser` / `cmd`**: read `node.Element`;
  observed-side display helpers took a type change only (bodies unchanged —
  `Element` is the same `tag/id/classes/attrs` subset).
- **fixtures + `component-schema.md`**: the structured `"selector"` key on
  component-tree JSON renamed to `"element"`.

## Notes

- **Behavior-neutral.** The observed side simply drops predicate fields it never
  populated. `ProbeComponent.Selector` (a *string*, a different struct) is
  untouched, so `probe.js` needs no change.
- **Verification:** `go build`/`vet`/`test ./...`, plus the `spec` conformance
  and examples validators, all pass; gofmt clean.
- A follow-up (untangling the observed network/console records + extraction from
  the CDP `browser` tool) will **stack on top of this branch**.
