### PR TITLE
cmd/sightmap: serve the canonical Corpus wire (retire compiledSightmapJSON) (#160)

### DIFF
--- a/.changeset/serve-corpus-wire.md
+++ b/.changeset/serve-corpus-wire.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`sightmap serve` and the `browser start` daemon now serve the canonical Corpus
+wire — the same shape library consumers see (`selectors[]` arrays, components
+nested under each view) — inside a thin `{site, version, corpus}` envelope,
+replacing the bespoke pre-compiled shape. The bundled browser extension consumes
+it directly; cache-busting via `/sightmap/version` is unchanged.

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -109,28 +109,28 @@ func runBrowserStart(args []string) error {
 
 	// ── Start sightmap HTTP server in background ──────────────────────────────
 	siteName := filepath.Base(cwd())
-	compiled, err := compileCorpus(*sightmapDir, siteName)
+	compiled, err := loadServedSightmap(*sightmapDir, siteName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "start: sightmap compile warning: %v\n", err)
+		fmt.Fprintf(os.Stderr, "start: sightmap load warning: %v\n", err)
 		// non-fatal: continue without corpus
 	}
 
 	var mu sync.RWMutex
 	current := compiled
 
-	recompile := func() {
-		c, compErr := compileCorpus(*sightmapDir, siteName)
-		if compErr != nil {
-			fmt.Fprintf(os.Stderr, "[serve-sightmap] compile error: %v\n", compErr)
+	reload := func() {
+		c, loadErr := loadServedSightmap(*sightmapDir, siteName)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "[serve-sightmap] load error: %v\n", loadErr)
 			return
 		}
 		mu.Lock()
 		current = c
 		mu.Unlock()
-		fmt.Fprintf(os.Stderr, "[serve-sightmap] recompiled (v%s)\n", c.Version)
+		fmt.Fprintf(os.Stderr, "[serve-sightmap] reloaded (v%s)\n", c.Version)
 	}
 
-	go watchSightmapDir(*sightmapDir, recompile)
+	go watchSightmapDir(*sightmapDir, reload)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sightmap/version", func(w http.ResponseWriter, r *http.Request) {

--- a/go/cmd/sightmap/cmd_serve.go
+++ b/go/cmd/sightmap/cmd_serve.go
@@ -17,80 +17,32 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
-type compiledComponent struct {
-	Name        string         `json:"name"`
-	Selector    string         `json:"selector"`    // selectors joined with ", "
-	ParentChain []string       `json:"parentChain"` // always array, never null
-	Properties  []compiledProp `json:"properties"`
+// servedSightmap is the thin transport envelope the extension fetches from
+// /sightmap: serve-only metadata (a site label and a cache-bust version stamp)
+// wrapped around the canonical Corpus wire. The Corpus body is byte-identical to
+// what a go-get/library consumer sees — serve no longer re-compiles the corpus
+// into a bespoke joined-selector shape. Cache-busting is unchanged: the extension
+// polls /sightmap/version and reloads when the stamp changes.
+type servedSightmap struct {
+	Site    string           `json:"site"`
+	Version string           `json:"version"`
+	Corpus  *sightmap.Corpus `json:"corpus"`
 }
 
-type compiledProp struct {
-	Name      string `json:"name"`
-	Extract   string `json:"extract"`
-	Transform string `json:"transform,omitempty"`
-}
-
-type compiledView struct {
-	Name  string `json:"name"`
-	Route string `json:"route"`
-}
-
-type compiledSightmapJSON struct {
-	Site           string                         `json:"site"`
-	Version        string                         `json:"version"`
-	Views          []compiledView                 `json:"views"`
-	Globals        []compiledComponent            `json:"globals"`
-	ViewComponents map[string][]compiledComponent `json:"viewComponents"`
-}
-
-func normaliseComponent(c sightmap.ComponentDef) compiledComponent {
-	chain := c.ParentChain
-	if chain == nil {
-		chain = []string{} // always emit [], never null
-	}
-	props := make([]compiledProp, 0, len(c.Properties))
-	for _, p := range c.Properties {
-		props = append(props, compiledProp{Name: p.Name, Extract: p.Extract, Transform: p.Transform})
-	}
-	return compiledComponent{
-		Name:        c.Name,
-		Selector:    strings.Join(c.Selectors, ", "),
-		ParentChain: chain,
-		Properties:  props,
-	}
-}
-
-func compileCorpus(sightmapDir, siteName string) (compiledSightmapJSON, error) {
+// loadServedSightmap loads the corpus and wraps it with serve metadata. The
+// version is a monotonic wall-clock stamp used only for cache-busting; the
+// selector-join / flattening the extension needs is done client-side now, so the
+// wire stays the canonical Corpus shape (selectors[] arrays, components nested
+// under each view).
+func loadServedSightmap(sightmapDir, siteName string) (servedSightmap, error) {
 	corp, err := sightmap.Load(sightmapDir)
 	if err != nil {
-		return compiledSightmapJSON{}, err
+		return servedSightmap{}, err
 	}
-
-	globals := make([]compiledComponent, 0, len(corp.GlobalComponents))
-	for _, c := range corp.GlobalComponents {
-		globals = append(globals, normaliseComponent(c))
-	}
-
-	viewList := make([]compiledView, 0, len(corp.Views))
-	viewComponents := make(map[string][]compiledComponent, len(corp.Views))
-	for _, v := range corp.Views {
-		if v.Route == "" {
-			continue
-		}
-		viewList = append(viewList, compiledView{Name: v.Name, Route: v.Route})
-		comps := make([]compiledComponent, 0, len(v.Components))
-		for _, c := range v.Components {
-			comps = append(comps, normaliseComponent(c))
-		}
-		viewComponents[v.Route] = comps
-	}
-
-	return compiledSightmapJSON{
-		Site:           siteName,
-		Version:        strconv.FormatInt(time.Now().UnixMilli(), 10),
-		Views:          viewList,
-		Globals:        globals,
-		ViewComponents: viewComponents,
+	return servedSightmap{
+		Site:    siteName,
+		Version: strconv.FormatInt(time.Now().UnixMilli(), 10),
+		Corpus:  corp,
 	}, nil
 }
 
@@ -104,29 +56,29 @@ func runServeSightmap(args []string) error {
 
 	siteName := filepath.Base(cwd())
 
-	// Initial compile.
-	compiled, err := compileCorpus(*sightmapDir, siteName)
+	// Initial load.
+	compiled, err := loadServedSightmap(*sightmapDir, siteName)
 	if err != nil {
-		return fmt.Errorf("serve-sightmap: initial compile: %w", err)
+		return fmt.Errorf("serve-sightmap: initial load: %w", err)
 	}
 
 	var mu sync.RWMutex
 	current := compiled
 
-	recompile := func() {
-		c, compErr := compileCorpus(*sightmapDir, siteName)
-		if compErr != nil {
-			fmt.Fprintf(os.Stderr, "[serve-sightmap] compile error: %v\n", compErr)
+	reload := func() {
+		c, loadErr := loadServedSightmap(*sightmapDir, siteName)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "[serve-sightmap] load error: %v\n", loadErr)
 			return
 		}
 		mu.Lock()
 		current = c
 		mu.Unlock()
-		fmt.Fprintf(os.Stderr, "[serve-sightmap] recompiled (v%s)\n", c.Version)
+		fmt.Fprintf(os.Stderr, "[serve-sightmap] reloaded (v%s)\n", c.Version)
 	}
 
 	// File watcher.
-	go watchSightmapDir(*sightmapDir, recompile)
+	go watchSightmapDir(*sightmapDir, reload)
 
 	// HTTP handlers.
 	mux := http.NewServeMux()

--- a/go/cmd/sightmap/extension/background.js
+++ b/go/cmd/sightmap/extension/background.js
@@ -58,9 +58,10 @@ function pushOverlayVisible(visible) {
 
 /** Build a sightmap-loaded status object from a /sightmap response. */
 function statusFromSightmap(data) {
+  const corpus = data.corpus ?? {};
   const componentCount =
-    (data.globals?.length ?? 0) +
-    Object.values(data.viewComponents ?? {}).reduce((s, a) => s + a.length, 0);
+    (corpus.globals?.length ?? 0) +
+    (corpus.views ?? []).reduce((s, v) => s + (v.components?.length ?? 0), 0);
   return {
     type: "sightmap-loaded",
     version: data.version,

--- a/go/cmd/sightmap/extension/content.js
+++ b/go/cmd/sightmap/extension/content.js
@@ -182,9 +182,7 @@ function matchRoute(pattern, pathname) {
 const state = {
   /** @type {import("./types.js").FlatComponent[]} globals always-active */
   globals: [],
-  /** @type {Record<string, import("./types.js").FlatComponent[]>} route→comps */
-  viewComponents: {},
-  /** @type {{name:string, route:string}[]} */
+  /** @type {{name:string, route:string, components:import("./types.js").FlatComponent[]}[]} */
   views: [],
   version: null,
   enabled: true, // Alt+S toggle
@@ -192,6 +190,22 @@ const state = {
   tooltipEl: null,
   hoverTarget: null,
 };
+
+/**
+ * Normalize a corpus ComponentDef (wire shape: a selectors[] array, components
+ * nested under each view) into the flat component the resolver consumes: a
+ * single closest()-compatible selector string plus parentChain/properties.
+ * Keeping the selector join here means resolver.js stays agnostic to the wire
+ * shape.
+ */
+function normalizeComp(c) {
+  return {
+    name: c.name,
+    selector: (c.selectors ?? []).join(", "),
+    parentChain: c.parentChain ?? [],
+    properties: c.properties ?? [],
+  };
+}
 
 /** Return the active component list for the current URL. */
 function activeComponents() {
@@ -201,9 +215,7 @@ function activeComponents() {
   for (const c of state.globals) byName.set(c.name, c);
   for (const view of state.views) {
     if (!matchRoute(view.route, pathname)) continue;
-    for (const c of state.viewComponents[view.route] ?? []) {
-      byName.set(c.name, c);
-    }
+    for (const c of view.components) byName.set(c.name, c);
   }
   return [...byName.values()];
 }
@@ -228,13 +240,17 @@ async function fetchSightmap() {
   try {
     const resp = await bgFetch("fetch-sightmap");
     const data = resp.data;
-    state.globals = data.globals ?? [];
-    state.viewComponents = data.viewComponents ?? {};
-    state.views = data.views ?? [];
+    const corpus = data.corpus ?? {};
+    state.globals = (corpus.globals ?? []).map(normalizeComp);
+    state.views = (corpus.views ?? []).map((v) => ({
+      name: v.name,
+      route: v.route,
+      components: (v.components ?? []).map(normalizeComp),
+    }));
     state.version = data.version;
     const total =
       state.globals.length +
-      Object.values(state.viewComponents).reduce((s, a) => s + a.length, 0);
+      state.views.reduce((s, v) => s + v.components.length, 0);
     console.log(
       `[sightmap] loaded ${total} components from ${data.site} v${data.version}`,
     );


### PR DESCRIPTION
Closes the remaining substantive piece of #160 (fbba.7).

## What

The sightmap server — both `serve-sightmap` and the `browser start` daemon, which share `compileCorpus` + the `/sightmap` handler — emitted a bespoke `compiledSightmapJSON`: a lossy re-compile of the corpus into the extension's private shape (joined-selector strings, a `viewComponents` route→components map, a flat `globals` list).

This replaces it with a thin transport envelope `{site, version, corpus}`, where **`corpus` is the canonical `Corpus` wire** — `selectors: []` arrays, components nested under each view, plus `requests`/`messages` — byte-identical to what a `go get` / library consumer (subtext, lidar) sees.

## Why

- **The browser extension becomes an internal consumer of the same wire we ship downstream.** That dogfoods the format against a real consumer *before* external parties lock in, and it's the cheapest place to surface any wire gaps.
- **Deletes an entire representation + a compile step** (`compiledComponent/Prop/View/SightmapJSON`, `normaliseComponent`) — net entropy reduction.

## Shape

`GET /sightmap`:
```json
{ "site": "smtest", "version": "1786…",
  "corpus": { "globals": [ { "name": "PageHeading", "selectors": ["h1"] } ],
              "views":   [ { "name": "Home", "route": "/",
                             "components": [ { "name": "TestBody", "selectors": ["body"] } ] } ],
              "requests": [ … ], "messages": [ … ] } }
```

- The `corpus` body is the pure canonical wire; `site`/`version` are serve-only transport metadata in the envelope.
- **Cache-busting unchanged:** `/sightmap/version` still serves the stamp; the extension polls it and reloads on change. (Kept the version in the envelope body rather than an ETag header because the extension fetches through a background service worker — reading response headers there would need service-worker + CORS-expose changes for no wire-purity gain, since `corpus` is already the bare canonical wire.)

## Extension

The selector-join and view flattening move client-side (`content.js` `normalizeComp`: `selectors[].join(", ")` → a `closest()`-compatible string), so **`resolver.js` is untouched**. `background.js`'s component-count helper reads the new nested shape. Server + extension change together in one PR (the extension is `go:embed`ed into the binary), so there's no half-broken intermediate.

## Verification

`go build/vet/test ./...` green, `gofmt` clean. Verified **end-to-end** against a live headless session (`--extensions` pointed at the repo dir): the extension logged `loaded 2 components` — a global + a routed view component — parsed from the new `selectors[]` wire, and the served JSON has the shape above.
