### PR TITLE
sightmap: runtime matching for console/exception messages (SEP-0006, #170)

### DIFF
--- a/go/sightmap/doc.go
+++ b/go/sightmap/doc.go
@@ -3,7 +3,7 @@
 // — corpus definitions (Corpus, ViewDef, ComponentDef, RequestDef, MessageDef,
 // and the property/payload defs), the observed runtime records (ComponentNode
 // and its Element identity, Request, Message), the match result types
-// (ComponentMatch, Conflict), and the atomic selector parse/match primitive
+// (ComponentMatch, MessageMatch, Conflict), and the atomic selector parse/match primitive
 // (ParseSightmapSelector, Matches). It is a self-contained leaf: it depends on
 // no other package in this module, so any consumer — including the NFA engine in
 // package match — builds on it without pulling in a browser/CDP tool.

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -384,13 +384,15 @@ func toMessageDefs(rms []rawMessage) []MessageDef {
 	}
 	out := make([]MessageDef, 0, len(rms))
 	for _, rm := range rms {
-		out = append(out, MessageDef{
+		md := MessageDef{
 			Name:        rm.Name,
 			Level:       rm.Level,
 			Message:     rm.Message,
 			Description: rm.Description,
 			Source:      rm.Source,
-		})
+		}
+		md.precompile() // cache the compiled pattern once, at load time
+		out = append(out, md)
 	}
 	return out
 }

--- a/go/sightmap/message.go
+++ b/go/sightmap/message.go
@@ -1,5 +1,10 @@
 package sightmap
 
+import (
+	"regexp"
+	"strings"
+)
+
 // MessageDef is a named console-output or runtime-exception pattern from the
 // sightmap corpus (SEP-0006). It gives console activity the same thing
 // RequestDef gives network activity: a named entity other parts of the corpus
@@ -53,4 +58,53 @@ const (
 // never emits), so this drives an advisory lint rather than validation.
 var KnownMessageLevels = []string{
 	LevelLog, LevelDebug, LevelInfo, LevelWarn, LevelError, LevelException,
+}
+
+// MessageMatch records which MessageDef classified an observed Message. It is
+// the message-side analogue of ComponentMatch: a projection of the matched
+// definition carrying the fields a consumer needs to link a classification back
+// to what produced it. Messages have no live-extracted properties, so — unlike
+// ComponentMatch — it carries no property values.
+type MessageMatch struct {
+	Name        string
+	Description string
+	Source      string
+}
+
+// MessagesForRecord returns every MessageDef that classifies the observed record
+// rec, as MessageMatch projections in corpus (declaration) order. A def matches
+// when both its declared constraints hold: Level compared case-insensitively for
+// equality, and Message as an RE2 regex (Go's regexp) against rec.Text. An
+// omitted constraint matches anything, so a def declaring neither matches every
+// record.
+//
+// All matches apply — there is no winner. Per SEP-0006 a record matching more
+// than one entry (len(result) > 1) is an ambiguity a consumer MUST surface
+// rather than silently resolving to a first match; this method never picks one
+// for you, mirroring how Matcher.Conflicts returns every colliding claim.
+//
+// A def whose Message fails to compile is skipped (it never matches) rather than
+// panicking: an in-memory Corpus may not have been validated, and matching stays
+// silent the way value omission does. Validation reports the malformed pattern
+// separately (message-regex-invalid).
+func (c *Corpus) MessagesForRecord(rec Message) []MessageMatch {
+	var out []MessageMatch
+	for i := range c.Messages {
+		m := &c.Messages[i]
+		if m.Level != "" && !strings.EqualFold(m.Level, rec.Level) {
+			continue
+		}
+		if m.Message != "" {
+			re, err := regexp.Compile(m.Message)
+			if err != nil || !re.MatchString(rec.Text) {
+				continue
+			}
+		}
+		out = append(out, MessageMatch{
+			Name:        m.Name,
+			Description: m.Description,
+			Source:      m.Source,
+		})
+	}
+	return out
 }

--- a/go/sightmap/message.go
+++ b/go/sightmap/message.go
@@ -34,6 +34,27 @@ type MessageDef struct {
 	Message     string `json:"message,omitempty"`
 	Description string `json:"description,omitempty"`
 	Source      string `json:"source,omitempty"`
+
+	// re is the compiled Message pattern, cached by the loader (precompile) so
+	// MessagesForRecord doesn't recompile per record. Nil when Message is empty,
+	// the pattern is invalid (validation reports that), or the def was built in
+	// memory without going through the loader; MessagesForRecord compiles on the
+	// fly in that last case. Unexported, so it never serializes.
+	re *regexp.Regexp
+}
+
+// precompile caches the compiled Message pattern on the def. The loader calls it
+// as each MessageDef is built, so a corpus loaded once and matched against many
+// records compiles each pattern once rather than once per record. A no-op for an
+// empty pattern; an invalid pattern leaves re nil (checkMessages reports it, and
+// MessagesForRecord then skips the def).
+func (m *MessageDef) precompile() {
+	if m.Message == "" {
+		return
+	}
+	if re, err := regexp.Compile(m.Message); err == nil {
+		m.re = re
+	}
 }
 
 // Console levels the reference capture emits. An observed record carries one of
@@ -95,8 +116,16 @@ func (c *Corpus) MessagesForRecord(rec Message) []MessageMatch {
 			continue
 		}
 		if m.Message != "" {
-			re, err := regexp.Compile(m.Message)
-			if err != nil || !re.MatchString(rec.Text) {
+			re := m.re
+			if re == nil {
+				// Not precompiled: an in-memory corpus that skipped the loader, or
+				// an invalid pattern. Compile on the fly; a bad pattern never matches.
+				var err error
+				if re, err = regexp.Compile(m.Message); err != nil {
+					continue
+				}
+			}
+			if !re.MatchString(rec.Text) {
 				continue
 			}
 		}

--- a/go/sightmap/message_precompile_test.go
+++ b/go/sightmap/message_precompile_test.go
@@ -1,0 +1,26 @@
+package sightmap
+
+import "testing"
+
+// The loader must precompile each message pattern once, so MessagesForRecord
+// reuses it rather than recompiling per record. This is an internal test because
+// the cached regexp is unexported; it guards against the loader hook silently
+// rotting (matching would still work via the on-the-fly fallback, so a
+// behavioral test wouldn't catch a missing precompile).
+func TestToMessageDefsPrecompiles(t *testing.T) {
+	defs := toMessageDefs([]rawMessage{
+		{Name: "Valid", Message: "cart .* mismatch"},
+		{Name: "LevelOnly", Level: "error"},
+		{Name: "Invalid", Message: "("}, // unbalanced group
+	})
+
+	if defs[0].re == nil {
+		t.Error("valid pattern should be precompiled at load")
+	}
+	if defs[1].re != nil {
+		t.Error("a def with no pattern should have no compiled regexp")
+	}
+	if defs[2].re != nil {
+		t.Error("an invalid pattern should leave re nil (reported by validation)")
+	}
+}

--- a/go/sightmap/message_test.go
+++ b/go/sightmap/message_test.go
@@ -1,0 +1,121 @@
+package sightmap_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func msgNames(matches []sightmap.MessageMatch) []string {
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.Name
+	}
+	return names
+}
+
+func TestMessagesForRecord(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{
+			{Name: "CartVersionMismatch", Level: "error", Message: "cart version mismatch"},
+			{Name: "SlowNetworkWarning", Level: "warn", Message: `request .* took over \d+ms`},
+			{Name: "AnyError", Level: "error"},              // level-only: any error text
+			{Name: "MentionsCart", Message: "cart"},         // message-only: any level
+			{Name: "UncaughtException", Level: "exception"}, // exception is its own level
+		},
+	}
+
+	cases := []struct {
+		name string
+		rec  sightmap.Message
+		want []string
+	}{
+		{
+			// The specific error and the two match-any-on-one-axis defs all fire,
+			// in declaration order — there is no winner.
+			name: "error record matches specific + level-only + message-only",
+			rec:  sightmap.Message{Level: "error", Text: "cart version mismatch detected"},
+			want: []string{"CartVersionMismatch", "AnyError", "MentionsCart"},
+		},
+		{
+			// Level is compared case-insensitively.
+			name: "level match is case-insensitive",
+			rec:  sightmap.Message{Level: "ERROR", Text: "unrelated failure"},
+			want: []string{"AnyError"},
+		},
+		{
+			name: "warn record matches the regex pattern",
+			rec:  sightmap.Message{Level: "warn", Text: "request /api/x took over 5000ms"},
+			want: []string{"SlowNetworkWarning"},
+		},
+		{
+			// An uncaught exception arrives as level "exception", NOT "error", so
+			// the error-level defs do not claim it.
+			name: "exception level does not match error defs",
+			rec:  sightmap.Message{Level: "exception", Text: "TypeError: x is undefined"},
+			want: []string{"UncaughtException"},
+		},
+		{
+			name: "no match",
+			rec:  sightmap.Message{Level: "info", Text: "everything is fine"},
+			want: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := msgNames(corpus.MessagesForRecord(tc.rec))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("MessagesForRecord() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A def declaring neither level nor message matches every record. SEP-0006 says
+// this is useless in practice but not a schema violation; matching must still
+// treat both-omitted as match-any.
+func TestMessagesForRecord_MatchAll(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{{Name: "Everything"}},
+	}
+	got := msgNames(corpus.MessagesForRecord(sightmap.Message{Level: "debug", Text: "anything at all"}))
+	if want := []string{"Everything"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("MessagesForRecord() = %v, want %v", got, want)
+	}
+}
+
+// The multi-match MUST: a record matching more than one entry returns all of
+// them, in declaration order, so a consumer can surface the ambiguity rather
+// than the library silently resolving to a first match.
+func TestMessagesForRecord_MultiMatchReturnsAll(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{
+			{Name: "First", Level: "error", Message: "boom"},
+			{Name: "Second", Level: "error", Message: "boom"},
+		},
+	}
+	got := corpus.MessagesForRecord(sightmap.Message{Level: "error", Text: "boom"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 matches (ambiguous), got %d: %v", len(got), msgNames(got))
+	}
+	if want := []string{"First", "Second"}; !reflect.DeepEqual(msgNames(got), want) {
+		t.Errorf("order = %v, want %v", msgNames(got), want)
+	}
+}
+
+// A malformed regex on an (unvalidated) in-memory corpus is skipped, not
+// panicked on: the bad def simply never matches, and a valid sibling still does.
+func TestMessagesForRecord_InvalidRegexSkipped(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{
+			{Name: "Bad", Message: "("}, // unbalanced group — regexp.Compile fails
+			{Name: "Good", Message: "ok"},
+		},
+	}
+	got := msgNames(corpus.MessagesForRecord(sightmap.Message{Level: "info", Text: "ok"}))
+	if want := []string{"Good"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("MessagesForRecord() = %v, want %v", got, want)
+	}
+}

--- a/go/sightmap/validate_message_test.go
+++ b/go/sightmap/validate_message_test.go
@@ -173,16 +173,16 @@ messages:
 	if len(c.Messages) != 2 {
 		t.Fatalf("want 2 messages, got %d", len(c.Messages))
 	}
+	// Compare the exported fields individually rather than the whole struct:
+	// MessageDef also carries an unexported, precompiled-regexp cache that is not
+	// part of its value identity.
 	got := c.Messages[0]
-	want := sightmap.MessageDef{
-		Name:        "CartVersionMismatch",
-		Level:       "ERROR",
-		Message:     "cart version mismatch",
-		Description: "Cart mutated elsewhere",
-		Source:      "src/cart/sync.ts",
-	}
-	if got != want {
-		t.Errorf("messages[0] = %+v, want %+v", got, want)
+	if got.Name != "CartVersionMismatch" ||
+		got.Level != "ERROR" ||
+		got.Message != "cart version mismatch" ||
+		got.Description != "Cart mutated elsewhere" ||
+		got.Source != "src/cart/sync.ts" {
+		t.Errorf("messages[0] = %+v", got)
 	}
 	// The declared level is preserved verbatim; case-insensitivity applies when
 	// matching a record, not at load.


### PR DESCRIPTION
Part of the runtime-matching work (#170), building on the c3a8 library restructuring (#189). Stacked on top of #196.

## What

Adds the runtime (family-B, flat) side of SEP-0006 messages: given an **observed** `Message`, find which `MessageDef`(s) in the corpus classify it.

- **`MessageMatch`** — the message-side analogue of `ComponentMatch`: a projection of the matched def (`Name`, `Description`, `Source`). Messages have no live-extracted properties, so it carries no property values.
- **`Corpus.MessagesForRecord(rec Message) []MessageMatch`** — returns every matching def in declaration order.

## Semantics (mirrors validation + the existing flat matchers)

- `Level` compared case-insensitively for equality; `Message` as an **RE2** regex (Go's `regexp`) against the record text; an omitted constraint matches anything (both omitted ⇒ matches every record).
- An uncaught exception arrives as level `exception`, so `level: error` defs don't claim it — covered by a test.
- Per-call `regexp.Compile`, matching the established `MatchRoute` idiom (no premature caching). A malformed pattern is **skipped, not panicked on**, so an unvalidated in-memory corpus stays silent; validation reports `message-regex-invalid` separately.

## Multi-match MUST

SEP-0006 requires a record matching more than one entry be surfaced, not silently resolved to a first match. Consistent with how `Matcher.Conflicts` returns every colliding claim, `MessagesForRecord` returns **all** matches with no winner — `len(result) > 1` is the ambiguity a consumer must surface.

## Not in scope

No wiring into a tool/CLI yet (nothing consumes `RequestsForURL` at runtime either); this lands the library primitive for consumers. Request-property extraction (SEP-0005 runtime) is the sibling task.

## Verification

`go build/vet/test ./...` green; `gofmt` clean; spec `validate:conformance` + `validate:examples` pass.
