### PR TITLE
sightmap: move component types to the model; flip the sightmap↔match edge

### DIFF
--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -448,21 +448,6 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 	return data, nil
 }
 
-// selectorString builds a simple CSS selector string from an observed Element.
-func selectorString(s *comps.Element) string {
-	if s == nil {
-		return ""
-	}
-	b := s.Tag
-	if s.Id != "" {
-		b += "#" + s.Id
-	}
-	for _, c := range s.Classes {
-		b += "." + c
-	}
-	return b
-}
-
 // ResolveBySightmapID resolves a probe id to a live element via its persisted
 // data-sightmap-id attribute (set on the DOM during the prior extraction) and
 // returns a ComponentNode carrying the element's CURRENT bounding box.
@@ -619,7 +604,7 @@ func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, 
 		// fall through to the bounds/selector paths below.
 	}
 	if node.Bounds == nil {
-		sel := selectorString(node.Element)
+		sel := node.Element.SelectorString()
 		if sel == "" {
 			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
@@ -805,7 +790,7 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 // (e.g. a bare numeric probe ID) degrades silently to the bounds path rather
 // than surfacing as an EvalJSON JS exception.
 func ScrollIntoView(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error {
-	if sel := selectorString(node.Element); sel != "" {
+	if sel := node.Element.SelectorString(); sel != "" {
 		script := fmt.Sprintf(
 			`try{const el=document.querySelector(%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,
 			sel,

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // DefaultMaxEntries is the per-stream ring-buffer cap (console and network are
@@ -17,29 +19,14 @@ import (
 // entries, which the query surface then reports as "N earlier entries dropped".
 const DefaultMaxEntries = 1000
 
-// ConsoleEntry is one captured console message (or uncaught exception, folded in
-// as level "exception"). Index is a monotonic per-collector id; it is the stable
-// handle for get-by-index.
-type ConsoleEntry struct {
-	Index int    `json:"index"`
-	Tab   string `json:"tab"`
-	Level string `json:"level"` // log, debug, info, warn, error, exception
-	Text  string `json:"text"`
-	Ts    int64  `json:"ts"` // unix milliseconds
-}
-
-// NetworkEntry is one captured request/response. Bodies are NOT buffered; they
-// are fetched lazily from the collector connection that saw the request (only
-// that connection can, via Network.getResponseBody / getRequestPostData).
-type NetworkEntry struct {
-	Index        int    `json:"index"`
-	Tab          string `json:"tab"`
-	Method       string `json:"method"`
-	URL          string `json:"url"`
-	Status       int    `json:"status"` // 0 until the response is received
-	StatusText   string `json:"statusText"`
-	ResourceType string `json:"resourceType"`
-	Ts           int64  `json:"ts"` // unix milliseconds
+// networkRecord is one buffered request/response: the tool-free sightmap.Request
+// the query surface returns, plus the CDP handle this tool keeps for lazy body
+// fetch. Bodies are NOT buffered; they are fetched from the collector connection
+// that saw the request (only that connection can, via Network.getResponseBody /
+// getRequestPostData). The handle fields are unexported so they never cross the
+// public surface or the wire.
+type networkRecord struct {
+	sightmap.Request
 
 	requestID string   // CDP requestId, for lazy body fetch
 	conn      *CDPConn // the collector connection that observed this request
@@ -55,8 +42,8 @@ type Collector struct {
 	maxEntries int
 
 	mu             sync.Mutex
-	console        []ConsoleEntry
-	network        []NetworkEntry
+	console        []sightmap.Message
+	network        []networkRecord
 	nextConsole    int
 	nextNetwork    int
 	consoleDropped int
@@ -211,7 +198,7 @@ func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, cons
 	}
 }
 
-func (c *Collector) addConsole(e ConsoleEntry) {
+func (c *Collector) addConsole(e sightmap.Message) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e.Index = c.nextConsole
@@ -223,7 +210,7 @@ func (c *Collector) addConsole(e ConsoleEntry) {
 	}
 }
 
-func (c *Collector) addNetwork(e NetworkEntry) {
+func (c *Collector) addNetwork(e networkRecord) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e.Index = c.nextNetwork
@@ -261,10 +248,10 @@ type ConsoleFilter struct {
 
 // Console returns the buffered console entries matching f (oldest→newest) plus
 // the number of entries dropped from the front of the ring.
-func (c *Collector) Console(f ConsoleFilter) ([]ConsoleEntry, int) {
+func (c *Collector) Console(f ConsoleFilter) ([]sightmap.Message, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	out := make([]ConsoleEntry, 0, len(c.console))
+	out := make([]sightmap.Message, 0, len(c.console))
 	for _, e := range c.console {
 		if f.Level != "" && e.Level != f.Level {
 			continue
@@ -288,12 +275,12 @@ type NetworkFilter struct {
 
 // Network returns the buffered network entries matching f (oldest→newest) plus
 // the number dropped from the front of the ring.
-func (c *Collector) Network(f NetworkFilter) ([]NetworkEntry, int) {
+func (c *Collector) Network(f NetworkFilter) ([]sightmap.Request, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	rt := strings.ToLower(f.ResourceType)
 	sub := strings.ToLower(f.URLSubstr)
-	out := make([]NetworkEntry, 0, len(c.network))
+	out := make([]sightmap.Request, 0, len(c.network))
 	for _, e := range c.network {
 		if rt != "" && strings.ToLower(e.ResourceType) != rt {
 			continue
@@ -304,7 +291,7 @@ func (c *Collector) Network(f NetworkFilter) ([]NetworkEntry, int) {
 		if f.Tab != "" && e.Tab != f.Tab {
 			continue
 		}
-		out = append(out, e)
+		out = append(out, e.Request)
 	}
 	out = tailLimit(out, f.Limit)
 	return out, c.networkDropped
@@ -354,7 +341,7 @@ func tailLimit[T any](s []T, n int) []T {
 
 // ── CDP event parsing (pure; unit-tested) ──────────────────────────────────
 
-func parseConsoleAPI(raw json.RawMessage) (ConsoleEntry, bool) {
+func parseConsoleAPI(raw json.RawMessage) (sightmap.Message, bool) {
 	var ev struct {
 		Type      string  `json:"type"`
 		Timestamp float64 `json:"timestamp"`
@@ -365,20 +352,20 @@ func parseConsoleAPI(raw json.RawMessage) (ConsoleEntry, bool) {
 		} `json:"args"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil {
-		return ConsoleEntry{}, false
+		return sightmap.Message{}, false
 	}
 	parts := make([]string, 0, len(ev.Args))
 	for _, a := range ev.Args {
 		parts = append(parts, renderArg(a.Value, a.Description))
 	}
-	return ConsoleEntry{
+	return sightmap.Message{
 		Level: consoleLevel(ev.Type),
 		Text:  strings.Join(parts, " "),
 		Ts:    int64(ev.Timestamp),
 	}, true
 }
 
-func parseException(raw json.RawMessage) (ConsoleEntry, bool) {
+func parseException(raw json.RawMessage) (sightmap.Message, bool) {
 	var ev struct {
 		Timestamp        float64 `json:"timestamp"`
 		ExceptionDetails struct {
@@ -389,16 +376,16 @@ func parseException(raw json.RawMessage) (ConsoleEntry, bool) {
 		} `json:"exceptionDetails"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil {
-		return ConsoleEntry{}, false
+		return sightmap.Message{}, false
 	}
 	text := ev.ExceptionDetails.Exception.Description
 	if text == "" {
 		text = ev.ExceptionDetails.Text
 	}
-	return ConsoleEntry{Level: "exception", Text: text, Ts: int64(ev.Timestamp)}, true
+	return sightmap.Message{Level: "exception", Text: text, Ts: int64(ev.Timestamp)}, true
 }
 
-func parseRequest(raw json.RawMessage) (NetworkEntry, bool) {
+func parseRequest(raw json.RawMessage) (networkRecord, bool) {
 	var ev struct {
 		RequestID string `json:"requestId"`
 		Type      string `json:"type"`
@@ -408,14 +395,16 @@ func parseRequest(raw json.RawMessage) (NetworkEntry, bool) {
 		} `json:"request"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
-		return NetworkEntry{}, false
+		return networkRecord{}, false
 	}
-	return NetworkEntry{
-		Method:       ev.Request.Method,
-		URL:          ev.Request.URL,
-		ResourceType: ev.Type,
-		Ts:           time.Now().UnixMilli(),
-		requestID:    ev.RequestID,
+	return networkRecord{
+		Request: sightmap.Request{
+			Method:       ev.Request.Method,
+			URL:          ev.Request.URL,
+			ResourceType: ev.Type,
+			Ts:           time.Now().UnixMilli(),
+		},
+		requestID: ev.RequestID,
 	}, true
 }
 

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -3,6 +3,8 @@ package browser
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func TestParseConsoleAPI(t *testing.T) {
@@ -57,7 +59,7 @@ func TestRingOverflowAndDropped(t *testing.T) {
 	c := NewCollector("localhost:0")
 	c.maxEntries = 3
 	for i := 0; i < 5; i++ {
-		c.addConsole(ConsoleEntry{Level: "log", Text: "m"})
+		c.addConsole(sightmap.Message{Level: "log", Text: "m"})
 	}
 	got, dropped := c.Console(ConsoleFilter{})
 	if len(got) != 3 {
@@ -74,9 +76,9 @@ func TestRingOverflowAndDropped(t *testing.T) {
 
 func TestConsoleFilterAndLimit(t *testing.T) {
 	c := NewCollector("localhost:0")
-	c.addConsole(ConsoleEntry{Level: "log", Text: "a", Tab: "T1"})
-	c.addConsole(ConsoleEntry{Level: "error", Text: "b", Tab: "T1"})
-	c.addConsole(ConsoleEntry{Level: "error", Text: "c", Tab: "T2"})
+	c.addConsole(sightmap.Message{Level: "log", Text: "a", Tab: "T1"})
+	c.addConsole(sightmap.Message{Level: "error", Text: "b", Tab: "T1"})
+	c.addConsole(sightmap.Message{Level: "error", Text: "c", Tab: "T2"})
 
 	errs, _ := c.Console(ConsoleFilter{Level: "error"})
 	if len(errs) != 2 {
@@ -94,8 +96,8 @@ func TestConsoleFilterAndLimit(t *testing.T) {
 
 func TestNetworkFilterAndResponseMatch(t *testing.T) {
 	c := NewCollector("localhost:0")
-	c.addNetwork(NetworkEntry{Method: "GET", URL: "https://x/style.css", ResourceType: "Stylesheet", requestID: "A"})
-	c.addNetwork(NetworkEntry{Method: "POST", URL: "https://x/api/cart", ResourceType: "XHR", requestID: "B"})
+	c.addNetwork(networkRecord{Request: sightmap.Request{Method: "GET", URL: "https://x/style.css", ResourceType: "Stylesheet"}, requestID: "A"})
+	c.addNetwork(networkRecord{Request: sightmap.Request{Method: "POST", URL: "https://x/api/cart", ResourceType: "XHR"}, requestID: "B"})
 	c.applyResponse("B", 500, "Server Error", "XHR")
 
 	xhr, _ := c.Network(NetworkFilter{ResourceType: "xhr"})
@@ -103,7 +105,7 @@ func TestNetworkFilterAndResponseMatch(t *testing.T) {
 		t.Fatalf("xhr filter/response = %+v", xhr)
 	}
 	byURL, _ := c.Network(NetworkFilter{URLSubstr: "CART"})
-	if len(byURL) != 1 || byURL[0].requestID != "B" {
+	if len(byURL) != 1 || byURL[0].URL != "https://x/api/cart" {
 		t.Errorf("url substring (case-insensitive) = %+v", byURL)
 	}
 }

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -155,7 +156,7 @@ func boundsByComponent(
 	if err != nil {
 		return nil, fmt.Errorf("bounds: load corpus: %w", err)
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+	matches := match.NewMatcher(corpus).MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("bounds: no sightmap components matched the current page (%s)", pageURL)
 	}

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -68,7 +68,7 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
-	m := sightmap.NewMatcher(corpus)
+	m := match.NewMatcher(corpus)
 	matches := m.MatchTree(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
@@ -83,13 +83,13 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	for _, part := range q.Parts {
 		queryNames[part.Name] = true
 	}
-	relevant := make(map[*comps.ComponentNode]*match.ComponentMatch)
+	relevant := make(map[*comps.ComponentNode]*sightmap.ComponentMatch)
 	for n, m := range matches {
 		if queryNames[m.Name] {
 			relevant[n] = m
 		}
 	}
-	compByName := make(map[string]match.ComponentDef, len(components))
+	compByName := make(map[string]sightmap.ComponentDef, len(components))
 	for _, c := range components {
 		compByName[c.Name] = c
 	}

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -124,7 +124,7 @@ func runCoverage(args []string) error {
 // can't be loaded, parsed, or matched. Shared by coverage/report/multi-coverage so
 // every reader matches a capture the same route-aware way instead of
 // each re-implementing the load/parse/match boilerplate.
-func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch, route string, ok bool) {
+func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch, route string, ok bool) {
 	treeFile := snapPath + ".tree.json"
 	data, err := os.ReadFile(treeFile)
 	if err != nil {
@@ -138,7 +138,7 @@ func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.Compone
 		return nil, nil, "", false
 	}
 	route = viewset.RouteOf(snapPath)
-	matches = sightmap.NewMatcher(corpus).MatchTree(root, route)
+	matches = match.NewMatcher(corpus).MatchTree(root, route)
 	return root, matches, route, true
 }
 

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // devtoolsGet fetches path (with query) from the daemon's HTTP server and
@@ -51,13 +52,13 @@ func devtoolsGet(sightmapDir, path string, query url.Values) ([]byte, error) {
 }
 
 type consoleResult struct {
-	Entries []browser.ConsoleEntry `json:"entries"`
-	Dropped int                    `json:"dropped"`
+	Entries []sightmap.Message `json:"entries"`
+	Dropped int                `json:"dropped"`
 }
 
 type networkResult struct {
-	Entries []browser.NetworkEntry `json:"entries"`
-	Dropped int                    `json:"dropped"`
+	Entries []sightmap.Request `json:"entries"`
+	Dropped int                `json:"dropped"`
 }
 
 // ── console ─────────────────────────────────────────────────────────────────
@@ -215,7 +216,7 @@ func runNetworkGet(args []string) error {
 	if err := json.Unmarshal(body, &res); err != nil {
 		return fmt.Errorf("parse response: %w", err)
 	}
-	var entry *browser.NetworkEntry
+	var entry *sightmap.Request
 	for i := range res.Entries {
 		if res.Entries[i].Index == idx {
 			entry = &res.Entries[i]
@@ -294,7 +295,7 @@ func printBodyPreview(b []byte) {
 	fmt.Printf("Response Body:\n%s\n", string(b))
 }
 
-func statusStr(e browser.NetworkEntry) string {
+func statusStr(e sightmap.Request) string {
 	if e.Status == 0 {
 		return "pending"
 	}
@@ -324,7 +325,7 @@ func singleIndexArg(args []string, cmd string) (int, error) {
 	return idx, nil
 }
 
-func spansMultipleTabs(entries []browser.ConsoleEntry) bool {
+func spansMultipleTabs(entries []sightmap.Message) bool {
 	seen := ""
 	for _, e := range entries {
 		if seen == "" {

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/match"
 )
 
 func runGap(args []string) error {
@@ -54,7 +54,7 @@ func runGap(args []string) error {
 	if loadErr != nil {
 		return loadErr
 	}
-	m := sightmap.NewMatcher(corpus)
+	m := match.NewMatcher(corpus)
 	matches := m.MatchTree(root, pageURL)
 
 	// ── Build parent map ─────────────────────────────────────────────────────

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -59,11 +59,11 @@ func runInspect(args []string) error {
 	}
 
 	// ── Load sightmap (optional enrichment; warn but don't fail on a bad corpus) ──
-	var inspectMatches map[*comps.ComponentNode]*match.ComponentMatch
+	var inspectMatches map[*comps.ComponentNode]*sightmap.ComponentMatch
 	if corpus, cErr := lf.loadCorpus(); cErr != nil {
 		fmt.Fprintf(os.Stderr, "inspect: load corpus: %v (continuing without component names)\n", cErr)
 	} else if corpus != nil {
-		inspectMatches = sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+		inspectMatches = match.NewMatcher(corpus).MatchTree(root, pageURL)
 	}
 
 	// ── Render ────────────────────────────────────────────────────────────────

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -272,7 +272,7 @@ func offlineSelectorCount(ctx context.Context, conn *browser.CDPConn, selector s
 	if err != nil {
 		return 0, err
 	}
-	defs := []match.ComponentDef{{Name: "__probe__", Selectors: []string{selector}}}
+	defs := []sightmap.ComponentDef{{Name: "__probe__", Selectors: []string{selector}}}
 	return len(match.ApplySightmap(root, defs)), nil
 }
 
@@ -357,7 +357,7 @@ func loadCompAnnotations(dir string) []compAnnotation {
 	if err != nil {
 		return nil
 	}
-	components := sightmap.NewMatcher(corpus).Components("")
+	components := match.NewMatcher(corpus).Components("")
 
 	annotations := make([]compAnnotation, 0, len(components))
 	for _, comp := range components {

--- a/go/cmd/sightmap/cmd_serve.go
+++ b/go/cmd/sightmap/cmd_serve.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -44,7 +43,7 @@ type compiledSightmapJSON struct {
 	ViewComponents map[string][]compiledComponent `json:"viewComponents"`
 }
 
-func normaliseComponent(c match.ComponentDef) compiledComponent {
+func normaliseComponent(c sightmap.ComponentDef) compiledComponent {
 	chain := c.ParentChain
 	if chain == nil {
 		chain = []string{} // always emit [], never null

--- a/go/cmd/sightmap/cmd_snapshot_json.go
+++ b/go/cmd/sightmap/cmd_snapshot_json.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -35,7 +34,7 @@ type annotatedNode struct {
 // each ComponentNode pointer with its ComponentMatch and any extracted props.
 func buildAnnotatedNode(
 	node *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	propValues map[string]map[string]string, // nodeID → {propName → value}; may be nil
 ) *annotatedNode {
 	an := &annotatedNode{
@@ -88,14 +87,14 @@ func writeAnnotatedJSON(
 	root *comps.ComponentNode,
 	path string,
 	view *sightmap.View,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	propValues map[string]map[string]string,
 ) error {
 	if root == nil {
 		return nil
 	}
 	if matches == nil {
-		matches = map[*comps.ComponentNode]*match.ComponentMatch{}
+		matches = map[*comps.ComponentNode]*sightmap.ComponentMatch{}
 	}
 
 	out := annotatedOutput{

--- a/go/cmd/sightmap/cmd_snapshot_json_test.go
+++ b/go/cmd/sightmap/cmd_snapshot_json_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -35,11 +34,11 @@ func TestWriteAnnotatedJSON_MatchedNode(t *testing.T) {
 		InViewport:    true,
 	}
 
-	sm := &match.ComponentMatch{
+	sm := &sightmap.ComponentMatch{
 		Name:   "SiteLogoLink",
 		Memory: []string{"main navigation logo"},
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		node: sm,
 	}
 	propValues := map[string]map[string]string{
@@ -101,7 +100,7 @@ func TestWriteAnnotatedJSON_UnmatchedNode(t *testing.T) {
 
 	// node is NOT in the matches map
 	other := &comps.ComponentNode{Id: "99"}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		other: {Name: "SomeOtherComponent"},
 	}
 

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sightmap/sightmap/go/authoring"
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -49,7 +50,7 @@ func runSuggest(args []string) error {
 		if corpus, cErr := lf.loadCorpus(); cErr != nil {
 			fmt.Fprintf(os.Stderr, "suggest: load corpus: %v (continuing without --exclude-known filtering)\n", cErr)
 		} else if corpus != nil {
-			for _, c := range sightmap.NewMatcher(corpus).Components("") {
+			for _, c := range match.NewMatcher(corpus).Components("") {
 				knownSelectors = append(knownSelectors, c.Selectors...)
 			}
 		}
@@ -242,7 +243,7 @@ func buildSightmapMatchMapForSuggest(
 	if err != nil {
 		return nil, fmt.Errorf("load corpus (fallback): %v", err)
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, pageURL)
+	matches := match.NewMatcher(corpus).MatchTree(root, pageURL)
 	m := make(map[string]string)
 	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {
@@ -268,7 +269,7 @@ func buildSightmapMatchMap(treeFile string, smDir string, pageURL string) (map[s
 	if err != nil {
 		return nil, fmt.Errorf("load corpus: %v", err)
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(&root, pageURL)
+	matches := match.NewMatcher(corpus).MatchTree(&root, pageURL)
 	m := make(map[string]string)
 	comps.Walk(&root, func(n *comps.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {

--- a/go/compquery/compquery.go
+++ b/go/compquery/compquery.go
@@ -27,11 +27,11 @@ package compquery
 import (
 	"errors"
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"sort"
 	"strings"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // Query is a parsed component query: a descendant chain of component matchers
@@ -111,7 +111,7 @@ func (q *Query) String() string {
 // disambiguates.
 func Resolve(
 	root *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 	q *Query,
 ) (*comps.ComponentNode, error) {
@@ -136,7 +136,7 @@ func Resolve(
 // (descendant semantics). Results are in document (pre-order) order.
 func FindCandidates(
 	root *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 	q *Query,
 ) []*comps.ComponentNode {
@@ -171,7 +171,7 @@ func FindCandidates(
 func satisfies(
 	node *comps.ComponentNode,
 	part Part,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 ) bool {
 	m := matches[node]
@@ -195,7 +195,7 @@ func satisfies(
 func subsequence(
 	prefix []Part,
 	ancestors []*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 ) bool {
 	i := 0
@@ -213,7 +213,7 @@ func subsequence(
 func ambiguityError(
 	q *Query,
 	cands []*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 ) error {
 	var b strings.Builder

--- a/go/compquery/compquery_test.go
+++ b/go/compquery/compquery_test.go
@@ -1,11 +1,11 @@
 package compquery
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // ── Parser ────────────────────────────────────────────────────────────────────
@@ -151,7 +151,7 @@ func TestPredicateMatch(t *testing.T) {
 //	└─ TileGroup
 //	    ├─ FulfillmentTileButton (t1) label=Pickup
 //	    └─ FulfillmentTileButton (t2) label=Delivery
-func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*match.ComponentMatch, map[string]map[string]string) {
+func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*sightmap.ComponentMatch, map[string]map[string]string) {
 	u1 := &comps.ComponentNode{Id: "u1"}
 	p1 := &comps.ComponentNode{Id: "p1"}
 	loginForm := &comps.ComponentNode{Id: "m2", Children: []*comps.ComponentNode{u1, p1}}
@@ -163,7 +163,7 @@ func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*match.Compo
 
 	root := &comps.ComponentNode{Id: "root", Children: []*comps.ComponentNode{mainPanel, tileGroup}}
 
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		mainPanel: {Name: "MainPanel"},
 		loginForm: {Name: "LoginForm"},
 		u1:        {Name: "UserNameInput"},

--- a/go/comps/component.go
+++ b/go/comps/component.go
@@ -1,6 +1,9 @@
 package comps
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // SelectorPart is the structured CSS identity of a DOM element, or a
 // synthetic identity for native mobile elements. It carries no proto
@@ -56,6 +59,26 @@ type Element struct {
 	Id      string            `json:"id,omitempty"`
 	Classes []string          `json:"classes,omitempty"`
 	Attrs   map[string]string `json:"attrs,omitempty"`
+}
+
+// SelectorString formats the element as a simple CSS selector, tag[#id][.cls...].
+// Attributes are omitted (they appear only in richer trace/anchor displays). A
+// nil receiver yields "".
+func (e *Element) SelectorString() string {
+	if e == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(e.Tag)
+	if e.Id != "" {
+		b.WriteByte('#')
+		b.WriteString(e.Id)
+	}
+	for _, c := range e.Classes {
+		b.WriteByte('.')
+		b.WriteString(c)
+	}
+	return b.String()
 }
 
 // Bounds holds the bounding box of a component in viewport coordinates.

--- a/go/coverage/anchor.go
+++ b/go/coverage/anchor.go
@@ -2,7 +2,6 @@ package coverage
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/sightmap/sightmap/go/comps"
 )
@@ -45,7 +44,7 @@ func DataAttrSelector(node *comps.ComponentNode) string {
 	if dc := a["data-component"]; dc != "" {
 		return fmt.Sprintf(`%s[data-component^="%s"]`, tag, dc)
 	}
-	return SelectorString(node.Element)
+	return node.Element.SelectorString()
 }
 
 // OrphanSlotKey is the cross-capture STRUCTURAL identity of an uncovered
@@ -92,24 +91,5 @@ func ArrowHint(node *comps.ComponentNode, parentMap ParentMap) string {
 	if dc := a["data-component"]; dc != "" {
 		return fmt.Sprintf(`[data-component^="%s"] %s`, dc, nodeTag)
 	}
-	return SelectorString(anc.Element) + " " + nodeTag
-}
-
-// SelectorString formats an observed Element as tag[#id][.cls1.cls2]. Attributes
-// are not included; they appear only in the trace/anchor displays above.
-func SelectorString(s *comps.Element) string {
-	if s == nil {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString(s.Tag)
-	if s.Id != "" {
-		b.WriteByte('#')
-		b.WriteString(s.Id)
-	}
-	for _, c := range s.Classes {
-		b.WriteByte('.')
-		b.WriteString(c)
-	}
-	return b.String()
+	return anc.Element.SelectorString() + " " + nodeTag
 }

--- a/go/coverage/coverage.go
+++ b/go/coverage/coverage.go
@@ -13,14 +13,14 @@
 package coverage
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"math"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // Matches maps a component node to the sightmap rule it matched.
-type Matches = map[*comps.ComponentNode]*match.ComponentMatch
+type Matches = map[*comps.ComponentNode]*sightmap.ComponentMatch
 
 // ParentMap maps each non-root node to its parent.
 type ParentMap = map[*comps.ComponentNode]*comps.ComponentNode

--- a/go/coverage/gaps_test.go
+++ b/go/coverage/gaps_test.go
@@ -1,10 +1,10 @@
 package coverage
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // gapsFixture builds a small tree and returns root + parentMap so each test can
@@ -38,7 +38,7 @@ func gapsFixture() (root, banner, image *comps.ComponentNode, parentMap map[*com
 
 func TestAnnotationGaps_FlaggedWhenNoContext(t *testing.T) {
 	root, _, image, pm := gapsFixture()
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{} // nothing matched
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{} // nothing matched
 
 	gaps := Gaps(root, matches, pm, true)
 	if len(gaps) != 1 {
@@ -59,7 +59,7 @@ func TestAnnotationGaps_FlaggedWhenNoContext(t *testing.T) {
 func TestAnnotationGaps_NotFlaggedWhenDirectlyMatched(t *testing.T) {
 	root, _, image, pm := gapsFixture()
 	// The content node itself is now captured by a component (T1).
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		image: {Name: "BannerImage"},
 	}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
@@ -70,7 +70,7 @@ func TestAnnotationGaps_NotFlaggedWhenDirectlyMatched(t *testing.T) {
 func TestAnnotationGaps_NotFlaggedWhenAncestorMatched(t *testing.T) {
 	root, banner, _, pm := gapsFixture()
 	// A matched ancestor gives the node component context → precision guard.
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		banner: {Name: "HeroBanner"},
 	}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
@@ -89,7 +89,7 @@ func TestAnnotationGaps_ShortAndEmptyNamesIgnored(t *testing.T) {
 		Children:  []*comps.ComponentNode{short, empty, symbols},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{}
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("want 0 gaps for short/empty/symbol names, got %d: %+v", len(gaps), gaps)
 	}
@@ -111,7 +111,7 @@ func TestAnnotationGaps_InteractiveSkipped(t *testing.T) {
 		Children:  []*comps.ComponentNode{link},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{}
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("want 0 gaps for interactive node, got %d: %+v", len(gaps), gaps)
 	}
@@ -131,7 +131,7 @@ func TestAnnotationGaps_VisibleOnly(t *testing.T) {
 		Children:  []*comps.ComponentNode{hidden},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{}
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{}
 
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("visibleOnly: want 0 gaps for hidden node, got %d", len(gaps))

--- a/go/match/class_selectors_test.go
+++ b/go/match/class_selectors_test.go
@@ -1,6 +1,7 @@
 package match_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
 
@@ -90,12 +91,12 @@ func TestClassAttrSelectors(t *testing.T) {
 				},
 			}
 
-			comp := match.ComponentDef{
+			comp := sightmap.ComponentDef{
 				Name:      "TestButton",
 				Selectors: []string{tt.selector},
 			}
 
-			matches := match.ApplySightmap(node, []match.ComponentDef{comp})
+			matches := match.ApplySightmap(node, []sightmap.ComponentDef{comp})
 			got := len(matches) > 0
 
 			if got != tt.want {

--- a/go/match/conflicts_test.go
+++ b/go/match/conflicts_test.go
@@ -1,6 +1,7 @@
 package match_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/match"
@@ -12,7 +13,7 @@ func TestFindConflicts_NodeClaimedByTwoNames(t *testing.T) {
 	root := node("root", "div", nil,
 		nodeAttr("dlg", "div", map[string]string{"role": "dialog", "data-testid": "login"}),
 	)
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "AppDialog", Selectors: []string{`[role="dialog"]`}},
 		{Name: "LoginDialog", Selectors: []string{`[data-testid="login"]`}},
 	}
@@ -36,7 +37,7 @@ func TestFindConflicts_SameNameManyNodes(t *testing.T) {
 		node("c2", "div", []string{"card"}),
 		node("c3", "div", []string{"card"}),
 	)
-	defs := []match.ComponentDef{{Name: "Card", Selectors: []string{".card"}}}
+	defs := []sightmap.ComponentDef{{Name: "Card", Selectors: []string{".card"}}}
 	if c := match.FindConflicts(root, defs); len(c) != 0 {
 		t.Errorf("same name matching many nodes must not conflict, got %+v", c)
 	}
@@ -49,7 +50,7 @@ func TestFindConflicts_DistinctNodes(t *testing.T) {
 		node("a", "div", []string{"a"}),
 		node("b", "div", []string{"b"}),
 	)
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "A", Selectors: []string{".a"}},
 		{Name: "B", Selectors: []string{".b"}},
 	}

--- a/go/match/conformance_test.go
+++ b/go/match/conformance_test.go
@@ -2,6 +2,7 @@ package match_test
 
 import (
 	"encoding/json"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,7 +36,7 @@ func TestConformance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read sightmap: %v", err)
 			}
-			var defs []match.ComponentDef
+			var defs []sightmap.ComponentDef
 			if err := yaml.Unmarshal(smData, &defs); err != nil {
 				t.Fatalf("parse sightmap: %v", err)
 			}

--- a/go/match/corpus_matcher.go
+++ b/go/match/corpus_matcher.go
@@ -1,10 +1,10 @@
-package sightmap
+package match
 
 import (
 	"sync"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // Matcher is the matching engine for a Corpus. It compiles the corpus's
@@ -15,21 +15,21 @@ import (
 // A Matcher holds a per-URL compiled-query cache and is safe for concurrent use.
 // Create one per Corpus and reuse it so the cache is shared across calls.
 type Matcher struct {
-	corpus *Corpus
+	corpus *sightmap.Corpus
 	mu     sync.Mutex
 	cache  map[string]*queryCacheEntry
 }
 
 // NewMatcher returns a Matcher bound to corpus.
-func NewMatcher(corpus *Corpus) *Matcher {
+func NewMatcher(corpus *sightmap.Corpus) *Matcher {
 	return &Matcher{corpus: corpus}
 }
 
 // queryCacheEntry stores the merged component list and compiled queries for one
 // page URL. Compilation is the expensive step, so it is cached per URL.
 type queryCacheEntry struct {
-	components []match.ComponentDef
-	queries    []match.MatchQuery
+	components []sightmap.ComponentDef
+	queries    []MatchQuery
 }
 
 // entryFor returns the cached (or freshly compiled) queries for pageURL.
@@ -43,7 +43,7 @@ func (m *Matcher) entryFor(pageURL string) *queryCacheEntry {
 		return e
 	}
 	compList := m.corpus.ComponentsForURL(pageURL)
-	queries, _ := match.ParseQueries(compList)
+	queries, _ := ParseQueries(compList)
 	e := &queryCacheEntry{components: compList, queries: queries}
 	m.cache[pageURL] = e
 	return e
@@ -53,20 +53,20 @@ func (m *Matcher) entryFor(pageURL string) *queryCacheEntry {
 // selects the matching view (falling back to global components), compiles the
 // queries if not already cached, then runs the NFA matcher over root. Returns
 // nil when root is nil or no queries apply.
-func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*match.ComponentMatch {
+func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*sightmap.ComponentMatch {
 	entry := m.entryFor(pageURL)
 	if root == nil || len(entry.queries) == 0 {
 		return nil
 	}
 
 	// Map component name → definition for memory resolution at match time.
-	byName := make(map[string]*match.ComponentDef, len(entry.components))
+	byName := make(map[string]*sightmap.ComponentDef, len(entry.components))
 	for i := range entry.components {
 		byName[entry.components[i].Name] = &entry.components[i]
 	}
 
-	result := make(map[*comps.ComponentNode]*match.ComponentMatch)
-	match.FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *match.MatchQuery) {
+	result := make(map[*comps.ComponentNode]*sightmap.ComponentMatch)
+	FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *MatchQuery) {
 		if _, already := result[node]; already {
 			return // first-match-wins
 		}
@@ -74,7 +74,7 @@ func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comp
 		if def := byName[q.Name]; def != nil {
 			memory = def.Memory
 		}
-		result[node] = &match.ComponentMatch{Name: q.Name, Memory: memory}
+		result[node] = &sightmap.ComponentMatch{Name: q.Name, Memory: memory}
 	})
 	return result
 }
@@ -82,6 +82,6 @@ func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comp
 // Components returns the merged component list for pageURL (view components plus
 // non-colliding globals) — the compiled inventory, for tools that need the
 // definitions without a tree to match against. Cached alongside the queries.
-func (m *Matcher) Components(pageURL string) []match.ComponentDef {
+func (m *Matcher) Components(pageURL string) []sightmap.ComponentDef {
 	return m.entryFor(pageURL).components
 }

--- a/go/match/has_test.go
+++ b/go/match/has_test.go
@@ -1,10 +1,10 @@
 package match_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // TestHas_FormGroupScoping is the end-to-end (snapshot/coverage) path for the
@@ -20,7 +20,7 @@ func TestHas_FormGroupScoping(t *testing.T) {
 		formGroup("protection", nodeAttr("rb", "input", map[string]string{"type": "radio"})),
 	)
 
-	defs := []match.ComponentDef{{
+	defs := []sightmap.ComponentDef{{
 		Name:      "AssemblyOption",
 		Selectors: []string{`[data-testid="form-group"]:has(input[type="checkbox"])`},
 	}}
@@ -37,7 +37,7 @@ func TestHas_DirectChildScoping(t *testing.T) {
 		node("hasDirect", "div", []string{"box"}, node("b1", "button", nil)),
 		node("hasNested", "div", []string{"box"}, node("", "span", nil, node("b2", "button", nil))),
 	)
-	defs := []match.ComponentDef{{
+	defs := []sightmap.ComponentDef{{
 		Name:      "BoxWithButton",
 		Selectors: []string{"div.box:has(> button)"},
 	}}

--- a/go/match/intermediate_test.go
+++ b/go/match/intermediate_test.go
@@ -4,6 +4,7 @@ package match_test
 // and ignored AX nodes.
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
@@ -63,7 +64,7 @@ func buildBreadcrumbTree() *comps.ComponentNode {
 // structural nodes sit between the Breadcrumb container and the link.
 func TestChildAnnotation_ThroughStructuralIntermediate(t *testing.T) {
 	root := buildBreadcrumbTree()
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "Breadcrumb", Selectors: []string{`[data-component^="breadcrumbs:Breadcrumbs"]`}},
 		// Flattened child selector: parent + " " + child
 		{Name: "BreadcrumbLink", Selectors: []string{`[data-component^="breadcrumbs:Breadcrumbs"] a`}},
@@ -107,7 +108,7 @@ func TestChildAnnotation_ThroughStructuralIntermediate(t *testing.T) {
 // claim a BreadcrumbLink node before the scoped match fires.
 func TestChildAnnotation_BroadGlobalDoesNotSteal(t *testing.T) {
 	root := buildBreadcrumbTree()
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		// FooterLink: broad global "a" selector — listed FIRST (lower index)
 		{Name: "FooterLink", Selectors: []string{`a`}},
 		// Breadcrumb + scoped child — listed AFTER FooterLink

--- a/go/match/matcher_test.go
+++ b/go/match/matcher_test.go
@@ -1,6 +1,7 @@
 package match_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"sort"
 	"testing"
 
@@ -38,7 +39,7 @@ func nodeInvisible(id, tag string) *comps.ComponentNode {
 // ---------- helpers ----------------------------------------------------------
 
 // applyDefs is a shorthand: build defs, apply, return matched node IDs by name.
-func applyDefs(t *testing.T, root *comps.ComponentNode, defs []match.ComponentDef) map[string][]string {
+func applyDefs(t *testing.T, root *comps.ComponentNode, defs []sightmap.ComponentDef) map[string][]string {
 	t.Helper()
 	m := match.ApplySightmap(root, defs)
 	result := make(map[string][]string)
@@ -111,7 +112,7 @@ func makeTree() *comps.ComponentNode {
 
 func TestSingleTag(t *testing.T) {
 	root := makeTree()
-	defs := []match.ComponentDef{{Name: "Nav", Selectors: []string{"nav"}}}
+	defs := []sightmap.ComponentDef{{Name: "Nav", Selectors: []string{"nav"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Nav", "nav")
 }
@@ -119,7 +120,7 @@ func TestSingleTag(t *testing.T) {
 func TestDescendant_TwoLevels(t *testing.T) {
 	// nav.main-nav a.nav-link: anchor inside nav, bridging intermediate nodes.
 	root := makeTree()
-	defs := []match.ComponentDef{{Name: "NavLink", Selectors: []string{"nav.main-nav a.nav-link"}}}
+	defs := []sightmap.ComponentDef{{Name: "NavLink", Selectors: []string{"nav.main-nav a.nav-link"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "NavLink", "a1", "a2")
 }
@@ -127,7 +128,7 @@ func TestDescendant_TwoLevels(t *testing.T) {
 func TestDescendant_DeepNesting(t *testing.T) {
 	// div button: button anywhere inside a div, even deeply nested.
 	root := makeTree()
-	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"div button"}}}
+	defs := []sightmap.ComponentDef{{Name: "Btn", Selectors: []string{"div button"}}}
 	got := applyDefs(t, root, defs)
 	// root is div, so all buttons (btn1, btn2, btn3) are descendants.
 	assertIDs(t, got, "Btn", "btn1", "btn2", "btn3")
@@ -136,7 +137,7 @@ func TestDescendant_DeepNesting(t *testing.T) {
 func TestDirectChild_Matches(t *testing.T) {
 	// form.search > button.submit: button DIRECTLY under form.
 	root := makeTree()
-	defs := []match.ComponentDef{{Name: "SubmitBtn", Selectors: []string{"form.search > button.submit"}}}
+	defs := []sightmap.ComponentDef{{Name: "SubmitBtn", Selectors: []string{"form.search > button.submit"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "SubmitBtn", "btn3")
 }
@@ -144,7 +145,7 @@ func TestDirectChild_Matches(t *testing.T) {
 func TestDirectChild_DoesNotMatchGrandchild(t *testing.T) {
 	// form.search > button.submit should NOT match btn1/btn2 (inside section > div.container).
 	root := makeTree()
-	defs := []match.ComponentDef{{Name: "DirectBtn", Selectors: []string{"div.container > button"}}}
+	defs := []sightmap.ComponentDef{{Name: "DirectBtn", Selectors: []string{"div.container > button"}}}
 	got := applyDefs(t, root, defs)
 	// btn1 and btn2 are direct children of div.container
 	assertIDs(t, got, "DirectBtn", "btn1", "btn2")
@@ -172,7 +173,7 @@ func TestDirectChild_TwoHops(t *testing.T) {
 			},
 		},
 	}
-	defs := []match.ComponentDef{{Name: "Link", Selectors: []string{"ul > li > a"}}}
+	defs := []sightmap.ComponentDef{{Name: "Link", Selectors: []string{"ul > li > a"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Link", "a")
 }
@@ -192,7 +193,7 @@ func TestDirectChild_NotTwoLevelsDeep(t *testing.T) {
 			},
 		},
 	}
-	defs := []match.ComponentDef{{Name: "Link", Selectors: []string{"ul > a"}}}
+	defs := []sightmap.ComponentDef{{Name: "Link", Selectors: []string{"ul > a"}}}
 	got := applyDefs(t, root, defs)
 	assertNoMatch(t, got, "Link")
 }
@@ -200,7 +201,7 @@ func TestDirectChild_NotTwoLevelsDeep(t *testing.T) {
 func TestMultiQuery_SinglePass(t *testing.T) {
 	// Two definitions matched in one pass; verify no state leakage between them.
 	root := makeTree()
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "NavLink", Selectors: []string{"nav.main-nav a.nav-link"}},
 		{Name: "SearchInput", Selectors: []string{`input[type="email"]`}},
 	}
@@ -214,7 +215,7 @@ func TestFirstMatchWins(t *testing.T) {
 	root := node("root", "div", nil,
 		node("btn", "button", []string{"primary", "submit"}),
 	)
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "Primary", Selectors: []string{"button.primary"}},
 		{Name: "Submit", Selectors: []string{"button.submit"}},
 	}
@@ -230,7 +231,7 @@ func TestInvisibleNodesIncluded(t *testing.T) {
 		nodeInvisible("hidden", "button"),
 		node("visible", "button", nil),
 	)
-	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
+	defs := []sightmap.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
 	got := applyDefs(t, root, defs)
 	// Both nodes should match, regardless of IsVisible.
 	assertIDs(t, got, "Btn", "hidden", "visible")
@@ -245,7 +246,7 @@ func TestNilSelectorNode_DoesNotMatchSpecificRule(t *testing.T) {
 			{Id: "child", Element: &comps.Element{Tag: "button"}},
 		},
 	}
-	defs := []match.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
+	defs := []sightmap.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
 	got := applyDefs(t, root, defs)
 	// Only "child" should match; "root" has no selector.
 	assertIDs(t, got, "Btn", "child")
@@ -256,7 +257,7 @@ func TestAttrSelector_Substring(t *testing.T) {
 		nodeAttr("n1", "div", map[string]string{"aria-label": "Search products"}),
 		nodeAttr("n2", "div", map[string]string{"aria-label": "Filter results"}),
 	)
-	defs := []match.ComponentDef{{Name: "Search", Selectors: []string{`[aria-label*="Search"]`}}}
+	defs := []sightmap.ComponentDef{{Name: "Search", Selectors: []string{`[aria-label*="Search"]`}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Search", "n1")
 }
@@ -266,7 +267,7 @@ func TestNotPseudo(t *testing.T) {
 		node("enabled", "button", []string{"primary"}),
 		node("disabled", "button", []string{"primary", "disabled"}),
 	)
-	defs := []match.ComponentDef{{Name: "Active", Selectors: []string{"button:not(.disabled)"}}}
+	defs := []sightmap.ComponentDef{{Name: "Active", Selectors: []string{"button:not(.disabled)"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "Active", "enabled")
 }
@@ -278,7 +279,7 @@ func TestFramePrefixedIDs_Traversed(t *testing.T) {
 			node("1_5", "a", []string{"nav-link"}),
 		),
 	)
-	defs := []match.ComponentDef{{Name: "NavLink", Selectors: []string{"nav a.nav-link"}}}
+	defs := []sightmap.ComponentDef{{Name: "NavLink", Selectors: []string{"nav a.nav-link"}}}
 	got := applyDefs(t, root, defs)
 	assertIDs(t, got, "NavLink", "1_5")
 }
@@ -298,7 +299,7 @@ func TestMobileSyntheticSelector(t *testing.T) {
 			},
 		},
 	}
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "AddToCart", Selectors: []string{`UIButton[label="Add to Cart"]`}},
 	}
 	got := applyDefs(t, root, defs)
@@ -306,7 +307,7 @@ func TestMobileSyntheticSelector(t *testing.T) {
 }
 
 func TestParseQueries_InvalidSelectorSkipped(t *testing.T) {
-	defs := []match.ComponentDef{
+	defs := []sightmap.ComponentDef{
 		{Name: "Valid", Selectors: []string{"button"}},
 		{Name: "Invalid", Selectors: []string{":hover"}}, // unsupported pseudo
 	}
@@ -320,7 +321,7 @@ func TestParseQueries_InvalidSelectorSkipped(t *testing.T) {
 }
 
 func TestApplySightmap_NilRoot(t *testing.T) {
-	defs := []match.ComponentDef{{Name: "X", Selectors: []string{"div"}}}
+	defs := []sightmap.ComponentDef{{Name: "X", Selectors: []string{"div"}}}
 	result := match.ApplySightmap(nil, defs)
 	if result != nil {
 		t.Errorf("expected nil for nil root, got %v", result)

--- a/go/match/sightmap.go
+++ b/go/match/sightmap.go
@@ -5,41 +5,14 @@ import (
 
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sel"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
-
-// ComponentDef is a single flattened sightmap component definition.
-// Hierarchical YAML selectors should be pre-flattened by the caller into
-// compound descendant selectors before calling ParseQueries.
-type ComponentDef struct {
-	Name        string     `json:"name"`
-	Selectors   []string   `json:"selectors"`
-	Source      string     `json:"source,omitempty"`
-	Memory      []string   `json:"memory,omitempty"`
-	Tags        []string   `json:"tags,omitempty"`
-	Properties  []Property `json:"properties,omitempty"`
-	ParentChain []string   `json:"parentChain,omitempty"` // ancestor component names, root-first
-	Stability   string     `json:"stability,omitempty"`   // "" (default), "uncertain", or "unstable"
-}
-
-// Property describes a value to extract from a matched DOM element.
-type Property struct {
-	Name      string `json:"name"`
-	Extract   string `json:"extract"`   // see extract modes: text, inner_text, text_only, attr=NAME, exists:SEL, CSS selector
-	Transform string `json:"transform"` // optional post-processing
-}
-
-// ComponentMatch records which component definition matched a node.
-type ComponentMatch struct {
-	Name   string
-	Memory []string
-	Tags   []string
-}
 
 // ParseQueries parses ComponentDef definitions into MatchQuery values.
 // Each selector string in each component becomes a separate MatchQuery.
 // Invalid selectors are skipped; their errors are returned alongside the
 // valid queries (non-fatal).
-func ParseQueries(defs []ComponentDef) ([]MatchQuery, []error) {
+func ParseQueries(defs []sightmap.ComponentDef) ([]MatchQuery, []error) {
 	var queries []MatchQuery
 	var errs []error
 
@@ -67,7 +40,7 @@ func ParseQueries(defs []ComponentDef) ([]MatchQuery, []error) {
 // (and earliest selector within that definition) takes precedence.
 //
 // Returns nil if defs is empty or root is nil.
-func ApplySightmap(root *comps.ComponentNode, defs []ComponentDef) map[*comps.ComponentNode]*ComponentMatch {
+func ApplySightmap(root *comps.ComponentNode, defs []sightmap.ComponentDef) map[*comps.ComponentNode]*sightmap.ComponentMatch {
 	if root == nil || len(defs) == 0 {
 		return nil
 	}
@@ -77,14 +50,14 @@ func ApplySightmap(root *comps.ComponentNode, defs []ComponentDef) map[*comps.Co
 		return nil
 	}
 
-	// Build a lookup from query name → ComponentMatch so we can resolve the
+	// Build a lookup from query name → ComponentDef so we can resolve the
 	// component definition at match time.
-	defByName := make(map[string]*ComponentDef, len(defs))
+	defByName := make(map[string]*sightmap.ComponentDef, len(defs))
 	for i := range defs {
 		defByName[defs[i].Name] = &defs[i]
 	}
 
-	result := make(map[*comps.ComponentNode]*ComponentMatch)
+	result := make(map[*comps.ComponentNode]*sightmap.ComponentMatch)
 
 	FindAllMatches(root, queries, func(node *comps.ComponentNode, q *MatchQuery) {
 		// First-match-wins: skip if already claimed.
@@ -92,7 +65,7 @@ func ApplySightmap(root *comps.ComponentNode, defs []ComponentDef) map[*comps.Co
 			return
 		}
 		def := defByName[q.Name]
-		result[node] = &ComponentMatch{
+		result[node] = &sightmap.ComponentMatch{
 			Name:   q.Name,
 			Memory: def.Memory,
 			Tags:   def.Tags,
@@ -102,21 +75,12 @@ func ApplySightmap(root *comps.ComponentNode, defs []ComponentDef) map[*comps.Co
 	return result
 }
 
-// Conflict records a DOM node directly matched by more than one DISTINCT
-// component name. ApplySightmap is first-match-wins, so only Names[0] actually
-// claims the node; the rest are silently dropped. Names are in first-seen
-// (definition) order.
-type Conflict struct {
-	Node  *comps.ComponentNode
-	Names []string
-}
-
 // FindConflicts returns the nodes that more than one distinct component name
 // matches directly. A single name matching many nodes (e.g. a list of cards) is
 // normal and never reported; a single node claimed by several names is the
 // ambiguity, since ApplySightmap keeps only the first. It reuses the same
 // traversal as ApplySightmap, so it sees exactly the same matches.
-func FindConflicts(root *comps.ComponentNode, defs []ComponentDef) []Conflict {
+func FindConflicts(root *comps.ComponentNode, defs []sightmap.ComponentDef) []sightmap.Conflict {
 	if root == nil || len(defs) == 0 {
 		return nil
 	}
@@ -140,10 +104,10 @@ func FindConflicts(root *comps.ComponentNode, defs []ComponentDef) []Conflict {
 		namesByNode[node] = append(names, q.Name)
 	})
 
-	var out []Conflict
+	var out []sightmap.Conflict
 	for _, node := range order {
 		if names := namesByNode[node]; len(names) >= 2 {
-			out = append(out, Conflict{Node: node, Names: names})
+			out = append(out, sightmap.Conflict{Node: node, Names: names})
 		}
 	}
 	return out

--- a/go/observe/format_test.go
+++ b/go/observe/format_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -65,7 +64,7 @@ func TestFormat_Conflicts(t *testing.T) {
 		CorpusApplied: true,
 		View:          &sightmap.View{Name: "AStar", Route: "/a/*"},
 		TiedViews:     []string{"AStar", "StarB"},
-		ComponentConflicts: []match.Conflict{{
+		ComponentConflicts: []sightmap.Conflict{{
 			Node:  &comps.ComponentNode{Id: "7", Role: "button", Name: "Save"},
 			Names: []string{"AppDialog", "LoginDialog"},
 		}},

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -18,9 +18,9 @@ import (
 type Result struct {
 	Root        *comps.ComponentNode
 	URL         string
-	Matches     map[*comps.ComponentNode]*match.ComponentMatch
+	Matches     map[*comps.ComponentNode]*sightmap.ComponentMatch
 	View        *sightmap.View
-	Components  []match.ComponentDef
+	Components  []sightmap.ComponentDef
 	GlobalNames map[string]bool
 	Props       map[string]map[string]string
 	Coverage    coverage.Result
@@ -37,7 +37,7 @@ type Result struct {
 	TiedViews []string
 	// ComponentConflicts holds DOM nodes claimed by more than one distinct
 	// component name (first-match-wins keeps only one; the rest are dropped).
-	ComponentConflicts []match.Conflict
+	ComponentConflicts []sightmap.Conflict
 }
 
 // Options controls how a page is observed.
@@ -75,7 +75,7 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 	}
 	res.CorpusApplied = true
 
-	m := sightmap.NewMatcher(corpus)
+	m := match.NewMatcher(corpus)
 	res.Matches = m.MatchTree(root, url)
 	res.View = corpus.ViewForURL(url)
 	res.Components = m.Components(url)
@@ -89,7 +89,7 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 	res.ComponentConflicts = match.FindConflicts(root, res.Components)
 
 	if opts.ExtractProps && len(res.Matches) > 0 && len(res.Components) > 0 {
-		compByName := make(map[string]match.ComponentDef, len(res.Components))
+		compByName := make(map[string]sightmap.ComponentDef, len(res.Components))
 		for _, c := range res.Components {
 			compByName[c.Name] = c
 		}

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // ExtractProperties runs a single batched JS evaluation against the live DOM
@@ -19,8 +19,8 @@ import (
 func ExtractProperties(
 	ctx context.Context,
 	conn *browser.CDPConn,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
-	compByName map[string]match.ComponentDef,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	compByName map[string]sightmap.ComponentDef,
 ) map[string]map[string]string {
 	type specProp struct {
 		Name      string `json:"name"`

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/render"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -110,7 +109,7 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 
 // writeGuide prints the [Guide] section: component names and match counts,
 // sorted by count descending then name ascending.
-func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.ComponentMatch) {
+func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) {
 	counts := make(map[string]int)
 	for _, m := range matches {
 		if m != nil {
@@ -158,8 +157,8 @@ func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*match.ComponentMa
 // excluded from the page-check since they match on any page.
 func writeZeroMatchWarnings(
 	w io.Writer,
-	viewComponents []match.ComponentDef,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	viewComponents []sightmap.ComponentDef,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	view *sightmap.View,
 	globalNames map[string]bool,
 ) {
@@ -342,7 +341,7 @@ func WriteT2Trace(
 	w io.Writer,
 	t2clusters map[*comps.ComponentNode]int,
 	t2children map[*comps.ComponentNode][]*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	view *sightmap.View,
 ) {
 	const minT2Count = 2 // ≥2 children required (single-child = simple wrapper)
@@ -423,7 +422,7 @@ func WriteT2Trace(
 // route (the topwork wizard returning the Dashboard). globalNames excludes
 // shared components (Header, TopworkApp, etc.) that match any page and would
 // suppress the warning spuriously. Pass nil to skip the exclusion.
-func CheckRootComponents(w io.Writer, viewComponents []match.ComponentDef, globalNames map[string]bool, counts map[string]int, viewName string) {
+func CheckRootComponents(w io.Writer, viewComponents []sightmap.ComponentDef, globalNames map[string]bool, counts map[string]int, viewName string) {
 	var topNames []string
 	for _, comp := range viewComponents {
 		if comp.Name == "" || len(comp.Selectors) == 0 || len(comp.ParentChain) > 0 {

--- a/go/observe/t2trace_test.go
+++ b/go/observe/t2trace_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -28,12 +27,12 @@ func TestWriteT2Trace_Basic(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "AppSidebar"},
 	}
 	view := &sightmap.View{
 		Name: "Home",
-		Components: []match.ComponentDef{
+		Components: []sightmap.ComponentDef{
 			{Name: "AppSidebar"},
 		},
 	}
@@ -76,11 +75,11 @@ func TestWriteT2Trace_SingleChildSuppressed(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: {child},
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "NavFooter"},
 	}
 	view := &sightmap.View{
-		Components: []match.ComponentDef{
+		Components: []sightmap.ComponentDef{
 			{Name: "NavFooter"},
 		},
 	}
@@ -113,11 +112,11 @@ func TestWriteT2Trace_MemoryNoteSuppressed(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "AppContent"},
 	}
 	view := &sightmap.View{
-		Components: []match.ComponentDef{
+		Components: []sightmap.ComponentDef{
 			{
 				Name:   "AppContent",
 				Memory: []string{"Investigated. All children use volatile classes."},
@@ -167,11 +166,11 @@ func TestWriteT2Trace_Truncation(t *testing.T) {
 	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "ProductGrid"},
 	}
 	view := &sightmap.View{
-		Components: []match.ComponentDef{
+		Components: []sightmap.ComponentDef{
 			{Name: "ProductGrid"},
 		},
 	}

--- a/go/render/inspect.go
+++ b/go/render/inspect.go
@@ -2,12 +2,12 @@ package render
 
 import (
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"io"
 	"sort"
 	"strings"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // InspectNode is a node in the unfiltered DOM-structural tree produced by Inspect().
@@ -22,7 +22,7 @@ type InspectNode struct {
 	IsVisible     bool
 	IsIgnored     bool
 	IsInteractive bool
-	Match         *match.ComponentMatch // non-nil when a sightmap definition matched
+	Match         *sightmap.ComponentMatch // non-nil when a sightmap definition matched
 	Children      []*InspectNode
 	Original      *comps.ComponentNode
 }
@@ -45,14 +45,14 @@ type InspectOpts struct {
 // Inspect builds an unfiltered InspectNode tree from a raw ComponentNode tree.
 // Every node is preserved — hidden, ignored, and structural nodes all appear.
 // If matches is non-nil, matched nodes have their Match field populated.
-func Inspect(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *InspectNode {
+func Inspect(root *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) *InspectNode {
 	if root == nil {
 		return nil
 	}
 	return buildInspectNode(root, matches)
 }
 
-func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *InspectNode {
+func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) *InspectNode {
 	tag := ""
 	if node.Element != nil && node.Element.Tag != "" {
 		tag = node.Element.Tag

--- a/go/render/inspect_test.go
+++ b/go/render/inspect_test.go
@@ -2,11 +2,11 @@ package render
 
 import (
 	"bytes"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // TestInspect_PreservesAllNodes verifies that invisible and ignored children
@@ -48,7 +48,7 @@ func TestInspect_NoFilteringVsFilter(t *testing.T) {
 // TestInspect_MatchAnnotation verifies that match is propagated onto InspectNode.
 func TestInspect_MatchAnnotation(t *testing.T) {
 	btn := node("1", "button", "OK", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		btn: {Name: "SubmitBtn"},
 	}
 
@@ -192,7 +192,7 @@ func TestFormatInspect_Selectors_ShowsAll(t *testing.T) {
 // TestFormatInspect_MatchAnnotation verifies ★Name is shown for matched nodes.
 func TestFormatInspect_MatchAnnotation(t *testing.T) {
 	btn := node("3", "button", "Shop", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		btn: {Name: "ShopButton"},
 	}
 	in := Inspect(btn, matches)

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -2,21 +2,21 @@ package render
 
 import (
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"io"
 	"sort"
 	"strings"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // Comp is a filtered, display-ready component node produced by Filter().
 type Comp struct {
 	Id       string
-	Role     string                // display role: AX role (interactive) or match name (structural)
-	Name     string                // accessible name; may be collapsed from StaticText children
-	Value    string                // form field value
-	Match    *match.ComponentMatch // non-nil when matched by a sightmap definition
+	Role     string                   // display role: AX role (interactive) or match name (structural)
+	Name     string                   // accessible name; may be collapsed from StaticText children
+	Value    string                   // form field value
+	Match    *sightmap.ComponentMatch // non-nil when matched by a sightmap definition
 	Children []*Comp
 	Original *comps.ComponentNode // original raw node; .Role has the unmodified AX role
 }
@@ -50,7 +50,7 @@ type FormatOpts struct {
 // StaticText child is collapsed into the parent's Name.
 //
 // If matches is nil or empty, no sightmap annotations are applied.
-func Filter(root *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) *Comp {
+func Filter(root *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) *Comp {
 	if root == nil {
 		return nil
 	}
@@ -216,7 +216,7 @@ func decide(node *comps.ComponentNode, matched bool) disposition {
 	return keepNode
 }
 
-func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) []*Comp {
+func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) []*Comp {
 	m := matches[node]
 	matched := m != nil
 
@@ -277,7 +277,7 @@ func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.
 	}}
 }
 
-func convertChildren(node *comps.ComponentNode, matches map[*comps.ComponentNode]*match.ComponentMatch) []*Comp {
+func convertChildren(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) []*Comp {
 	var out []*Comp
 	for _, ch := range node.Children {
 		out = append(out, convert(ch, matches)...)

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -2,11 +2,11 @@ package render
 
 import (
 	"bytes"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // node builds a ComponentNode for use in tests.
@@ -215,7 +215,7 @@ func TestFilter_MergeAdjacentStaticText_Mixed(t *testing.T) {
 
 func TestFilter_MatchProtectsFromTransparency(t *testing.T) {
 	div := node("1", "none", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		div: {Name: "ProductCard"},
 	}
 	comp := Filter(div, matches)
@@ -234,7 +234,7 @@ func TestFilter_MatchedLinkRoleReplaced(t *testing.T) {
 	// Mirrors the canonical extractor's DisplayRole(): match name always replaces AX role,
 	// even for interactive roles like "link". No ★ annotation.
 	a := node("1", "link", "Home", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "NavLink"},
 	}
 	comp := Filter(a, matches)
@@ -251,7 +251,7 @@ func TestFilter_MatchedLinkRoleReplaced(t *testing.T) {
 
 func TestFilter_StructuralRoleReplacedByMatchName(t *testing.T) {
 	nav := node("1", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		nav: {Name: "GlobalNav"},
 	}
 	comp := Filter(nav, matches)
@@ -291,7 +291,7 @@ func TestFilter_Value_Preserved(t *testing.T) {
 
 func TestFilter_EmptyMatches(t *testing.T) {
 	root := node("1", "button", "OK", true, true, false)
-	comp := Filter(root, map[*comps.ComponentNode]*match.ComponentMatch{})
+	comp := Filter(root, map[*comps.ComponentNode]*sightmap.ComponentMatch{})
 	if comp == nil {
 		t.Fatal("expected non-nil comp")
 	}
@@ -325,7 +325,7 @@ func TestFormat_NilComp(t *testing.T) {
 
 func TestFormat_WithMatchAnnotation_Interactive(t *testing.T) {
 	a := node("1", "link", "Home", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "NavLink"},
 	}
 	comp := Filter(a, matches)
@@ -341,7 +341,7 @@ func TestFormat_WithMatchAnnotation_Interactive(t *testing.T) {
 
 func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 	nav := node("1", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		nav: {Name: "GlobalNav"},
 	}
 	comp := Filter(nav, matches)
@@ -356,7 +356,7 @@ func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 
 func TestFormat_WithPropValues(t *testing.T) {
 	a := node("1", "link", "Garden Center", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "CategoryTile"},
 	}
 	comp := Filter(a, matches)
@@ -376,7 +376,7 @@ func TestFormat_WithPropValues(t *testing.T) {
 
 func TestFormat_WithPropValues_SortedKeys(t *testing.T) {
 	a := node("1", "link", "Item", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "Tile"},
 	}
 	comp := Filter(a, matches)
@@ -598,7 +598,7 @@ func TestFilter_MultipleChildren_ParentNameKept(t *testing.T) {
 func TestFormat_Bracket_NoPropsNoName(t *testing.T) {
 	// Matched structural node with no text and no props → bare [CompName]
 	nav := node("42", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		nav: {Name: "SiteHeader"},
 	}
 	comp := Filter(nav, matches)
@@ -613,7 +613,7 @@ func TestFormat_Bracket_NoPropsNoName(t *testing.T) {
 func TestFormat_Bracket_NameKept_NoProps(t *testing.T) {
 	// Matched node, name present, no props → name shown last inside brackets
 	a := node("7", "link", "Shop Now", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "BannerLink"},
 	}
 	comp := Filter(a, matches)
@@ -628,7 +628,7 @@ func TestFormat_Bracket_NameKept_NoProps(t *testing.T) {
 func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 	// Rule A: name exactly matches a prop value → name omitted
 	a := node("3", "link", "Explore", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "DesktopNavLink"},
 	}
 	comp := Filter(a, matches)
@@ -647,7 +647,7 @@ func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 func TestFormat_RuleA_NameKept_CaseDiffers(t *testing.T) {
 	// Rule A is exact — case difference means name is kept last
 	a := node("5", "link", "FRI Aug 21 7:00pm", true, true, false)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "ShowDateRow"},
 	}
 	comp := Filter(a, matches)
@@ -671,7 +671,7 @@ func TestFormat_RuleB_StaticTextSuppressed(t *testing.T) {
 	btn := node("3", "button", "Open menu", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
 	// generic with name "foo bar" is kept (name != "")
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "NavItem"},
 	}
 	comp := Filter(parent, matches)
@@ -700,7 +700,7 @@ func TestFormat_RuleB_StaticTextKept_NoMatch(t *testing.T) {
 	st := node("2", "StaticText", "other text", true, false, false)
 	btn := node("3", "button", "OK", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "MyComp"},
 	}
 	comp := Filter(parent, matches)
@@ -724,7 +724,7 @@ func TestFormat_ValueFallback_InBrackets(t *testing.T) {
 		Id: "7", Role: "textbox", Name: "Search", Value: "query text",
 		IsVisible: true, IsInteractive: true,
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		n: {Name: "SearchInput"},
 	}
 	comp := Filter(n, matches)
@@ -744,7 +744,7 @@ func TestFormat_ValueOverride_SightmapWins(t *testing.T) {
 		Id: "8", Role: "textbox", Name: "Dropdown", Value: "AX value",
 		IsVisible: true, IsInteractive: true,
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		n: {Name: "CustomSelect"},
 	}
 	comp := Filter(n, matches)
@@ -804,7 +804,7 @@ func TestFormat_Selectors_AfterBracket(t *testing.T) {
 			Attrs: map[string]string{"data-testid": "home-link"},
 		},
 	}
-	matches := map[*comps.ComponentNode]*match.ComponentMatch{
+	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
 		n: {Name: "HomeLink"},
 	}
 	comp := Filter(n, matches)

--- a/go/sightmap/component.go
+++ b/go/sightmap/component.go
@@ -1,0 +1,40 @@
+package sightmap
+
+import "github.com/sightmap/sightmap/go/comps"
+
+// ComponentDef is a single flattened sightmap component definition.
+// Hierarchical YAML selectors should be pre-flattened by the caller into
+// compound descendant selectors before compiling into match queries.
+type ComponentDef struct {
+	Name        string     `json:"name"`
+	Selectors   []string   `json:"selectors"`
+	Source      string     `json:"source,omitempty"`
+	Memory      []string   `json:"memory,omitempty"`
+	Tags        []string   `json:"tags,omitempty"`
+	Properties  []Property `json:"properties,omitempty"`
+	ParentChain []string   `json:"parentChain,omitempty"` // ancestor component names, root-first
+	Stability   string     `json:"stability,omitempty"`   // "" (default), "uncertain", or "unstable"
+}
+
+// Property describes a value to extract from a matched DOM element.
+type Property struct {
+	Name      string `json:"name"`
+	Extract   string `json:"extract"`   // see extract modes: text, inner_text, text_only, attr=NAME, exists:SEL, CSS selector
+	Transform string `json:"transform"` // optional post-processing
+}
+
+// ComponentMatch records which component definition matched a node.
+type ComponentMatch struct {
+	Name   string
+	Memory []string
+	Tags   []string
+}
+
+// Conflict records a DOM node directly matched by more than one DISTINCT
+// component name. Component matching is first-match-wins, so only Names[0]
+// actually claims the node; the rest are silently dropped. Names are in
+// first-seen (definition) order.
+type Conflict struct {
+	Node  *comps.ComponentNode
+	Names []string
+}

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -4,8 +4,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // Corpus is the parsed, $ref-expanded, hierarchy-flattened sightmap data. It is
@@ -23,7 +21,7 @@ type Corpus struct {
 
 	// GlobalComponents is the flat list of globally-defined components
 	// (from components.yaml), with children already flattened.
-	GlobalComponents []match.ComponentDef `json:"globals,omitempty"`
+	GlobalComponents []ComponentDef `json:"globals,omitempty"`
 
 	// Views contains per-route component lists, with $refs expanded and
 	// children flattened.
@@ -61,11 +59,11 @@ func (a Access) IsOpen() bool {
 
 // View is a per-URL-pattern view definition from the sightmap corpus.
 type View struct {
-	Name       string               `json:"name"`
-	Route      string               `json:"route,omitempty"`
-	Memory     []string             `json:"memory,omitempty"`
-	Components []match.ComponentDef `json:"components,omitempty"`
-	Requests   []RequestDef         `json:"requests,omitempty"` // view-scoped API request definitions
+	Name       string         `json:"name"`
+	Route      string         `json:"route,omitempty"`
+	Memory     []string       `json:"memory,omitempty"`
+	Components []ComponentDef `json:"components,omitempty"`
+	Requests   []RequestDef   `json:"requests,omitempty"` // view-scoped API request definitions
 
 	// Authoring/tooling fields — kept out of the serialized wire form.
 	Stability  string     `json:"-"` // "" (default/active), "stub", or "deferred"
@@ -117,7 +115,7 @@ func (v *View) SnapBasename() string {
 // ComponentsForURL returns the merged flat component list for a given URL:
 // view components first, then global components that don't collide on name.
 // Returns GlobalComponents only if no view matches.
-func (c *Corpus) ComponentsForURL(pageURL string) []match.ComponentDef {
+func (c *Corpus) ComponentsForURL(pageURL string) []ComponentDef {
 	v := c.ViewForURL(pageURL)
 	if v == nil {
 		return c.GlobalComponents
@@ -129,7 +127,7 @@ func (c *Corpus) ComponentsForURL(pageURL string) []match.ComponentDef {
 		viewNames[vc.Name] = true
 	}
 
-	result := make([]match.ComponentDef, 0, len(v.Components)+len(c.GlobalComponents))
+	result := make([]ComponentDef, 0, len(v.Components)+len(c.GlobalComponents))
 	result = append(result, v.Components...)
 	for _, gc := range c.GlobalComponents {
 		if !viewNames[gc.Name] {
@@ -145,10 +143,10 @@ func (c *Corpus) ComponentsForURL(pageURL string) []match.ComponentDef {
 // (global list first, then views in corpus order) wins. Route is not considered — this is
 // for a whole-corpus consumer (a linter, a coverage report, an upload payload builder), not
 // a per-page match; use ComponentsForURL for a single page's applicable list.
-func (c *Corpus) AllComponents() []match.ComponentDef {
+func (c *Corpus) AllComponents() []ComponentDef {
 	seen := make(map[string]bool)
-	var out []match.ComponentDef
-	add := func(comp match.ComponentDef) {
+	var out []ComponentDef
+	add := func(comp ComponentDef) {
 		if comp.Name == "" || seen[comp.Name] {
 			return
 		}

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -2,13 +2,13 @@ package sightmap_test
 
 import (
 	"fmt"
+	"github.com/sightmap/sightmap/go/match"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -275,17 +275,17 @@ views:
 
 func TestRouteMatching(t *testing.T) {
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.ComponentDef{
+		GlobalComponents: []sightmap.ComponentDef{
 			{Name: "Global", Selectors: []string{"body"}},
 		},
 		Views: []sightmap.View{
-			{Name: "B", Route: "/b/**", Components: []match.ComponentDef{
+			{Name: "B", Route: "/b/**", Components: []sightmap.ComponentDef{
 				{Name: "BComp", Selectors: []string{".b"}},
 			}},
-			{Name: "Product", Route: "/product/*", Components: []match.ComponentDef{
+			{Name: "Product", Route: "/product/*", Components: []sightmap.ComponentDef{
 				{Name: "PComp", Selectors: []string{".p"}},
 			}},
-			{Name: "Home", Route: "/", Components: []match.ComponentDef{
+			{Name: "Home", Route: "/", Components: []sightmap.ComponentDef{
 				{Name: "HomeComp", Selectors: []string{".home"}},
 			}},
 		},
@@ -329,15 +329,15 @@ func TestRouteMatching(t *testing.T) {
 // ---- 5. ComponentsForURL merging --------------------------------------------
 
 func TestComponentsForURL(t *testing.T) {
-	globalA := match.ComponentDef{Name: "A", Selectors: []string{"#a"}}
-	globalB := match.ComponentDef{Name: "B", Selectors: []string{"#b-global"}}
-	viewB := match.ComponentDef{Name: "B", Selectors: []string{"#b-view"}}
-	viewC := match.ComponentDef{Name: "C", Selectors: []string{"#c"}}
+	globalA := sightmap.ComponentDef{Name: "A", Selectors: []string{"#a"}}
+	globalB := sightmap.ComponentDef{Name: "B", Selectors: []string{"#b-global"}}
+	viewB := sightmap.ComponentDef{Name: "B", Selectors: []string{"#b-view"}}
+	viewC := sightmap.ComponentDef{Name: "C", Selectors: []string{"#c"}}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.ComponentDef{globalA, globalB},
+		GlobalComponents: []sightmap.ComponentDef{globalA, globalB},
 		Views: []sightmap.View{
-			{Route: "/page", Components: []match.ComponentDef{viewB, viewC}},
+			{Route: "/page", Components: []sightmap.ComponentDef{viewB, viewC}},
 		},
 	}
 
@@ -373,15 +373,15 @@ func TestComponentsForURL(t *testing.T) {
 }
 
 func TestAllComponents(t *testing.T) {
-	globalA := match.ComponentDef{Name: "A", Selectors: []string{"#a"}}
-	globalB := match.ComponentDef{Name: "B", Selectors: []string{"#b-global"}}
-	viewB := match.ComponentDef{Name: "B", Selectors: []string{"#b-view"}} // $ref-expanded global, same name
-	viewC := match.ComponentDef{Name: "C", Selectors: []string{"#c"}}
+	globalA := sightmap.ComponentDef{Name: "A", Selectors: []string{"#a"}}
+	globalB := sightmap.ComponentDef{Name: "B", Selectors: []string{"#b-global"}}
+	viewB := sightmap.ComponentDef{Name: "B", Selectors: []string{"#b-view"}} // $ref-expanded global, same name
+	viewC := sightmap.ComponentDef{Name: "C", Selectors: []string{"#c"}}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.ComponentDef{globalA, globalB},
+		GlobalComponents: []sightmap.ComponentDef{globalA, globalB},
 		Views: []sightmap.View{
-			{Route: "/page", Components: []match.ComponentDef{viewB, viewC}},
+			{Route: "/page", Components: []sightmap.ComponentDef{viewB, viewC}},
 		},
 	}
 
@@ -425,14 +425,14 @@ func TestMatchTreeEndToEnd(t *testing.T) {
 	}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.ComponentDef{
+		GlobalComponents: []sightmap.ComponentDef{
 			{Name: "SearchForm", Selectors: []string{"form#search-form"}, Memory: []string{"search form hint"}},
 			{Name: "SearchInput", Selectors: []string{"form#search-form input"}},
 			{Name: "SearchSubmit", Selectors: []string{"form#search-form button"}, Memory: []string{"submit hint"}},
 		},
 	}
 
-	matches := sightmap.NewMatcher(corpus).MatchTree(root, "https://example.com/search")
+	matches := match.NewMatcher(corpus).MatchTree(root, "https://example.com/search")
 
 	// formNode → SearchForm
 	m := mustMatch(t, matches, formNode, "formNode")
@@ -477,7 +477,7 @@ func TestConcurrentSafety(t *testing.T) {
 	}
 
 	corpus := &sightmap.Corpus{
-		GlobalComponents: []match.ComponentDef{
+		GlobalComponents: []sightmap.ComponentDef{
 			{Name: "Button", Selectors: []string{"button"}},
 		},
 	}
@@ -492,7 +492,7 @@ func TestConcurrentSafety(t *testing.T) {
 			defer wg.Done()
 			// Use a few distinct URLs to exercise the multi-key cache path.
 			url := fmt.Sprintf("https://example.com/page/%d", i%5)
-			matches := sightmap.NewMatcher(corpus).MatchTree(root, url)
+			matches := match.NewMatcher(corpus).MatchTree(root, url)
 			if _, ok := matches[buttonNode]; !ok {
 				errs[i] = fmt.Errorf("goroutine %d: button not matched", i)
 			}
@@ -519,15 +519,15 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-func indexByName(cs []match.ComponentDef) map[string]match.ComponentDef {
-	m := make(map[string]match.ComponentDef, len(cs))
+func indexByName(cs []sightmap.ComponentDef) map[string]sightmap.ComponentDef {
+	m := make(map[string]sightmap.ComponentDef, len(cs))
 	for _, c := range cs {
 		m[c.Name] = c
 	}
 	return m
 }
 
-func compNames(cs []match.ComponentDef) []string {
+func compNames(cs []sightmap.ComponentDef) []string {
 	names := make([]string, len(cs))
 	for i, c := range cs {
 		names[i] = c.Name
@@ -547,7 +547,7 @@ func equalSels(a, b []string) bool {
 	return true
 }
 
-func hasComp(cs []match.ComponentDef, name string) bool {
+func hasComp(cs []sightmap.ComponentDef, name string) bool {
 	for _, c := range cs {
 		if c.Name == name {
 			return true
@@ -556,7 +556,7 @@ func hasComp(cs []match.ComponentDef, name string) bool {
 	return false
 }
 
-func mustGet(t *testing.T, m map[string]match.ComponentDef, name string) match.ComponentDef {
+func mustGet(t *testing.T, m map[string]sightmap.ComponentDef, name string) sightmap.ComponentDef {
 	t.Helper()
 	c, ok := m[name]
 	if !ok {
@@ -573,10 +573,10 @@ func mustGet(t *testing.T, m map[string]match.ComponentDef, name string) match.C
 
 func mustMatch(
 	t *testing.T,
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	node *comps.ComponentNode,
 	label string,
-) *match.ComponentMatch {
+) *sightmap.ComponentMatch {
 	t.Helper()
 	m, ok := matches[node]
 	if !ok {

--- a/go/sightmap/corpus_wire_test.go
+++ b/go/sightmap/corpus_wire_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -15,7 +14,7 @@ import (
 func TestCorpusWireRoundTrip(t *testing.T) {
 	orig := &sightmap.Corpus{
 		Memory:           []string{"file note"},
-		GlobalComponents: []match.ComponentDef{{Name: "Nav", Selectors: []string{"nav"}}},
+		GlobalComponents: []sightmap.ComponentDef{{Name: "Nav", Selectors: []string{"nav"}}},
 		Requests: []sightmap.RequestDef{
 			{Name: "Search", Route: "/api/search", Method: "POST",
 				Request: &sightmap.Payload{Fields: []sightmap.Field{{Name: "q", Type: "string"}}}},
@@ -24,7 +23,7 @@ func TestCorpusWireRoundTrip(t *testing.T) {
 		Views: []sightmap.View{{
 			Name:       "Home",
 			Route:      "/",
-			Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
+			Components: []sightmap.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 			Requests:   []sightmap.RequestDef{{Name: "Ping", Route: "/api/ping"}},
 			// Authoring fields that must NOT appear on the wire:
 			URL:        "https://x.test/",

--- a/go/sightmap/lint.go
+++ b/go/sightmap/lint.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sel"
 )
 
@@ -277,14 +276,14 @@ func lintMessageLevels(msgs []MessageDef) []LintWarning {
 
 // lintComponent runs per-component lint rules.
 // global controls whether rules restricted to global scope are applied.
-func lintComponent(comp match.ComponentDef, global bool) []LintWarning {
+func lintComponent(comp ComponentDef, global bool) []LintWarning {
 	return lintComponentWithCounts(comp, global, nil)
 }
 
 // lintComponentWithCounts is the full implementation of per-component lint
 // rules. counts (component name → match count) optionally augments the
 // multi-instance-no-property warning; pass nil to use static heuristics only.
-func lintComponentWithCounts(comp match.ComponentDef, global bool, counts map[string]int) []LintWarning {
+func lintComponentWithCounts(comp ComponentDef, global bool, counts map[string]int) []LintWarning {
 	var warnings []LintWarning
 
 	name := comp.Name

--- a/go/sightmap/lint_snapshot_test.go
+++ b/go/sightmap/lint_snapshot_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -12,7 +11,7 @@ import (
 // multi-instance-no-property under static heuristics:
 // a bare generic button with a utility class and no properties.
 func broadComp(name string) *sightmap.Corpus {
-	return corpusFrom([]match.ComponentDef{
+	return corpusFrom([]sightmap.ComponentDef{
 		{Name: name, Selectors: []string{"button.btn-action"}},
 	}, nil)
 }
@@ -112,7 +111,7 @@ func TestLintSnapshot_EmptyCountsMap(t *testing.T) {
 // TestLintSnapshot_UnrelatedComponentsUnaffected verifies that a count entry
 // for one component does not affect warnings for a different component.
 func TestLintSnapshot_UnrelatedComponentsUnaffected(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "AddToCart", Selectors: []string{"button.btn-action"}},
 		{Name: "QuickBuy", Selectors: []string{"button.btn-quick"}},
 	}, nil)

--- a/go/sightmap/lint_stability_test.go
+++ b/go/sightmap/lint_stability_test.go
@@ -3,19 +3,18 @@ package sightmap_test
 import (
 	"testing"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func TestLint_StabilitySuppression(t *testing.T) {
 	tests := []struct {
 		name     string
-		comp     match.ComponentDef
+		comp     sightmap.ComponentDef
 		wantRule string // empty if no warning expected
 	}{
 		{
 			name: "unstable suppresses multi-instance warning",
-			comp: match.ComponentDef{
+			comp: sightmap.ComponentDef{
 				Name:       "VolatileButton",
 				Selectors:  []string{"button.css-module-xyz"},
 				Stability:  "unstable",
@@ -25,7 +24,7 @@ func TestLint_StabilitySuppression(t *testing.T) {
 		},
 		{
 			name: "uncertain does not suppress multi-instance warning",
-			comp: match.ComponentDef{
+			comp: sightmap.ComponentDef{
 				Name:       "UncertainButton",
 				Selectors:  []string{"button.btn-primary"},
 				Stability:  "uncertain",
@@ -35,7 +34,7 @@ func TestLint_StabilitySuppression(t *testing.T) {
 		},
 		{
 			name: "no stability triggers warning",
-			comp: match.ComponentDef{
+			comp: sightmap.ComponentDef{
 				Name:       "GenericButton",
 				Selectors:  []string{"button.btn"},
 				Stability:  "",
@@ -47,7 +46,7 @@ func TestLint_StabilitySuppression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := corpusFrom([]match.ComponentDef{tt.comp}, nil)
+			c := corpusFrom([]sightmap.ComponentDef{tt.comp}, nil)
 			warnings := sightmap.Lint(c)
 
 			foundRule := ""

--- a/go/sightmap/lint_test.go
+++ b/go/sightmap/lint_test.go
@@ -3,7 +3,6 @@ package sightmap_test
 import (
 	"testing"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -19,7 +18,7 @@ func hasRule(ws []sightmap.LintWarning, rule string) bool {
 
 func TestLint_NameCase(t *testing.T) {
 	// ".nav-link" is a class selector — won't trigger broad-tag-selector.
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "navLink", Selectors: []string{".nav-link"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -32,7 +31,7 @@ func TestLint_NameCase(t *testing.T) {
 }
 
 func TestLint_BroadTagGlobal(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "Button", Selectors: []string{"button"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -52,7 +51,7 @@ func TestLint_BroadTagInView(t *testing.T) {
 		{
 			Name:  "Page",
 			Route: "/",
-			Components: []match.ComponentDef{
+			Components: []sightmap.ComponentDef{
 				{Name: "Button", Selectors: []string{"button"}},
 			},
 		},
@@ -70,7 +69,7 @@ func TestLint_BroadTagInView(t *testing.T) {
 }
 
 func TestLint_IdHash(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "Root", Selectors: []string{"div#root-12345"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -83,7 +82,7 @@ func TestLint_IdHash(t *testing.T) {
 }
 
 func TestLint_DeepNesting(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "Input", Selectors: []string{"form div section input"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -100,7 +99,7 @@ func TestLint_CommaInSelector(t *testing.T) {
 	// "a, button" contains a comma that should have been split by the loader.
 	// It also fails ParseSightmapSelector (comma stops the parse), so we
 	// expect both a "validation" warning and a "comma-in-selector" warning.
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "Link", Selectors: []string{"a, button"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -112,7 +111,7 @@ func TestLint_CommaInSelector(t *testing.T) {
 func TestLint_ValidationErrors(t *testing.T) {
 	// A component with an empty name is a validation error; Lint should
 	// surface it as a warning with Rule="validation".
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "", Selectors: []string{"div"}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -127,7 +126,7 @@ func TestLint_ValidationErrors(t *testing.T) {
 func TestLint_DeepNestingFalsePositive(t *testing.T) {
 	// Selector with spaces INSIDE a quoted attribute value should NOT trigger
 	// deep-nesting — only 2 real selector parts (1 combinator).
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "LogoLink", Selectors: []string{`#nav-header a[aria-label="Link to homepage"]`}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -140,7 +139,7 @@ func TestLint_DeepNestingFalsePositive(t *testing.T) {
 
 func TestLint_CommaInIsNotFlagged(t *testing.T) {
 	// A comma inside :is() is valid and must NOT trigger comma-in-selector.
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "Content", Selectors: []string{`:is([data-testid="main"], [data-testid="top"]) [data-testid="foo"]`}},
 	}, nil)
 	warnings := sightmap.Lint(c)
@@ -154,12 +153,12 @@ func TestLint_CommaInIsNotFlagged(t *testing.T) {
 func TestLint_NoDuplicateWarnings(t *testing.T) {
 	// A global component referenced via $ref in two views should produce
 	// at most one warning per (rule, component, selector) triplet.
-	global := match.ComponentDef{Name: "Button", Selectors: []string{"button"}}
+	global := sightmap.ComponentDef{Name: "Button", Selectors: []string{"button"}}
 	c := corpusFrom(
-		[]match.ComponentDef{global},
+		[]sightmap.ComponentDef{global},
 		[]sightmap.View{
-			{Name: "PageA", Route: "/a", Components: []match.ComponentDef{global}},
-			{Name: "PageB", Route: "/b", Components: []match.ComponentDef{global}},
+			{Name: "PageA", Route: "/a", Components: []sightmap.ComponentDef{global}},
+			{Name: "PageB", Route: "/b", Components: []sightmap.ComponentDef{global}},
 		},
 	)
 	warnings := sightmap.Lint(c)
@@ -178,14 +177,14 @@ func TestLint_NoDuplicateWarnings(t *testing.T) {
 func TestLint_Clean(t *testing.T) {
 	// nav.navbar: has a class, so it is not a bare-tag selector.
 	c := corpusFrom(
-		[]match.ComponentDef{
+		[]sightmap.ComponentDef{
 			{Name: "NavBar", Selectors: []string{"nav.navbar"}},
 		},
 		[]sightmap.View{
 			{
 				Name:       "Home",
 				Route:      "/",
-				Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
+				Components: []sightmap.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 			},
 		},
 	)
@@ -198,7 +197,7 @@ func TestLint_Clean(t *testing.T) {
 // TestLint_MultiInstanceNoProperty tests that components with broad selectors
 // and no properties trigger the multi-instance-no-property warning.
 func TestLint_MultiInstanceNoProperty_Button(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "DeleteButton", Selectors: []string{"button.btn-danger"}},
 	}, nil)
 
@@ -216,7 +215,7 @@ func TestLint_MultiInstanceNoProperty_Button(t *testing.T) {
 }
 
 func TestLint_MultiInstanceNoProperty_Card(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "ProductCard", Selectors: []string{`[data-component="product-card"]`}},
 	}, nil)
 
@@ -228,11 +227,11 @@ func TestLint_MultiInstanceNoProperty_Card(t *testing.T) {
 }
 
 func TestLint_MultiInstanceWithProperties_NoWarn(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{
 			Name:      "ProductCard",
 			Selectors: []string{`[data-component="product-card"]`},
-			Properties: []match.Property{
+			Properties: []sightmap.Property{
 				{Name: "sku", Extract: "attr:data-sku"},
 			},
 		},
@@ -249,7 +248,7 @@ func TestLint_MultiInstanceWithProperties_NoWarn(t *testing.T) {
 
 func TestLint_Singleton_NoWarn(t *testing.T) {
 	// Singletons like SiteHeader should not warn even without properties
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "SiteHeader", Selectors: []string{`header[role="banner"]`}},
 	}, nil)
 
@@ -264,7 +263,7 @@ func TestLint_Singleton_NoWarn(t *testing.T) {
 
 func TestLint_UniqueSelector_NoWarn(t *testing.T) {
 	// Selectors with data-testid are unique and should not warn
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "SubmitButton", Selectors: []string{`button[data-testid="submit-form"]`}},
 	}, nil)
 
@@ -290,7 +289,7 @@ func TestLint_ColonAnchoredDataComponent_NoWarn(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := corpusFrom([]match.ComponentDef{
+			c := corpusFrom([]sightmap.ComponentDef{
 				{Name: "TheComp", Selectors: []string{tc.sel}},
 			}, nil)
 			for _, w := range sightmap.Lint(c) {
@@ -302,7 +301,7 @@ func TestLint_ColonAnchoredDataComponent_NoWarn(t *testing.T) {
 	}
 
 	// ^= prefix is still broad and SHOULD warn
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "TheComp", Selectors: []string{`[data-component^="product-details:ProductDetails"]`}},
 	}, nil)
 	hasWarn := false
@@ -318,7 +317,7 @@ func TestLint_ColonAnchoredDataComponent_NoWarn(t *testing.T) {
 
 func TestLint_UniqueIdSelector_NoWarn(t *testing.T) {
 	// Selectors with #id are unique and should not warn
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "MainNav", Selectors: []string{"#main-navigation"}},
 	}, nil)
 
@@ -341,7 +340,7 @@ func TestLint_ChildRepeatsParent_Warns(t *testing.T) {
 		{
 			Name:  "DashboardPage",
 			Route: "/dashboard",
-			Components: []match.ComponentDef{
+			Components: []sightmap.ComponentDef{
 				{
 					Name:        "FreelancerCard",
 					Selectors:   []string{".dashboard .dashboard .freelancer-card"},
@@ -362,7 +361,7 @@ func TestLint_ChildRepeatsParent_MultiClass(t *testing.T) {
 		{
 			Name:  "Page",
 			Route: "/",
-			Components: []match.ComponentDef{
+			Components: []sightmap.ComponentDef{
 				{
 					Name:        "HelpLink",
 					Selectors:   []string{".help-card .help-card a"},
@@ -383,7 +382,7 @@ func TestLint_ChildRepeatsParent_NoWarnCorrect(t *testing.T) {
 		{
 			Name:  "DashboardPage",
 			Route: "/dashboard",
-			Components: []match.ComponentDef{
+			Components: []sightmap.ComponentDef{
 				{
 					Name:        "FreelancerCard",
 					Selectors:   []string{".freelancer-card"},
@@ -403,7 +402,7 @@ func TestLint_ChildRepeatsParent_NoWarnCorrect(t *testing.T) {
 func TestLint_ChildRepeatsParent_NoWarnGlobal(t *testing.T) {
 	// A top-level global component with a multi-class selector like ".x .x" must
 	// NOT trigger child-repeats-parent — the rule is gated on ParentChain.
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{
 			Name:        "WeirdGlobal",
 			Selectors:   []string{".nav .nav"},
@@ -424,11 +423,11 @@ func TestLint_ChildComponent_NoWarn(t *testing.T) {
 		{
 			Name:  "ProductPage",
 			Route: "/product",
-			Components: []match.ComponentDef{
+			Components: []sightmap.ComponentDef{
 				{
 					Name:      "ProductGrid",
 					Selectors: []string{`[data-testid="product-grid"]`},
-					Properties: []match.Property{
+					Properties: []sightmap.Property{
 						{Name: "ProductCard", Extract: ".product-card"},
 					},
 				},

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // Loader is the source of sightmap corpus data.
@@ -300,14 +298,14 @@ func loadDir(path string) (*Corpus, error) {
 
 // ---- flattening helpers -----------------------------------------------------
 
-// rawPropsToMatch converts a slice of rawProperty to match.Property.
-func rawPropsToMatch(rps []rawProperty) []match.Property {
+// rawPropsToMatch converts a slice of rawProperty to Property.
+func rawPropsToMatch(rps []rawProperty) []Property {
 	if len(rps) == 0 {
 		return nil
 	}
-	ps := make([]match.Property, len(rps))
+	ps := make([]Property, len(rps))
 	for i, rp := range rps {
-		ps[i] = match.Property{Name: rp.Name, Extract: rp.Extract, Transform: rp.Transform}
+		ps[i] = Property{Name: rp.Name, Extract: rp.Extract, Transform: rp.Transform}
 	}
 	return ps
 }
@@ -488,8 +486,8 @@ func (ctx *flattenCtx) recordCircular(chain []string) {
 // stable: components in declaration order, each parent immediately before its
 // flattened children (pre-order). Combined with loadDir's lexical file walk this
 // gives the corpus a reproducible flattened/wire ordering.
-func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.ComponentDef {
-	var result []match.ComponentDef
+func flattenAll(rcs []rawComponent, ctx *flattenCtx) []ComponentDef {
+	var result []ComponentDef
 	for _, rc := range rcs {
 		result = append(result, flattenOne(rc, nil, ctx, nil, nil)...)
 	}
@@ -504,7 +502,7 @@ func flattenAll(rcs []rawComponent, ctx *flattenCtx) []match.ComponentDef {
 // extension can scope child selectors to their parent's DOM subtree.
 // refStack is the chain of $ref names currently being expanded; it guards
 // against circular references, which would otherwise recurse forever.
-func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentChain []string, refStack []string) []match.ComponentDef {
+func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentChain []string, refStack []string) []ComponentDef {
 	// Expand $ref: replace the placeholder with a deep copy of the named global.
 	if rc.Ref != "" {
 		for _, prev := range refStack {
@@ -572,7 +570,7 @@ func flattenOne(rc rawComponent, parentSels []string, ctx *flattenCtx, parentCha
 		}
 	}
 
-	result := []match.ComponentDef{{
+	result := []ComponentDef{{
 		Name:        rc.Name,
 		Selectors:   mySels,
 		Source:      rc.Source,

--- a/go/sightmap/loader_stability_test.go
+++ b/go/sightmap/loader_stability_test.go
@@ -4,15 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/match"
 )
 
 func TestLoader_ComponentStability(t *testing.T) {
 	tests := []struct {
 		name     string
 		yaml     string
-		wantComp match.ComponentDef
+		wantComp ComponentDef
 	}{
 		{
 			name: "omitted defaults to empty",
@@ -21,7 +19,7 @@ components:
   - name: TestComponent
     selector: button
 `,
-			wantComp: match.ComponentDef{
+			wantComp: ComponentDef{
 				Name:       "TestComponent",
 				Selectors:  []string{"button"},
 				Stability:  "",
@@ -36,7 +34,7 @@ components:
     selector: '[data-testid="sheet"]'
     stability: uncertain
 `,
-			wantComp: match.ComponentDef{
+			wantComp: ComponentDef{
 				Name:       "UncertainComponent",
 				Selectors:  []string{`[data-testid="sheet"]`},
 				Stability:  "uncertain",
@@ -53,7 +51,7 @@ components:
     memory:
       - Selector uses volatile CSS module class names
 `,
-			wantComp: match.ComponentDef{
+			wantComp: ComponentDef{
 				Name:      "UnstableComponent",
 				Selectors: []string{".css-module-class"},
 				Stability: "unstable",
@@ -108,7 +106,7 @@ views:
 				Name:       "HomePage",
 				Route:      "/",
 				Stability:  "",
-				Components: []match.ComponentDef{},
+				Components: []ComponentDef{},
 			},
 		},
 		{
@@ -124,7 +122,7 @@ views:
 				Name:       "LegacyCMSPage",
 				Route:      "/legacy/**",
 				Stability:  "stub",
-				Components: []match.ComponentDef{},
+				Components: []ComponentDef{},
 			},
 		},
 		{
@@ -140,7 +138,7 @@ views:
 				Name:       "AdminPanel",
 				Route:      "/admin/**",
 				Stability:  "deferred",
-				Components: []match.ComponentDef{},
+				Components: []ComponentDef{},
 			},
 		},
 	}
@@ -200,7 +198,7 @@ components:
 	}
 
 	// Find each component by name
-	var parent, child *match.ComponentDef
+	var parent, child *ComponentDef
 	for i := range corpus.GlobalComponents {
 		if corpus.GlobalComponents[i].Name == "ParentComponent" {
 			parent = &corpus.GlobalComponents[i]

--- a/go/sightmap/loader_test.go
+++ b/go/sightmap/loader_test.go
@@ -33,7 +33,7 @@ func TestLoadDir_FileLevelMemoryAccumulatesInPathOrder(t *testing.T) {
 	}
 }
 
-// A component's tags: and source: flatten onto its match.ComponentDef, and neither
+// A component's tags: and source: flatten onto its ComponentDef, and neither
 // is inherited by children — matching Memory/Properties/Stability's existing convention
 // (only the selector prefix cascades to a child).
 func TestLoadDir_ComponentTagsAndSourceDoNotInheritToChildren(t *testing.T) {

--- a/go/sightmap/records.go
+++ b/go/sightmap/records.go
@@ -1,0 +1,33 @@
+package sightmap
+
+// Observed runtime records. These are the tool-free, wire-friendly counterparts
+// of the corpus definitions: a Message is what a MessageDef classifies, a
+// Request is what a RequestDef classifies. They carry only facts an observer
+// captured — no live connection or fetch handle — so any consumer (not just the
+// CDP browser tool) can produce and match them without depending on a driver.
+
+// Message is one observed console/exception record. Level is the six-level
+// vocabulary the reference capture emits (log, debug, info, warn, error,
+// exception); an uncaught exception arrives as level "exception". Index is a
+// monotonic per-source id, the stable handle for get-by-index.
+type Message struct {
+	Index int    `json:"index"`
+	Tab   string `json:"tab"`
+	Level string `json:"level"`
+	Text  string `json:"text"`
+	Ts    int64  `json:"ts"` // unix milliseconds
+}
+
+// Request is one observed network request/response. Bodies are not included —
+// they are large and, for a live capture, fetched lazily by the tool that
+// observed the request. Status is 0 until the response is seen.
+type Request struct {
+	Index        int    `json:"index"`
+	Tab          string `json:"tab"`
+	Method       string `json:"method"`
+	URL          string `json:"url"`
+	Status       int    `json:"status"`
+	StatusText   string `json:"statusText"`
+	ResourceType string `json:"resourceType"`
+	Ts           int64  `json:"ts"` // unix milliseconds
+}

--- a/go/sightmap/stats.go
+++ b/go/sightmap/stats.go
@@ -2,8 +2,6 @@ package sightmap
 
 import (
 	"strings"
-
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // Stats is a count summary of a loaded Corpus: corpus-wide totals plus a
@@ -99,7 +97,7 @@ func (c *Corpus) Stats() Stats {
 	// same-named local components each contribute while a $ref-expanded copy
 	// of a global does not double-count.
 	seen := make(map[string]bool)
-	countComponent := func(comp match.ComponentDef) {
+	countComponent := func(comp ComponentDef) {
 		if comp.Name == "" {
 			return
 		}
@@ -144,7 +142,7 @@ func (c *Corpus) Stats() Stats {
 // ComponentDefs are the same definition. It covers every field of the
 // definition, so an exact copy (what a top-level $ref expands to) collapses
 // while anything an author wrote differently does not.
-func componentIdentity(c match.ComponentDef) string {
+func componentIdentity(c ComponentDef) string {
 	var b strings.Builder
 	writeField := func(parts ...string) {
 		for _, p := range parts {

--- a/go/sightmap/stats_test.go
+++ b/go/sightmap/stats_test.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/match"
 )
 
 // TestStats_DedupesSharedGlobals models the loader's output for a multi-file
@@ -14,14 +12,14 @@ import (
 // three times across the corpus. Totals must count it — and its memory entries
 // — exactly once, while each per-view row still counts its own expanded copy.
 func TestStats_DedupesSharedGlobals(t *testing.T) {
-	nav := match.ComponentDef{
+	nav := ComponentDef{
 		Name:      "Navigation",
 		Selectors: []string{`nav[data-component="Navigation"]`},
 		Memory:    []string{"sticky on scroll"},
 	}
 	corpus := &Corpus{
 		Memory: []string{"file-level note"},
-		GlobalComponents: []match.ComponentDef{
+		GlobalComponents: []ComponentDef{
 			nav,
 			{Name: "Footer", Selectors: []string{`footer[data-component="Footer"]`}},
 		},
@@ -33,7 +31,7 @@ func TestStats_DedupesSharedGlobals(t *testing.T) {
 				Name:   "Checkout",
 				Route:  "/checkout",
 				Memory: []string{"guest checkout allowed"},
-				Components: []match.ComponentDef{
+				Components: []ComponentDef{
 					nav, // $ref-expanded copy of the global
 					{Name: "CartSummary", Selectors: []string{`[data-component="CartSummary"]`}},
 					{Name: "PaymentForm", Selectors: []string{`[data-component="PaymentForm"]`}},
@@ -47,10 +45,10 @@ func TestStats_DedupesSharedGlobals(t *testing.T) {
 			{
 				Name:  "Dashboard",
 				Route: "/dashboard",
-				Components: []match.ComponentDef{
+				Components: []ComponentDef{
 					nav, // same global, reused by a second view
 					{Name: "ActivityFeed", Selectors: []string{`[data-component="ActivityFeed"]`},
-						Properties: []match.Property{{Name: "count", Extract: "text"}}},
+						Properties: []Property{{Name: "count", Extract: "text"}}},
 				},
 			},
 		},
@@ -102,21 +100,21 @@ func TestStats_SameNamedViewComponents(t *testing.T) {
 			{
 				Name:  "Products",
 				Route: "/products",
-				Components: []match.ComponentDef{{
+				Components: []ComponentDef{{
 					Name:       "Card",
 					Selectors:  []string{`[data-component="ProductCard"]`},
 					Memory:     []string{"price hides while the quote refreshes"},
-					Properties: []match.Property{{Name: "title", Extract: "text"}},
+					Properties: []Property{{Name: "title", Extract: "text"}},
 				}},
 			},
 			{
 				Name:  "Blog",
 				Route: "/blog",
-				Components: []match.ComponentDef{{
+				Components: []ComponentDef{{
 					Name:      "Card", // same local name, a different component
 					Selectors: []string{`[data-component="PostCard"]`},
 					Memory:    []string{"excerpt is truncated server-side"},
-					Properties: []match.Property{
+					Properties: []Property{
 						{Name: "headline", Extract: "text"},
 						{Name: "author", Extract: "attr=data-author"},
 					},
@@ -145,9 +143,9 @@ func TestStats_SameNamedViewComponents(t *testing.T) {
 // so the JSON contract serializes it as [].
 func TestStats_GlobalsOnlyCorpus(t *testing.T) {
 	corpus := &Corpus{
-		GlobalComponents: []match.ComponentDef{
+		GlobalComponents: []ComponentDef{
 			{Name: "Header", Selectors: []string{"#header"},
-				Properties: []match.Property{{Name: "brand", Extract: "text"}}},
+				Properties: []Property{{Name: "brand", Extract: "text"}}},
 		},
 		Requests: []RequestDef{
 			{Name: "Ping", Route: "/api/ping"},

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sel"
 )
 
@@ -218,7 +217,7 @@ func viewLocList(vs []View) string {
 // seen maps component name → sorted-selector fingerprint so that the same
 // name is only flagged as a duplicate when the selector set is also identical.
 // Same name + different selectors = intentional child-component reuse = OK.
-func validateComponent(comp match.ComponentDef, seen map[string]string) []ValidationError {
+func validateComponent(comp ComponentDef, seen map[string]string) []ValidationError {
 	var errs []ValidationError
 
 	// empty-name: no further named checks are possible.

--- a/go/sightmap/validate_test.go
+++ b/go/sightmap/validate_test.go
@@ -3,17 +3,16 @@ package sightmap_test
 import (
 	"testing"
 
-	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // corpusFrom is a convenience constructor for test corpora.
-func corpusFrom(globals []match.ComponentDef, views []sightmap.View) *sightmap.Corpus {
+func corpusFrom(globals []sightmap.ComponentDef, views []sightmap.View) *sightmap.Corpus {
 	return &sightmap.Corpus{GlobalComponents: globals, Views: views}
 }
 
 func TestValidate_EmptyName(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "", Selectors: []string{"div"}},
 	}, nil)
 	errs := sightmap.Validate(c)
@@ -26,7 +25,7 @@ func TestValidate_EmptyName(t *testing.T) {
 }
 
 func TestValidate_NoSelector(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "NavBar", Selectors: nil},
 	}, nil)
 	errs := sightmap.Validate(c)
@@ -39,7 +38,7 @@ func TestValidate_NoSelector(t *testing.T) {
 }
 
 func TestValidate_BadSelector(t *testing.T) {
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "NavBar", Selectors: []string{":hover"}},
 	}, nil)
 	errs := sightmap.Validate(c)
@@ -56,7 +55,7 @@ func TestValidate_BadSelector(t *testing.T) {
 
 func TestValidate_DuplicateNameGlobal(t *testing.T) {
 	// True duplicate: same name AND same selector — should error.
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "NavBar", Selectors: []string{"nav"}},
 		{Name: "NavBar", Selectors: []string{"nav"}},
 	}, nil)
@@ -75,7 +74,7 @@ func TestValidate_DuplicateNameInView(t *testing.T) {
 		{
 			Name:  "Home",
 			Route: "/",
-			Components: []match.ComponentDef{
+			Components: []sightmap.ComponentDef{
 				{Name: "Hero", Selectors: []string{".hero"}},
 				{Name: "Hero", Selectors: []string{".hero"}},
 			},
@@ -93,7 +92,7 @@ func TestValidate_DuplicateNameInView(t *testing.T) {
 func TestValidate_SameNameDifferentSelector_OK(t *testing.T) {
 	// Intentional reuse: same child name under different parent components
 	// (e.g. CarouselScrollButton under multiple carousels). Must NOT error.
-	c := corpusFrom([]match.ComponentDef{
+	c := corpusFrom([]sightmap.ComponentDef{
 		{Name: "ScrollBtn", Selectors: []string{"[data-testid='carousel-a'] button"}},
 		{Name: "ScrollBtn", Selectors: []string{"[data-testid='carousel-b'] button"}},
 		{Name: "ScrollBtn", Selectors: []string{"[data-testid='carousel-c'] button"}},
@@ -109,7 +108,7 @@ func TestValidate_MissingRoute(t *testing.T) {
 		{
 			Name:       "Home",
 			Route:      "",
-			Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
+			Components: []sightmap.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 		},
 	})
 	errs := sightmap.Validate(c)
@@ -123,14 +122,14 @@ func TestValidate_MissingRoute(t *testing.T) {
 
 func TestValidate_Clean(t *testing.T) {
 	c := corpusFrom(
-		[]match.ComponentDef{
+		[]sightmap.ComponentDef{
 			{Name: "NavBar", Selectors: []string{"nav"}},
 		},
 		[]sightmap.View{
 			{
 				Name:       "Home",
 				Route:      "/",
-				Components: []match.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
+				Components: []sightmap.ComponentDef{{Name: "Hero", Selectors: []string{".hero"}}},
 			},
 		},
 	)

--- a/go/viewset/novelty.go
+++ b/go/viewset/novelty.go
@@ -16,7 +16,7 @@ import (
 // by the offline path (SlotsForCapture) and the live capture path (the capture
 // command) so both gate on the same notion of "new".
 func SlotsFromMatch(
-	matches map[*comps.ComponentNode]*match.ComponentMatch,
+	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
 	orphans []*comps.ComponentNode,
 	parentMap coverage.ParentMap,
 ) Slots {
@@ -45,7 +45,7 @@ func SlotsForCapture(snapPath string, corpus *sightmap.Corpus) (Slots, bool) {
 	if json.Unmarshal(data, &root) != nil {
 		return Slots{}, false
 	}
-	matches := sightmap.NewMatcher(corpus).MatchTree(&root, RouteOf(snapPath))
+	matches := match.NewMatcher(corpus).MatchTree(&root, RouteOf(snapPath))
 	cov := coverage.Score(&root, matches, coverage.Options{VisibleOnly: true})
 	return SlotsFromMatch(matches, cov.Orphans, cov.ParentMap), true
 }


### PR DESCRIPTION
First consolidation step of the library restructuring (#189). **Stacked on #191**
(base `refactor/observed-runtime-records`); review/merge that first.

Makes `sightmap` the home for the component data types and **inverts the
dependency** so the engine (`match`) depends on the model, not the reverse — the
change that lets a consumer import `sightmap` for corpus types without pulling in
the matcher.

## Changes

- **`sightmap`**: `ComponentDef`, `Property`, `ComponentMatch`, `Conflict` move
  here from `match` (new `component.go`). **Production `sightmap` no longer
  imports `match`.**
- **`match`**: keeps the NFA engine (`ParseQueries` / `ApplySightmap` /
  `FindConflicts` / `FindAllMatches`) and now consumes the `sightmap` types. The
  corpus `Matcher` wrapper moves here from `sightmap` (`corpus_matcher.go`) as
  `match.Matcher` / `match.NewMatcher`.
- **callers**: `match.ComponentDef` → `sightmap.ComponentDef` (etc.);
  `sightmap.NewMatcher` → `match.NewMatcher` across
  `cmd`/`observe`/`render`/`coverage`/`viewset`/`compquery`.

## Note on scope

Pure **relocation + edge flip** — no renames (`View`/`Property` keep their names)
and `comps`/`sel` are not yet folded into `sightmap`; those are follow-up slices.

The `Matcher`-wrapper move (nominally the next step's territory) **had to ride
with this change**: moving `ComponentDef` into `sightmap` forces `match` to
import `sightmap`, so the wrapper — which calls into the NFA — could not stay in
`sightmap` without creating a `sightmap ↔ match` cycle. What remains for the
"engines" step is the API cleanup (collapse the redundant `MatchTree` /
`ApplySightmap` / `FindConflicts` front doors into one `Matcher`), not the move
itself.

## Verification

`go build`/`vet`/`test ./...`, `spec` conformance + examples, gofmt — all green.
Behavior unchanged.
