### PR TITLE
chore: changesets for the landed library restructure + runtime matching

### DIFF
--- a/.changeset/library-restructure.md
+++ b/.changeset/library-restructure.md
@@ -1,0 +1,11 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Restructure the Go library for downstream consumers. All corpus vocabulary,
+observed runtime records, and match-result types now live in a single
+self-contained `sightmap` package, with the matching engines consolidated behind
+one `match.Matcher`. Types follow a consistent naming model — `…Def` for a spec,
+bare structs for observed records, `…Match` for results — and extracted values
+share a typed `PropertyValue`. This is a breaking change to the Go import surface
+for library consumers (there were none before this release).

--- a/.changeset/runtime-message-matching.md
+++ b/.changeset/runtime-message-matching.md
@@ -1,0 +1,12 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add runtime matching for console/exception messages. `Corpus.MessagesForRecord`
+classifies an observed console record against `messages:` definitions
+(case-insensitive level equality + an RE2 `message` regex, precompiled at load),
+returning every match so an ambiguous record is surfaced rather than silently
+resolved. The `sightmap console` and `sightmap network` devtools listings now
+annotate each captured record with the corpus definitions that classify it —
+messages via `MessagesForRecord`, requests via route+method identity — leading
+each line with the match.


### PR DESCRIPTION
The c3a8 library restructuring (#190, #191, #193–#196) and the b7e2 runtime-matching work (#198, #199) merged **without changesets**, so the release workflow has nothing to release — the work is sitting on `main` at 0.20.0, untagged, and downstream consumers (subtext/lidar) can't `go get` a version that reflects it.

Since changesets can't be retro-added to merged PRs, this adds catch-up changesets:

- **library-restructure** (minor) — the c3a8 single-`sightmap`-package + one-`match.Matcher` reshape; breaking to the Go import surface (no consumers before this release).
- **runtime-message-matching** (minor) — `Corpus.MessagesForRecord` + the devtools console/network match annotation.

Net bump: **0.20.0 → 0.21.0**. On merge, the release workflow opens/updates the Version Packages PR; merging that tags `v0.21.0` + `go/v0.21.0` and publishes.

Bump level / wording are easy to tweak before merge if you'd prefer different granularity. (#200's own changeset lands on its branch separately so it folds into the same release if merged first.)