### PR TITLE
cmd/sightmap: corpus-aware devtools — annotate console+network with matches (#170)

### DIFF
--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -153,7 +153,7 @@ func runBrowserStart(args []string) error {
 	// Devtools query surface. The collector is created after Chrome is ready
 	// (below); the handlers return 503 until then.
 	var collectorPtr atomic.Pointer[browser.Collector]
-	registerDevtoolsHandlers(mux, &collectorPtr)
+	registerDevtoolsHandlers(mux, &collectorPtr, *sightmapDir)
 
 	// Bind the sightmap server on the IPv4 loopback (not the ":port" wildcard) so
 	// it shares an address family with Chrome's CDP and with FindFreePort's probe.

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -51,14 +51,70 @@ func devtoolsGet(sightmapDir, path string, query url.Values) ([]byte, error) {
 	return body, nil
 }
 
+// consoleEntry / networkEntry are an observed record plus the names of the
+// corpus definitions that classify it. The daemon annotates entries in the
+// devtools handler (the collector stays corpus-blind); Matches is empty when no
+// corpus is loaded or nothing matched. Embedding promotes the record's own JSON
+// fields to the top level, so the wire shape is the record plus "matches".
+type consoleEntry struct {
+	sightmap.Message
+	Matches []string `json:"matches,omitempty"`
+}
+
+type networkEntry struct {
+	sightmap.Request
+	Matches []string `json:"matches,omitempty"`
+}
+
 type consoleResult struct {
-	Entries []sightmap.Message `json:"entries"`
-	Dropped int                `json:"dropped"`
+	Entries []consoleEntry `json:"entries"`
+	Dropped int            `json:"dropped"`
 }
 
 type networkResult struct {
-	Entries []sightmap.Request `json:"entries"`
-	Dropped int                `json:"dropped"`
+	Entries []networkEntry `json:"entries"`
+	Dropped int            `json:"dropped"`
+}
+
+// annotateConsole / annotateNetwork project each observed record together with
+// the names of the corpus defs that classify it. A nil corpus (none loaded, or a
+// load error) yields entries with no matches — devtools stays useful without a
+// corpus. Kept pure (corpus passed in, not loaded here) so they're unit-testable
+// without a daemon or disk.
+func annotateConsole(c *sightmap.Corpus, msgs []sightmap.Message) []consoleEntry {
+	out := make([]consoleEntry, len(msgs))
+	for i, m := range msgs {
+		e := consoleEntry{Message: m}
+		if c != nil {
+			for _, mm := range c.MessagesForRecord(m) {
+				e.Matches = append(e.Matches, mm.Name)
+			}
+		}
+		out[i] = e
+	}
+	return out
+}
+
+func annotateNetwork(c *sightmap.Corpus, reqs []sightmap.Request) []networkEntry {
+	out := make([]networkEntry, len(reqs))
+	for i, r := range reqs {
+		e := networkEntry{Request: r}
+		if c != nil {
+			for _, rd := range c.RequestsForURL(r.URL, r.Method) {
+				e.Matches = append(e.Matches, rd.Name)
+			}
+		}
+		out[i] = e
+	}
+	return out
+}
+
+// matchSuffix renders matched def names for a list line, or "" when none.
+func matchSuffix(matches []string) string {
+	if len(matches) == 0 {
+		return ""
+	}
+	return "  → " + strings.Join(matches, ", ")
 }
 
 // ── console ─────────────────────────────────────────────────────────────────
@@ -106,9 +162,9 @@ func runConsoleList(args []string) error {
 		multiTab := spansMultipleTabs(res.Entries)
 		for _, e := range res.Entries {
 			if multiTab {
-				fmt.Printf("[%d] %-9s [%s] %s\n", e.Index, e.Level, shortTab(e.Tab), e.Text)
+				fmt.Printf("[%d] %-9s [%s] %s%s\n", e.Index, e.Level, shortTab(e.Tab), e.Text, matchSuffix(e.Matches))
 			} else {
-				fmt.Printf("[%d] %-9s %s\n", e.Index, e.Level, e.Text)
+				fmt.Printf("[%d] %-9s %s%s\n", e.Index, e.Level, e.Text, matchSuffix(e.Matches))
 			}
 		}
 	}
@@ -137,6 +193,9 @@ func runConsoleGet(args []string) error {
 	for _, e := range res.Entries {
 		if e.Index == idx {
 			fmt.Printf("[%d] %s  (tab %s)\n%s\n", e.Index, e.Level, shortTab(e.Tab), e.Text)
+			if len(e.Matches) > 0 {
+				fmt.Printf("Matches: %s\n", strings.Join(e.Matches, ", "))
+			}
 			return nil
 		}
 	}
@@ -188,7 +247,7 @@ func runNetworkList(args []string) error {
 		fmt.Println("No network requests captured.")
 	} else {
 		for _, e := range res.Entries {
-			fmt.Printf("[%d] %s %s → %s (%s)\n", e.Index, e.Method, e.URL, statusStr(e), e.ResourceType)
+			fmt.Printf("[%d] %s %s → %s (%s)%s\n", e.Index, e.Method, e.URL, statusStr(e.Request), e.ResourceType, matchSuffix(e.Matches))
 		}
 	}
 	reportDropped(res.Dropped, "network")
@@ -216,7 +275,7 @@ func runNetworkGet(args []string) error {
 	if err := json.Unmarshal(body, &res); err != nil {
 		return fmt.Errorf("parse response: %w", err)
 	}
-	var entry *sightmap.Request
+	var entry *networkEntry
 	for i := range res.Entries {
 		if res.Entries[i].Index == idx {
 			entry = &res.Entries[i]
@@ -230,8 +289,11 @@ func runNetworkGet(args []string) error {
 	fmt.Printf("Method: %s\n", entry.Method)
 	fmt.Printf("URL: %s\n", entry.URL)
 	fmt.Printf("Resource Type: %s\n", entry.ResourceType)
-	fmt.Printf("Status: %s\n", statusStr(*entry))
+	fmt.Printf("Status: %s\n", statusStr(entry.Request))
 	fmt.Printf("Tab: %s\n", entry.Tab)
+	if len(entry.Matches) > 0 {
+		fmt.Printf("Matches: %s\n", strings.Join(entry.Matches, ", "))
+	}
 
 	if *reqFile != "" {
 		if err := saveBody(*sightmapDir, idx, "request", *reqFile); err != nil {
@@ -325,7 +387,7 @@ func singleIndexArg(args []string, cmd string) (int, error) {
 	return idx, nil
 }
 
-func spansMultipleTabs(entries []sightmap.Message) bool {
+func spansMultipleTabs(entries []consoleEntry) bool {
 	seen := ""
 	for _, e := range entries {
 		if seen == "" {

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -109,12 +109,18 @@ func annotateNetwork(c *sightmap.Corpus, reqs []sightmap.Request) []networkEntry
 	return out
 }
 
-// matchSuffix renders matched def names for a list line, or "" when none.
-func matchSuffix(matches []string) string {
-	if len(matches) == 0 {
-		return ""
+// matchSlot renders the leading corpus-match token for a list line: the matched
+// def name(s) in brackets, or "[--]" when unmatched. It leads the line (before
+// the record's own payload) so an agent reads the classification first, mirroring
+// how snapshots foreground a component's [Name]. Multi-match renders every name
+// ("[A, B]") so the ambiguity is visible up front. Left-padded to a modest width
+// so short tokens align for human scanning; long ones overflow.
+func matchSlot(matches []string) string {
+	token := "[--]"
+	if len(matches) > 0 {
+		token = "[" + strings.Join(matches, ", ") + "]"
 	}
-	return "  → " + strings.Join(matches, ", ")
+	return fmt.Sprintf("%-22s", token)
 }
 
 // ── console ─────────────────────────────────────────────────────────────────
@@ -162,9 +168,9 @@ func runConsoleList(args []string) error {
 		multiTab := spansMultipleTabs(res.Entries)
 		for _, e := range res.Entries {
 			if multiTab {
-				fmt.Printf("[%d] %-9s [%s] %s%s\n", e.Index, e.Level, shortTab(e.Tab), e.Text, matchSuffix(e.Matches))
+				fmt.Printf("[%d] %s %-9s [%s] %s\n", e.Index, matchSlot(e.Matches), e.Level, shortTab(e.Tab), e.Text)
 			} else {
-				fmt.Printf("[%d] %-9s %s%s\n", e.Index, e.Level, e.Text, matchSuffix(e.Matches))
+				fmt.Printf("[%d] %s %-9s %s\n", e.Index, matchSlot(e.Matches), e.Level, e.Text)
 			}
 		}
 	}
@@ -247,7 +253,7 @@ func runNetworkList(args []string) error {
 		fmt.Println("No network requests captured.")
 	} else {
 		for _, e := range res.Entries {
-			fmt.Printf("[%d] %s %s → %s (%s)%s\n", e.Index, e.Method, e.URL, statusStr(e.Request), e.ResourceType, matchSuffix(e.Matches))
+			fmt.Printf("[%d] %s %s %s → %s (%s)\n", e.Index, matchSlot(e.Matches), e.Method, e.URL, statusStr(e.Request), e.ResourceType)
 		}
 	}
 	reportDropped(res.Dropped, "network")

--- a/go/cmd/sightmap/cmd_devtools_server.go
+++ b/go/cmd/sightmap/cmd_devtools_server.go
@@ -14,19 +14,37 @@ import (
 	"time"
 
 	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // registerDevtoolsHandlers wires the /devtools/* endpoints onto mux. The
 // collector is supplied via ptr because it is created only after Chrome is
 // ready, whereas handlers must be registered before the server starts serving.
 // Until the collector exists the endpoints return 503.
-func registerDevtoolsHandlers(mux *http.ServeMux, ptr *atomic.Pointer[browser.Collector]) {
+//
+// sightmapDir is the corpus location. The console/network handlers annotate each
+// observed record with the corpus defs that classify it, loading the corpus
+// fresh per request so on-disk edits are reflected the same way the component
+// CLI's per-invocation sightmap.Load() is (corpora are tiny; the I/O is
+// negligible). A missing or malformed corpus degrades to no annotations rather
+// than failing the query.
+func registerDevtoolsHandlers(mux *http.ServeMux, ptr *atomic.Pointer[browser.Collector], sightmapDir string) {
 	load := func(w http.ResponseWriter) (*browser.Collector, bool) {
 		if c := ptr.Load(); c != nil {
 			return c, true
 		}
 		http.Error(w, "collector not ready", http.StatusServiceUnavailable)
 		return nil, false
+	}
+
+	// corpusNow loads the corpus fresh, returning nil on any error so the
+	// handler degrades to un-annotated entries.
+	corpusNow := func() *sightmap.Corpus {
+		c, err := sightmap.Load(sightmapDir)
+		if err != nil {
+			return nil
+		}
+		return c
 	}
 
 	mux.HandleFunc("/devtools/console", func(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +58,7 @@ func registerDevtoolsHandlers(mux *http.ServeMux, ptr *atomic.Pointer[browser.Co
 			Tab:   q.Get("tab"),
 			Limit: atoiDefault(q.Get("limit"), 0),
 		})
-		writeJSON(w, map[string]any{"entries": entries, "dropped": dropped})
+		writeJSON(w, map[string]any{"entries": annotateConsole(corpusNow(), entries), "dropped": dropped})
 	})
 
 	mux.HandleFunc("/devtools/network", func(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +73,7 @@ func registerDevtoolsHandlers(mux *http.ServeMux, ptr *atomic.Pointer[browser.Co
 			Tab:          q.Get("tab"),
 			Limit:        atoiDefault(q.Get("limit"), 0),
 		})
-		writeJSON(w, map[string]any{"entries": entries, "dropped": dropped})
+		writeJSON(w, map[string]any{"entries": annotateNetwork(corpusNow(), entries), "dropped": dropped})
 	})
 
 	mux.HandleFunc("/devtools/network/body", func(w http.ResponseWriter, r *http.Request) {

--- a/go/cmd/sightmap/cmd_devtools_test.go
+++ b/go/cmd/sightmap/cmd_devtools_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func TestAnnotateConsole(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{
+			{Name: "CartVersionMismatch", Level: "error", Message: "cart version mismatch"},
+			{Name: "AnyError", Level: "error"},
+		},
+	}
+	msgs := []sightmap.Message{
+		{Index: 1, Level: "error", Text: "cart version mismatch detected"}, // both defs
+		{Index: 2, Level: "info", Text: "all good"},                        // none
+	}
+	got := annotateConsole(corpus, msgs)
+
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	// Record fields survive (embedding) and matches are attached in corpus order.
+	if got[0].Index != 1 || !reflect.DeepEqual(got[0].Matches, []string{"CartVersionMismatch", "AnyError"}) {
+		t.Errorf("entry0 = %+v", got[0])
+	}
+	if got[1].Index != 2 || len(got[1].Matches) != 0 {
+		t.Errorf("entry1 should have no matches, got %+v", got[1])
+	}
+}
+
+func TestAnnotateNetwork(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{
+			{Name: "CheckoutPayment", Route: "/api/checkout/pay", Method: "POST"},
+			{Name: "AnyCheckout", Route: "/api/checkout/**"}, // any method
+		},
+	}
+	reqs := []sightmap.Request{
+		{Index: 1, Method: "POST", URL: "https://x.test/api/checkout/pay"}, // both
+		{Index: 2, Method: "GET", URL: "https://x.test/api/other"},         // none
+	}
+	got := annotateNetwork(corpus, reqs)
+
+	if got[0].URL != "https://x.test/api/checkout/pay" ||
+		!reflect.DeepEqual(got[0].Matches, []string{"CheckoutPayment", "AnyCheckout"}) {
+		t.Errorf("entry0 = %+v", got[0])
+	}
+	if len(got[1].Matches) != 0 {
+		t.Errorf("entry1 should have no matches, got %+v", got[1])
+	}
+}
+
+// A nil corpus (none loaded, or a load error) must degrade to entries with no
+// matches rather than panicking — devtools stays useful without a corpus.
+func TestAnnotate_NilCorpusDegrades(t *testing.T) {
+	c := annotateConsole(nil, []sightmap.Message{{Index: 1, Level: "error", Text: "x"}})
+	if len(c) != 1 || len(c[0].Matches) != 0 {
+		t.Errorf("console nil-corpus = %+v", c)
+	}
+	n := annotateNetwork(nil, []sightmap.Request{{Index: 1, Method: "GET", URL: "https://x.test/a"}})
+	if len(n) != 1 || len(n[0].Matches) != 0 {
+		t.Errorf("network nil-corpus = %+v", n)
+	}
+}

--- a/go/cmd/sightmap/cmd_devtools_test.go
+++ b/go/cmd/sightmap/cmd_devtools_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/sightmap"
@@ -51,6 +52,30 @@ func TestAnnotateNetwork(t *testing.T) {
 	}
 	if len(got[1].Matches) != 0 {
 		t.Errorf("entry1 should have no matches, got %+v", got[1])
+	}
+}
+
+func TestMatchSlot(t *testing.T) {
+	cases := []struct {
+		name    string
+		matches []string
+		want    string // trimmed of the alignment padding
+	}{
+		{"unmatched", nil, "[--]"},
+		{"single", []string{"CartVersionMismatch"}, "[CartVersionMismatch]"},
+		{"multi (ambiguity up front)", []string{"CheckoutPayment", "AnyCheckout"}, "[CheckoutPayment, AnyCheckout]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.TrimRight(matchSlot(tc.matches), " ")
+			if got != tc.want {
+				t.Errorf("matchSlot(%v) = %q, want %q", tc.matches, got, tc.want)
+			}
+		})
+	}
+	// The unmatched token stays quiet (no def name could be mistaken for it).
+	if strings.Contains(matchSlot(nil), "match") {
+		t.Error("unmatched token should be an unobtrusive placeholder, not a word")
 	}
 }
 


### PR DESCRIPTION
Part of the runtime-matching work (#170), stacked on top of #198.

## What

Makes the `browser start` daemon **corpus-aware** and gives the two flat matchers (`MessagesForRecord` from #198, and the already-landed `RequestsForURL`) their first non-test consumer. Until now the devtools path was corpus-blind: `sightmap console`/`network` rendered raw records with no corpus loaded anywhere.

The `/devtools/console` and `/devtools/network` handlers now annotate each observed record with the names of the corpus defs that classify it:

- **console** → `Corpus.MessagesForRecord` (level + message-regex)
- **network** → `Corpus.RequestsForURL` (route + method **identity**)

`console`/`network` `list` and `get` render the matched names.

## New Output
This winds request/message matches into the `sightmap browser` devtools output like so:

```
console:
[0] [CartVersionMismatch]  error     cart version mismatch
[1] [--]                   log       just a plain log line

network:
[1] [PageDocument]         GET  http://localhost:8799/                  → 200 OK (Document)
[2] [CheckoutPayment]      POST http://localhost:8799/api/checkout/pay  → 501 … (Fetch)
[5] [--]                   GET  http://localhost:8799/favicon.ico       → 404 … (Fetch)
```

## Design (per discussion)

- **Per-request corpus load.** The corpus is loaded fresh on each devtools request, so daemon annotations reflect on-disk edits exactly like the component CLI's per-invocation `sightmap.Load()`. Corpora are tiny; the I/O is negligible. (An mtime short-circuit is a trivial later optimization if needed.)
- **Handler-side, collector stays simple.** Annotation lives in the devtools handler; the collector remains a pure observation buffer.
- **Graceful degrade.** A missing or malformed corpus yields un-annotated entries rather than failing the query — devtools stays useful without a corpus.
- **Wire format.** Each entry gains a `"matches"` list; the record's own fields are promoted via embedding, so the shape is just the record plus `matches`.

## Relation to the daemon north star (#85a4-ish)

This is a deliberate first corpus-aware step for the daemon, not throwaway: the north star (route all browser ops through the daemon, CLI/MCP as thin front-ends) explicitly grows the protocol *from* the `/devtools/*` query surface, and a corpus-aware daemon returning matched records is exactly that curated-op shape.

## Not in scope

- **Request property/signal extraction** — needs req/rsp headers + bodies (the buffered record has neither; bodies are lazily fetched), so it lands separately and layers onto this same handler annotation.
- **Eliminating the double corpus load** (component CLI still loads client-side) — a later daemon-convergence step.

## Verification

`go build/vet/test ./...` green; `gofmt` clean; spec `validate:conformance` + `validate:examples` pass. Pure annotation helpers (`annotateConsole`/`annotateNetwork`) are unit-tested, including nil-corpus degrade.
