### PR TITLE
sightmap: lift observed Request/Message records out of the browser tool

### DIFF
--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -448,21 +448,6 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 	return data, nil
 }
 
-// selectorString builds a simple CSS selector string from an observed Element.
-func selectorString(s *comps.Element) string {
-	if s == nil {
-		return ""
-	}
-	b := s.Tag
-	if s.Id != "" {
-		b += "#" + s.Id
-	}
-	for _, c := range s.Classes {
-		b += "." + c
-	}
-	return b
-}
-
 // ResolveBySightmapID resolves a probe id to a live element via its persisted
 // data-sightmap-id attribute (set on the DOM during the prior extraction) and
 // returns a ComponentNode carrying the element's CURRENT bounding box.
@@ -619,7 +604,7 @@ func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, 
 		// fall through to the bounds/selector paths below.
 	}
 	if node.Bounds == nil {
-		sel := selectorString(node.Element)
+		sel := node.Element.SelectorString()
 		if sel == "" {
 			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
@@ -805,7 +790,7 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 // (e.g. a bare numeric probe ID) degrades silently to the bounds path rather
 // than surfacing as an EvalJSON JS exception.
 func ScrollIntoView(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error {
-	if sel := selectorString(node.Element); sel != "" {
+	if sel := node.Element.SelectorString(); sel != "" {
 		script := fmt.Sprintf(
 			`try{const el=document.querySelector(%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,
 			sel,

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // DefaultMaxEntries is the per-stream ring-buffer cap (console and network are
@@ -17,29 +19,14 @@ import (
 // entries, which the query surface then reports as "N earlier entries dropped".
 const DefaultMaxEntries = 1000
 
-// ConsoleEntry is one captured console message (or uncaught exception, folded in
-// as level "exception"). Index is a monotonic per-collector id; it is the stable
-// handle for get-by-index.
-type ConsoleEntry struct {
-	Index int    `json:"index"`
-	Tab   string `json:"tab"`
-	Level string `json:"level"` // log, debug, info, warn, error, exception
-	Text  string `json:"text"`
-	Ts    int64  `json:"ts"` // unix milliseconds
-}
-
-// NetworkEntry is one captured request/response. Bodies are NOT buffered; they
-// are fetched lazily from the collector connection that saw the request (only
-// that connection can, via Network.getResponseBody / getRequestPostData).
-type NetworkEntry struct {
-	Index        int    `json:"index"`
-	Tab          string `json:"tab"`
-	Method       string `json:"method"`
-	URL          string `json:"url"`
-	Status       int    `json:"status"` // 0 until the response is received
-	StatusText   string `json:"statusText"`
-	ResourceType string `json:"resourceType"`
-	Ts           int64  `json:"ts"` // unix milliseconds
+// networkRecord is one buffered request/response: the tool-free sightmap.Request
+// the query surface returns, plus the CDP handle this tool keeps for lazy body
+// fetch. Bodies are NOT buffered; they are fetched from the collector connection
+// that saw the request (only that connection can, via Network.getResponseBody /
+// getRequestPostData). The handle fields are unexported so they never cross the
+// public surface or the wire.
+type networkRecord struct {
+	sightmap.Request
 
 	requestID string   // CDP requestId, for lazy body fetch
 	conn      *CDPConn // the collector connection that observed this request
@@ -55,8 +42,8 @@ type Collector struct {
 	maxEntries int
 
 	mu             sync.Mutex
-	console        []ConsoleEntry
-	network        []NetworkEntry
+	console        []sightmap.Message
+	network        []networkRecord
 	nextConsole    int
 	nextNetwork    int
 	consoleDropped int
@@ -211,7 +198,7 @@ func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, cons
 	}
 }
 
-func (c *Collector) addConsole(e ConsoleEntry) {
+func (c *Collector) addConsole(e sightmap.Message) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e.Index = c.nextConsole
@@ -223,7 +210,7 @@ func (c *Collector) addConsole(e ConsoleEntry) {
 	}
 }
 
-func (c *Collector) addNetwork(e NetworkEntry) {
+func (c *Collector) addNetwork(e networkRecord) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e.Index = c.nextNetwork
@@ -261,10 +248,10 @@ type ConsoleFilter struct {
 
 // Console returns the buffered console entries matching f (oldest→newest) plus
 // the number of entries dropped from the front of the ring.
-func (c *Collector) Console(f ConsoleFilter) ([]ConsoleEntry, int) {
+func (c *Collector) Console(f ConsoleFilter) ([]sightmap.Message, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	out := make([]ConsoleEntry, 0, len(c.console))
+	out := make([]sightmap.Message, 0, len(c.console))
 	for _, e := range c.console {
 		if f.Level != "" && e.Level != f.Level {
 			continue
@@ -288,12 +275,12 @@ type NetworkFilter struct {
 
 // Network returns the buffered network entries matching f (oldest→newest) plus
 // the number dropped from the front of the ring.
-func (c *Collector) Network(f NetworkFilter) ([]NetworkEntry, int) {
+func (c *Collector) Network(f NetworkFilter) ([]sightmap.Request, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	rt := strings.ToLower(f.ResourceType)
 	sub := strings.ToLower(f.URLSubstr)
-	out := make([]NetworkEntry, 0, len(c.network))
+	out := make([]sightmap.Request, 0, len(c.network))
 	for _, e := range c.network {
 		if rt != "" && strings.ToLower(e.ResourceType) != rt {
 			continue
@@ -304,7 +291,7 @@ func (c *Collector) Network(f NetworkFilter) ([]NetworkEntry, int) {
 		if f.Tab != "" && e.Tab != f.Tab {
 			continue
 		}
-		out = append(out, e)
+		out = append(out, e.Request)
 	}
 	out = tailLimit(out, f.Limit)
 	return out, c.networkDropped
@@ -354,7 +341,7 @@ func tailLimit[T any](s []T, n int) []T {
 
 // ── CDP event parsing (pure; unit-tested) ──────────────────────────────────
 
-func parseConsoleAPI(raw json.RawMessage) (ConsoleEntry, bool) {
+func parseConsoleAPI(raw json.RawMessage) (sightmap.Message, bool) {
 	var ev struct {
 		Type      string  `json:"type"`
 		Timestamp float64 `json:"timestamp"`
@@ -365,20 +352,20 @@ func parseConsoleAPI(raw json.RawMessage) (ConsoleEntry, bool) {
 		} `json:"args"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil {
-		return ConsoleEntry{}, false
+		return sightmap.Message{}, false
 	}
 	parts := make([]string, 0, len(ev.Args))
 	for _, a := range ev.Args {
 		parts = append(parts, renderArg(a.Value, a.Description))
 	}
-	return ConsoleEntry{
+	return sightmap.Message{
 		Level: consoleLevel(ev.Type),
 		Text:  strings.Join(parts, " "),
 		Ts:    int64(ev.Timestamp),
 	}, true
 }
 
-func parseException(raw json.RawMessage) (ConsoleEntry, bool) {
+func parseException(raw json.RawMessage) (sightmap.Message, bool) {
 	var ev struct {
 		Timestamp        float64 `json:"timestamp"`
 		ExceptionDetails struct {
@@ -389,16 +376,16 @@ func parseException(raw json.RawMessage) (ConsoleEntry, bool) {
 		} `json:"exceptionDetails"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil {
-		return ConsoleEntry{}, false
+		return sightmap.Message{}, false
 	}
 	text := ev.ExceptionDetails.Exception.Description
 	if text == "" {
 		text = ev.ExceptionDetails.Text
 	}
-	return ConsoleEntry{Level: "exception", Text: text, Ts: int64(ev.Timestamp)}, true
+	return sightmap.Message{Level: "exception", Text: text, Ts: int64(ev.Timestamp)}, true
 }
 
-func parseRequest(raw json.RawMessage) (NetworkEntry, bool) {
+func parseRequest(raw json.RawMessage) (networkRecord, bool) {
 	var ev struct {
 		RequestID string `json:"requestId"`
 		Type      string `json:"type"`
@@ -408,14 +395,16 @@ func parseRequest(raw json.RawMessage) (NetworkEntry, bool) {
 		} `json:"request"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
-		return NetworkEntry{}, false
+		return networkRecord{}, false
 	}
-	return NetworkEntry{
-		Method:       ev.Request.Method,
-		URL:          ev.Request.URL,
-		ResourceType: ev.Type,
-		Ts:           time.Now().UnixMilli(),
-		requestID:    ev.RequestID,
+	return networkRecord{
+		Request: sightmap.Request{
+			Method:       ev.Request.Method,
+			URL:          ev.Request.URL,
+			ResourceType: ev.Type,
+			Ts:           time.Now().UnixMilli(),
+		},
+		requestID: ev.RequestID,
 	}, true
 }
 

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -3,6 +3,8 @@ package browser
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func TestParseConsoleAPI(t *testing.T) {
@@ -57,7 +59,7 @@ func TestRingOverflowAndDropped(t *testing.T) {
 	c := NewCollector("localhost:0")
 	c.maxEntries = 3
 	for i := 0; i < 5; i++ {
-		c.addConsole(ConsoleEntry{Level: "log", Text: "m"})
+		c.addConsole(sightmap.Message{Level: "log", Text: "m"})
 	}
 	got, dropped := c.Console(ConsoleFilter{})
 	if len(got) != 3 {
@@ -74,9 +76,9 @@ func TestRingOverflowAndDropped(t *testing.T) {
 
 func TestConsoleFilterAndLimit(t *testing.T) {
 	c := NewCollector("localhost:0")
-	c.addConsole(ConsoleEntry{Level: "log", Text: "a", Tab: "T1"})
-	c.addConsole(ConsoleEntry{Level: "error", Text: "b", Tab: "T1"})
-	c.addConsole(ConsoleEntry{Level: "error", Text: "c", Tab: "T2"})
+	c.addConsole(sightmap.Message{Level: "log", Text: "a", Tab: "T1"})
+	c.addConsole(sightmap.Message{Level: "error", Text: "b", Tab: "T1"})
+	c.addConsole(sightmap.Message{Level: "error", Text: "c", Tab: "T2"})
 
 	errs, _ := c.Console(ConsoleFilter{Level: "error"})
 	if len(errs) != 2 {
@@ -94,8 +96,8 @@ func TestConsoleFilterAndLimit(t *testing.T) {
 
 func TestNetworkFilterAndResponseMatch(t *testing.T) {
 	c := NewCollector("localhost:0")
-	c.addNetwork(NetworkEntry{Method: "GET", URL: "https://x/style.css", ResourceType: "Stylesheet", requestID: "A"})
-	c.addNetwork(NetworkEntry{Method: "POST", URL: "https://x/api/cart", ResourceType: "XHR", requestID: "B"})
+	c.addNetwork(networkRecord{Request: sightmap.Request{Method: "GET", URL: "https://x/style.css", ResourceType: "Stylesheet"}, requestID: "A"})
+	c.addNetwork(networkRecord{Request: sightmap.Request{Method: "POST", URL: "https://x/api/cart", ResourceType: "XHR"}, requestID: "B"})
 	c.applyResponse("B", 500, "Server Error", "XHR")
 
 	xhr, _ := c.Network(NetworkFilter{ResourceType: "xhr"})
@@ -103,7 +105,7 @@ func TestNetworkFilterAndResponseMatch(t *testing.T) {
 		t.Fatalf("xhr filter/response = %+v", xhr)
 	}
 	byURL, _ := c.Network(NetworkFilter{URLSubstr: "CART"})
-	if len(byURL) != 1 || byURL[0].requestID != "B" {
+	if len(byURL) != 1 || byURL[0].URL != "https://x/api/cart" {
 		t.Errorf("url substring (case-insensitive) = %+v", byURL)
 	}
 }

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // devtoolsGet fetches path (with query) from the daemon's HTTP server and
@@ -51,13 +52,13 @@ func devtoolsGet(sightmapDir, path string, query url.Values) ([]byte, error) {
 }
 
 type consoleResult struct {
-	Entries []browser.ConsoleEntry `json:"entries"`
-	Dropped int                    `json:"dropped"`
+	Entries []sightmap.Message `json:"entries"`
+	Dropped int                `json:"dropped"`
 }
 
 type networkResult struct {
-	Entries []browser.NetworkEntry `json:"entries"`
-	Dropped int                    `json:"dropped"`
+	Entries []sightmap.Request `json:"entries"`
+	Dropped int                `json:"dropped"`
 }
 
 // ── console ─────────────────────────────────────────────────────────────────
@@ -215,7 +216,7 @@ func runNetworkGet(args []string) error {
 	if err := json.Unmarshal(body, &res); err != nil {
 		return fmt.Errorf("parse response: %w", err)
 	}
-	var entry *browser.NetworkEntry
+	var entry *sightmap.Request
 	for i := range res.Entries {
 		if res.Entries[i].Index == idx {
 			entry = &res.Entries[i]
@@ -294,7 +295,7 @@ func printBodyPreview(b []byte) {
 	fmt.Printf("Response Body:\n%s\n", string(b))
 }
 
-func statusStr(e browser.NetworkEntry) string {
+func statusStr(e sightmap.Request) string {
 	if e.Status == 0 {
 		return "pending"
 	}
@@ -324,7 +325,7 @@ func singleIndexArg(args []string, cmd string) (int, error) {
 	return idx, nil
 }
 
-func spansMultipleTabs(entries []browser.ConsoleEntry) bool {
+func spansMultipleTabs(entries []sightmap.Message) bool {
 	seen := ""
 	for _, e := range entries {
 		if seen == "" {

--- a/go/comps/component.go
+++ b/go/comps/component.go
@@ -1,6 +1,9 @@
 package comps
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // SelectorPart is the structured CSS identity of a DOM element, or a
 // synthetic identity for native mobile elements. It carries no proto
@@ -56,6 +59,26 @@ type Element struct {
 	Id      string            `json:"id,omitempty"`
 	Classes []string          `json:"classes,omitempty"`
 	Attrs   map[string]string `json:"attrs,omitempty"`
+}
+
+// SelectorString formats the element as a simple CSS selector, tag[#id][.cls...].
+// Attributes are omitted (they appear only in richer trace/anchor displays). A
+// nil receiver yields "".
+func (e *Element) SelectorString() string {
+	if e == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(e.Tag)
+	if e.Id != "" {
+		b.WriteByte('#')
+		b.WriteString(e.Id)
+	}
+	for _, c := range e.Classes {
+		b.WriteByte('.')
+		b.WriteString(c)
+	}
+	return b.String()
 }
 
 // Bounds holds the bounding box of a component in viewport coordinates.

--- a/go/coverage/anchor.go
+++ b/go/coverage/anchor.go
@@ -2,7 +2,6 @@ package coverage
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/sightmap/sightmap/go/comps"
 )
@@ -45,7 +44,7 @@ func DataAttrSelector(node *comps.ComponentNode) string {
 	if dc := a["data-component"]; dc != "" {
 		return fmt.Sprintf(`%s[data-component^="%s"]`, tag, dc)
 	}
-	return SelectorString(node.Element)
+	return node.Element.SelectorString()
 }
 
 // OrphanSlotKey is the cross-capture STRUCTURAL identity of an uncovered
@@ -92,24 +91,5 @@ func ArrowHint(node *comps.ComponentNode, parentMap ParentMap) string {
 	if dc := a["data-component"]; dc != "" {
 		return fmt.Sprintf(`[data-component^="%s"] %s`, dc, nodeTag)
 	}
-	return SelectorString(anc.Element) + " " + nodeTag
-}
-
-// SelectorString formats an observed Element as tag[#id][.cls1.cls2]. Attributes
-// are not included; they appear only in the trace/anchor displays above.
-func SelectorString(s *comps.Element) string {
-	if s == nil {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString(s.Tag)
-	if s.Id != "" {
-		b.WriteByte('#')
-		b.WriteString(s.Id)
-	}
-	for _, c := range s.Classes {
-		b.WriteByte('.')
-		b.WriteString(c)
-	}
-	return b.String()
+	return anc.Element.SelectorString() + " " + nodeTag
 }

--- a/go/sightmap/records.go
+++ b/go/sightmap/records.go
@@ -1,0 +1,33 @@
+package sightmap
+
+// Observed runtime records. These are the tool-free, wire-friendly counterparts
+// of the corpus definitions: a Message is what a MessageDef classifies, a
+// Request is what a RequestDef classifies. They carry only facts an observer
+// captured — no live connection or fetch handle — so any consumer (not just the
+// CDP browser tool) can produce and match them without depending on a driver.
+
+// Message is one observed console/exception record. Level is the six-level
+// vocabulary the reference capture emits (log, debug, info, warn, error,
+// exception); an uncaught exception arrives as level "exception". Index is a
+// monotonic per-source id, the stable handle for get-by-index.
+type Message struct {
+	Index int    `json:"index"`
+	Tab   string `json:"tab"`
+	Level string `json:"level"`
+	Text  string `json:"text"`
+	Ts    int64  `json:"ts"` // unix milliseconds
+}
+
+// Request is one observed network request/response. Bodies are not included —
+// they are large and, for a live capture, fetched lazily by the tool that
+// observed the request. Status is 0 until the response is seen.
+type Request struct {
+	Index        int    `json:"index"`
+	Tab          string `json:"tab"`
+	Method       string `json:"method"`
+	URL          string `json:"url"`
+	Status       int    `json:"status"`
+	StatusText   string `json:"statusText"`
+	ResourceType string `json:"resourceType"`
+	Ts           int64  `json:"ts"` // unix milliseconds
+}


### PR DESCRIPTION
Second structural slice of the library restructuring for downstream consumers
(#189). **Stacked on #190** (base branch `refactor/observed-element-identity`);
review/merge that first.

Untangles the observed network/console records from the CDP `browser` tool. They
lived inside the tool and — for network — were entangled with a live CDP
connection, so a consumer with its own capture (e.g. a session-review pipeline)
had to depend on the browser driver just to reuse the records. This moves the
pure records into the `sightmap` model as the observed counterparts of
`RequestDef` / `MessageDef`.

## Changes

- **`sightmap`**: add observed records `Request` and `Message` — tool-free,
  wire-friendly, carrying no connection or fetch handle.
- **`browser`**: `ConsoleEntry` → `sightmap.Message` (it was already pure).
  `NetworkEntry` becomes an internal `networkRecord` that embeds
  `sightmap.Request` plus the **unexported** CDP fetch handle
  (`requestID` + `conn`). `Collector.Console`/`Network` now return the pure
  `sightmap` records; lazy response-body fetch keeps using the handle. `browser`
  now imports `sightmap` (acyclic — `sightmap` never imports `browser`).
- **`cmd/sightmap` devtools**: consume `sightmap.Message` / `sightmap.Request`.

## Notes

- **Behavior-neutral.** The public devtools JSON is unchanged: the embedded
  `Request`'s fields promote inline in JSON, and the handle stays unexported.
- `extract` (tree normalization) already has no `browser` dependency, so a
  consumer can now produce a `ComponentNode` tree + `sightmap` records and match
  them without importing the CDP driver at all.
- **Verification:** `go build`/`vet`/`test ./...`, plus `spec` conformance and
  examples validators, all pass; gofmt clean.


---

**Update (rebased onto `main` after #190 merged).** Also folds in a small
opportunistic cleanup: `coverage.SelectorString` and `browser.selectorString`
were byte-identical `tag[#id][.cls]` formatters over `*comps.Element` — merged
into one nil-safe method, `comps.(*Element).SelectorString`, with both call sites
repointed. Separate commit in this PR.
