### PR TITLE
sightmap: fold comps + sel into the model (sightmap becomes a self-contained leaf)

### DIFF
--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -5,10 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"time"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // Navigate sends Page.navigate. Does NOT wait for load.
@@ -461,7 +460,7 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 //
 // Returns an error when no element carries the id (the node was removed or the
 // page was re-probed since), so callers can prompt for a fresh snapshot.
-func ResolveBySightmapID(ctx context.Context, conn *CDPConn, id string) (*comps.ComponentNode, error) {
+func ResolveBySightmapID(ctx context.Context, conn *CDPConn, id string) (*sightmap.ComponentNode, error) {
 	script := fmt.Sprintf(`(function(){
   var el=document.querySelector('[data-sightmap-id=%q]');
   if(!el) return null;
@@ -476,11 +475,11 @@ func ResolveBySightmapID(ctx context.Context, conn *CDPConn, id string) (*comps.
 		return nil, fmt.Errorf(
 			"component %q not found in live DOM (data-sightmap-id absent; re-run sightmap snapshot)", id)
 	}
-	var b comps.Bounds
+	var b sightmap.Bounds
 	if err := json.Unmarshal(raw, &b); err != nil {
 		return nil, fmt.Errorf("resolve %q: unmarshal bounds: %w", id, err)
 	}
-	return &comps.ComponentNode{Id: id, Bounds: &b}, nil
+	return &sightmap.ComponentNode{Id: id, Bounds: &b}, nil
 }
 
 // HoverAt moves the mouse to absolute page coordinates x, y without clicking.
@@ -508,7 +507,7 @@ func ClickAt(ctx context.Context, conn *CDPConn, x, y int) error {
 
 // Drag moves a component by (deltaX, deltaY) pixels via CDP mouse events.
 // Sequence: move to center → press → move to target → release.
-func Drag(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, deltaX, deltaY int) error {
+func Drag(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode, deltaX, deltaY int) error {
 	if node.Bounds == nil {
 		return fmt.Errorf("drag: node %q has no bounds", node.Id)
 	}
@@ -586,7 +585,7 @@ func locateForClick(ctx context.Context, conn *CDPConn, id string) (clickTarget,
 // off-screen no-op). A node with no data-sightmap-id and no bounds falls back to
 // A node with no data-sightmap-id and no bounds falls back to
 // a selector-based JS click() and returns (-1, -1).
-func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, int, error) {
+func Click(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) (int, int, error) {
 	if node.Id != "" {
 		if t, err := locateForClick(ctx, conn, node.Id); err == nil && t.Found {
 			if !t.InViewport {
@@ -620,7 +619,7 @@ func Click(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) (int, 
 }
 
 // Hover moves the mouse to the center of node's bounding box.
-func Hover(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error {
+func Hover(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) error {
 	if node.Bounds == nil {
 		return fmt.Errorf("Hover: node %q has no bounds", node.Id)
 	}
@@ -634,7 +633,7 @@ func Hover(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error 
 
 // Fill clears the current value of a form field and types value into it.
 // Clicks the element first, then Ctrl+A to select all, then types each rune.
-func Fill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, value string) error {
+func Fill(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode, value string) error {
 	if _, _, err := Click(ctx, conn, node); err != nil {
 		return fmt.Errorf("Fill: click to focus: %w", err)
 	}
@@ -704,7 +703,7 @@ func readInputValue(ctx context.Context, conn *CDPConn, id string) (string, bool
 // (reliable on React-controlled inputs where Ctrl+A may not select), then types
 // value using keystroke events. Use instead of Fill when a React input accumulates
 // text across multiple fill calls.
-func ClearAndFill(ctx context.Context, conn *CDPConn, node *comps.ComponentNode, value string) error {
+func ClearAndFill(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode, value string) error {
 	if _, _, err := Click(ctx, conn, node); err != nil {
 		return fmt.Errorf("ClearAndFill: click to focus: %w", err)
 	}
@@ -789,7 +788,7 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 // querySelector is wrapped in try-catch so a syntactically invalid selector
 // (e.g. a bare numeric probe ID) degrades silently to the bounds path rather
 // than surfacing as an EvalJSON JS exception.
-func ScrollIntoView(ctx context.Context, conn *CDPConn, node *comps.ComponentNode) error {
+func ScrollIntoView(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) error {
 	if sel := node.Element.SelectorString(); sel != "" {
 		script := fmt.Sprintf(
 			`try{const el=document.querySelector(%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,

--- a/go/browser/actions_test.go
+++ b/go/browser/actions_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,8 +14,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 var wsUpgrader = websocket.Upgrader{
@@ -305,9 +304,9 @@ func TestClick_WithBounds(t *testing.T) {
 	})
 
 	// Center = (100+60/2, 200+40/2) = (130, 220)
-	node := &comps.ComponentNode{
+	node := &sightmap.ComponentNode{
 		Id:     "test",
-		Bounds: &comps.Bounds{X: 100, Y: 200, Width: 60, Height: 40},
+		Bounds: &sightmap.Bounds{X: 100, Y: 200, Width: 60, Height: 40},
 	}
 	if _, _, err := Click(context.Background(), conn, node); err != nil {
 		t.Fatal(err)
@@ -345,9 +344,9 @@ func TestClick_NoBounds(t *testing.T) {
 		return json.RawMessage(`{}`)
 	})
 
-	node := &comps.ComponentNode{
+	node := &sightmap.ComponentNode{
 		Id:      "test",
-		Element: &comps.Element{Tag: "button", Id: "submit"},
+		Element: &sightmap.Element{Tag: "button", Id: "submit"},
 	}
 	if _, _, err := Click(context.Background(), conn, node); err != nil {
 		t.Fatal(err)
@@ -407,7 +406,7 @@ func TestResolveBySightmapID(t *testing.T) {
 	if node.Bounds == nil {
 		t.Fatal("node Bounds is nil")
 	}
-	if got := *node.Bounds; got != (comps.Bounds{X: 10, Y: 20, Width: 30, Height: 40}) {
+	if got := *node.Bounds; got != (sightmap.Bounds{X: 10, Y: 20, Width: 30, Height: 40}) {
 		t.Errorf("bounds = %+v, want {10 20 30 40}", got)
 	}
 }
@@ -448,9 +447,9 @@ func TestFill(t *testing.T) {
 		return json.RawMessage(`{}`)
 	})
 
-	node := &comps.ComponentNode{
+	node := &sightmap.ComponentNode{
 		Id:     "field",
-		Bounds: &comps.Bounds{X: 0, Y: 0, Width: 100, Height: 30},
+		Bounds: &sightmap.Bounds{X: 0, Y: 0, Width: 100, Height: 30},
 	}
 	if err := Fill(context.Background(), conn, node, "hi"); err != nil {
 		t.Fatal(err)

--- a/go/browser/browser.go
+++ b/go/browser/browser.go
@@ -3,8 +3,8 @@ package browser
 import (
 	"context"
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/extract"
 )
 
@@ -31,7 +31,7 @@ type Page interface {
 
 // ExtractComponents runs the full extraction pipeline on page:
 // RunProbe → GetA11YTree → GetDOMTree → extract.BuildTree.
-func ExtractComponents(ctx context.Context, page Page) (*comps.ComponentNode, error) {
+func ExtractComponents(ctx context.Context, page Page) (*sightmap.ComponentNode, error) {
 	probeResult, err := page.RunProbe(ctx, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("browser: run probe: %w", err)

--- a/go/browser/click_verify_test.go
+++ b/go/browser/click_verify_test.go
@@ -3,10 +3,9 @@ package browser
 import (
 	"context"
 	"encoding/json"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // evalResult wraps a JS return value in the CDP Runtime.evaluate envelope the
@@ -23,8 +22,8 @@ func exprOf(params json.RawMessage) string {
 	return p.Expression
 }
 
-func nodeWithID(id string) *comps.ComponentNode {
-	return &comps.ComponentNode{Id: id, Bounds: &comps.Bounds{X: 0, Y: 0, Width: 20, Height: 10}}
+func nodeWithID(id string) *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{Id: id, Bounds: &sightmap.Bounds{X: 0, Y: 0, Width: 20, Height: 10}}
 }
 
 func TestClick_OffScreenErrors(t *testing.T) {

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -185,7 +184,7 @@ func boundsByComponent(
 
 	var results []boundsResult
 	seenComp := map[string]bool{}
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		m := matches[n]
 		if m == nil || !nameMatches(m.Name) {
 			return true
@@ -265,7 +264,7 @@ func boundsBySelector(
 
 	results := make([]boundsResult, 0, len(rects))
 	for _, r := range rects {
-		b := &comps.Bounds{
+		b := &sightmap.Bounds{
 			X:      int(math.Round(r.X)),
 			Y:      int(math.Round(r.Y)),
 			Width:  int(math.Round(r.Width)),
@@ -344,7 +343,7 @@ func resolveScreenshotClip(
 
 // makeBoundsResult converts viewport-relative px bounds into viewport-% and
 // determines whether the box intersects the viewport at all.
-func makeBoundsResult(comp, label, id string, b *comps.Bounds, vw, vh int) boundsResult {
+func makeBoundsResult(comp, label, id string, b *sightmap.Bounds, vw, vh int) boundsResult {
 	return boundsResult{
 		Comp:       comp,
 		Label:      label,
@@ -359,7 +358,7 @@ func makeBoundsResult(comp, label, id string, b *comps.Bounds, vw, vh int) bound
 }
 
 // intersectsViewport reports whether the box overlaps the [0,vw]x[0,vh] region.
-func intersectsViewport(b *comps.Bounds, vw, vh int) bool {
+func intersectsViewport(b *sightmap.Bounds, vw, vh int) bool {
 	if b.Width <= 0 || b.Height <= 0 {
 		return false
 	}

--- a/go/cmd/sightmap/cmd_browser_feedback_test.go
+++ b/go/cmd/sightmap/cmd_browser_feedback_test.go
@@ -2,21 +2,20 @@ package main
 
 import (
 	"errors"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 func TestActionLabel(t *testing.T) {
-	withBounds := &comps.ComponentNode{
+	withBounds := &sightmap.ComponentNode{
 		Id:     "42",
-		Bounds: &comps.Bounds{X: 100, Y: 40, Width: 80, Height: 20},
+		Bounds: &sightmap.Bounds{X: 100, Y: 40, Width: 80, Height: 20},
 	}
 	if got, want := actionLabel("CartNavButton", withBounds), "CartNavButton @ (140,50)"; got != want {
 		t.Errorf("actionLabel(bounds) = %q, want %q", got, want)
 	}
 
-	noBounds := &comps.ComponentNode{Id: "7"}
+	noBounds := &sightmap.ComponentNode{Id: "7"}
 	if got, want := actionLabel("7", noBounds), "7"; got != want {
 		t.Errorf("actionLabel(no bounds) = %q, want %q", got, want)
 	}

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/compquery"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -29,7 +28,7 @@ import (
 // root cause of the snapshot->click race. Resolving through the
 // already-present attribute keeps the id stable across re-renders that don't
 // remount the target.
-func resolveNode(ctx context.Context, conn *browser.CDPConn, id string) (*comps.ComponentNode, error) {
+func resolveNode(ctx context.Context, conn *browser.CDPConn, id string) (*sightmap.ComponentNode, error) {
 	return browser.ResolveBySightmapID(ctx, conn, id)
 }
 
@@ -37,7 +36,7 @@ func resolveNode(ctx context.Context, conn *browser.CDPConn, id string) (*comps.
 // the caller passed (a probe id or component query) plus the element's click
 // point when its bounds are known. Interaction commands echo one of these on
 // success so an agent driving the browser sees what happened.
-func actionLabel(arg string, node *comps.ComponentNode) string {
+func actionLabel(arg string, node *sightmap.ComponentNode) string {
 	if node != nil && node.Bounds != nil {
 		x := node.Bounds.X + node.Bounds.Width/2
 		y := node.Bounds.Y + node.Bounds.Height/2

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/compquery"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -33,7 +32,7 @@ func looksLikeProbeID(arg string) bool {
 
 // resolveTarget resolves an interaction target that may be either a probe id or
 // a component query, returning a node with current bounds ready to act on.
-func resolveTarget(ctx context.Context, conn *browser.CDPConn, sightmapDir, arg string) (*comps.ComponentNode, error) {
+func resolveTarget(ctx context.Context, conn *browser.CDPConn, sightmapDir, arg string) (*sightmap.ComponentNode, error) {
 	if looksLikeProbeID(arg) {
 		return resolveNode(ctx, conn, arg)
 	}
@@ -45,7 +44,7 @@ func resolveTarget(ctx context.Context, conn *browser.CDPConn, sightmapDir, arg 
 // the query to a single node. Everything happens within one extraction, so the
 // returned node's bounds are fresh and no id crosses a call boundary — the
 // atomic resolve+act that fixes the dynamic-page race.
-func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapDir, queryStr string) (*comps.ComponentNode, error) {
+func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapDir, queryStr string) (*sightmap.ComponentNode, error) {
 	q, err := compquery.ParseQuery(queryStr)
 	if err != nil {
 		return nil, err
@@ -83,7 +82,7 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	for _, part := range q.Parts {
 		queryNames[part.Name] = true
 	}
-	relevant := make(map[*comps.ComponentNode]*sightmap.ComponentMatch)
+	relevant := make(map[*sightmap.ComponentNode]*sightmap.ComponentMatch)
 	for n, m := range matches {
 		if queryNames[m.Name] {
 			relevant[n] = m

--- a/go/cmd/sightmap/cmd_coverage.go
+++ b/go/cmd/sightmap/cmd_coverage.go
@@ -8,11 +8,9 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/observe"
-	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
 	"github.com/sightmap/sightmap/go/viewset"
 )
@@ -124,7 +122,7 @@ func runCoverage(args []string) error {
 // can't be loaded, parsed, or matched. Shared by coverage/report/multi-coverage so
 // every reader matches a capture the same route-aware way instead of
 // each re-implementing the load/parse/match boilerplate.
-func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch, route string, ok bool) {
+func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch, route string, ok bool) {
 	treeFile := snapPath + ".tree.json"
 	data, err := os.ReadFile(treeFile)
 	if err != nil {
@@ -132,7 +130,7 @@ func matchCapture(snapPath string, corpus *sightmap.Corpus) (root *comps.Compone
 			filepath.Base(snapPath), treeFile)
 		return nil, nil, "", false
 	}
-	root = &comps.ComponentNode{}
+	root = &sightmap.ComponentNode{}
 	if err := json.Unmarshal(data, root); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: parse tree JSON: %v\n", filepath.Base(snapPath), err)
 		return nil, nil, "", false
@@ -241,15 +239,15 @@ func coverCapture(snapPath string, corpus *sightmap.Corpus, visible, trace bool)
 // (last) SelectorPart of selStr, ignoring all ancestor scoping. Used to
 // distinguish a broken scoped selector (leaf matches > 0) from a legitimately-
 // absent component (leaf matches == 0).
-func countLeafMatches(root *comps.ComponentNode, selStr string) int {
-	ps, err := sel.ParseSightmapSelector(selStr)
+func countLeafMatches(root *sightmap.ComponentNode, selStr string) int {
+	ps, err := sightmap.ParseSightmapSelector(selStr)
 	if err != nil || len(ps.Parts) == 0 {
 		return 0
 	}
 	leafPart := ps.Parts[len(ps.Parts)-1]
 	count := 0
-	comps.Walk(root, func(node *comps.ComponentNode, _ int) bool {
-		if sel.MatchesNode(node, leafPart) {
+	sightmap.Walk(root, func(node *sightmap.ComponentNode, _ int) bool {
+		if sightmap.MatchesNode(node, leafPart) {
 			count++
 		}
 		return true

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"sort"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
 )
@@ -61,7 +61,7 @@ func runGap(args []string) error {
 	parentMap := coverage.BuildParentMap(root)
 
 	// ── Handle --scope flag ──────────────────────────────────────────────────
-	var scopeNode *comps.ComponentNode
+	var scopeNode *sightmap.ComponentNode
 	if *scopeFlag != "" {
 		// Find the named component in matches
 		for node, matchInfo := range matches {
@@ -102,10 +102,10 @@ func runGap(args []string) error {
 	}
 
 	// ── Collect nodes based on scope ─────────────────────────────────────
-	var gapNodes []*comps.ComponentNode
+	var gapNodes []*sightmap.ComponentNode
 
 	// Helper to check if a node is within the scope subtree
-	isInScope := func(n *comps.ComponentNode) bool {
+	isInScope := func(n *sightmap.ComponentNode) bool {
 		if scopeNode == nil {
 			return true // no scope filter
 		}
@@ -122,7 +122,7 @@ func runGap(args []string) error {
 	// scope component that are not matched).
 	// When --scope is absent, collect T3 nodes (interactive nodes with no matched
 	// ancestor anywhere).
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		if !n.IsInteractive {
 			return true
 		}
@@ -167,7 +167,7 @@ func runGap(args []string) error {
 	// ── Group by nearest stable-anchor ancestor ────────────────────────────
 	type t3Group struct {
 		ancestorDesc string
-		nodes        []*comps.ComponentNode
+		nodes        []*sightmap.ComponentNode
 	}
 
 	type groupKey struct {
@@ -208,7 +208,7 @@ func runGap(args []string) error {
 		} else {
 			clusters[key] = &t3Group{
 				ancestorDesc: inside,
-				nodes:        []*comps.ComponentNode{n},
+				nodes:        []*sightmap.ComponentNode{n},
 			}
 			order = append(order, key)
 		}

--- a/go/cmd/sightmap/cmd_inspect.go
+++ b/go/cmd/sightmap/cmd_inspect.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/render"
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -59,7 +58,7 @@ func runInspect(args []string) error {
 	}
 
 	// ── Load sightmap (optional enrichment; warn but don't fail on a bad corpus) ──
-	var inspectMatches map[*comps.ComponentNode]*sightmap.ComponentMatch
+	var inspectMatches map[*sightmap.ComponentNode]*sightmap.ComponentMatch
 	if corpus, cErr := lf.loadCorpus(); cErr != nil {
 		fmt.Fprintf(os.Stderr, "inspect: load corpus: %v (continuing without component names)\n", cErr)
 	} else if corpus != nil {

--- a/go/cmd/sightmap/cmd_lint.go
+++ b/go/cmd/sightmap/cmd_lint.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -100,14 +98,14 @@ func computeSnapshotCounts(corpus *sightmap.Corpus, treeFiles []string) (map[str
 	// Pre-parse selectors: component index → slice of last SelectorParts.
 	type parsedEntry struct {
 		name      string
-		lastParts []*comps.SelectorPart
+		lastParts []*sightmap.SelectorPart
 	}
 	all := corpus.AllComponents()
 	parsed := make([]parsedEntry, 0, len(all))
 	for _, comp := range all {
-		var lasts []*comps.SelectorPart
+		var lasts []*sightmap.SelectorPart
 		for _, selStr := range comp.Selectors {
-			ps, err := sel.ParseSightmapSelector(selStr)
+			ps, err := sightmap.ParseSightmapSelector(selStr)
 			if err != nil || len(ps.Parts) == 0 {
 				continue
 			}
@@ -129,7 +127,7 @@ func computeSnapshotCounts(corpus *sightmap.Corpus, treeFiles []string) (map[str
 			fmt.Fprintf(os.Stderr, "lint: %s: tree file not found, skipping\n", tf)
 			continue
 		}
-		var root comps.ComponentNode
+		var root sightmap.ComponentNode
 		if err := json.Unmarshal(data, &root); err != nil {
 			fmt.Fprintf(os.Stderr, "lint: %s: parse tree JSON: %v, skipping\n", tf, err)
 			continue
@@ -143,8 +141,8 @@ func computeSnapshotCounts(corpus *sightmap.Corpus, treeFiles []string) (map[str
 			maxForTree := 0
 			for _, lastPart := range pe.lastParts {
 				count := 0
-				comps.Walk(&root, func(node *comps.ComponentNode, _ int) bool {
-					if sel.MatchesNode(node, lastPart) {
+				sightmap.Walk(&root, func(node *sightmap.ComponentNode, _ int) bool {
+					if sightmap.MatchesNode(node, lastPart) {
 						count++
 					}
 					return true

--- a/go/cmd/sightmap/cmd_sel_check.go
+++ b/go/cmd/sightmap/cmd_sel_check.go
@@ -7,12 +7,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"io"
 	"os"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 // errSelCheckNoMatches is returned (exit code 1) when the selector matches
@@ -62,7 +60,7 @@ func runSelCheckOut(args []string, out io.Writer) error {
 	treeFile, displayName := selCheckResolvePaths(inputFile)
 
 	// Parse the user's selector.
-	ps, err := sel.ParseSightmapSelector(selectorStr)
+	ps, err := sightmap.ParseSightmapSelector(selectorStr)
 	if err != nil {
 		return err
 	}
@@ -80,16 +78,16 @@ func runSelCheckOut(args []string, out io.Writer) error {
 		return fmt.Errorf("cannot read tree file %s: %w", treeFile, err)
 	}
 
-	var root comps.ComponentNode
+	var root sightmap.ComponentNode
 	if err := json.Unmarshal(data, &root); err != nil {
 		return fmt.Errorf("parse tree JSON %s: %w", treeFile, err)
 	}
 
 	// Walk the full tree and collect every node whose selector matches.
-	var matches []*comps.ComponentNode
-	comps.Walk(&root, func(node *comps.ComponentNode, _ int) bool {
+	var matches []*sightmap.ComponentNode
+	sightmap.Walk(&root, func(node *sightmap.ComponentNode, _ int) bool {
 		// MatchesNode handles :has() (against node's subtree) and nil selectors.
-		if sel.MatchesNode(node, rulePart) {
+		if sightmap.MatchesNode(node, rulePart) {
 			matches = append(matches, node)
 		}
 		return true // always descend

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
-	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -87,7 +85,7 @@ type parentInfo struct {
 // its first selector. Used for Go-side parent-chain annotation.
 type compAnnotation struct {
 	name string
-	part *comps.SelectorPart
+	part *sightmap.SelectorPart
 }
 
 func runSelProbe(args []string) error {
@@ -281,7 +279,7 @@ func offlineSelectorCount(ctx context.Context, conn *browser.CDPConn, selector s
 // best-known traps — attribute selectors on `id` and on `class` — and otherwise
 // gives a general nudge about the reduced offline node model.
 func offlineDivergenceHints(selector string) []string {
-	ps, err := sel.ParseSightmapSelector(selector)
+	ps, err := sightmap.ParseSightmapSelector(selector)
 	if err != nil {
 		return []string{"the offline selector parser could not parse this selector, so it matches nothing offline"}
 	}
@@ -364,7 +362,7 @@ func loadCompAnnotations(dir string) []compAnnotation {
 		if len(comp.Selectors) == 0 {
 			continue
 		}
-		ps, parseErr := sel.ParseSightmapSelector(comp.Selectors[0])
+		ps, parseErr := sightmap.ParseSightmapSelector(comp.Selectors[0])
 		if parseErr != nil || len(ps.Parts) == 0 {
 			continue
 		}
@@ -379,7 +377,7 @@ func loadCompAnnotations(dir string) []compAnnotation {
 // findCompAnnotation returns the name of the first component whose first
 // pattern matches the parent node, or "" if none match.
 func findCompAnnotation(annotations []compAnnotation, p parentInfo) string {
-	node := &comps.Element{
+	node := &sightmap.Element{
 		Tag:     p.Tag,
 		Id:      p.Id,
 		Classes: p.Cls,
@@ -393,7 +391,7 @@ func findCompAnnotation(annotations []compAnnotation, p parentInfo) string {
 	}
 
 	for _, ann := range annotations {
-		if sel.Matches(node, ann.part) {
+		if sightmap.Matches(node, ann.part) {
 			return ann.name
 		}
 	}

--- a/go/cmd/sightmap/cmd_sel_probe_test.go
+++ b/go/cmd/sightmap/cmd_sel_probe_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // makeAnnotation is a test helper that builds a compAnnotation matching a
@@ -11,7 +10,7 @@ import (
 func makeAnnotation(name, tag string, classes []string) compAnnotation {
 	return compAnnotation{
 		name: name,
-		part: &comps.SelectorPart{Tag: tag, Classes: classes},
+		part: &sightmap.SelectorPart{Tag: tag, Classes: classes},
 	}
 }
 
@@ -19,7 +18,7 @@ func makeAnnotation(name, tag string, classes []string) compAnnotation {
 func makeAnnotationDt(name, tag, dt string) compAnnotation {
 	return compAnnotation{
 		name: name,
-		part: &comps.SelectorPart{
+		part: &sightmap.SelectorPart{
 			Tag:   tag,
 			Attrs: map[string]string{"data-testid": dt},
 		},

--- a/go/cmd/sightmap/cmd_snapshot.go
+++ b/go/cmd/sightmap/cmd_snapshot.go
@@ -12,7 +12,6 @@ import (
 	"os"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -146,7 +145,7 @@ func runSnapshot(args []string) error {
 // ── Formatting helpers ────────────────────────────────────────────────────────
 
 // writeTreeJSON serialises root as JSON to path atomically.
-func writeTreeJSON(root *comps.ComponentNode, path string) error {
+func writeTreeJSON(root *sightmap.ComponentNode, path string) error {
 	data, err := json.Marshal(root)
 	if err != nil {
 		return err

--- a/go/cmd/sightmap/cmd_snapshot_json.go
+++ b/go/cmd/sightmap/cmd_snapshot_json.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -12,17 +11,17 @@ import (
 // It adds component name, memory notes, and extracted prop values from the
 // sightmap corpus, omitting those fields when the node is unmatched.
 type annotatedNode struct {
-	ID            string         `json:"id"`
-	Role          string         `json:"role"`
-	Name          string         `json:"name,omitempty"`
-	Value         string         `json:"value,omitempty"`
-	Element       *comps.Element `json:"element,omitempty"`
-	Bounds        *comps.Bounds  `json:"bounds,omitempty"`
-	IsVisible     bool           `json:"isVisible"`
-	IsInteractive bool           `json:"isInteractive"`
-	InViewport    bool           `json:"inViewport"`
-	IsIgnored     bool           `json:"isIgnored,omitempty"`
-	NthChild      int            `json:"nthChild,omitempty"`
+	ID            string            `json:"id"`
+	Role          string            `json:"role"`
+	Name          string            `json:"name,omitempty"`
+	Value         string            `json:"value,omitempty"`
+	Element       *sightmap.Element `json:"element,omitempty"`
+	Bounds        *sightmap.Bounds  `json:"bounds,omitempty"`
+	IsVisible     bool              `json:"isVisible"`
+	IsInteractive bool              `json:"isInteractive"`
+	InViewport    bool              `json:"inViewport"`
+	IsIgnored     bool              `json:"isIgnored,omitempty"`
+	NthChild      int               `json:"nthChild,omitempty"`
 	// sightmap-added fields — omitted when the node is unmatched or has no props
 	Component string            `json:"component,omitempty"`
 	Memory    []string          `json:"memory,omitempty"`
@@ -33,8 +32,8 @@ type annotatedNode struct {
 // buildAnnotatedNode recursively constructs an annotatedNode tree by joining
 // each ComponentNode pointer with its ComponentMatch and any extracted props.
 func buildAnnotatedNode(
-	node *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	node *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	propValues map[string]map[string]string, // nodeID → {propName → value}; may be nil
 ) *annotatedNode {
 	an := &annotatedNode{
@@ -84,17 +83,17 @@ type annotatedOutput struct {
 // The top-level object also carries the matched view name and route.
 // Writes atomically via a .tmp file (same pattern as writeTreeJSON).
 func writeAnnotatedJSON(
-	root *comps.ComponentNode,
+	root *sightmap.ComponentNode,
 	path string,
 	view *sightmap.ViewDef,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	propValues map[string]map[string]string,
 ) error {
 	if root == nil {
 		return nil
 	}
 	if matches == nil {
-		matches = map[*comps.ComponentNode]*sightmap.ComponentMatch{}
+		matches = map[*sightmap.ComponentNode]*sightmap.ComponentMatch{}
 	}
 
 	out := annotatedOutput{

--- a/go/cmd/sightmap/cmd_snapshot_json_test.go
+++ b/go/cmd/sightmap/cmd_snapshot_json_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -25,7 +24,7 @@ func treeNode(t *testing.T, data []byte) map[string]any {
 }
 
 func TestWriteAnnotatedJSON_MatchedNode(t *testing.T) {
-	node := &comps.ComponentNode{
+	node := &sightmap.ComponentNode{
 		Id:            "1",
 		Role:          "link",
 		Name:          "The Home Depot",
@@ -38,7 +37,7 @@ func TestWriteAnnotatedJSON_MatchedNode(t *testing.T) {
 		Name:   "SiteLogoLink",
 		Memory: []string{"main navigation logo"},
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		node: sm,
 	}
 	propValues := map[string]map[string]string{
@@ -92,15 +91,15 @@ func TestWriteAnnotatedJSON_MatchedNode(t *testing.T) {
 }
 
 func TestWriteAnnotatedJSON_UnmatchedNode(t *testing.T) {
-	node := &comps.ComponentNode{
+	node := &sightmap.ComponentNode{
 		Id:   "2",
 		Role: "button",
 		Name: "Add to Cart",
 	}
 
 	// node is NOT in the matches map
-	other := &comps.ComponentNode{Id: "99"}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	other := &sightmap.ComponentNode{Id: "99"}
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		other: {Name: "SomeOtherComponent"},
 	}
 
@@ -144,11 +143,11 @@ func TestWriteAnnotatedJSON_UnmatchedNode(t *testing.T) {
 }
 
 func TestWriteAnnotatedJSON_NilMatches(t *testing.T) {
-	node := &comps.ComponentNode{
+	node := &sightmap.ComponentNode{
 		Id:   "3",
 		Role: "heading",
 		Name: "Welcome",
-		Children: []*comps.ComponentNode{
+		Children: []*sightmap.ComponentNode{
 			{Id: "4", Role: "StaticText", Name: "Hello"},
 		},
 	}

--- a/go/cmd/sightmap/cmd_suggest.go
+++ b/go/cmd/sightmap/cmd_suggest.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sightmap/sightmap/go/authoring"
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -245,7 +244,7 @@ func buildSightmapMatchMapForSuggest(
 	}
 	matches := match.NewMatcher(corpus).MatchTree(root, pageURL)
 	m := make(map[string]string)
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {
 			m[n.Id] = sm.Name
 		}
@@ -261,7 +260,7 @@ func buildSightmapMatchMap(treeFile string, smDir string, pageURL string) (map[s
 	if err != nil {
 		return nil, err
 	}
-	var root comps.ComponentNode
+	var root sightmap.ComponentNode
 	if err := json.Unmarshal(data, &root); err != nil {
 		return nil, fmt.Errorf("parse tree JSON: %v", err)
 	}
@@ -271,7 +270,7 @@ func buildSightmapMatchMap(treeFile string, smDir string, pageURL string) (map[s
 	}
 	matches := match.NewMatcher(corpus).MatchTree(&root, pageURL)
 	m := make(map[string]string)
-	comps.Walk(&root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(&root, func(n *sightmap.ComponentNode, _ int) bool {
 		if sm := matches[n]; sm != nil && n.Id != "" {
 			m[n.Id] = sm.Name
 		}

--- a/go/compquery/compquery.go
+++ b/go/compquery/compquery.go
@@ -30,8 +30,6 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"sort"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // Query is a parsed component query: a descendant chain of component matchers
@@ -106,15 +104,15 @@ func (q *Query) String() string {
 
 // Resolve finds the single component node matching q. matches maps tree nodes to
 // their sightmap identity; props maps node id -> extracted property values
-// (keyed by comps.ComponentNode.Id). It returns a descriptive error when nothing
+// (keyed by sightmap.ComponentNode.Id). It returns a descriptive error when nothing
 // matches, or when several components match and no occurrence index (#N)
 // disambiguates.
 func Resolve(
-	root *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	root *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 	q *Query,
-) (*comps.ComponentNode, error) {
+) (*sightmap.ComponentNode, error) {
 	cands := FindCandidates(root, matches, props, q)
 	if len(cands) == 0 {
 		return nil, fmt.Errorf("no component matches query %s", q)
@@ -135,20 +133,20 @@ func Resolve(
 // ancestors satisfy the preceding chain parts as an ordered subsequence
 // (descendant semantics). Results are in document (pre-order) order.
 func FindCandidates(
-	root *comps.ComponentNode,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	root *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 	q *Query,
-) []*comps.ComponentNode {
+) []*sightmap.ComponentNode {
 	if root == nil || q == nil || len(q.Parts) == 0 {
 		return nil
 	}
 	target := q.Parts[len(q.Parts)-1]
 	prefix := q.Parts[:len(q.Parts)-1]
 
-	var out []*comps.ComponentNode
-	var walk func(node *comps.ComponentNode, ancestors []*comps.ComponentNode)
-	walk = func(node *comps.ComponentNode, ancestors []*comps.ComponentNode) {
+	var out []*sightmap.ComponentNode
+	var walk func(node *sightmap.ComponentNode, ancestors []*sightmap.ComponentNode)
+	walk = func(node *sightmap.ComponentNode, ancestors []*sightmap.ComponentNode) {
 		if satisfies(node, target, matches, props) && subsequence(prefix, ancestors, matches, props) {
 			out = append(out, node)
 		}
@@ -156,7 +154,7 @@ func FindCandidates(
 		if matches[node] != nil {
 			// Only matched (named) nodes can satisfy chain parts, so only they
 			// extend the ancestor scope.
-			next = append(append([]*comps.ComponentNode(nil), ancestors...), node)
+			next = append(append([]*sightmap.ComponentNode(nil), ancestors...), node)
 		}
 		for _, ch := range node.Children {
 			walk(ch, next)
@@ -169,9 +167,9 @@ func FindCandidates(
 // satisfies reports whether node is matched as part.Name and all of part's
 // predicates hold against the node's extracted properties.
 func satisfies(
-	node *comps.ComponentNode,
+	node *sightmap.ComponentNode,
 	part Part,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 ) bool {
 	m := matches[node]
@@ -194,8 +192,8 @@ func satisfies(
 // ancestors (each ancestor consumed at most once). An empty prefix is satisfied.
 func subsequence(
 	prefix []Part,
-	ancestors []*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	ancestors []*sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 ) bool {
 	i := 0
@@ -212,8 +210,8 @@ func subsequence(
 
 func ambiguityError(
 	q *Query,
-	cands []*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	cands []*sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	props map[string]map[string]string,
 ) error {
 	var b strings.Builder

--- a/go/compquery/compquery_test.go
+++ b/go/compquery/compquery_test.go
@@ -4,8 +4,6 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // ── Parser ────────────────────────────────────────────────────────────────────
@@ -151,19 +149,19 @@ func TestPredicateMatch(t *testing.T) {
 //	└─ TileGroup
 //	    ├─ FulfillmentTileButton (t1) label=Pickup
 //	    └─ FulfillmentTileButton (t2) label=Delivery
-func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*sightmap.ComponentMatch, map[string]map[string]string) {
-	u1 := &comps.ComponentNode{Id: "u1"}
-	p1 := &comps.ComponentNode{Id: "p1"}
-	loginForm := &comps.ComponentNode{Id: "m2", Children: []*comps.ComponentNode{u1, p1}}
-	mainPanel := &comps.ComponentNode{Id: "m1", Children: []*comps.ComponentNode{loginForm}}
+func buildFixture() (*sightmap.ComponentNode, map[*sightmap.ComponentNode]*sightmap.ComponentMatch, map[string]map[string]string) {
+	u1 := &sightmap.ComponentNode{Id: "u1"}
+	p1 := &sightmap.ComponentNode{Id: "p1"}
+	loginForm := &sightmap.ComponentNode{Id: "m2", Children: []*sightmap.ComponentNode{u1, p1}}
+	mainPanel := &sightmap.ComponentNode{Id: "m1", Children: []*sightmap.ComponentNode{loginForm}}
 
-	t1 := &comps.ComponentNode{Id: "t1"}
-	t2 := &comps.ComponentNode{Id: "t2"}
-	tileGroup := &comps.ComponentNode{Id: "g1", Children: []*comps.ComponentNode{t1, t2}}
+	t1 := &sightmap.ComponentNode{Id: "t1"}
+	t2 := &sightmap.ComponentNode{Id: "t2"}
+	tileGroup := &sightmap.ComponentNode{Id: "g1", Children: []*sightmap.ComponentNode{t1, t2}}
 
-	root := &comps.ComponentNode{Id: "root", Children: []*comps.ComponentNode{mainPanel, tileGroup}}
+	root := &sightmap.ComponentNode{Id: "root", Children: []*sightmap.ComponentNode{mainPanel, tileGroup}}
 
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		mainPanel: {Name: "MainPanel"},
 		loginForm: {Name: "LoginForm"},
 		u1:        {Name: "UserNameInput"},
@@ -178,7 +176,7 @@ func buildFixture() (*comps.ComponentNode, map[*comps.ComponentNode]*sightmap.Co
 	return root, matches, props
 }
 
-func mustResolve(t *testing.T, queryStr string) *comps.ComponentNode {
+func mustResolve(t *testing.T, queryStr string) *sightmap.ComponentNode {
 	t.Helper()
 	root, matches, props := buildFixture()
 	q, err := ParseQuery(queryStr)

--- a/go/comps/doc.go
+++ b/go/comps/doc.go
@@ -1,5 +1,0 @@
-// Package comps defines the canonical component model types: ComponentNode,
-// SelectorPart, and Bounds. These are the wire format for the extraction
-// pipeline — probe.js produces data in this shape, and the NFA matcher in
-// match/ consumes it.
-package comps

--- a/go/coverage/anchor.go
+++ b/go/coverage/anchor.go
@@ -2,8 +2,7 @@ package coverage
 
 import (
 	"fmt"
-
-	"github.com/sightmap/sightmap/go/comps"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // The anchor helpers locate the nearest stable (data-attr-bearing) ancestor of a
@@ -13,7 +12,7 @@ import (
 
 // NearestDataAttrAncestor walks up parentMap to the nearest ancestor whose
 // selector carries a data-testid or data-component attribute, or nil if none.
-func NearestDataAttrAncestor(node *comps.ComponentNode, parentMap ParentMap) *comps.ComponentNode {
+func NearestDataAttrAncestor(node *sightmap.ComponentNode, parentMap ParentMap) *sightmap.ComponentNode {
 	curr := parentMap[node]
 	for curr != nil {
 		if curr.Element != nil {
@@ -29,7 +28,7 @@ func NearestDataAttrAncestor(node *comps.ComponentNode, parentMap ParentMap) *co
 
 // DataAttrSelector formats an ancestor node for an "inside:" display line.
 // Prefers data-testid, then data-component, then falls back to tag#id.cls.
-func DataAttrSelector(node *comps.ComponentNode) string {
+func DataAttrSelector(node *sightmap.ComponentNode) string {
 	if node.Element == nil {
 		return node.Role
 	}
@@ -53,7 +52,7 @@ func DataAttrSelector(node *comps.ComponentNode) string {
 // its nearest data-attr ancestor — deliberately WITHOUT the node's instance text,
 // so different instances of the same widget (e.g. each product link in a
 // carousel) collapse to one slot and don't read as endless novelty.
-func OrphanSlotKey(node *comps.ComponentNode, parentMap ParentMap) string {
+func OrphanSlotKey(node *sightmap.ComponentNode, parentMap ParentMap) string {
 	role := node.Role
 	if role == "" {
 		role = "?"
@@ -68,7 +67,7 @@ func OrphanSlotKey(node *comps.ComponentNode, parentMap ParentMap) string {
 // ArrowHint builds the "→ selector" suggestion for a T3 node: the nearest
 // data-attr ancestor as the scope plus the node's own tag as the leaf. Returns
 // "" when there is no stable ancestor to anchor on.
-func ArrowHint(node *comps.ComponentNode, parentMap ParentMap) string {
+func ArrowHint(node *sightmap.ComponentNode, parentMap ParentMap) string {
 	nodeTag := ""
 	if node.Element != nil {
 		nodeTag = node.Element.Tag

--- a/go/coverage/coverage.go
+++ b/go/coverage/coverage.go
@@ -15,15 +15,13 @@ package coverage
 import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"math"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // Matches maps a component node to the sightmap rule it matched.
-type Matches = map[*comps.ComponentNode]*sightmap.ComponentMatch
+type Matches = map[*sightmap.ComponentNode]*sightmap.ComponentMatch
 
 // ParentMap maps each non-root node to its parent.
-type ParentMap = map[*comps.ComponentNode]*comps.ComponentNode
+type ParentMap = map[*sightmap.ComponentNode]*sightmap.ComponentNode
 
 // Options controls how coverage is scored.
 type Options struct {
@@ -40,27 +38,27 @@ type Result struct {
 	VisibleOnly       bool
 
 	// Orphans are the T3 nodes (interactive, no matched ancestor).
-	Orphans []*comps.ComponentNode
+	Orphans []*sightmap.ComponentNode
 	// Scopes maps a matched ancestor to its count of T2 children.
-	Scopes map[*comps.ComponentNode]int
+	Scopes map[*sightmap.ComponentNode]int
 	// ScopeChildren maps a matched ancestor to its T2 children.
-	ScopeChildren map[*comps.ComponentNode][]*comps.ComponentNode
+	ScopeChildren map[*sightmap.ComponentNode][]*sightmap.ComponentNode
 	// ParentMap is the node→parent map built during scoring.
 	ParentMap ParentMap
 }
 
 // Score classifies every interactive node in the tree into T1/T2/T3.
-func Score(root *comps.ComponentNode, matches Matches, opts Options) Result {
+func Score(root *sightmap.ComponentNode, matches Matches, opts Options) Result {
 	res := Result{
 		VisibleOnly:   opts.VisibleOnly,
-		Scopes:        make(map[*comps.ComponentNode]int),
-		ScopeChildren: make(map[*comps.ComponentNode][]*comps.ComponentNode),
+		Scopes:        make(map[*sightmap.ComponentNode]int),
+		ScopeChildren: make(map[*sightmap.ComponentNode][]*sightmap.ComponentNode),
 		ParentMap:     BuildParentMap(root),
 	}
 	if root == nil {
 		return res
 	}
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		if !n.IsInteractive {
 			return true
 		}
@@ -87,12 +85,12 @@ func Score(root *comps.ComponentNode, matches Matches, opts Options) Result {
 // the same visibility filter Score uses. It is the corpus-independent way to ask
 // "does this page have any actionable content?" — useful for detecting a blank or
 // still-loading page before a corpus is even involved.
-func CountInteractive(root *comps.ComponentNode, visibleOnly bool) int {
+func CountInteractive(root *sightmap.ComponentNode, visibleOnly bool) int {
 	if root == nil {
 		return 0
 	}
 	n := 0
-	comps.Walk(root, func(node *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(node *sightmap.ComponentNode, _ int) bool {
 		if !node.IsInteractive {
 			return true
 		}
@@ -106,12 +104,12 @@ func CountInteractive(root *comps.ComponentNode, visibleOnly bool) int {
 }
 
 // BuildParentMap returns a map from each non-root node to its parent.
-func BuildParentMap(root *comps.ComponentNode) ParentMap {
+func BuildParentMap(root *sightmap.ComponentNode) ParentMap {
 	pm := make(ParentMap)
 	if root == nil {
 		return pm
 	}
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		for _, child := range n.Children {
 			pm[child] = n
 		}
@@ -122,7 +120,7 @@ func BuildParentMap(root *comps.ComponentNode) ParentMap {
 
 // nearestMatchedAncestor returns the nearest ancestor of node that has a
 // sightmap match, or nil if none exists.
-func nearestMatchedAncestor(node *comps.ComponentNode, parentMap ParentMap, matches Matches) *comps.ComponentNode {
+func nearestMatchedAncestor(node *sightmap.ComponentNode, parentMap ParentMap, matches Matches) *sightmap.ComponentNode {
 	curr := parentMap[node]
 	for curr != nil {
 		if matches[curr] != nil {

--- a/go/coverage/gaps.go
+++ b/go/coverage/gaps.go
@@ -1,12 +1,11 @@
 package coverage
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // Annotation-completeness detector
@@ -67,12 +66,12 @@ func isContentName(s string) bool {
 // T1/T2/T3 tiers; this detector exists to catch NON-interactive content that
 // coverage cannot see. visibleOnly mirrors Score: hidden/ignored nodes are
 // skipped when set.
-func Gaps(root *comps.ComponentNode, matches Matches, parentMap ParentMap, visibleOnly bool) []ContentGap {
+func Gaps(root *sightmap.ComponentNode, matches Matches, parentMap ParentMap, visibleOnly bool) []ContentGap {
 	var gaps []ContentGap
 	if root == nil {
 		return gaps
 	}
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		if n.IsInteractive {
 			return true // scored by T1/T2/T3 already
 		}

--- a/go/coverage/gaps_test.go
+++ b/go/coverage/gaps_test.go
@@ -3,8 +3,6 @@ package coverage
 import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // gapsFixture builds a small tree and returns root + parentMap so each test can
@@ -13,32 +11,32 @@ import (
 //	root (generic)
 //	└─ banner (generic, data-testid="hero")
 //	   └─ image  name="UP TO $800 OFF select appliances"   (the content node)
-func gapsFixture() (root, banner, image *comps.ComponentNode, parentMap map[*comps.ComponentNode]*comps.ComponentNode) {
-	image = &comps.ComponentNode{
+func gapsFixture() (root, banner, image *sightmap.ComponentNode, parentMap map[*sightmap.ComponentNode]*sightmap.ComponentNode) {
+	image = &sightmap.ComponentNode{
 		Id:        "img",
 		Role:      "image",
 		Name:      "UP TO $800 OFF select appliances",
 		IsVisible: true,
 	}
-	banner = &comps.ComponentNode{
+	banner = &sightmap.ComponentNode{
 		Id:        "banner",
 		Role:      "generic",
 		IsVisible: true,
-		Element:   &comps.Element{Tag: "div", Attrs: map[string]string{"data-testid": "hero"}},
-		Children:  []*comps.ComponentNode{image},
+		Element:   &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "hero"}},
+		Children:  []*sightmap.ComponentNode{image},
 	}
-	root = &comps.ComponentNode{
+	root = &sightmap.ComponentNode{
 		Id:        "root",
 		Role:      "generic",
 		IsVisible: true,
-		Children:  []*comps.ComponentNode{banner},
+		Children:  []*sightmap.ComponentNode{banner},
 	}
 	return root, banner, image, BuildParentMap(root)
 }
 
 func TestAnnotationGaps_FlaggedWhenNoContext(t *testing.T) {
 	root, _, image, pm := gapsFixture()
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{} // nothing matched
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{} // nothing matched
 
 	gaps := Gaps(root, matches, pm, true)
 	if len(gaps) != 1 {
@@ -59,7 +57,7 @@ func TestAnnotationGaps_FlaggedWhenNoContext(t *testing.T) {
 func TestAnnotationGaps_NotFlaggedWhenDirectlyMatched(t *testing.T) {
 	root, _, image, pm := gapsFixture()
 	// The content node itself is now captured by a component (T1).
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		image: {Name: "BannerImage"},
 	}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
@@ -70,7 +68,7 @@ func TestAnnotationGaps_NotFlaggedWhenDirectlyMatched(t *testing.T) {
 func TestAnnotationGaps_NotFlaggedWhenAncestorMatched(t *testing.T) {
 	root, banner, _, pm := gapsFixture()
 	// A matched ancestor gives the node component context → precision guard.
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		banner: {Name: "HeroBanner"},
 	}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
@@ -79,17 +77,17 @@ func TestAnnotationGaps_NotFlaggedWhenAncestorMatched(t *testing.T) {
 }
 
 func TestAnnotationGaps_ShortAndEmptyNamesIgnored(t *testing.T) {
-	short := &comps.ComponentNode{Id: "s", Role: "image", Name: "Sale", IsVisible: true}
-	empty := &comps.ComponentNode{Id: "e", Role: "image", Name: "   ", IsVisible: true}
-	symbols := &comps.ComponentNode{Id: "y", Role: "image", Name: "$$$ 100% !!!!!", IsVisible: true}
-	root := &comps.ComponentNode{
+	short := &sightmap.ComponentNode{Id: "s", Role: "image", Name: "Sale", IsVisible: true}
+	empty := &sightmap.ComponentNode{Id: "e", Role: "image", Name: "   ", IsVisible: true}
+	symbols := &sightmap.ComponentNode{Id: "y", Role: "image", Name: "$$$ 100% !!!!!", IsVisible: true}
+	root := &sightmap.ComponentNode{
 		Id:        "root",
 		Role:      "generic",
 		IsVisible: true,
-		Children:  []*comps.ComponentNode{short, empty, symbols},
+		Children:  []*sightmap.ComponentNode{short, empty, symbols},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{}
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("want 0 gaps for short/empty/symbol names, got %d: %+v", len(gaps), gaps)
 	}
@@ -97,41 +95,41 @@ func TestAnnotationGaps_ShortAndEmptyNamesIgnored(t *testing.T) {
 
 func TestAnnotationGaps_InteractiveSkipped(t *testing.T) {
 	// An interactive long-named orphan is scored by T1/T2/T3, not here.
-	link := &comps.ComponentNode{
+	link := &sightmap.ComponentNode{
 		Id:            "l",
 		Role:          "link",
 		Name:          "Shop all appliance deals today",
 		IsVisible:     true,
 		IsInteractive: true,
 	}
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:        "root",
 		Role:      "generic",
 		IsVisible: true,
-		Children:  []*comps.ComponentNode{link},
+		Children:  []*sightmap.ComponentNode{link},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{}
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{}
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("want 0 gaps for interactive node, got %d: %+v", len(gaps), gaps)
 	}
 }
 
 func TestAnnotationGaps_VisibleOnly(t *testing.T) {
-	hidden := &comps.ComponentNode{
+	hidden := &sightmap.ComponentNode{
 		Id:        "h",
 		Role:      "image",
 		Name:      "Hidden promotional banner copy",
 		IsVisible: false,
 	}
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:        "root",
 		Role:      "generic",
 		IsVisible: true,
-		Children:  []*comps.ComponentNode{hidden},
+		Children:  []*sightmap.ComponentNode{hidden},
 	}
 	pm := BuildParentMap(root)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{}
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{}
 
 	if gaps := Gaps(root, matches, pm, true); len(gaps) != 0 {
 		t.Fatalf("visibleOnly: want 0 gaps for hidden node, got %d", len(gaps))

--- a/go/coverage/status_test.go
+++ b/go/coverage/status_test.go
@@ -1,9 +1,8 @@
 package coverage
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 func TestResultStatus(t *testing.T) {
@@ -35,9 +34,9 @@ func TestResultStatus(t *testing.T) {
 }
 
 func TestCountInteractive(t *testing.T) {
-	tree := &comps.ComponentNode{
+	tree := &sightmap.ComponentNode{
 		Id: "root", Role: "document", IsVisible: true,
-		Children: []*comps.ComponentNode{
+		Children: []*sightmap.ComponentNode{
 			{Id: "btn", Role: "button", IsInteractive: true, IsVisible: true},
 			{Id: "hidden-btn", Role: "button", IsInteractive: true, IsVisible: false},
 			{Id: "ignored-btn", Role: "button", IsInteractive: true, IsVisible: true, IsIgnored: true},

--- a/go/extract/build.go
+++ b/go/extract/build.go
@@ -2,10 +2,8 @@ package extract
 
 import (
 	"fmt"
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 // BuildTree runs the full post-probe pipeline:
@@ -16,13 +14,13 @@ import (
 //  4. Return the root ComponentNode
 //
 // The string selector from ProbeComponent is parsed into a SelectorPart using
-// sel.ParseSightmapSelector. On parse error, a SelectorPart with just Tag set
+// sightmap.ParseSightmapSelector. On parse error, a SelectorPart with just Tag set
 // (from TagName) is used as a fallback.
 func BuildTree(
 	probe *ProbeResult,
 	a11y []A11YNode,
 	domRoot *DOMNode,
-) (*comps.ComponentNode, error) {
+) (*sightmap.ComponentNode, error) {
 	// 1. Index probe results by ID.
 	probeByID := make(map[string]*ProbeComponent, len(probe.Results))
 	for i := range probe.Results {
@@ -63,7 +61,7 @@ func walkDOMNode(
 	node *DOMNode,
 	probeByID map[string]*ProbeComponent,
 	a11yByID map[int]*A11YNode,
-) (*comps.ComponentNode, []*comps.ComponentNode) {
+) (*sightmap.ComponentNode, []*sightmap.ComponentNode) {
 	// Treat shadow roots as ordinary children (appended after regular children
 	// to preserve document order of the light tree first).
 	allDOM := make([]*DOMNode, 0, len(node.Children)+len(node.ShadowRoots))
@@ -71,7 +69,7 @@ func walkDOMNode(
 	allDOM = append(allDOM, node.ShadowRoots...)
 
 	// Recursively collect component children.
-	var compChildren []*comps.ComponentNode
+	var compChildren []*sightmap.ComponentNode
 	for _, child := range allDOM {
 		childNode, grandchildren := walkDOMNode(child, probeByID, a11yByID)
 		if childNode != nil {
@@ -107,7 +105,7 @@ func walkDOMNode(
 	a11yNode := a11yByID[node.BackendNodeID]
 	role, name, value, ignored, props := mergeA11Y(pc, a11yNode)
 
-	compNode := &comps.ComponentNode{
+	compNode := &sightmap.ComponentNode{
 		Id:            pc.Id,
 		Role:          role,
 		Name:          name,
@@ -126,23 +124,23 @@ func walkDOMNode(
 	return compNode, nil
 }
 
-// elementFor parses ProbeComponent.Selector with sel.ParseSightmapSelector and
+// elementFor parses ProbeComponent.Selector with sightmap.ParseSightmapSelector and
 // projects the last (most-specific) compound into an observed Element. On any
 // error it falls back to an Element with Tag = strings.ToLower(pc.TagName).
 //
 // The returned Element has its Classes duplicated into Attrs["class"] to support
 // attribute selectors like [class*="partial"], [class^="prefix-"], etc.
-func elementFor(pc *ProbeComponent) *comps.Element {
-	var el *comps.Element
+func elementFor(pc *ProbeComponent) *sightmap.Element {
+	var el *sightmap.Element
 	if pc.Selector != "" {
-		parsed, err := sel.ParseSightmapSelector(pc.Selector)
+		parsed, err := sightmap.ParseSightmapSelector(pc.Selector)
 		if err == nil && len(parsed.Parts) > 0 {
 			p := parsed.Parts[len(parsed.Parts)-1]
-			el = &comps.Element{Tag: p.Tag, Id: p.Id, Classes: p.Classes, Attrs: p.Attrs}
+			el = &sightmap.Element{Tag: p.Tag, Id: p.Id, Classes: p.Classes, Attrs: p.Attrs}
 		}
 	}
 	if el == nil {
-		el = &comps.Element{Tag: strings.ToLower(pc.TagName)}
+		el = &sightmap.Element{Tag: strings.ToLower(pc.TagName)}
 	}
 
 	// Duplicate classes into Attrs["class"] for attribute selector support.

--- a/go/extract/types.go
+++ b/go/extract/types.go
@@ -1,6 +1,6 @@
 package extract
 
-import "github.com/sightmap/sightmap/go/comps"
+import "github.com/sightmap/sightmap/go/sightmap"
 
 // ProbeResult is the top-level response from running probe.js in the page.
 type ProbeResult struct {
@@ -13,14 +13,14 @@ type ProbeResult struct {
 // ProbeComponent is the JSON output of probe.js for one element.
 // The Selector field is a CSS selector string.
 // probe.js will output a structured object; for now, parse
-// the string using sel.ParseSightmapSelector.
+// the string using sightmap.ParseSightmapSelector.
 type ProbeComponent struct {
 	Id            string            `json:"id"`
 	Role          string            `json:"role"`  // empty pre-merge
 	Text          string            `json:"text"`  // raw textContent
 	Value         string            `json:"value"` // empty pre-merge
 	Properties    map[string]string `json:"properties"`
-	Bounds        *comps.Bounds     `json:"bounds"`
+	Bounds        *sightmap.Bounds  `json:"bounds"`
 	Selector      string            `json:"selector"` // CSS selector string
 	OnTop         bool              `json:"onTop"`
 	IsVisible     bool              `json:"isVisible"`

--- a/go/match/class_selectors_test.go
+++ b/go/match/class_selectors_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 )
 
@@ -81,10 +80,10 @@ func TestClassAttrSelectors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			node := &comps.ComponentNode{
+			node := &sightmap.ComponentNode{
 				Id:   "test-node",
 				Role: "button",
-				Element: &comps.Element{
+				Element: &sightmap.Element{
 					Tag:     "button",
 					Classes: tt.classes,
 					Attrs:   map[string]string{"class": strings.Join(tt.classes, " ")},

--- a/go/match/conformance_test.go
+++ b/go/match/conformance_test.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 	"gopkg.in/yaml.v3"
 )
@@ -26,7 +25,7 @@ func TestConformance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read tree: %v", err)
 			}
-			var root comps.ComponentNode
+			var root sightmap.ComponentNode
 			if err := json.Unmarshal(treeData, &root); err != nil {
 				t.Fatalf("parse tree: %v", err)
 			}

--- a/go/match/corpus_matcher.go
+++ b/go/match/corpus_matcher.go
@@ -3,7 +3,6 @@ package match
 import (
 	"sync"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -53,7 +52,7 @@ func (m *Matcher) entryFor(pageURL string) *queryCacheEntry {
 // selects the matching view (falling back to global components), compiles the
 // queries if not already cached, then runs the NFA matcher over root. Returns
 // nil when root is nil or no queries apply.
-func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comps.ComponentNode]*sightmap.ComponentMatch {
+func (m *Matcher) MatchTree(root *sightmap.ComponentNode, pageURL string) map[*sightmap.ComponentNode]*sightmap.ComponentMatch {
 	entry := m.entryFor(pageURL)
 	if root == nil || len(entry.queries) == 0 {
 		return nil
@@ -65,8 +64,8 @@ func (m *Matcher) MatchTree(root *comps.ComponentNode, pageURL string) map[*comp
 		byName[entry.components[i].Name] = &entry.components[i]
 	}
 
-	result := make(map[*comps.ComponentNode]*sightmap.ComponentMatch)
-	FindAllMatches(root, entry.queries, func(node *comps.ComponentNode, q *MatchQuery) {
+	result := make(map[*sightmap.ComponentNode]*sightmap.ComponentMatch)
+	FindAllMatches(root, entry.queries, func(node *sightmap.ComponentNode, q *MatchQuery) {
 		if _, already := result[node]; already {
 			return // first-match-wins
 		}

--- a/go/match/doc.go
+++ b/go/match/doc.go
@@ -1,4 +1,4 @@
 // Package match implements the NFA multi-query sightmap rule matcher.
-// It traverses a comps.ComponentNode tree once in O(M) time, matching N
-// sightmap component definitions simultaneously via sel.Matches.
+// It traverses a sightmap.ComponentNode tree once in O(M) time, matching N
+// sightmap component definitions simultaneously via sightmap.Matches.
 package match

--- a/go/match/has_test.go
+++ b/go/match/has_test.go
@@ -3,15 +3,13 @@ package match_test
 import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // TestHas_FormGroupScoping is the end-to-end (snapshot/coverage) path for the
 // :has() relational pseudo-class: only the form-group that contains a checkbox
 // should match, mirroring the homedepot assembly-vs-protection rows.
 func TestHas_FormGroupScoping(t *testing.T) {
-	formGroup := func(id string, control *comps.ComponentNode) *comps.ComponentNode {
+	formGroup := func(id string, control *sightmap.ComponentNode) *sightmap.ComponentNode {
 		return nodeAttr(id, "div", map[string]string{"data-testid": "form-group"},
 			node("", "div", nil, control))
 	}

--- a/go/match/intermediate_test.go
+++ b/go/match/intermediate_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 )
 
@@ -18,36 +17,36 @@ import (
 //	  ol (list — structural, no data attributes)
 //	    li (listitem — structural)
 //	      a (link — BreadcrumbLink target)
-func buildBreadcrumbTree() *comps.ComponentNode {
-	return &comps.ComponentNode{
+func buildBreadcrumbTree() *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{
 		Id:      "page",
-		Element: &comps.Element{Tag: "div"},
-		Children: []*comps.ComponentNode{
+		Element: &sightmap.Element{Tag: "div"},
+		Children: []*sightmap.ComponentNode{
 			{
 				Id:   "breadcrumb",
 				Role: "navigation",
-				Element: &comps.Element{
+				Element: &sightmap.Element{
 					Tag:   "nav",
 					Attrs: map[string]string{"data-component": "breadcrumbs:Breadcrumbs:v14.0.1"},
 				},
-				Children: []*comps.ComponentNode{
+				Children: []*sightmap.ComponentNode{
 					{
 						Id:      "list",
 						Role:    "list",
-						Element: &comps.Element{Tag: "ol"},
-						Children: []*comps.ComponentNode{
+						Element: &sightmap.Element{Tag: "ol"},
+						Children: []*sightmap.ComponentNode{
 							{
 								Id:        "listitem",
 								Role:      "listitem",
 								IsIgnored: false,
-								Element:   &comps.Element{Tag: "li"},
-								Children: []*comps.ComponentNode{
+								Element:   &sightmap.Element{Tag: "li"},
+								Children: []*sightmap.ComponentNode{
 									{
 										Id:            "link",
 										Role:          "link",
 										IsInteractive: true,
 										IsVisible:     true,
-										Element:       &comps.Element{Tag: "a"},
+										Element:       &sightmap.Element{Tag: "a"},
 									},
 								},
 							},
@@ -73,8 +72,8 @@ func TestChildAnnotation_ThroughStructuralIntermediate(t *testing.T) {
 	result := match.ApplySightmap(root, defs)
 
 	// Find the specific nodes
-	var breadcrumbNode, linkNode *comps.ComponentNode
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	var breadcrumbNode, linkNode *sightmap.ComponentNode
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		switch n.Id {
 		case "breadcrumb":
 			breadcrumbNode = n
@@ -118,8 +117,8 @@ func TestChildAnnotation_BroadGlobalDoesNotSteal(t *testing.T) {
 
 	result := match.ApplySightmap(root, defs)
 
-	var linkNode *comps.ComponentNode
-	comps.Walk(root, func(n *comps.ComponentNode, _ int) bool {
+	var linkNode *sightmap.ComponentNode
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
 		if n.Id == "link" {
 			linkNode = n
 		}

--- a/go/match/matcher.go
+++ b/go/match/matcher.go
@@ -1,8 +1,7 @@
 package match
 
 import (
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // MatchQuery pairs a semantic name with a parsed, root-first selector chain.
@@ -11,7 +10,7 @@ import (
 //   - Subsequent entries are " " (descendant) or ">" (direct child)
 type MatchQuery struct {
 	Name        string
-	Parts       []*comps.SelectorPart
+	Parts       []*sightmap.SelectorPart
 	Combinators []string
 }
 
@@ -24,9 +23,9 @@ type MatchQuery struct {
 // special handling — component IDs are globally unique and require no frame
 // boundary logic here.
 func FindAllMatches(
-	root *comps.ComponentNode,
+	root *sightmap.ComponentNode,
 	queries []MatchQuery,
-	onMatch func(*comps.ComponentNode, *MatchQuery),
+	onMatch func(*sightmap.ComponentNode, *MatchQuery),
 ) {
 	if root == nil || len(queries) == 0 {
 		return
@@ -49,10 +48,10 @@ type selectorState struct {
 //	direct     – states that must be checked at this node ONLY (direct-child
 //	             combinator consumed one level).
 func findAllMatchesNFA(
-	node *comps.ComponentNode,
+	node *sightmap.ComponentNode,
 	descendant, direct []selectorState,
 	queries []MatchQuery,
-	onMatch func(*comps.ComponentNode, *MatchQuery),
+	onMatch func(*sightmap.ComponentNode, *MatchQuery),
 ) {
 	// Build de-duplicated set of states to evaluate at this node.
 	// Fresh starts ({q, 0}) are added for every query at every node — this is
@@ -103,7 +102,7 @@ func findAllMatchesNFA(
 		rule := state.q.Parts[state.idx]
 		// MatchesNode honors :has() (needs node's subtree); falls back to the
 		// flat checks for everything else.
-		if !sel.MatchesNode(node, rule) {
+		if !sightmap.MatchesNode(node, rule) {
 			continue
 		}
 

--- a/go/match/matcher_test.go
+++ b/go/match/matcher_test.go
@@ -5,41 +5,40 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/match"
 )
 
 // ---------- tree builders ----------------------------------------------------
 
-func node(id, tag string, classes []string, children ...*comps.ComponentNode) *comps.ComponentNode {
-	return &comps.ComponentNode{
+func node(id, tag string, classes []string, children ...*sightmap.ComponentNode) *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{
 		Id:        id,
-		Element:   &comps.Element{Tag: tag, Classes: classes},
+		Element:   &sightmap.Element{Tag: tag, Classes: classes},
 		IsVisible: true,
 		Children:  children,
 	}
 }
 
-func nodeAttr(id, tag string, attrs map[string]string, children ...*comps.ComponentNode) *comps.ComponentNode {
-	return &comps.ComponentNode{
+func nodeAttr(id, tag string, attrs map[string]string, children ...*sightmap.ComponentNode) *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{
 		Id:       id,
-		Element:  &comps.Element{Tag: tag, Attrs: attrs},
+		Element:  &sightmap.Element{Tag: tag, Attrs: attrs},
 		Children: children,
 	}
 }
 
-func nodeInvisible(id, tag string) *comps.ComponentNode {
-	return &comps.ComponentNode{
+func nodeInvisible(id, tag string) *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{
 		Id:        id,
 		IsVisible: false,
-		Element:   &comps.Element{Tag: tag},
+		Element:   &sightmap.Element{Tag: tag},
 	}
 }
 
 // ---------- helpers ----------------------------------------------------------
 
 // applyDefs is a shorthand: build defs, apply, return matched node IDs by name.
-func applyDefs(t *testing.T, root *comps.ComponentNode, defs []sightmap.ComponentDef) map[string][]string {
+func applyDefs(t *testing.T, root *sightmap.ComponentNode, defs []sightmap.ComponentDef) map[string][]string {
 	t.Helper()
 	m := match.ApplySightmap(root, defs)
 	result := make(map[string][]string)
@@ -91,7 +90,7 @@ func assertNoMatch(t *testing.T, got map[string][]string, name string) {
 //       input[type=email] [id=inp1]
 //       button.submit     [id=btn3]   ← direct child of form
 
-func makeTree() *comps.ComponentNode {
+func makeTree() *sightmap.ComponentNode {
 	return node("root", "div", nil,
 		node("nav", "nav", []string{"main-nav"},
 			node("a1", "a", []string{"nav-link"}),
@@ -160,15 +159,15 @@ func TestDirectChild_DoesNotMatchGrandchild(t *testing.T) {
 
 func TestDirectChild_TwoHops(t *testing.T) {
 	// A > B > C chain.
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:      "r",
-		Element: &comps.Element{Tag: "ul"},
-		Children: []*comps.ComponentNode{
+		Element: &sightmap.Element{Tag: "ul"},
+		Children: []*sightmap.ComponentNode{
 			{
 				Id:      "li",
-				Element: &comps.Element{Tag: "li"},
-				Children: []*comps.ComponentNode{
-					{Id: "a", Element: &comps.Element{Tag: "a"}},
+				Element: &sightmap.Element{Tag: "li"},
+				Children: []*sightmap.ComponentNode{
+					{Id: "a", Element: &sightmap.Element{Tag: "a"}},
 				},
 			},
 		},
@@ -180,15 +179,15 @@ func TestDirectChild_TwoHops(t *testing.T) {
 
 func TestDirectChild_NotTwoLevelsDeep(t *testing.T) {
 	// ul > a should NOT match a inside li (two levels deep).
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:      "r",
-		Element: &comps.Element{Tag: "ul"},
-		Children: []*comps.ComponentNode{
+		Element: &sightmap.Element{Tag: "ul"},
+		Children: []*sightmap.ComponentNode{
 			{
 				Id:      "li",
-				Element: &comps.Element{Tag: "li"},
-				Children: []*comps.ComponentNode{
-					{Id: "a", Element: &comps.Element{Tag: "a"}},
+				Element: &sightmap.Element{Tag: "li"},
+				Children: []*sightmap.ComponentNode{
+					{Id: "a", Element: &sightmap.Element{Tag: "a"}},
 				},
 			},
 		},
@@ -239,11 +238,11 @@ func TestInvisibleNodesIncluded(t *testing.T) {
 
 func TestNilSelectorNode_DoesNotMatchSpecificRule(t *testing.T) {
 	// A node with nil Selector cannot satisfy a specific selector rule.
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:      "root",
 		Element: nil,
-		Children: []*comps.ComponentNode{
-			{Id: "child", Element: &comps.Element{Tag: "button"}},
+		Children: []*sightmap.ComponentNode{
+			{Id: "child", Element: &sightmap.Element{Tag: "button"}},
 		},
 	}
 	defs := []sightmap.ComponentDef{{Name: "Btn", Selectors: []string{"button"}}}
@@ -286,13 +285,13 @@ func TestFramePrefixedIDs_Traversed(t *testing.T) {
 
 func TestMobileSyntheticSelector(t *testing.T) {
 	// Native mobile component with synthetic selectors.
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:      "screen",
-		Element: &comps.Element{Tag: "UIView"},
-		Children: []*comps.ComponentNode{
+		Element: &sightmap.Element{Tag: "UIView"},
+		Children: []*sightmap.ComponentNode{
 			{
 				Id: "btn",
-				Element: &comps.Element{
+				Element: &sightmap.Element{
 					Tag:   "UIButton",
 					Attrs: map[string]string{"label": "Add to Cart"},
 				},

--- a/go/match/sightmap.go
+++ b/go/match/sightmap.go
@@ -3,8 +3,6 @@ package match
 import (
 	"fmt"
 
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -18,7 +16,7 @@ func ParseQueries(defs []sightmap.ComponentDef) ([]MatchQuery, []error) {
 
 	for _, def := range defs {
 		for _, selStr := range def.Selectors {
-			ps, err := sel.ParseSightmapSelector(selStr)
+			ps, err := sightmap.ParseSightmapSelector(selStr)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("component %q selector %q: %w", def.Name, selStr, err))
 				continue
@@ -40,7 +38,7 @@ func ParseQueries(defs []sightmap.ComponentDef) ([]MatchQuery, []error) {
 // (and earliest selector within that definition) takes precedence.
 //
 // Returns nil if defs is empty or root is nil.
-func ApplySightmap(root *comps.ComponentNode, defs []sightmap.ComponentDef) map[*comps.ComponentNode]*sightmap.ComponentMatch {
+func ApplySightmap(root *sightmap.ComponentNode, defs []sightmap.ComponentDef) map[*sightmap.ComponentNode]*sightmap.ComponentMatch {
 	if root == nil || len(defs) == 0 {
 		return nil
 	}
@@ -57,9 +55,9 @@ func ApplySightmap(root *comps.ComponentNode, defs []sightmap.ComponentDef) map[
 		defByName[defs[i].Name] = &defs[i]
 	}
 
-	result := make(map[*comps.ComponentNode]*sightmap.ComponentMatch)
+	result := make(map[*sightmap.ComponentNode]*sightmap.ComponentMatch)
 
-	FindAllMatches(root, queries, func(node *comps.ComponentNode, q *MatchQuery) {
+	FindAllMatches(root, queries, func(node *sightmap.ComponentNode, q *MatchQuery) {
 		// First-match-wins: skip if already claimed.
 		if _, already := result[node]; already {
 			return
@@ -80,7 +78,7 @@ func ApplySightmap(root *comps.ComponentNode, defs []sightmap.ComponentDef) map[
 // normal and never reported; a single node claimed by several names is the
 // ambiguity, since ApplySightmap keeps only the first. It reuses the same
 // traversal as ApplySightmap, so it sees exactly the same matches.
-func FindConflicts(root *comps.ComponentNode, defs []sightmap.ComponentDef) []sightmap.Conflict {
+func FindConflicts(root *sightmap.ComponentNode, defs []sightmap.ComponentDef) []sightmap.Conflict {
 	if root == nil || len(defs) == 0 {
 		return nil
 	}
@@ -89,9 +87,9 @@ func FindConflicts(root *comps.ComponentNode, defs []sightmap.ComponentDef) []si
 		return nil
 	}
 
-	namesByNode := make(map[*comps.ComponentNode][]string)
-	var order []*comps.ComponentNode
-	FindAllMatches(root, queries, func(node *comps.ComponentNode, q *MatchQuery) {
+	namesByNode := make(map[*sightmap.ComponentNode][]string)
+	var order []*sightmap.ComponentNode
+	FindAllMatches(root, queries, func(node *sightmap.ComponentNode, q *MatchQuery) {
 		names := namesByNode[node]
 		for _, n := range names {
 			if n == q.Name {

--- a/go/observe/format_test.go
+++ b/go/observe/format_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -20,7 +19,7 @@ func renderResult(r *Result) string {
 // renderer must say so, not silently omit the header.
 func TestFormat_NoViewMatched(t *testing.T) {
 	r := &Result{
-		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		Root:          &sightmap.ComponentNode{Id: "1", Role: "document", IsVisible: true},
 		URL:           "https://app.example.com/login",
 		CorpusApplied: true,
 		View:          nil,
@@ -39,7 +38,7 @@ func TestFormat_NoViewMatched(t *testing.T) {
 // [Coverage] line must still print (all orphans), not vanish.
 func TestFormat_CoverageWithZeroMatches(t *testing.T) {
 	r := &Result{
-		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		Root:          &sightmap.ComponentNode{Id: "1", Role: "document", IsVisible: true},
 		URL:           "https://app.example.com/x",
 		CorpusApplied: true,
 		View:          &sightmap.ViewDef{Name: "Stub", Route: "/x"},
@@ -59,13 +58,13 @@ func TestFormat_CoverageWithZeroMatches(t *testing.T) {
 // multiple components) surface in a [Conflicts] section.
 func TestFormat_Conflicts(t *testing.T) {
 	r := &Result{
-		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		Root:          &sightmap.ComponentNode{Id: "1", Role: "document", IsVisible: true},
 		URL:           "https://app.example.com/a/b",
 		CorpusApplied: true,
 		View:          &sightmap.ViewDef{Name: "AStar", Route: "/a/*"},
 		TiedViews:     []string{"AStar", "StarB"},
 		ComponentConflicts: []sightmap.Conflict{{
-			Node:  &comps.ComponentNode{Id: "7", Role: "button", Name: "Save"},
+			Node:  &sightmap.ComponentNode{Id: "7", Role: "button", Name: "Save"},
 			Names: []string{"AppDialog", "LoginDialog"},
 		}},
 	}
@@ -85,7 +84,7 @@ func TestFormat_Conflicts(t *testing.T) {
 // [Coverage] line should appear (the raw tree stands on its own).
 func TestFormat_NoCorpus(t *testing.T) {
 	r := &Result{
-		Root:          &comps.ComponentNode{Id: "1", Role: "document", IsVisible: true},
+		Root:          &sightmap.ComponentNode{Id: "1", Role: "document", IsVisible: true},
 		URL:           "https://app.example.com/x",
 		CorpusApplied: false,
 	}

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -16,9 +15,9 @@ import (
 // nil unless Options.ExtractProps was set. Matches/View/Coverage are zero when no
 // corpus was supplied.
 type Result struct {
-	Root        *comps.ComponentNode
+	Root        *sightmap.ComponentNode
 	URL         string
-	Matches     map[*comps.ComponentNode]*sightmap.ComponentMatch
+	Matches     map[*sightmap.ComponentNode]*sightmap.ComponentMatch
 	View        *sightmap.ViewDef
 	Components  []sightmap.ComponentDef
 	GlobalNames map[string]bool

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/sightmap/sightmap/go/browser"
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -19,7 +18,7 @@ import (
 func ExtractProperties(
 	ctx context.Context,
 	conn *browser.CDPConn,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	compByName map[string]sightmap.ComponentDef,
 ) map[string]map[string]string {
 	type specProp struct {

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/render"
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -109,7 +108,7 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 
 // writeGuide prints the [Guide] section: component names and match counts,
 // sorted by count descending then name ascending.
-func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) {
+func writeGuide(w io.Writer, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) {
 	counts := make(map[string]int)
 	for _, m := range matches {
 		if m != nil {
@@ -158,7 +157,7 @@ func writeGuide(w io.Writer, matches map[*comps.ComponentNode]*sightmap.Componen
 func writeZeroMatchWarnings(
 	w io.Writer,
 	viewComponents []sightmap.ComponentDef,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	view *sightmap.ViewDef,
 	globalNames map[string]bool,
 ) {
@@ -226,7 +225,7 @@ func writeConflicts(w io.Writer, r *Result) {
 
 // conflictNodeLabel formats a node for a conflict line: its probe id plus role
 // and accessible name when present.
-func conflictNodeLabel(n *comps.ComponentNode) string {
+func conflictNodeLabel(n *sightmap.ComponentNode) string {
 	if n == nil {
 		return "(node)"
 	}
@@ -260,8 +259,8 @@ func writeCoverage(w io.Writer, cov coverage.Result) {
 // and sorted by count descending.
 func WriteTrace(
 	w io.Writer,
-	t3nodes []*comps.ComponentNode,
-	parentMap map[*comps.ComponentNode]*comps.ComponentNode,
+	t3nodes []*sightmap.ComponentNode,
+	parentMap map[*sightmap.ComponentNode]*sightmap.ComponentNode,
 ) {
 	type clusterKey struct {
 		role   string
@@ -270,7 +269,7 @@ func WriteTrace(
 	}
 	type cluster struct {
 		count int
-		rep   *comps.ComponentNode
+		rep   *sightmap.ComponentNode
 	}
 
 	var order []clusterKey
@@ -339,9 +338,9 @@ func WriteTrace(
 //   - Large lists truncate at 8 items with "… (N more)"
 func WriteT2Trace(
 	w io.Writer,
-	t2clusters map[*comps.ComponentNode]int,
-	t2children map[*comps.ComponentNode][]*comps.ComponentNode,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
+	t2clusters map[*sightmap.ComponentNode]int,
+	t2children map[*sightmap.ComponentNode][]*sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	view *sightmap.ViewDef,
 ) {
 	const minT2Count = 2 // ≥2 children required (single-child = simple wrapper)
@@ -350,7 +349,7 @@ func WriteT2Trace(
 	type entry struct {
 		name      string
 		count     int
-		children  []*comps.ComponentNode
+		children  []*sightmap.ComponentNode
 		hasMemory bool
 	}
 	var entries []entry

--- a/go/observe/t2trace_test.go
+++ b/go/observe/t2trace_test.go
@@ -4,30 +4,29 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // TestWriteT2Trace_Basic verifies basic T2 enumeration functionality.
 func TestWriteT2Trace_Basic(t *testing.T) {
 	// Create a simple tree with T2 children
-	parent := &comps.ComponentNode{
+	parent := &sightmap.ComponentNode{
 		Id:   "parent",
 		Role: "complementary",
 	}
-	children := []*comps.ComponentNode{
+	children := []*sightmap.ComponentNode{
 		{Id: "c1", Role: "button", Name: "Create", IsInteractive: true},
 		{Id: "c2", Role: "button", Name: "Delete", IsInteractive: true},
 		{Id: "c3", Role: "link", Name: "Settings", IsInteractive: true},
 	}
 
-	t2clusters := map[*comps.ComponentNode]int{
+	t2clusters := map[*sightmap.ComponentNode]int{
 		parent: 3,
 	}
-	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
+	t2children := map[*sightmap.ComponentNode][]*sightmap.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "AppSidebar"},
 	}
 	view := &sightmap.ViewDef{
@@ -61,21 +60,21 @@ func TestWriteT2Trace_Basic(t *testing.T) {
 
 // TestWriteT2Trace_SingleChildSuppressed verifies single-child T2 is suppressed.
 func TestWriteT2Trace_SingleChildSuppressed(t *testing.T) {
-	parent := &comps.ComponentNode{
+	parent := &sightmap.ComponentNode{
 		Id:   "parent",
 		Role: "navigation",
 	}
-	child := &comps.ComponentNode{
+	child := &sightmap.ComponentNode{
 		Id: "c1", Role: "link", Name: "Privacy", IsInteractive: true,
 	}
 
-	t2clusters := map[*comps.ComponentNode]int{
+	t2clusters := map[*sightmap.ComponentNode]int{
 		parent: 1, // single child
 	}
-	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
+	t2children := map[*sightmap.ComponentNode][]*sightmap.ComponentNode{
 		parent: {child},
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "NavFooter"},
 	}
 	view := &sightmap.ViewDef{
@@ -96,23 +95,23 @@ func TestWriteT2Trace_SingleChildSuppressed(t *testing.T) {
 
 // TestWriteT2Trace_MemoryNoteSuppressed verifies memory note suppression.
 func TestWriteT2Trace_MemoryNoteSuppressed(t *testing.T) {
-	parent := &comps.ComponentNode{
+	parent := &sightmap.ComponentNode{
 		Id:   "parent",
 		Role: "main",
 	}
-	children := []*comps.ComponentNode{
+	children := []*sightmap.ComponentNode{
 		{Id: "c1", Role: "button", Name: "Action 1", IsInteractive: true},
 		{Id: "c2", Role: "button", Name: "Action 2", IsInteractive: true},
 		{Id: "c3", Role: "button", Name: "Action 3", IsInteractive: true},
 	}
 
-	t2clusters := map[*comps.ComponentNode]int{
+	t2clusters := map[*sightmap.ComponentNode]int{
 		parent: 3,
 	}
-	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
+	t2children := map[*sightmap.ComponentNode][]*sightmap.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "AppContent"},
 	}
 	view := &sightmap.ViewDef{
@@ -145,14 +144,14 @@ func TestWriteT2Trace_MemoryNoteSuppressed(t *testing.T) {
 
 // TestWriteT2Trace_Truncation verifies large lists are truncated.
 func TestWriteT2Trace_Truncation(t *testing.T) {
-	parent := &comps.ComponentNode{
+	parent := &sightmap.ComponentNode{
 		Id:   "parent",
 		Role: "region",
 	}
 	// Create 10 children
-	var children []*comps.ComponentNode
+	var children []*sightmap.ComponentNode
 	for i := 1; i <= 10; i++ {
-		children = append(children, &comps.ComponentNode{
+		children = append(children, &sightmap.ComponentNode{
 			Id:            string(rune('0' + i)),
 			Role:          "link",
 			Name:          "Product " + string(rune('0'+i)),
@@ -160,13 +159,13 @@ func TestWriteT2Trace_Truncation(t *testing.T) {
 		})
 	}
 
-	t2clusters := map[*comps.ComponentNode]int{
+	t2clusters := map[*sightmap.ComponentNode]int{
 		parent: 10,
 	}
-	t2children := map[*comps.ComponentNode][]*comps.ComponentNode{
+	t2children := map[*sightmap.ComponentNode][]*sightmap.ComponentNode{
 		parent: children,
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "ProductGrid"},
 	}
 	view := &sightmap.ViewDef{

--- a/go/render/inspect.go
+++ b/go/render/inspect.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // InspectNode is a node in the unfiltered DOM-structural tree produced by Inspect().
@@ -15,16 +13,16 @@ import (
 // every node from the raw component tree and shows full selector details.
 type InspectNode struct {
 	Id            string
-	Tag           string         // element tag (from Element.Tag or Role fallback)
-	Element       *comps.Element // observed element identity from probe.js
-	Role          string         // AX role (informational)
-	Name          string         // AX accessible name (shown when non-empty)
+	Tag           string            // element tag (from Element.Tag or Role fallback)
+	Element       *sightmap.Element // observed element identity from probe.js
+	Role          string            // AX role (informational)
+	Name          string            // AX accessible name (shown when non-empty)
 	IsVisible     bool
 	IsIgnored     bool
 	IsInteractive bool
 	Match         *sightmap.ComponentMatch // non-nil when a sightmap definition matched
 	Children      []*InspectNode
-	Original      *comps.ComponentNode
+	Original      *sightmap.ComponentNode
 }
 
 // InspectOpts controls the output of FormatInspect.
@@ -45,14 +43,14 @@ type InspectOpts struct {
 // Inspect builds an unfiltered InspectNode tree from a raw ComponentNode tree.
 // Every node is preserved — hidden, ignored, and structural nodes all appear.
 // If matches is non-nil, matched nodes have their Match field populated.
-func Inspect(root *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) *InspectNode {
+func Inspect(root *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) *InspectNode {
 	if root == nil {
 		return nil
 	}
 	return buildInspectNode(root, matches)
 }
 
-func buildInspectNode(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) *InspectNode {
+func buildInspectNode(node *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) *InspectNode {
 	tag := ""
 	if node.Element != nil && node.Element.Tag != "" {
 		tag = node.Element.Tag
@@ -149,7 +147,7 @@ func (n *InspectNode) formatInspectNode(w io.Writer, indent string, depth int, o
 // Default (no flags): tag#id [data-*] [aria-*] [role] [type] [href] [name] [for] [action] [src] [placeholder]
 // --classes:          also prepends .class1.class2
 // --selectors:        shows ALL attributes (complete probe.js output)
-func inspectSelectorDisplay(sel *comps.Element, tag string, opts InspectOpts) string {
+func inspectSelectorDisplay(sel *sightmap.Element, tag string, opts InspectOpts) string {
 	if sel == nil {
 		return tag
 	}

--- a/go/render/inspect_test.go
+++ b/go/render/inspect_test.go
@@ -5,8 +5,6 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // TestInspect_PreservesAllNodes verifies that invisible and ignored children
@@ -48,7 +46,7 @@ func TestInspect_NoFilteringVsFilter(t *testing.T) {
 // TestInspect_MatchAnnotation verifies that match is propagated onto InspectNode.
 func TestInspect_MatchAnnotation(t *testing.T) {
 	btn := node("1", "button", "OK", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		btn: {Name: "SubmitBtn"},
 	}
 
@@ -86,9 +84,9 @@ func TestFormatInspect_Basic(t *testing.T) {
 
 // TestFormatInspect_WithSelector verifies tag#id[data-testid] selector display.
 func TestFormatInspect_WithSelector(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "7", Role: "button", Name: "Add", IsVisible: true, IsInteractive: true,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag:   "button",
 			Id:    "add-btn",
 			Attrs: map[string]string{"data-testid": "add-to-cart"},
@@ -135,9 +133,9 @@ func TestFormatInspect_Ignored(t *testing.T) {
 
 // TestFormatInspect_Classes verifies CSS classes are shown only when Classes is set.
 func TestFormatInspect_Classes(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "div", IsVisible: true,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag:     "div",
 			Classes: []string{"btn", "btn-primary"},
 		},
@@ -162,9 +160,9 @@ func TestFormatInspect_Classes(t *testing.T) {
 // TestFormatInspect_Selectors_ShowsAll verifies --selectors shows attrs that
 // are normally hidden (e.g. tabindex).
 func TestFormatInspect_Selectors_ShowsAll(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "input", IsVisible: true, IsInteractive: true,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag: "input",
 			Attrs: map[string]string{
 				"data-testid": "search",
@@ -192,7 +190,7 @@ func TestFormatInspect_Selectors_ShowsAll(t *testing.T) {
 // TestFormatInspect_MatchAnnotation verifies ★Name is shown for matched nodes.
 func TestFormatInspect_MatchAnnotation(t *testing.T) {
 	btn := node("3", "button", "Shop", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		btn: {Name: "ShopButton"},
 	}
 	in := Inspect(btn, matches)

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // Comp is a filtered, display-ready component node produced by Filter().
@@ -18,7 +16,7 @@ type Comp struct {
 	Value    string                   // form field value
 	Match    *sightmap.ComponentMatch // non-nil when matched by a sightmap definition
 	Children []*Comp
-	Original *comps.ComponentNode // original raw node; .Role has the unmodified AX role
+	Original *sightmap.ComponentNode // original raw node; .Role has the unmodified AX role
 }
 
 // FormatOpts controls the output of Format.
@@ -50,7 +48,7 @@ type FormatOpts struct {
 // StaticText child is collapsed into the parent's Name.
 //
 // If matches is nil or empty, no sightmap annotations are applied.
-func Filter(root *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) *Comp {
+func Filter(root *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) *Comp {
 	if root == nil {
 		return nil
 	}
@@ -169,7 +167,7 @@ const (
 	dropNode                    // remove node and entire subtree
 )
 
-func decide(node *comps.ComponentNode, matched bool) disposition {
+func decide(node *sightmap.ComponentNode, matched bool) disposition {
 	// Drop non-semantic embedded resources.
 	if node.Element != nil {
 		switch strings.ToLower(node.Element.Tag) {
@@ -216,7 +214,7 @@ func decide(node *comps.ComponentNode, matched bool) disposition {
 	return keepNode
 }
 
-func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) []*Comp {
+func convert(node *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) []*Comp {
 	m := matches[node]
 	matched := m != nil
 
@@ -277,7 +275,7 @@ func convert(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightm
 	}}
 }
 
-func convertChildren(node *comps.ComponentNode, matches map[*comps.ComponentNode]*sightmap.ComponentMatch) []*Comp {
+func convertChildren(node *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) []*Comp {
 	var out []*Comp
 	for _, ch := range node.Children {
 		out = append(out, convert(ch, matches)...)
@@ -398,7 +396,7 @@ func truncate(s string, maxRunes int) string {
 
 // selectorHint builds a compact selector string showing only tag, #id,
 // [data-testid], and [data-component] — no CSS classes.
-func selectorHint(sel *comps.Element) string {
+func selectorHint(sel *sightmap.Element) string {
 	if sel == nil {
 		return ""
 	}

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -5,13 +5,11 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // node builds a ComponentNode for use in tests.
-func node(id, role, name string, visible, interactive, ignored bool, children ...*comps.ComponentNode) *comps.ComponentNode {
-	return &comps.ComponentNode{
+func node(id, role, name string, visible, interactive, ignored bool, children ...*sightmap.ComponentNode) *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{
 		Id: id, Role: role, Name: name,
 		IsVisible: visible, IsInteractive: interactive, IsIgnored: ignored,
 		Children: children,
@@ -19,9 +17,9 @@ func node(id, role, name string, visible, interactive, ignored bool, children ..
 }
 
 // nodeWithTag builds a ComponentNode with a Selector tag set.
-func nodeWithTag(id, role, name, tag string, visible, interactive, ignored bool, children ...*comps.ComponentNode) *comps.ComponentNode {
+func nodeWithTag(id, role, name, tag string, visible, interactive, ignored bool, children ...*sightmap.ComponentNode) *sightmap.ComponentNode {
 	n := node(id, role, name, visible, interactive, ignored, children...)
-	n.Element = &comps.Element{Tag: tag}
+	n.Element = &sightmap.Element{Tag: tag}
 	return n
 }
 
@@ -215,7 +213,7 @@ func TestFilter_MergeAdjacentStaticText_Mixed(t *testing.T) {
 
 func TestFilter_MatchProtectsFromTransparency(t *testing.T) {
 	div := node("1", "none", "", true, false, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		div: {Name: "ProductCard"},
 	}
 	comp := Filter(div, matches)
@@ -234,7 +232,7 @@ func TestFilter_MatchedLinkRoleReplaced(t *testing.T) {
 	// Mirrors the canonical extractor's DisplayRole(): match name always replaces AX role,
 	// even for interactive roles like "link". No ★ annotation.
 	a := node("1", "link", "Home", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "NavLink"},
 	}
 	comp := Filter(a, matches)
@@ -251,7 +249,7 @@ func TestFilter_MatchedLinkRoleReplaced(t *testing.T) {
 
 func TestFilter_StructuralRoleReplacedByMatchName(t *testing.T) {
 	nav := node("1", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		nav: {Name: "GlobalNav"},
 	}
 	comp := Filter(nav, matches)
@@ -276,7 +274,7 @@ func TestFilter_GenericWithNameIsKept(t *testing.T) {
 }
 
 func TestFilter_Value_Preserved(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "textbox", Name: "Search", Value: "hello world",
 		IsVisible: true, IsInteractive: true,
 	}
@@ -291,7 +289,7 @@ func TestFilter_Value_Preserved(t *testing.T) {
 
 func TestFilter_EmptyMatches(t *testing.T) {
 	root := node("1", "button", "OK", true, true, false)
-	comp := Filter(root, map[*comps.ComponentNode]*sightmap.ComponentMatch{})
+	comp := Filter(root, map[*sightmap.ComponentNode]*sightmap.ComponentMatch{})
 	if comp == nil {
 		t.Fatal("expected non-nil comp")
 	}
@@ -325,7 +323,7 @@ func TestFormat_NilComp(t *testing.T) {
 
 func TestFormat_WithMatchAnnotation_Interactive(t *testing.T) {
 	a := node("1", "link", "Home", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "NavLink"},
 	}
 	comp := Filter(a, matches)
@@ -341,7 +339,7 @@ func TestFormat_WithMatchAnnotation_Interactive(t *testing.T) {
 
 func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 	nav := node("1", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		nav: {Name: "GlobalNav"},
 	}
 	comp := Filter(nav, matches)
@@ -356,7 +354,7 @@ func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 
 func TestFormat_WithPropValues(t *testing.T) {
 	a := node("1", "link", "Garden Center", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "CategoryTile"},
 	}
 	comp := Filter(a, matches)
@@ -376,7 +374,7 @@ func TestFormat_WithPropValues(t *testing.T) {
 
 func TestFormat_WithPropValues_SortedKeys(t *testing.T) {
 	a := node("1", "link", "Item", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "Tile"},
 	}
 	comp := Filter(a, matches)
@@ -410,9 +408,9 @@ func TestFormat_Nested(t *testing.T) {
 }
 
 func TestFormat_Selectors(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "button", Name: "Add", IsVisible: true, IsInteractive: true,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag:   "button",
 			Attrs: map[string]string{"data-testid": "add-btn"},
 		},
@@ -433,9 +431,9 @@ func TestFormat_Selectors(t *testing.T) {
 }
 
 func TestFormat_Selectors_NoClasses(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "button", Name: "Add", IsVisible: true, IsInteractive: true,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag:     "button",
 			Classes: []string{"btn", "btn-primary"},
 			Id:      "submit-btn",
@@ -454,9 +452,9 @@ func TestFormat_Selectors_NoClasses(t *testing.T) {
 }
 
 func TestFormat_Selectors_DataComponent(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "generic", Name: "Canvas", IsVisible: true, IsInteractive: false,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag:   "div",
 			Attrs: map[string]string{"data-component": "LayoutCanvas"},
 		},
@@ -523,7 +521,7 @@ func TestFormat_Interactive_SkipsNonInteractive(t *testing.T) {
 }
 
 func TestFormat_ValueInOutput(t *testing.T) {
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "1", Role: "textbox", Name: "Search", Value: "hello",
 		IsVisible: true, IsInteractive: true,
 	}
@@ -598,7 +596,7 @@ func TestFilter_MultipleChildren_ParentNameKept(t *testing.T) {
 func TestFormat_Bracket_NoPropsNoName(t *testing.T) {
 	// Matched structural node with no text and no props → bare [CompName]
 	nav := node("42", "navigation", "", true, false, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		nav: {Name: "SiteHeader"},
 	}
 	comp := Filter(nav, matches)
@@ -613,7 +611,7 @@ func TestFormat_Bracket_NoPropsNoName(t *testing.T) {
 func TestFormat_Bracket_NameKept_NoProps(t *testing.T) {
 	// Matched node, name present, no props → name shown last inside brackets
 	a := node("7", "link", "Shop Now", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "BannerLink"},
 	}
 	comp := Filter(a, matches)
@@ -628,7 +626,7 @@ func TestFormat_Bracket_NameKept_NoProps(t *testing.T) {
 func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 	// Rule A: name exactly matches a prop value → name omitted
 	a := node("3", "link", "Explore", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "DesktopNavLink"},
 	}
 	comp := Filter(a, matches)
@@ -647,7 +645,7 @@ func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 func TestFormat_RuleA_NameKept_CaseDiffers(t *testing.T) {
 	// Rule A is exact — case difference means name is kept last
 	a := node("5", "link", "FRI Aug 21 7:00pm", true, true, false)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		a: {Name: "ShowDateRow"},
 	}
 	comp := Filter(a, matches)
@@ -671,7 +669,7 @@ func TestFormat_RuleB_StaticTextSuppressed(t *testing.T) {
 	btn := node("3", "button", "Open menu", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
 	// generic with name "foo bar" is kept (name != "")
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "NavItem"},
 	}
 	comp := Filter(parent, matches)
@@ -700,7 +698,7 @@ func TestFormat_RuleB_StaticTextKept_NoMatch(t *testing.T) {
 	st := node("2", "StaticText", "other text", true, false, false)
 	btn := node("3", "button", "OK", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		parent: {Name: "MyComp"},
 	}
 	comp := Filter(parent, matches)
@@ -720,11 +718,11 @@ func TestFormat_RuleB_StaticTextKept_NoMatch(t *testing.T) {
 func TestFormat_ValueFallback_InBrackets(t *testing.T) {
 	// AX Comp.Value appears as value="..." inside brackets for matched nodes
 	// when no sightmap "value" property is declared.
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "7", Role: "textbox", Name: "Search", Value: "query text",
 		IsVisible: true, IsInteractive: true,
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		n: {Name: "SearchInput"},
 	}
 	comp := Filter(n, matches)
@@ -740,11 +738,11 @@ func TestFormat_ValueFallback_InBrackets(t *testing.T) {
 
 func TestFormat_ValueOverride_SightmapWins(t *testing.T) {
 	// Sightmap-extracted "value" prop overrides AX Comp.Value.
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "8", Role: "textbox", Name: "Dropdown", Value: "AX value",
 		IsVisible: true, IsInteractive: true,
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		n: {Name: "CustomSelect"},
 	}
 	comp := Filter(n, matches)
@@ -764,7 +762,7 @@ func TestFormat_ValueOverride_SightmapWins(t *testing.T) {
 
 func TestFormat_UnmatchedNode_ValueAsSuffix(t *testing.T) {
 	// Unmatched nodes: AX value is a suffix, NOT inside brackets.
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "9", Role: "textbox", Name: "Search", Value: "hello",
 		IsVisible: true, IsInteractive: true,
 	}
@@ -779,7 +777,7 @@ func TestFormat_UnmatchedNode_ValueAsSuffix(t *testing.T) {
 
 func TestFormat_EmptyId_NoPrefix(t *testing.T) {
 	// Comp with empty Id produces no leading space.
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "", Role: "button", Name: "OK",
 		IsVisible: true, IsInteractive: true,
 	}
@@ -797,14 +795,14 @@ func TestFormat_EmptyId_NoPrefix(t *testing.T) {
 
 func TestFormat_Selectors_AfterBracket(t *testing.T) {
 	// --selectors hint appears AFTER the closing bracket for matched nodes.
-	n := &comps.ComponentNode{
+	n := &sightmap.ComponentNode{
 		Id: "5", Role: "link", Name: "Home", IsVisible: true, IsInteractive: true,
-		Element: &comps.Element{
+		Element: &sightmap.Element{
 			Tag:   "a",
 			Attrs: map[string]string{"data-testid": "home-link"},
 		},
 	}
-	matches := map[*comps.ComponentNode]*sightmap.ComponentMatch{
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		n: {Name: "HomeLink"},
 	}
 	comp := Filter(n, matches)
@@ -832,7 +830,7 @@ func TestSelectorHint_Empty(t *testing.T) {
 }
 
 func TestSelectorHint_TagOnly(t *testing.T) {
-	sel := &comps.Element{Tag: "div"}
+	sel := &sightmap.Element{Tag: "div"}
 	got := selectorHint(sel)
 	if got != "div" {
 		t.Errorf("expected 'div', got %q", got)
@@ -840,7 +838,7 @@ func TestSelectorHint_TagOnly(t *testing.T) {
 }
 
 func TestSelectorHint_TagAndId(t *testing.T) {
-	sel := &comps.Element{Tag: "nav", Id: "main-nav"}
+	sel := &sightmap.Element{Tag: "nav", Id: "main-nav"}
 	got := selectorHint(sel)
 	if got != "nav#main-nav" {
 		t.Errorf("expected 'nav#main-nav', got %q", got)
@@ -848,7 +846,7 @@ func TestSelectorHint_TagAndId(t *testing.T) {
 }
 
 func TestSelectorHint_NoClasses(t *testing.T) {
-	sel := &comps.Element{
+	sel := &sightmap.Element{
 		Tag:     "button",
 		Classes: []string{"foo", "bar"},
 	}

--- a/go/sel/doc.go
+++ b/go/sel/doc.go
@@ -1,5 +1,0 @@
-// Package sel provides CSS selector parsing and single-node matching against
-// comps.SelectorPart. It implements the sightmap selector subset: tag, id,
-// class, attribute operators (=, ^=, $=, *=, ~=, |=, presence), :not(), and
-// descendant/direct-child combinators.
-package sel

--- a/go/sightmap/component.go
+++ b/go/sightmap/component.go
@@ -1,7 +1,5 @@
 package sightmap
 
-import "github.com/sightmap/sightmap/go/comps"
-
 // ComponentDef is a single flattened sightmap component definition.
 // Hierarchical YAML selectors should be pre-flattened by the caller into
 // compound descendant selectors before compiling into match queries.
@@ -35,6 +33,6 @@ type ComponentMatch struct {
 // actually claims the node; the rest are silently dropped. Names are in
 // first-seen (definition) order.
 type Conflict struct {
-	Node  *comps.ComponentNode
+	Node  *ComponentNode
 	Names []string
 }

--- a/go/sightmap/comps_component.go
+++ b/go/sightmap/comps_component.go
@@ -1,4 +1,4 @@
-package comps
+package sightmap
 
 import (
 	"encoding/json"
@@ -29,7 +29,7 @@ type SelectorPart struct {
 	// Has, if non-empty, contains one entry per :has() pseudo-class on this
 	// compound selector. The element matches only if its subtree satisfies
 	// EVERY entry (multiple :has() are AND-ed). Evaluating :has() requires tree
-	// context, so it is handled by sel.MatchesNode (not the flat sel.Matches).
+	// context, so it is handled by MatchesNode (not the flat Matches).
 	Has []*HasSelector `json:"has,omitempty"`
 }
 

--- a/go/sightmap/comps_component_test.go
+++ b/go/sightmap/comps_component_test.go
@@ -1,4 +1,4 @@
-package comps
+package sightmap
 
 import (
 	"encoding/json"

--- a/go/sightmap/comps_fixtures_test.go
+++ b/go/sightmap/comps_fixtures_test.go
@@ -1,4 +1,4 @@
-package comps
+package sightmap
 
 import (
 	"encoding/json"

--- a/go/sightmap/comps_tree.go
+++ b/go/sightmap/comps_tree.go
@@ -1,4 +1,4 @@
-package comps
+package sightmap
 
 // Predicate tests whether a node should be included in a filtered tree.
 // Returns (include bool, descend bool):

--- a/go/sightmap/comps_tree_test.go
+++ b/go/sightmap/comps_tree_test.go
@@ -1,9 +1,8 @@
-package comps_test
+package sightmap_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // buildTestTree constructs the shared test tree used across multiple tests:
@@ -16,64 +15,64 @@ import (
 //	    button (role=button,    isVisible=true,  isInteractive=true, inViewport=true, bounds={10,10,100,30})
 //	  p     (role=paragraph,   isVisible=false)
 //	    span  (role=StaticText, isVisible=false)
-func buildTestTree() *comps.ComponentNode {
-	a1 := &comps.ComponentNode{
+func buildTestTree() *sightmap.ComponentNode {
+	a1 := &sightmap.ComponentNode{
 		Id:            "a1",
 		Role:          "link",
 		IsVisible:     true,
 		IsInteractive: true,
 		InViewport:    true,
 	}
-	a2 := &comps.ComponentNode{
+	a2 := &sightmap.ComponentNode{
 		Id:            "a2",
 		Role:          "link",
 		IsVisible:     true,
 		IsInteractive: true,
 		InViewport:    false,
 	}
-	nav := &comps.ComponentNode{
+	nav := &sightmap.ComponentNode{
 		Id:            "nav",
 		Role:          "navigation",
 		IsVisible:     true,
 		IsInteractive: false,
-		Children:      []*comps.ComponentNode{a1, a2},
+		Children:      []*sightmap.ComponentNode{a1, a2},
 	}
-	button := &comps.ComponentNode{
+	button := &sightmap.ComponentNode{
 		Id:            "button",
 		Role:          "button",
 		IsVisible:     true,
 		IsInteractive: true,
 		InViewport:    true,
-		Bounds:        &comps.Bounds{X: 10, Y: 10, Width: 100, Height: 30},
+		Bounds:        &sightmap.Bounds{X: 10, Y: 10, Width: 100, Height: 30},
 	}
-	section := &comps.ComponentNode{
+	section := &sightmap.ComponentNode{
 		Id:        "section",
 		Role:      "generic",
 		IsVisible: true,
-		Children:  []*comps.ComponentNode{nav, button},
+		Children:  []*sightmap.ComponentNode{nav, button},
 	}
-	span := &comps.ComponentNode{
+	span := &sightmap.ComponentNode{
 		Id:        "span",
 		Role:      "StaticText",
 		IsVisible: false,
 	}
-	p := &comps.ComponentNode{
+	p := &sightmap.ComponentNode{
 		Id:        "p",
 		Role:      "paragraph",
 		IsVisible: false,
-		Children:  []*comps.ComponentNode{span},
+		Children:  []*sightmap.ComponentNode{span},
 	}
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:        "root",
 		Role:      "document",
 		IsVisible: true,
-		Children:  []*comps.ComponentNode{section, p},
+		Children:  []*sightmap.ComponentNode{section, p},
 	}
 	return root
 }
 
 // assertNodeIds verifies that nodes have exactly the expected IDs in order.
-func assertNodeIds(t *testing.T, nodes []*comps.ComponentNode, wantIds []string) {
+func assertNodeIds(t *testing.T, nodes []*sightmap.ComponentNode, wantIds []string) {
 	t.Helper()
 	gotIds := make([]string, len(nodes))
 	for i, n := range nodes {
@@ -97,7 +96,7 @@ func TestWalk_AllNodes_DFSPreOrder(t *testing.T) {
 
 	var visitedIds []string
 	var visitedDepths []int
-	comps.Walk(root, func(node *comps.ComponentNode, depth int) bool {
+	sightmap.Walk(root, func(node *sightmap.ComponentNode, depth int) bool {
 		visitedIds = append(visitedIds, node.Id)
 		visitedDepths = append(visitedDepths, depth)
 		return true
@@ -124,7 +123,7 @@ func TestWalk_StopsDescending_WhenFnReturnsFalse(t *testing.T) {
 	root := buildTestTree()
 
 	var visitedIds []string
-	comps.Walk(root, func(node *comps.ComponentNode, depth int) bool {
+	sightmap.Walk(root, func(node *sightmap.ComponentNode, depth int) bool {
 		visitedIds = append(visitedIds, node.Id)
 		// Returning false for "section" skips its entire subtree.
 		return node.Id != "section"
@@ -147,13 +146,13 @@ func TestWalk_StopsDescending_WhenFnReturnsFalse(t *testing.T) {
 
 func TestCollect_IsInteractive(t *testing.T) {
 	root := buildTestTree()
-	got := comps.Collect(root, comps.IsInteractive())
+	got := sightmap.Collect(root, sightmap.IsInteractive())
 	assertNodeIds(t, got, []string{"a1", "a2", "button"})
 }
 
 func TestCollect_InViewport(t *testing.T) {
 	root := buildTestTree()
-	got := comps.Collect(root, comps.InViewport())
+	got := sightmap.Collect(root, sightmap.InViewport())
 	assertNodeIds(t, got, []string{"a1", "button"})
 }
 
@@ -161,13 +160,13 @@ func TestCollect_And_VisibleAndInteractive(t *testing.T) {
 	root := buildTestTree()
 	// All interactive nodes in the tree are also visible, so the result
 	// should be the same as IsInteractive() alone.
-	got := comps.Collect(root, comps.And(comps.IsVisible(), comps.IsInteractive()))
+	got := sightmap.Collect(root, sightmap.And(sightmap.IsVisible(), sightmap.IsInteractive()))
 	assertNodeIds(t, got, []string{"a1", "a2", "button"})
 }
 
 func TestCollect_Not_Visible(t *testing.T) {
 	root := buildTestTree()
-	got := comps.Collect(root, comps.Not(comps.IsVisible()))
+	got := sightmap.Collect(root, sightmap.Not(sightmap.IsVisible()))
 	assertNodeIds(t, got, []string{"p", "span"})
 }
 
@@ -175,7 +174,7 @@ func TestCollect_Not_Visible(t *testing.T) {
 
 func TestFilter_IsInteractive_StructuralConnectors(t *testing.T) {
 	root := buildTestTree()
-	filtered := comps.Filter(root, comps.IsInteractive())
+	filtered := sightmap.Filter(root, sightmap.IsInteractive())
 
 	if filtered == nil {
 		t.Fatal("Filter returned nil, want non-nil")
@@ -224,7 +223,7 @@ func TestFilter_IsInteractive_StructuralConnectors(t *testing.T) {
 
 func TestFilter_HasBounds_OnlyButtonMatches(t *testing.T) {
 	root := buildTestTree()
-	filtered := comps.Filter(root, comps.HasBounds())
+	filtered := sightmap.Filter(root, sightmap.HasBounds())
 
 	if filtered == nil {
 		t.Fatal("Filter returned nil, want non-nil")
@@ -260,10 +259,10 @@ func TestFilter_HasBounds_OnlyButtonMatches(t *testing.T) {
 func TestFilter_NothingMatches_ReturnsNil(t *testing.T) {
 	root := buildTestTree()
 	// IsIgnored is false on every node in the test tree.
-	neverMatch := func(node *comps.ComponentNode, _ int) (bool, bool) {
+	neverMatch := func(node *sightmap.ComponentNode, _ int) (bool, bool) {
 		return node.IsIgnored, true
 	}
-	filtered := comps.Filter(root, neverMatch)
+	filtered := sightmap.Filter(root, neverMatch)
 	if filtered != nil {
 		t.Errorf("Filter returned %q, want nil", filtered.Id)
 	}
@@ -274,6 +273,6 @@ func TestFilter_NothingMatches_ReturnsNil(t *testing.T) {
 func TestCollect_Or_InteractiveOrNotVisible(t *testing.T) {
 	root := buildTestTree()
 	// Interactive nodes (a1, a2, button) plus not-visible nodes (p, span).
-	got := comps.Collect(root, comps.Or(comps.IsInteractive(), comps.Not(comps.IsVisible())))
+	got := sightmap.Collect(root, sightmap.Or(sightmap.IsInteractive(), sightmap.Not(sightmap.IsVisible())))
 	assertNodeIds(t, got, []string{"a1", "a2", "button", "p", "span"})
 }

--- a/go/sightmap/corpus_test.go
+++ b/go/sightmap/corpus_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -406,22 +405,22 @@ func TestAllComponents(t *testing.T) {
 
 func TestMatchTreeEndToEnd(t *testing.T) {
 	// Tree: root → form#search → {input, button}
-	inputNode := &comps.ComponentNode{
+	inputNode := &sightmap.ComponentNode{
 		Id:      "input",
-		Element: &comps.Element{Tag: "input"},
+		Element: &sightmap.Element{Tag: "input"},
 	}
-	buttonNode := &comps.ComponentNode{
+	buttonNode := &sightmap.ComponentNode{
 		Id:      "button",
-		Element: &comps.Element{Tag: "button"},
+		Element: &sightmap.Element{Tag: "button"},
 	}
-	formNode := &comps.ComponentNode{
+	formNode := &sightmap.ComponentNode{
 		Id:       "form",
-		Element:  &comps.Element{Tag: "form", Id: "search-form"},
-		Children: []*comps.ComponentNode{inputNode, buttonNode},
+		Element:  &sightmap.Element{Tag: "form", Id: "search-form"},
+		Children: []*sightmap.ComponentNode{inputNode, buttonNode},
 	}
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:       "root",
-		Children: []*comps.ComponentNode{formNode},
+		Children: []*sightmap.ComponentNode{formNode},
 	}
 
 	corpus := &sightmap.Corpus{
@@ -467,13 +466,13 @@ func TestMatchTreeEndToEnd(t *testing.T) {
 // ---- 8. Concurrent safety (run with -race) ----------------------------------
 
 func TestConcurrentSafety(t *testing.T) {
-	buttonNode := &comps.ComponentNode{
+	buttonNode := &sightmap.ComponentNode{
 		Id:      "btn",
-		Element: &comps.Element{Tag: "button"},
+		Element: &sightmap.Element{Tag: "button"},
 	}
-	root := &comps.ComponentNode{
+	root := &sightmap.ComponentNode{
 		Id:       "root",
-		Children: []*comps.ComponentNode{buttonNode},
+		Children: []*sightmap.ComponentNode{buttonNode},
 	}
 
 	corpus := &sightmap.Corpus{
@@ -573,8 +572,8 @@ func mustGet(t *testing.T, m map[string]sightmap.ComponentDef, name string) sigh
 
 func mustMatch(
 	t *testing.T,
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
-	node *comps.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	node *sightmap.ComponentNode,
 	label string,
 ) *sightmap.ComponentMatch {
 	t.Helper()

--- a/go/sightmap/lint.go
+++ b/go/sightmap/lint.go
@@ -6,8 +6,6 @@ import (
 	"slices"
 	"strings"
 	"unicode"
-
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 // LintWarning describes a style or maintainability issue that doesn't prevent
@@ -157,7 +155,7 @@ func hasUniquenessAnchor(selStr string) bool {
 // - Generic data-component attributes without instance-specific values
 func isBroadSelector(selStr string) bool {
 	// Parse to check if it's a bare tag or generic pattern
-	if ps, err := sel.ParseSightmapSelector(selStr); err == nil && len(ps.Parts) > 0 {
+	if ps, err := ParseSightmapSelector(selStr); err == nil && len(ps.Parts) > 0 {
 		// Check the last part (most specific)
 		lastPart := ps.Parts[len(ps.Parts)-1]
 
@@ -346,7 +344,7 @@ func lintComponentWithCounts(comp ComponentDef, global bool, counts map[string]i
 	for _, selStr := range comp.Selectors {
 		// broad-tag-selector: bare tag name at global scope (e.g. "div", "button").
 		if global {
-			if ps, err := sel.ParseSightmapSelector(selStr); err == nil && len(ps.Parts) == 1 {
+			if ps, err := ParseSightmapSelector(selStr); err == nil && len(ps.Parts) == 1 {
 				p := ps.Parts[0]
 				if p.Tag != "" && p.Id == "" && len(p.Classes) == 0 && len(p.Attrs) == 0 && p.Not == nil {
 					warnings = append(warnings, LintWarning{
@@ -373,7 +371,7 @@ func lintComponentWithCounts(comp ComponentDef, global bool, counts map[string]i
 		// Use the parsed part count, NOT raw space counting, to avoid false
 		// positives from spaces inside quoted attribute values like
 		// [aria-label="Link to homepage"].
-		if ps, parseErr := sel.ParseSightmapSelector(selStr); parseErr == nil && len(ps.Parts) >= 4 {
+		if ps, parseErr := ParseSightmapSelector(selStr); parseErr == nil && len(ps.Parts) >= 4 {
 			warnings = append(warnings, LintWarning{
 				Component: name,
 				Selector:  selStr,
@@ -400,7 +398,7 @@ func lintComponentWithCounts(comp ComponentDef, global bool, counts map[string]i
 		// ".parent .parent .leaf"), which matches zero nodes. Only relevant for
 		// child components (non-empty ParentChain).
 		if len(comp.ParentChain) > 0 {
-			if ps, parseErr := sel.ParseSightmapSelector(selStr); parseErr == nil {
+			if ps, parseErr := ParseSightmapSelector(selStr); parseErr == nil {
 				if cls := firstRepeatedDescendantClass(ps); cls != "" {
 					warnings = append(warnings, LintWarning{
 						Component: name,
@@ -424,7 +422,7 @@ func lintComponentWithCounts(comp ComponentDef, global bool, counts map[string]i
 // ancestor part and the immediately following descendant part of ps. Returns ""
 // if no such repetition exists. This is the exact pattern produced by flattenOne
 // when a child component's raw selector already includes the parent class.
-func firstRepeatedDescendantClass(ps sel.ParsedSelector) string {
+func firstRepeatedDescendantClass(ps ParsedSelector) string {
 	for i := 0; i+1 < len(ps.Parts); i++ {
 		if ps.Combinators[i+1] != " " {
 			continue // only flag descendant combinators, not direct-child (>)

--- a/go/sightmap/sel_match.go
+++ b/go/sightmap/sel_match.go
@@ -1,9 +1,7 @@
-package sel
+package sightmap
 
 import (
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // MatchesNode reports whether a tree node satisfies rule, including the
@@ -11,13 +9,13 @@ import (
 // applies the flat checks via Matches, then verifies every :has() entry against
 // node's descendants. Tree-walking callers (the rule matcher, sel-check, lint)
 // should use this instead of Matches so :has() is honored.
-func MatchesNode(node *comps.ComponentNode, rule *comps.SelectorPart) bool {
+func MatchesNode(node *ComponentNode, rule *SelectorPart) bool {
 	if rule == nil {
 		return true
 	}
 	el := node.Element
 	if el == nil {
-		el = &comps.Element{}
+		el = &Element{}
 	}
 	if !Matches(el, rule) {
 		return false
@@ -33,7 +31,7 @@ func MatchesNode(node *comps.ComponentNode, rule *comps.SelectorPart) bool {
 
 // hasMatches reports whether node's subtree satisfies the :has() selector h
 // (any of its comma-separated alternatives).
-func hasMatches(node *comps.ComponentNode, h *comps.HasSelector) bool {
+func hasMatches(node *ComponentNode, h *HasSelector) bool {
 	for _, alt := range h.Alternatives {
 		if relMatches(node, alt.Parts, alt.Combinators, 0) {
 			return true
@@ -46,10 +44,10 @@ func hasMatches(node *comps.ComponentNode, h *comps.HasSelector) bool {
 // within anchor's subtree. combs[idx] links anchor to parts[idx]: ">" means
 // parts[idx] must match a direct child of anchor; " " means any descendant.
 // MatchesNode is used for each candidate so nested :has() works.
-func relMatches(anchor *comps.ComponentNode, parts []*comps.SelectorPart, combs []string, idx int) bool {
+func relMatches(anchor *ComponentNode, parts []*SelectorPart, combs []string, idx int) bool {
 	direct := combs[idx] == ">"
-	var search func(n *comps.ComponentNode) bool
-	search = func(n *comps.ComponentNode) bool {
+	var search func(n *ComponentNode) bool
+	search = func(n *ComponentNode) bool {
 		for _, child := range n.Children {
 			if MatchesNode(child, parts[idx]) {
 				if idx+1 == len(parts) {
@@ -72,7 +70,7 @@ func relMatches(anchor *comps.ComponentNode, parts []*comps.SelectorPart, combs 
 // attribute operators, :not(), and :is()/:where(). It does NOT evaluate :has()
 // (which needs tree context — use MatchesNode for that). A nil rule matches
 // everything. el is the observed element's identity (the subject).
-func Matches(el *comps.Element, rule *comps.SelectorPart) bool {
+func Matches(el *Element, rule *SelectorPart) bool {
 	if rule == nil {
 		return true
 	}
@@ -146,7 +144,7 @@ func Matches(el *comps.Element, rule *comps.SelectorPart) bool {
 // them there to match offline the way the browser matches them live. Attrs is
 // consulted first (it wins when populated); id/class then fall back to their
 // dedicated fields. All other attributes come straight from Attrs.
-func effectiveAttrValue(el *comps.Element, key string) (string, bool) {
+func effectiveAttrValue(el *Element, key string) (string, bool) {
 	if v, ok := el.Attrs[key]; ok {
 		return v, true
 	}

--- a/go/sightmap/sel_match_has_test.go
+++ b/go/sightmap/sel_match_has_test.go
@@ -1,22 +1,20 @@
-package sel_test
+package sightmap_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 // cn builds a ComponentNode with the given observed element identity and children.
-func cn(el *comps.Element, children ...*comps.ComponentNode) *comps.ComponentNode {
-	return &comps.ComponentNode{Element: el, Children: children}
+func cn(el *sightmap.Element, children ...*sightmap.ComponentNode) *sightmap.ComponentNode {
+	return &sightmap.ComponentNode{Element: el, Children: children}
 }
 
 // mustLastPart parses a selector and returns its final (target) part.
-func mustLastPart(t *testing.T, s string) *comps.SelectorPart {
+func mustLastPart(t *testing.T, s string) *sightmap.SelectorPart {
 	t.Helper()
-	ps, err := sel.ParseSightmapSelector(s)
+	ps, err := sightmap.ParseSightmapSelector(s)
 	if err != nil {
 		t.Fatalf("parse %q: %v", s, err)
 	}
@@ -102,7 +100,7 @@ func TestParse_Has_Errors(t *testing.T) {
 		{"div:zzz(x)", "unsupported pseudo-class"},
 	}
 	for _, tc := range cases {
-		_, err := sel.ParseSightmapSelector(tc.sel)
+		_, err := sightmap.ParseSightmapSelector(tc.sel)
 		if err == nil {
 			t.Errorf("%q: expected error, got nil", tc.sel)
 			continue
@@ -121,10 +119,10 @@ func TestMatchesNode_Has_Descendant(t *testing.T) {
 		cn(nodeWith("span", "", nil, nil),
 			cn(nodeWith("input", "", nil, nil))))
 
-	if !sel.MatchesNode(tree, mustLastPart(t, "div:has(input)")) {
+	if !sightmap.MatchesNode(tree, mustLastPart(t, "div:has(input)")) {
 		t.Error("div:has(input) should match a div with a nested input")
 	}
-	if sel.MatchesNode(tree, mustLastPart(t, "div:has(button)")) {
+	if sightmap.MatchesNode(tree, mustLastPart(t, "div:has(button)")) {
 		t.Error("div:has(button) should not match (no button)")
 	}
 }
@@ -134,14 +132,14 @@ func TestMatchesNode_Has_DirectChild(t *testing.T) {
 	deep := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("span", "", nil, nil),
 			cn(nodeWith("input", "", nil, nil))))
-	if sel.MatchesNode(deep, mustLastPart(t, "div:has(> input)")) {
+	if sightmap.MatchesNode(deep, mustLastPart(t, "div:has(> input)")) {
 		t.Error("div:has(> input) should NOT match a grandchild input")
 	}
 
 	// div > input   (direct child)
 	shallow := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("input", "", nil, nil)))
-	if !sel.MatchesNode(shallow, mustLastPart(t, "div:has(> input)")) {
+	if !sightmap.MatchesNode(shallow, mustLastPart(t, "div:has(> input)")) {
 		t.Error("div:has(> input) should match a direct-child input")
 	}
 }
@@ -151,10 +149,10 @@ func TestMatchesNode_Has_Chain(t *testing.T) {
 	tree := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("", "", []string{"row"}, nil),
 			cn(nodeWith("", "", []string{"price"}, nil))))
-	if !sel.MatchesNode(tree, mustLastPart(t, "div:has(.row .price)")) {
+	if !sightmap.MatchesNode(tree, mustLastPart(t, "div:has(.row .price)")) {
 		t.Error("div:has(.row .price) should match")
 	}
-	if sel.MatchesNode(tree, mustLastPart(t, "div:has(.price .row)")) {
+	if sightmap.MatchesNode(tree, mustLastPart(t, "div:has(.price .row)")) {
 		t.Error("div:has(.price .row) should NOT match (wrong order)")
 	}
 }
@@ -163,13 +161,13 @@ func TestMatchesNode_Has_MultipleAreAnded(t *testing.T) {
 	both := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("input", "", nil, nil)),
 		cn(nodeWith("", "", []string{"price"}, nil)))
-	if !sel.MatchesNode(both, mustLastPart(t, "div:has(input):has(.price)")) {
+	if !sightmap.MatchesNode(both, mustLastPart(t, "div:has(input):has(.price)")) {
 		t.Error("both :has present should match")
 	}
 
 	onlyInput := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("input", "", nil, nil)))
-	if sel.MatchesNode(onlyInput, mustLastPart(t, "div:has(input):has(.price)")) {
+	if sightmap.MatchesNode(onlyInput, mustLastPart(t, "div:has(input):has(.price)")) {
 		t.Error("missing one :has should NOT match (AND semantics)")
 	}
 }
@@ -177,10 +175,10 @@ func TestMatchesNode_Has_MultipleAreAnded(t *testing.T) {
 func TestMatchesNode_Has_CommaAlternativesAreOred(t *testing.T) {
 	tree := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("input", "", nil, nil)))
-	if !sel.MatchesNode(tree, mustLastPart(t, "div:has(button, input)")) {
+	if !sightmap.MatchesNode(tree, mustLastPart(t, "div:has(button, input)")) {
 		t.Error("div:has(button, input) should match when input present (OR)")
 	}
-	if sel.MatchesNode(tree, mustLastPart(t, "div:has(button, a)")) {
+	if sightmap.MatchesNode(tree, mustLastPart(t, "div:has(button, a)")) {
 		t.Error("div:has(button, a) should NOT match (neither present)")
 	}
 }
@@ -190,17 +188,17 @@ func TestMatchesNode_Has_Nested(t *testing.T) {
 	tree := cn(nodeWith("div", "", nil, nil),
 		cn(nodeWith("", "", []string{"row"}, nil),
 			cn(nodeWith("input", "", nil, nil))))
-	if !sel.MatchesNode(tree, mustLastPart(t, "div:has(.row:has(input))")) {
+	if !sightmap.MatchesNode(tree, mustLastPart(t, "div:has(.row:has(input))")) {
 		t.Error("nested :has should match")
 	}
-	if sel.MatchesNode(tree, mustLastPart(t, "div:has(.row:has(button))")) {
+	if sightmap.MatchesNode(tree, mustLastPart(t, "div:has(.row:has(button))")) {
 		t.Error("nested :has should NOT match when inner missing")
 	}
 }
 
 func TestMatchesNode_Has_RealFormGroup(t *testing.T) {
 	// The HD assembly case: only the form-group containing a checkbox should match.
-	fg := func(control *comps.ComponentNode) *comps.ComponentNode {
+	fg := func(control *sightmap.ComponentNode) *sightmap.ComponentNode {
 		return cn(nodeWith("div", "", nil, map[string]string{"data-testid": "form-group"}),
 			cn(nodeWith("div", "", nil, nil), control))
 	}
@@ -208,10 +206,10 @@ func TestMatchesNode_Has_RealFormGroup(t *testing.T) {
 	protection := fg(cn(nodeWith("input", "", nil, map[string]string{"type": "radio"})))
 
 	rule := mustLastPart(t, `[data-testid="form-group"]:has(input[type="checkbox"])`)
-	if !sel.MatchesNode(assembly, rule) {
+	if !sightmap.MatchesNode(assembly, rule) {
 		t.Error("assembly form-group (with checkbox) should match")
 	}
-	if sel.MatchesNode(protection, rule) {
+	if sightmap.MatchesNode(protection, rule) {
 		t.Error("protection form-group (radio only) should NOT match")
 	}
 }

--- a/go/sightmap/sel_match_test.go
+++ b/go/sightmap/sel_match_test.go
@@ -1,27 +1,25 @@
-package sel_test
+package sightmap_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 func TestMatches_NilRule(t *testing.T) {
 	node := nodeWith("div", "", nil, nil)
-	if !sel.Matches(node, nil) {
+	if !sightmap.Matches(node, nil) {
 		t.Error("nil rule should match everything")
 	}
 }
 
 func TestMatches_Tag(t *testing.T) {
 	node := nodeWith("button", "", nil, nil)
-	rule := &comps.SelectorPart{Tag: "button"}
-	if !sel.Matches(node, rule) {
+	rule := &sightmap.SelectorPart{Tag: "button"}
+	if !sightmap.Matches(node, rule) {
 		t.Error("button should match button rule")
 	}
-	ruleDiv := &comps.SelectorPart{Tag: "div"}
-	if sel.Matches(node, ruleDiv) {
+	ruleDiv := &sightmap.SelectorPart{Tag: "div"}
+	if sightmap.Matches(node, ruleDiv) {
 		t.Error("button should not match div rule")
 	}
 }
@@ -29,8 +27,8 @@ func TestMatches_Tag(t *testing.T) {
 func TestMatches_TagCaseInsensitive(t *testing.T) {
 	// node tag might come from DOM (lowercase) or from structured SelectorPart
 	node := nodeWith("button", "", nil, nil)
-	rule := &comps.SelectorPart{Tag: "BUTTON"}
-	if !sel.Matches(node, rule) {
+	rule := &sightmap.SelectorPart{Tag: "BUTTON"}
+	if !sightmap.Matches(node, rule) {
 		t.Error("tag match should be case-insensitive")
 	}
 }
@@ -38,18 +36,18 @@ func TestMatches_TagCaseInsensitive(t *testing.T) {
 func TestMatches_MobileTagCaseInsensitive(t *testing.T) {
 	// Synthetic mobile tag: node has "UIButton", parsed rule has "uibutton"
 	node := nodeWith("UIButton", "", nil, nil)
-	rule := &comps.SelectorPart{Tag: "uibutton"}
-	if !sel.Matches(node, rule) {
+	rule := &sightmap.SelectorPart{Tag: "uibutton"}
+	if !sightmap.Matches(node, rule) {
 		t.Error("UIButton should match uibutton rule (case-insensitive)")
 	}
 }
 
 func TestMatches_ID(t *testing.T) {
 	node := nodeWith("", "main-nav", nil, nil)
-	if !sel.Matches(node, &comps.SelectorPart{Id: "main-nav"}) {
+	if !sightmap.Matches(node, &sightmap.SelectorPart{Id: "main-nav"}) {
 		t.Error("id match failed")
 	}
-	if sel.Matches(node, &comps.SelectorPart{Id: "other"}) {
+	if sightmap.Matches(node, &sightmap.SelectorPart{Id: "other"}) {
 		t.Error("wrong id should not match")
 	}
 }
@@ -58,44 +56,44 @@ func TestMatches_Classes(t *testing.T) {
 	node := nodeWith("", "", []string{"btn", "primary", "large"}, nil)
 
 	// Single class
-	if !sel.Matches(node, &comps.SelectorPart{Classes: []string{"btn"}}) {
+	if !sightmap.Matches(node, &sightmap.SelectorPart{Classes: []string{"btn"}}) {
 		t.Error("single class should match")
 	}
 	// Multiple classes (subset)
-	if !sel.Matches(node, &comps.SelectorPart{Classes: []string{"btn", "primary"}}) {
+	if !sightmap.Matches(node, &sightmap.SelectorPart{Classes: []string{"btn", "primary"}}) {
 		t.Error("class subset should match")
 	}
 	// Class not present
-	if sel.Matches(node, &comps.SelectorPart{Classes: []string{"disabled"}}) {
+	if sightmap.Matches(node, &sightmap.SelectorPart{Classes: []string{"disabled"}}) {
 		t.Error("absent class should not match")
 	}
 }
 
 func TestMatches_AttrExact(t *testing.T) {
 	node := nodeWith("input", "", nil, map[string]string{"type": "email"})
-	rule := &comps.SelectorPart{Attrs: map[string]string{"type": "email"}}
-	if !sel.Matches(node, rule) {
+	rule := &sightmap.SelectorPart{Attrs: map[string]string{"type": "email"}}
+	if !sightmap.Matches(node, rule) {
 		t.Error("exact attr should match")
 	}
-	ruleBad := &comps.SelectorPart{Attrs: map[string]string{"type": "text"}}
-	if sel.Matches(node, ruleBad) {
+	ruleBad := &sightmap.SelectorPart{Attrs: map[string]string{"type": "text"}}
+	if sightmap.Matches(node, ruleBad) {
 		t.Error("wrong attr value should not match")
 	}
 }
 
 func TestMatches_AttrPresence(t *testing.T) {
 	node := nodeWith("input", "", nil, map[string]string{"disabled": ""})
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"disabled": ""},
 		AttrOps: map[string]string{"disabled": "[]"},
 	}
-	if !sel.Matches(node, rule) {
+	if !sightmap.Matches(node, rule) {
 		t.Error("presence attr should match")
 	}
 
 	// Node without the attr
 	nodeNoAttr := nodeWith("input", "", nil, nil)
-	if sel.Matches(nodeNoAttr, rule) {
+	if sightmap.Matches(nodeNoAttr, rule) {
 		t.Error("absent attr should not match presence rule")
 	}
 }
@@ -105,37 +103,37 @@ func TestMatches_AttrOnID_ResolvesToIdField(t *testing.T) {
 	// ([id^=...] etc.) must still resolve to it so they match offline like live.
 	node := nodeWith("div", "issue_9f1c-42", nil, nil)
 
-	prefix := &comps.SelectorPart{
+	prefix := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"id": "issue_"},
 		AttrOps: map[string]string{"id": "^="},
 	}
-	if !sel.Matches(node, prefix) {
+	if !sightmap.Matches(node, prefix) {
 		t.Error(`[id^="issue_"] should match id="issue_9f1c-42"`)
 	}
 
-	exact := &comps.SelectorPart{Attrs: map[string]string{"id": "issue_9f1c-42"}}
-	if !sel.Matches(node, exact) {
+	exact := &sightmap.SelectorPart{Attrs: map[string]string{"id": "issue_9f1c-42"}}
+	if !sightmap.Matches(node, exact) {
 		t.Error(`[id="issue_9f1c-42"] should match`)
 	}
 
-	presence := &comps.SelectorPart{
+	presence := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"id": ""},
 		AttrOps: map[string]string{"id": "[]"},
 	}
-	if !sel.Matches(node, presence) {
+	if !sightmap.Matches(node, presence) {
 		t.Error("[id] presence should match a node with an id")
 	}
 
-	bad := &comps.SelectorPart{
+	bad := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"id": "cycle_"},
 		AttrOps: map[string]string{"id": "^="},
 	}
-	if sel.Matches(node, bad) {
+	if sightmap.Matches(node, bad) {
 		t.Error(`[id^="cycle_"] should not match id="issue_9f1c-42"`)
 	}
 
 	noID := nodeWith("div", "", nil, nil)
-	if sel.Matches(noID, presence) {
+	if sightmap.Matches(noID, presence) {
 		t.Error("[id] presence should not match a node with no id")
 	}
 }
@@ -145,59 +143,59 @@ func TestMatches_AttrOnClass_ResolvesToClassesField(t *testing.T) {
 	// reachable by attribute selectors like [class*=...].
 	node := nodeWith("svg", "", []string{"lucide", "lucide-check"}, nil)
 
-	contains := &comps.SelectorPart{
+	contains := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"class": "lucide-check"},
 		AttrOps: map[string]string{"class": "*="},
 	}
-	if !sel.Matches(node, contains) {
+	if !sightmap.Matches(node, contains) {
 		t.Error(`[class*="lucide-check"] should match Classes {lucide, lucide-check}`)
 	}
 
-	word := &comps.SelectorPart{
+	word := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"class": "lucide"},
 		AttrOps: map[string]string{"class": "~="},
 	}
-	if !sel.Matches(node, word) {
+	if !sightmap.Matches(node, word) {
 		t.Error(`[class~="lucide"] should match`)
 	}
 }
 
 func TestMatches_AttrPrefix(t *testing.T) {
 	node := nodeWith("a", "", nil, map[string]string{"href": "https://example.com"})
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"href": "https://"},
 		AttrOps: map[string]string{"href": "^="},
 	}
-	if !sel.Matches(node, rule) {
+	if !sightmap.Matches(node, rule) {
 		t.Error("prefix attr should match")
 	}
-	ruleHttp := &comps.SelectorPart{
+	ruleHttp := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"href": "http://"},
 		AttrOps: map[string]string{"href": "^="},
 	}
-	if sel.Matches(node, ruleHttp) {
+	if sightmap.Matches(node, ruleHttp) {
 		t.Error("wrong prefix should not match")
 	}
 }
 
 func TestMatches_AttrSuffix(t *testing.T) {
 	node := nodeWith("a", "", nil, map[string]string{"href": "index.html"})
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"href": ".html"},
 		AttrOps: map[string]string{"href": "$="},
 	}
-	if !sel.Matches(node, rule) {
+	if !sightmap.Matches(node, rule) {
 		t.Error("suffix attr should match")
 	}
 }
 
 func TestMatches_AttrSubstring(t *testing.T) {
 	node := nodeWith("", "", nil, map[string]string{"aria-label": "Search products"})
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"aria-label": "Search"},
 		AttrOps: map[string]string{"aria-label": "*="},
 	}
-	if !sel.Matches(node, rule) {
+	if !sightmap.Matches(node, rule) {
 		t.Error("substring attr should match")
 	}
 }
@@ -205,18 +203,18 @@ func TestMatches_AttrSubstring(t *testing.T) {
 func TestMatches_AttrIncludeWord(t *testing.T) {
 	// ~= whitespace-separated word
 	node := nodeWith("", "", nil, map[string]string{"class": "btn primary large"})
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"class": "primary"},
 		AttrOps: map[string]string{"class": "~="},
 	}
-	if !sel.Matches(node, rule) {
+	if !sightmap.Matches(node, rule) {
 		t.Error("~= should match word in list")
 	}
-	ruleBad := &comps.SelectorPart{
+	ruleBad := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"class": "prim"},
 		AttrOps: map[string]string{"class": "~="},
 	}
-	if sel.Matches(node, ruleBad) {
+	if sightmap.Matches(node, ruleBad) {
 		t.Error("~= should not match partial word")
 	}
 }
@@ -224,21 +222,21 @@ func TestMatches_AttrIncludeWord(t *testing.T) {
 func TestMatches_AttrDashMatch(t *testing.T) {
 	// |= matches exact or "value-"
 	node := nodeWith("", "", nil, map[string]string{"lang": "en-US"})
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Attrs:   map[string]string{"lang": "en"},
 		AttrOps: map[string]string{"lang": "|="},
 	}
-	if !sel.Matches(node, rule) {
+	if !sightmap.Matches(node, rule) {
 		t.Error("|= should match 'en' against 'en-US'")
 	}
 
 	nodeExact := nodeWith("", "", nil, map[string]string{"lang": "en"})
-	if !sel.Matches(nodeExact, rule) {
+	if !sightmap.Matches(nodeExact, rule) {
 		t.Error("|= should match exact 'en'")
 	}
 
 	nodeFr := nodeWith("", "", nil, map[string]string{"lang": "fr"})
-	if sel.Matches(nodeFr, rule) {
+	if sightmap.Matches(nodeFr, rule) {
 		t.Error("|= should not match 'fr' against 'en'")
 	}
 }
@@ -248,15 +246,15 @@ func TestMatches_Not(t *testing.T) {
 	enabled := nodeWith("button", "", []string{"primary"}, nil)
 	disabled := nodeWith("button", "", []string{"primary", "disabled"}, nil)
 
-	rule := &comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
 		Tag: "button",
-		Not: &comps.SelectorPart{Classes: []string{"disabled"}},
+		Not: &sightmap.SelectorPart{Classes: []string{"disabled"}},
 	}
 
-	if !sel.Matches(enabled, rule) {
+	if !sightmap.Matches(enabled, rule) {
 		t.Error("enabled button should match button:not(.disabled)")
 	}
-	if sel.Matches(disabled, rule) {
+	if sightmap.Matches(disabled, rule) {
 		t.Error("disabled button should not match button:not(.disabled)")
 	}
 }
@@ -267,26 +265,26 @@ func TestMatches_Is(t *testing.T) {
 	nodeBar := nodeWith("div", "", []string{"bar"}, nil)
 	nodeOther := nodeWith("div", "", []string{"other"}, nil)
 
-	rule := &comps.SelectorPart{
-		Is: []*comps.SelectorPart{
+	rule := &sightmap.SelectorPart{
+		Is: []*sightmap.SelectorPart{
 			{Classes: []string{"foo"}},
 			{Classes: []string{"bar"}},
 		},
 	}
-	if !sel.Matches(nodeFoo, rule) {
+	if !sightmap.Matches(nodeFoo, rule) {
 		t.Error("nodeFoo should match :is(.foo, .bar)")
 	}
-	if !sel.Matches(nodeBar, rule) {
+	if !sightmap.Matches(nodeBar, rule) {
 		t.Error("nodeBar should match :is(.foo, .bar)")
 	}
-	if sel.Matches(nodeOther, rule) {
+	if sightmap.Matches(nodeOther, rule) {
 		t.Error("nodeOther should not match :is(.foo, .bar)")
 	}
 }
 
 func TestMatches_ParsedAndMatched(t *testing.T) {
 	// End-to-end: parse a selector string, match against a node.
-	ps, err := sel.ParseSightmapSelector(`div[data-testid="add-to-cart"]`)
+	ps, err := sightmap.ParseSightmapSelector(`div[data-testid="add-to-cart"]`)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -296,13 +294,13 @@ func TestMatches_ParsedAndMatched(t *testing.T) {
 	noMatch := nodeWith("div", "", nil, map[string]string{"data-testid": "remove"})
 	wrongTag := nodeWith("span", "", nil, map[string]string{"data-testid": "add-to-cart"})
 
-	if !sel.Matches(match, rule) {
+	if !sightmap.Matches(match, rule) {
 		t.Error("expected match")
 	}
-	if sel.Matches(noMatch, rule) {
+	if sightmap.Matches(noMatch, rule) {
 		t.Error("wrong attr value should not match")
 	}
-	if sel.Matches(wrongTag, rule) {
+	if sightmap.Matches(wrongTag, rule) {
 		t.Error("wrong tag should not match")
 	}
 }

--- a/go/sightmap/sel_parse.go
+++ b/go/sightmap/sel_parse.go
@@ -1,13 +1,11 @@
 // Package sel provides CSS selector parsing and single-node matching for the
 // sightmap selector subset. See doc.go for the supported grammar.
-package sel
+package sightmap
 
 import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/comps"
 )
 
 // ParsedSelector is the result of parsing a CSS selector string.
@@ -16,7 +14,7 @@ import (
 // that precedes Parts[i]: empty string for Parts[0], " " (descendant) or ">"
 // (direct child) for subsequent parts.
 type ParsedSelector struct {
-	Parts       []*comps.SelectorPart
+	Parts       []*SelectorPart
 	Combinators []string
 }
 
@@ -219,8 +217,8 @@ func (p *parser) parseString() (string, error) {
 // parseSimpleSelectors parses a compound selector (a sequence of simple
 // selectors with no combinators between them, e.g. div.foo#bar[attr]) and
 // merges them into a single SelectorPart.
-func (p *parser) parseSimpleSelectors() (*comps.SelectorPart, error) {
-	part := &comps.SelectorPart{}
+func (p *parser) parseSimpleSelectors() (*SelectorPart, error) {
+	part := &SelectorPart{}
 	sawAny := false
 
 	for p.i < len(p.s) {
@@ -293,7 +291,7 @@ done:
 
 // parseAttr parses an attribute selector of the form [key], [key=val],
 // [key^=val], etc., merging it into part.
-func (p *parser) parseAttr(part *comps.SelectorPart) error {
+func (p *parser) parseAttr(part *SelectorPart) error {
 	if p.i >= len(p.s) || p.s[p.i] != '[' {
 		return fmt.Errorf("expected '['")
 	}
@@ -388,7 +386,7 @@ func (p *parser) parseAttrOp() (string, error) {
 }
 
 // parsePseudo parses a pseudo-class selector. Only :not() is supported.
-func (p *parser) parsePseudo(part *comps.SelectorPart) error {
+func (p *parser) parsePseudo(part *SelectorPart) error {
 	if p.i >= len(p.s) || p.s[p.i] != ':' {
 		return fmt.Errorf("expected ':'")
 	}
@@ -409,13 +407,13 @@ func (p *parser) parsePseudo(part *comps.SelectorPart) error {
 			return fmt.Errorf("expected '(' after :has")
 		}
 		p.i++ // consume '('
-		h := &comps.HasSelector{}
+		h := &HasSelector{}
 		for {
 			parts, combs, relErr := p.parseRelativeSelector()
 			if relErr != nil {
 				return fmt.Errorf(":has() argument: %w", relErr)
 			}
-			h.Alternatives = append(h.Alternatives, comps.HasRelative{Parts: parts, Combinators: combs})
+			h.Alternatives = append(h.Alternatives, HasRelative{Parts: parts, Combinators: combs})
 			p.skipWhitespace()
 			if p.i >= len(p.s) {
 				return fmt.Errorf("expected ')' or ',' in :has()")
@@ -437,7 +435,7 @@ func (p *parser) parsePseudo(part *comps.SelectorPart) error {
 			return fmt.Errorf("expected '(' after :%s", name)
 		}
 		p.i++ // consume '('
-		var alts []*comps.SelectorPart
+		var alts []*SelectorPart
 		for {
 			p.skipWhitespace()
 			inner, err := p.parseSimpleSelectors()
@@ -496,7 +494,7 @@ func (p *parser) parsePseudo(part *comps.SelectorPart) error {
 // descendant) and returns the compound parts plus their combinators, where
 // Combinators[0] links the :has() anchor element to Parts[0]. Sibling
 // combinators (+, ~) are rejected — the matcher has no sibling support.
-func (p *parser) parseRelativeSelector() ([]*comps.SelectorPart, []string, error) {
+func (p *parser) parseRelativeSelector() ([]*SelectorPart, []string, error) {
 	p.skipWhitespace()
 
 	leading := " "
@@ -515,7 +513,7 @@ func (p *parser) parseRelativeSelector() ([]*comps.SelectorPart, []string, error
 	if err != nil {
 		return nil, nil, err
 	}
-	parts := []*comps.SelectorPart{first}
+	parts := []*SelectorPart{first}
 	combinators := []string{leading}
 
 	for {
@@ -562,7 +560,7 @@ func (p *parser) parseSelector() (ParsedSelector, error) {
 		return ParsedSelector{}, err
 	}
 
-	parts := []*comps.SelectorPart{first}
+	parts := []*SelectorPart{first}
 	combinators := []string{""}
 
 	for {

--- a/go/sightmap/sel_parse_test.go
+++ b/go/sightmap/sel_parse_test.go
@@ -1,16 +1,14 @@
-package sel_test
+package sightmap_test
 
 import (
+	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
-
-	"github.com/sightmap/sightmap/go/comps"
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 // parseOK parses s and fails t if there's an error.
-func parseOK(t *testing.T, s string) sel.ParsedSelector {
+func parseOK(t *testing.T, s string) sightmap.ParsedSelector {
 	t.Helper()
-	ps, err := sel.ParseSightmapSelector(s)
+	ps, err := sightmap.ParseSightmapSelector(s)
 	if err != nil {
 		t.Fatalf("ParseSightmapSelector(%q) error: %v", s, err)
 	}
@@ -20,7 +18,7 @@ func parseOK(t *testing.T, s string) sel.ParsedSelector {
 // parseErr asserts that parsing s returns an error.
 func parseErr(t *testing.T, s string) {
 	t.Helper()
-	_, err := sel.ParseSightmapSelector(s)
+	_, err := sightmap.ParseSightmapSelector(s)
 	if err == nil {
 		t.Fatalf("ParseSightmapSelector(%q) expected error, got nil", s)
 	}
@@ -45,7 +43,7 @@ func TestParse_TagCaseNormalized(t *testing.T) {
 
 func TestParse_SyntheticMobileTag(t *testing.T) {
 	// Mobile tags like UIButton are preserved (lowercased by the parser,
-	// but matched case-insensitively by sel.Matches).
+	// but matched case-insensitively by sightmap.Matches).
 	ps := parseOK(t, "UIButton")
 	if ps.Parts[0].Tag != "uibutton" {
 		t.Errorf("tag: got %q, want %q", ps.Parts[0].Tag, "uibutton")
@@ -403,8 +401,8 @@ func TestParse_MultipleAttributes(t *testing.T) {
 }
 
 // nodeWith builds a minimal observed Element for testing Matches.
-func nodeWith(tag, id string, classes []string, attrs map[string]string) *comps.Element {
-	return &comps.Element{
+func nodeWith(tag, id string, classes []string, attrs map[string]string) *sightmap.Element {
+	return &sightmap.Element{
 		Tag:     tag,
 		Id:      id,
 		Classes: classes,

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/sightmap/sightmap/go/sel"
 )
 
 // Severity classifies a validation finding. Errors fail validation (nonzero
@@ -243,7 +241,7 @@ func validateComponent(comp ComponentDef, seen map[string]string) []ValidationEr
 
 	// selector-parse
 	for _, selStr := range comp.Selectors {
-		if _, err := sel.ParseSightmapSelector(selStr); err != nil {
+		if _, err := ParseSightmapSelector(selStr); err != nil {
 			errs = append(errs, ValidationError{
 				Component: comp.Name,
 				Selector:  selStr,

--- a/go/viewset/novelty.go
+++ b/go/viewset/novelty.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sightmap/sightmap/go/comps"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -16,8 +15,8 @@ import (
 // by the offline path (SlotsForCapture) and the live capture path (the capture
 // command) so both gate on the same notion of "new".
 func SlotsFromMatch(
-	matches map[*comps.ComponentNode]*sightmap.ComponentMatch,
-	orphans []*comps.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	orphans []*sightmap.ComponentNode,
 	parentMap coverage.ParentMap,
 ) Slots {
 	cs := Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}
@@ -41,7 +40,7 @@ func SlotsForCapture(snapPath string, corpus *sightmap.Corpus) (Slots, bool) {
 	if err != nil {
 		return Slots{}, false
 	}
-	var root comps.ComponentNode
+	var root sightmap.ComponentNode
 	if json.Unmarshal(data, &root) != nil {
 		return Slots{}, false
 	}


### PR DESCRIPTION
Final consolidation step of the library restructuring (#189): fold the
observed-tree model (`comps`) and the selector parse/match primitive (`sel`) into
`sightmap`, so every corpus, observed, and result type — plus the atomic selector
matching — comes from **one import**. **Stacked on #193**.

## Changes

- **`comps` → `sightmap`**: `ComponentNode`, `Element`, `SelectorPart`, `Bounds`,
  `HasSelector`, `HasRelative`, the tree walkers/predicates
  (`Walk`/`Collect`/`Filter`/`And`/`Or`/`Not`/…), and `Element.SelectorString`.
- **`sel` → `sightmap`**: `ParseSightmapSelector`, `ParsedSelector`, `Matches`,
  `MatchesNode` (the atomic single-node selector primitive). `sel` had to fold in
  too — `SelectorPart` is model data and `sightmap`'s own lint/validate call the
  parser, which would cycle once `SelectorPart` lives in the model.
- The `comps` and `sel` **packages are deleted**. `sightmap` now imports **no
  internal package** — a self-contained leaf; `match` and every other consumer
  import `sightmap`.

## Safety

Pure mechanical move + package-qualifier rewrite (`comps.X`/`sel.X` →
`sightmap.X`, or bare inside the package). Two hazards handled explicitly:

- a **local variable named `sel`** (an `*Element` in the inspect renderer) — only
  the four `sel.<Func>` package identifiers were rewritten, not `sel.Tag`/`.Id`/…;
- the **`comps.yaml`** fixture-filename string — only `comps.<Type>` identifiers
  were rewritten.

Behavior unchanged: `go build`/`vet`/`test ./...`, `spec` conformance + examples,
gofmt — all green.

## Result

`.3` (the model consolidation) is complete. `sightmap` is the single, tool-free,
self-contained home for the whole vocabulary. What remains is `.4` — collapse the
redundant `MatchTree`/`ApplySightmap`/`FindConflicts` doors into one `Matcher`
API (the engine wrapper already moved in #193).
