### PR TITLE
sightmap: structured PropertyValue output, folded into the match result

### DIFF
--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -92,7 +92,24 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	for _, c := range components {
 		compByName[c.Name] = c
 	}
-	props := observe.ExtractProperties(ctx, conn, relevant, compByName)
+	observe.ExtractProperties(ctx, conn, relevant, compByName)
 
-	return compquery.Resolve(root, matches, props, q)
+	return compquery.Resolve(root, matches, propsByNodeID(matches), q)
+}
+
+// propsByNodeID projects the extracted property values folded into each match
+// back into the node-id → (name → value) map the component-query engine consumes.
+func propsByNodeID(matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) map[string]map[string]string {
+	out := make(map[string]map[string]string)
+	for node, m := range matches {
+		if m == nil || len(m.Properties) == 0 {
+			continue
+		}
+		pm := make(map[string]string, len(m.Properties))
+		for _, pv := range m.Properties {
+			pm[pv.Name] = pv.Value
+		}
+		out[node.Id] = pm
+	}
+	return out
 }

--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -114,7 +114,7 @@ func runCapture(args []string) error {
 	}
 	if *jsonOutFlag {
 		jsonPath := strings.TrimSuffix(snapPath, ".snap") + ".snap.annotated.json"
-		if err := writeAnnotatedJSON(res.Root, jsonPath, res.View, res.Matches, res.Props); err != nil {
+		if err := writeAnnotatedJSON(res.Root, jsonPath, res.View, res.Matches); err != nil {
 			fmt.Fprintf(os.Stderr, "capture: json: %v\n", err)
 		}
 	}
@@ -205,7 +205,7 @@ func runCaptureAll(
 		}
 		if jsonOut {
 			jsonPath := strings.TrimSuffix(snapPath, ".snap") + ".snap.annotated.json"
-			writeAnnotatedJSON(res.Root, jsonPath, res.View, res.Matches, nil) // no propValues in --all mode
+			writeAnnotatedJSON(res.Root, jsonPath, res.View, res.Matches)
 		}
 
 		results = append(results, result{name: label, t1: cov.T1, t2: cov.T2, t3: cov.T3, total: cov.Total})

--- a/go/cmd/sightmap/cmd_snapshot.go
+++ b/go/cmd/sightmap/cmd_snapshot.go
@@ -114,7 +114,7 @@ func runSnapshot(args []string) error {
 		}
 	}
 	if *jsonOutFlag != "" {
-		if err := writeAnnotatedJSON(res.Root, *jsonOutFlag, res.View, res.Matches, res.Props); err != nil {
+		if err := writeAnnotatedJSON(res.Root, *jsonOutFlag, res.View, res.Matches); err != nil {
 			fmt.Fprintf(os.Stderr, "snapshot: json-out: %v\n", err)
 		}
 	}

--- a/go/cmd/sightmap/cmd_snapshot_json.go
+++ b/go/cmd/sightmap/cmd_snapshot_json.go
@@ -34,7 +34,6 @@ type annotatedNode struct {
 func buildAnnotatedNode(
 	node *sightmap.ComponentNode,
 	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
-	propValues map[string]map[string]string, // nodeID → {propName → value}; may be nil
 ) *annotatedNode {
 	an := &annotatedNode{
 		ID:            node.Id,
@@ -53,16 +52,16 @@ func buildAnnotatedNode(
 	if m, ok := matches[node]; ok && m != nil {
 		an.Component = m.Name
 		an.Memory = m.Memory
-	}
-
-	if propValues != nil {
-		if props, ok := propValues[node.Id]; ok && len(props) > 0 {
-			an.Props = props
+		if len(m.Properties) > 0 {
+			an.Props = make(map[string]string, len(m.Properties))
+			for _, pv := range m.Properties {
+				an.Props[pv.Name] = pv.Value
+			}
 		}
 	}
 
 	for _, child := range node.Children {
-		an.Children = append(an.Children, buildAnnotatedNode(child, matches, propValues))
+		an.Children = append(an.Children, buildAnnotatedNode(child, matches))
 	}
 
 	return an
@@ -87,7 +86,6 @@ func writeAnnotatedJSON(
 	path string,
 	view *sightmap.ViewDef,
 	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
-	propValues map[string]map[string]string,
 ) error {
 	if root == nil {
 		return nil
@@ -97,7 +95,7 @@ func writeAnnotatedJSON(
 	}
 
 	out := annotatedOutput{
-		Tree: buildAnnotatedNode(root, matches, propValues),
+		Tree: buildAnnotatedNode(root, matches),
 	}
 	if view != nil {
 		out.View = view.Name

--- a/go/cmd/sightmap/cmd_snapshot_json_test.go
+++ b/go/cmd/sightmap/cmd_snapshot_json_test.go
@@ -34,21 +34,19 @@ func TestWriteAnnotatedJSON_MatchedNode(t *testing.T) {
 	}
 
 	sm := &sightmap.ComponentMatch{
-		Name:   "SiteLogoLink",
-		Memory: []string{"main navigation logo"},
+		Name:       "SiteLogoLink",
+		Memory:     []string{"main navigation logo"},
+		Properties: []sightmap.PropertyValue{{Name: "label", Value: "The Home Depot"}},
 	}
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
 		node: sm,
-	}
-	propValues := map[string]map[string]string{
-		"1": {"label": "The Home Depot"},
 	}
 	view := &sightmap.ViewDef{Name: "HomePage", Route: "/"}
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.json")
 
-	if err := writeAnnotatedJSON(node, path, view, matches, propValues); err != nil {
+	if err := writeAnnotatedJSON(node, path, view, matches); err != nil {
 		t.Fatalf("writeAnnotatedJSON: %v", err)
 	}
 
@@ -106,7 +104,7 @@ func TestWriteAnnotatedJSON_UnmatchedNode(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.json")
 
-	if err := writeAnnotatedJSON(node, path, nil, matches, nil); err != nil {
+	if err := writeAnnotatedJSON(node, path, nil, matches); err != nil {
 		t.Fatalf("writeAnnotatedJSON: %v", err)
 	}
 
@@ -156,7 +154,7 @@ func TestWriteAnnotatedJSON_NilMatches(t *testing.T) {
 	path := filepath.Join(dir, "out.json")
 
 	// nil matches — should write clean tree JSON without any component fields
-	if err := writeAnnotatedJSON(node, path, nil, nil, nil); err != nil {
+	if err := writeAnnotatedJSON(node, path, nil, nil); err != nil {
 		t.Fatalf("writeAnnotatedJSON: %v", err)
 	}
 

--- a/go/observe/observe.go
+++ b/go/observe/observe.go
@@ -11,9 +11,9 @@ import (
 
 // Result is one observation of a live page: the extracted component tree, the
 // corpus matches applied to it, the view it resolved to, and the coverage score.
-// Props holds live-extracted property values (nodeID → propName → value) and is
-// nil unless Options.ExtractProps was set. Matches/View/Coverage are zero when no
-// corpus was supplied.
+// Matches/View/Coverage are zero when no corpus was supplied. When
+// Options.ExtractProps was set, each ComponentMatch in Matches carries its
+// live-extracted property values (ComponentMatch.Properties).
 type Result struct {
 	Root        *sightmap.ComponentNode
 	URL         string
@@ -21,8 +21,8 @@ type Result struct {
 	View        *sightmap.ViewDef
 	Components  []sightmap.ComponentDef
 	GlobalNames map[string]bool
-	Props       map[string]map[string]string
-	Coverage    coverage.Result
+
+	Coverage coverage.Result
 
 	// CorpusApplied is true when a corpus was supplied and matched against the
 	// tree, even if no view matched the URL or no component matched a node. It
@@ -92,7 +92,7 @@ func Page(ctx context.Context, conn *browser.CDPConn, corpus *sightmap.Corpus, o
 		for _, c := range res.Components {
 			compByName[c.Name] = c
 		}
-		res.Props = ExtractProperties(ctx, conn, res.Matches, compByName)
+		ExtractProperties(ctx, conn, res.Matches, compByName)
 	}
 	return res, nil
 }

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -11,16 +11,16 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
-// ExtractProperties runs a single batched JS evaluation against the live DOM
-// to extract property values for all matched nodes that have property
-// definitions. Returns a map from nodeID to {propName → value}.
-// At most 200 nodes are evaluated to avoid JS timeout.
+// ExtractProperties runs a single batched JS evaluation against the live DOM to
+// extract property values for all matched nodes that have property definitions,
+// folding the results into each ComponentMatch's Properties (in definition
+// order). At most 200 nodes are evaluated to avoid JS timeout.
 func ExtractProperties(
 	ctx context.Context,
 	conn *browser.CDPConn,
 	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	compByName map[string]sightmap.ComponentDef,
-) map[string]map[string]string {
+) {
 	type specProp struct {
 		Name      string `json:"name"`
 		Extract   string `json:"extract"`
@@ -53,13 +53,13 @@ func ExtractProperties(
 		specs = append(specs, sp)
 	}
 	if len(specs) == 0 {
-		return nil
+		return
 	}
 
 	specsJSON, err := json.Marshal(specs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "observe: marshal property specs: %v\n", err)
-		return nil
+		return
 	}
 
 	const jsTemplate = `(function(specs) {
@@ -130,13 +130,32 @@ func ExtractProperties(
 	resultJSON, evalErr := browser.EvalJSON(ctx, conn, script)
 	if evalErr != nil {
 		fmt.Fprintf(os.Stderr, "observe: property extraction: %v\n", evalErr)
-		return nil
+		return
 	}
 
 	var propValues map[string]map[string]string
 	if err := json.Unmarshal(resultJSON, &propValues); err != nil {
 		fmt.Fprintf(os.Stderr, "observe: property extraction unmarshal: %v\n", err)
-		return nil
+		return
 	}
-	return propValues
+
+	// Fold the extracted values into each match, in the definition's property
+	// order, keeping only values that were actually extracted.
+	for node, m := range matches {
+		vals := propValues[node.Id]
+		if len(vals) == 0 {
+			continue
+		}
+		comp, ok := compByName[m.Name]
+		if !ok {
+			continue
+		}
+		var props []sightmap.PropertyValue
+		for _, p := range comp.Properties {
+			if v, ok := vals[p.Name]; ok {
+				props = append(props, sightmap.PropertyValue{Name: p.Name, Value: v})
+			}
+		}
+		m.Properties = props
+	}
 }

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -66,7 +66,6 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 					Selectors:   opts.Selectors,
 					MaxDepth:    opts.MaxDepth,
 					Interactive: opts.Interactive,
-					PropValues:  r.Props,
 				})
 			}
 		}

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -2,10 +2,11 @@ package render
 
 import (
 	"fmt"
-	"github.com/sightmap/sightmap/go/sightmap"
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // Comp is a filtered, display-ready component node produced by Filter().
@@ -29,9 +30,6 @@ type FormatOpts struct {
 	// Interactive, if true, skips nodes (and collapses their indentation) when
 	// neither the node nor any of its Comp descendants is interactive.
 	Interactive bool
-	// PropValues maps node ID → (prop name → value) for property annotations.
-	// Populated by the snapshot CLI after DOM extraction; nil in library use.
-	PropValues map[string]map[string]string
 }
 
 // Filter builds a compact, filtered Comp tree from a raw ComponentNode tree.
@@ -107,7 +105,7 @@ func (c *Comp) formatNode(w io.Writer, indent string, depth int, opts FormatOpts
 		line.WriteString(c.Role) // already set to match name by convert()
 
 		// Merged props: sightmap-extracted + AX value fallback.
-		props := mergedProps(c, opts)
+		props := mergedProps(c)
 
 		// Props sorted alphabetically, before text.
 		for _, k := range sortedKeys(props) {
@@ -143,7 +141,7 @@ func (c *Comp) formatNode(w io.Writer, indent string, depth int, opts FormatOpts
 	// Compute parent props once for Rule B check below.
 	var parentProps map[string]string
 	if c.Match != nil {
-		parentProps = mergedProps(c, opts)
+		parentProps = mergedProps(c)
 	}
 
 	childIndent := indent + "  "
@@ -334,18 +332,21 @@ func markInteractive(c *Comp, set map[*Comp]bool) bool {
 }
 
 // mergedProps builds the combined property map for a matched Comp node.
-// Sightmap-extracted properties (opts.PropValues[c.Id]) take precedence.
+// Sightmap-extracted properties (c.Match.Properties) take precedence.
 // If no "value" key is present and the AX Comp.Value is non-empty, it is
 // added as "value" (reserved-but-overridable built-in).
 // Returns nil when there are no props and no AX value.
-func mergedProps(c *Comp, opts FormatOpts) map[string]string {
-	smap := opts.PropValues[c.Id]
-	if len(smap) == 0 && c.Value == "" {
+func mergedProps(c *Comp) map[string]string {
+	var match []sightmap.PropertyValue
+	if c.Match != nil {
+		match = c.Match.Properties
+	}
+	if len(match) == 0 && c.Value == "" {
 		return nil
 	}
-	props := make(map[string]string, len(smap)+1)
-	for k, v := range smap {
-		props[k] = v
+	props := make(map[string]string, len(match)+1)
+	for _, pv := range match {
+		props[pv.Name] = pv.Value
 	}
 	if _, hasValue := props["value"]; !hasValue && c.Value != "" {
 		props["value"] = c.Value

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -355,15 +355,11 @@ func TestFormat_WithMatchAnnotation_Structural(t *testing.T) {
 func TestFormat_WithPropValues(t *testing.T) {
 	a := node("1", "link", "Garden Center", true, true, false)
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		a: {Name: "CategoryTile"},
+		a: {Name: "CategoryTile", Properties: []sightmap.PropertyValue{{Name: "category", Value: "Garden Center"}}},
 	}
 	comp := Filter(a, matches)
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"1": {"category": "Garden Center"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	got := buf.String()
 	// Rule A: name exactly matches category prop → name suppressed inside brackets.
 	want := "1 [CategoryTile category=\"Garden Center\"]\n"
@@ -375,15 +371,11 @@ func TestFormat_WithPropValues(t *testing.T) {
 func TestFormat_WithPropValues_SortedKeys(t *testing.T) {
 	a := node("1", "link", "Item", true, true, false)
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		a: {Name: "Tile"},
+		a: {Name: "Tile", Properties: []sightmap.PropertyValue{{Name: "zzz", Value: "last"}, {Name: "aaa", Value: "first"}, {Name: "mmm", Value: "mid"}}},
 	}
 	comp := Filter(a, matches)
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"1": {"zzz": "last", "aaa": "first", "mmm": "mid"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	got := buf.String()
 	// Keys sorted alphabetically; name "Item" ≠ any prop value → kept last.
 	want := "1 [Tile aaa=\"first\" mmm=\"mid\" zzz=\"last\" \"Item\"]\n"
@@ -627,15 +619,11 @@ func TestFormat_RuleA_NameSuppressed(t *testing.T) {
 	// Rule A: name exactly matches a prop value → name omitted
 	a := node("3", "link", "Explore", true, true, false)
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		a: {Name: "DesktopNavLink"},
+		a: {Name: "DesktopNavLink", Properties: []sightmap.PropertyValue{{Name: "label", Value: "Explore"}}},
 	}
 	comp := Filter(a, matches)
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"3": {"label": "Explore"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	want := "3 [DesktopNavLink label=\"Explore\"]\n"
 	if got := buf.String(); got != want {
 		t.Errorf("expected %q, got %q", want, got)
@@ -646,15 +634,11 @@ func TestFormat_RuleA_NameKept_CaseDiffers(t *testing.T) {
 	// Rule A is exact — case difference means name is kept last
 	a := node("5", "link", "FRI Aug 21 7:00pm", true, true, false)
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		a: {Name: "ShowDateRow"},
+		a: {Name: "ShowDateRow", Properties: []sightmap.PropertyValue{{Name: "date", Value: "Fri Aug 21 7:00pm"}}},
 	}
 	comp := Filter(a, matches)
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"5": {"date": "Fri Aug 21 7:00pm"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	// "FRI Aug..." ≠ "Fri Aug..." → name kept last
 	want := "5 [ShowDateRow date=\"Fri Aug 21 7:00pm\" \"FRI Aug 21 7:00pm\"]\n"
 	if got := buf.String(); got != want {
@@ -670,18 +654,14 @@ func TestFormat_RuleB_StaticTextSuppressed(t *testing.T) {
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
 	// generic with name "foo bar" is kept (name != "")
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		parent: {Name: "NavItem"},
+		parent: {Name: "NavItem", Properties: []sightmap.PropertyValue{{Name: "label", Value: "Explore"}}},
 	}
 	comp := Filter(parent, matches)
 	if comp == nil {
 		t.Fatal("expected non-nil comp")
 	}
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"1": {"label": "Explore"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	got := buf.String()
 	// StaticText "Explore" == prop "Explore" → suppressed
 	if strings.Contains(got, "StaticText") {
@@ -699,15 +679,11 @@ func TestFormat_RuleB_StaticTextKept_NoMatch(t *testing.T) {
 	btn := node("3", "button", "OK", true, true, false)
 	parent := node("1", "generic", "foo bar", true, false, false, st, btn)
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		parent: {Name: "MyComp"},
+		parent: {Name: "MyComp", Properties: []sightmap.PropertyValue{{Name: "label", Value: "Explore"}}},
 	}
 	comp := Filter(parent, matches)
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"1": {"label": "Explore"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	got := buf.String()
 	// "other text" ≠ "Explore" → StaticText kept
 	if !strings.Contains(got, "StaticText") {
@@ -743,15 +719,11 @@ func TestFormat_ValueOverride_SightmapWins(t *testing.T) {
 		IsVisible: true, IsInteractive: true,
 	}
 	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
-		n: {Name: "CustomSelect"},
+		n: {Name: "CustomSelect", Properties: []sightmap.PropertyValue{{Name: "value", Value: "sightmap value"}}},
 	}
 	comp := Filter(n, matches)
 	var buf bytes.Buffer
-	comp.Format(&buf, "", FormatOpts{
-		PropValues: map[string]map[string]string{
-			"8": {"value": "sightmap value"},
-		},
-	})
+	comp.Format(&buf, "", FormatOpts{})
 	got := buf.String()
 	// Sightmap "value" wins; AX "AX value" is ignored; name "Dropdown" ≠ "sightmap value" → kept
 	want := "8 [CustomSelect value=\"sightmap value\" \"Dropdown\"]\n"

--- a/go/sightmap/component.go
+++ b/go/sightmap/component.go
@@ -21,11 +21,24 @@ type ComponentPropertyDef struct {
 	Transform string `json:"transform"` // optional post-processing
 }
 
-// ComponentMatch records which component definition matched a node.
+// ComponentMatch records which component definition matched a node, and carries
+// any live-extracted property values for it (Properties, in the definition's
+// order; nil unless properties were extracted).
 type ComponentMatch struct {
-	Name   string
-	Memory []string
-	Tags   []string
+	Name       string
+	Memory     []string
+	Tags       []string
+	Properties []PropertyValue
+}
+
+// Property returns the extracted value named name, if present.
+func (m *ComponentMatch) Property(name string) (PropertyValue, bool) {
+	for _, p := range m.Properties {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return PropertyValue{}, false
 }
 
 // Conflict records a DOM node directly matched by more than one DISTINCT

--- a/go/sightmap/property_value.go
+++ b/go/sightmap/property_value.go
@@ -1,0 +1,39 @@
+package sightmap
+
+import (
+	"strconv"
+	"strings"
+)
+
+// PropertyValue is one property value extracted from live observation of a
+// matched entity. Value is the extracted, post-transform string; the typed
+// accessors parse it on demand. The extraction itself (which selector/field to
+// read, and any transform) is described by the entity's property definitions
+// (ComponentPropertyDef / RequestPropertyDef) — a PropertyValue is only the
+// output.
+type PropertyValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// String returns the raw extracted value.
+func (v PropertyValue) String() string { return v.Value }
+
+// Int parses the value as a base-10 integer. ok is false when it doesn't parse.
+func (v PropertyValue) Int() (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(v.Value))
+	return n, err == nil
+}
+
+// Float parses the value as a float64. ok is false when it doesn't parse.
+func (v PropertyValue) Float() (float64, bool) {
+	f, err := strconv.ParseFloat(strings.TrimSpace(v.Value), 64)
+	return f, err == nil
+}
+
+// Bool parses the value as a boolean (per strconv.ParseBool: 1/t/true/…,
+// 0/f/false/…). ok is false when it doesn't parse.
+func (v PropertyValue) Bool() (bool, bool) {
+	b, err := strconv.ParseBool(strings.TrimSpace(v.Value))
+	return b, err == nil
+}


### PR DESCRIPTION
Replaces `observe`'s untyped property side-map with a typed value that rides on
the match. **Stacked on #195.** (The design was agreed up front.)

- **`sightmap`**: new `PropertyValue{Name, Value}` with typed accessors
  (`String`/`Int`/`Float`/`Bool`, parse-on-demand). `ComponentMatch` gains
  `Properties []PropertyValue` (definition order) + a `Property(name)` lookup.
- **`observe.ExtractProperties`** folds the extracted values into each
  `ComponentMatch.Properties` instead of returning a `map[nodeID]map[name]string`;
  **`observe.Result.Props` is removed** (props live on the matches now).
- **Consumers read from the match**: the tree renderer via `c.Match.Properties`
  (drops `FormatOpts.PropValues`); snapshot JSON via `matches[node].Properties`
  (same `"props": {name: value}` output — **wire unchanged**). The component-query
  CLI still takes the legacy node-id map, derived from the matches at its one call
  site (`compquery` stays CLI-scoped per the resolved knot).

## Boundaries
Transforms are deliberately **untouched** (still applied in JS, still string
output) — the transform-vocab rethink stays separate (`sightmap-8b0a`).

Verification: `go build`/`vet`/`test ./...`, `spec` conformance + examples, gofmt
— all green. Behavior unchanged.
