### PR TITLE
cmd/sightmap: add 'export'/'push' to emit the canonical Corpus wire

### DIFF
--- a/.changeset/sightmap-export.md
+++ b/.changeset/sightmap-export.md
@@ -1,0 +1,19 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add `sightmap export [dir]`: load a `.sightmap/` corpus and emit the canonical
+Corpus wire — the exact `json.Marshal(sightmap.Corpus)` shape a library consumer
+reads (`selectors[]` arrays, components nested under each view, plus `requests`
+and `messages`) — to stdout, a file (`-o FILE`), or an HTTP endpoint (`--url`,
+POSTed as `application/json` with no auth headers). The `.sightmap/` directory is
+auto-detected by walking up from `[dir]` or the cwd, and TLS verification is
+skipped for local hosts (`localhost`, `127.0.0.1`, `.test`) or under an explicit
+`--insecure`. A companion `sightmap push URL [FILE]` POSTs a corpus JSON (from a
+file or stdin) through the same transport.
+
+This replaces the hand-rolled Python collector (`collect_and_upload_sightmap.py`)
+that shipped a second, lossy serializer — it flattened views into compound
+selectors and dropped routes, requests, and messages. Routing the upload through
+the Go loader makes it the single source of truth and shares the exact
+`sightmap.Corpus` type with the server-side reader, so the two ends cannot drift.

--- a/go/cmd/sightmap/cmd_export.go
+++ b/go/cmd/sightmap/cmd_export.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// runExport implements `sightmap export [dir]`: load a .sightmap/ corpus and
+// emit the canonical Corpus wire — the exact json.Marshal(sightmap.Corpus) shape
+// a go-get/library consumer reads, byte-for-byte — to stdout, a file (-o), or an
+// HTTP endpoint (--url).
+//
+// It replaces the hand-rolled Python collector (collect_and_upload_sightmap.py
+// in the subtext-sightmap skill), a second, lossy serializer that flattened
+// views into compound selectors and dropped routes/requests/messages. Routing
+// the upload through the Go loader makes the loader the single source of truth
+// and shares the exact sightmap.Corpus type with the server-side reader, so the
+// two ends cannot drift.
+func runExport(args []string) error {
+	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+	out := fs.String("o", "", "write to FILE instead of stdout (ignored when --url is set)")
+	postURL := fs.String("url", "", "POST the corpus to this URL as application/json (no auth headers; the URL carries its own token)")
+	sightmapDir := fs.String("sightmap-dir", "", "path to the .sightmap/ dir (default: the nearest one at or above [dir] or cwd)")
+	insecure := fs.Bool("insecure", false, "skip TLS verification when POSTing (auto-enabled for localhost and .test hosts)")
+
+	positional, err := parseFlagsAroundArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(positional) > 1 {
+		return fmt.Errorf("export: expected at most one [dir], got %d", len(positional))
+	}
+
+	dir, err := resolveExportDir(*sightmapDir, positional)
+	if err != nil {
+		return err
+	}
+
+	corp, err := sightmap.Load(dir)
+	if err != nil {
+		return fmt.Errorf("export: load %s: %w", dir, err)
+	}
+
+	// The canonical wire: indented for human/file readability; any JSON reader
+	// (the server-side sightmap.Corpus reader included) parses it the same.
+	data, err := json.MarshalIndent(corp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("export: marshal corpus: %w", err)
+	}
+
+	if *postURL != "" {
+		return postJSON(*postURL, data, *insecure)
+	}
+	return writeOut(*out, func(w io.Writer) error {
+		_, werr := w.Write(append(data, '\n'))
+		return werr
+	})
+}
+
+// runPush implements `sightmap push URL [FILE]`: POST FILE (or stdin) to URL as
+// application/json. It is the transport half of export split off as a composable
+// primitive, so `sightmap export -o corpus.json` then `sightmap push URL
+// corpus.json`, or `sightmap export | sightmap push URL`, both work. Both paths
+// share postJSON, so the wire contract (no auth headers, local-host TLS skip) is
+// defined in exactly one place.
+func runPush(args []string) error {
+	fs := flag.NewFlagSet("push", flag.ContinueOnError)
+	insecure := fs.Bool("insecure", false, "skip TLS verification (auto-enabled for localhost and .test hosts)")
+
+	positional, err := parseFlagsAroundArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(positional) < 1 {
+		return fmt.Errorf("push: usage: sightmap push URL [FILE]")
+	}
+	if len(positional) > 2 {
+		return fmt.Errorf("push: expected URL [FILE], got %d arguments", len(positional))
+	}
+	target := positional[0]
+
+	var body []byte
+	if len(positional) == 2 && positional[1] != "-" {
+		if body, err = os.ReadFile(positional[1]); err != nil {
+			return fmt.Errorf("push: read %s: %w", positional[1], err)
+		}
+	} else {
+		if body, err = io.ReadAll(os.Stdin); err != nil {
+			return fmt.Errorf("push: read stdin: %w", err)
+		}
+	}
+	return postJSON(target, body, *insecure)
+}
+
+// resolveExportDir picks the .sightmap/ directory to load. Precedence:
+//  1. an explicit --sightmap-dir, used as-is (consistent with every other command);
+//  2. otherwise, the nearest .sightmap/ at or above the positional [dir], or cwd
+//     when no [dir] is given — the upward walk the Python collector did.
+func resolveExportDir(flagDir string, positional []string) (string, error) {
+	if flagDir != "" {
+		return flagDir, nil
+	}
+	start := cwd()
+	if len(positional) == 1 {
+		start = positional[0]
+	}
+	if dir := findSightmapDir(start); dir != "" {
+		return dir, nil
+	}
+	return "", fmt.Errorf("export: no .sightmap/ directory found at or above %s", start)
+}
+
+// findSightmapDir returns the nearest .sightmap/ directory at or above start, or
+// "" if none exists. When start is itself a .sightmap directory it is returned
+// directly; otherwise start/.sightmap and each ancestor's .sightmap is tried.
+func findSightmapDir(start string) string {
+	abs, err := filepath.Abs(start)
+	if err != nil {
+		abs = start
+	}
+	if filepath.Base(abs) == ".sightmap" && isDir(abs) {
+		return abs
+	}
+	for d := abs; ; {
+		if cand := filepath.Join(d, ".sightmap"); isDir(cand) {
+			return cand
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return ""
+		}
+		d = parent
+	}
+}
+
+func isDir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}
+
+// postJSON POSTs body to rawURL as application/json with NO auth headers: the
+// destination URL is expected to carry a single-use token as a query parameter,
+// so the tool needs zero knowledge of the consumer. TLS verification is skipped
+// when insecure is set or the host is local (localhost, 127.0.0.1, ::1, or a
+// *.test / *.localhost name) — the self-signed-cert case for local dev servers,
+// matching the old Python uploader.
+func postJSON(rawURL string, body []byte, insecure bool) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https, got %q", u.Scheme)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	if insecure || isLocalHost(u.Hostname()) {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // local dev / explicit opt-in only
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodPost, rawURL, strings.NewReader(string(body)))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST %s: %w", u.Host, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("POST %s failed (HTTP %d): %s", u.Host, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	// Consumer-agnostic: report success and echo any short response body (the
+	// destination decides its own confirmation shape) to stderr.
+	fmt.Fprintf(os.Stderr, "sightmap: uploaded %d bytes to %s (HTTP %d)\n", len(body), u.Host, resp.StatusCode)
+	if trimmed := strings.TrimSpace(string(respBody)); trimmed != "" {
+		fmt.Fprintf(os.Stderr, "%s\n", trimmed)
+	}
+	return nil
+}
+
+// isLocalHost reports whether host is a loopback or local development name, for
+// which self-signed TLS is skipped automatically.
+func isLocalHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return strings.HasSuffix(host, ".test") || strings.HasSuffix(host, ".localhost")
+}

--- a/go/cmd/sightmap/cmd_export_test.go
+++ b/go/cmd/sightmap/cmd_export_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// exportCorpus is a corpus exercising every top-level wire section the legacy
+// Python collector dropped — views (with routes), view-scoped + global requests,
+// and messages — so the round-trip asserts export emits the FULL canonical
+// Corpus, not the lossy flattened-components shape.
+var exportCorpus = map[string]string{
+	"components.yaml": `version: 1
+memory:
+  - corpus-wide note
+components:
+  - name: Navigation
+    selector: 'nav[data-component="Navigation"]'
+requests:
+  - name: GetCurrentUser
+    route: /api/me
+    method: GET
+messages:
+  - name: CartVersionMismatch
+    level: error
+    message: cart version mismatch
+`,
+	"views/checkout.yaml": `version: 1
+views:
+  - name: Checkout
+    route: /checkout
+    components:
+      - name: PaymentForm
+        selector: '[data-component="PaymentForm"]'
+    requests:
+      - name: CheckoutPayment
+        route: /api/checkout/pay
+        method: POST
+        properties:
+          - name: outcome
+            source: rsp.body
+            field: status
+`,
+}
+
+func writeCorpus(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	sdir := filepath.Join(dir, ".sightmap")
+	for rel, body := range files {
+		path := filepath.Join(sdir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return sdir
+}
+
+func TestExport_ToFile_CanonicalWire(t *testing.T) {
+	sdir := writeCorpus(t, exportCorpus)
+	outPath := filepath.Join(t.TempDir(), "corpus.json")
+
+	if err := runExport([]string{"--sightmap-dir", sdir, "-o", outPath}); err != nil {
+		t.Fatalf("runExport: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read out: %v", err)
+	}
+
+	// The emitted bytes must parse back into the canonical Corpus type — proving
+	// export and the library/server reader share one shape.
+	var corp sightmap.Corpus
+	if err := json.Unmarshal(data, &corp); err != nil {
+		t.Fatalf("emitted JSON is not a canonical Corpus: %v", err)
+	}
+
+	if len(corp.GlobalComponents) != 1 || corp.GlobalComponents[0].Name != "Navigation" {
+		t.Errorf("globals: got %+v", corp.GlobalComponents)
+	}
+	if len(corp.Requests) != 1 || corp.Requests[0].Name != "GetCurrentUser" {
+		t.Errorf("global requests: got %+v", corp.Requests)
+	}
+	if len(corp.Messages) != 1 || corp.Messages[0].Name != "CartVersionMismatch" {
+		t.Errorf("messages: got %+v", corp.Messages)
+	}
+	if len(corp.Views) != 1 || corp.Views[0].Route != "/checkout" {
+		t.Fatalf("views: got %+v", corp.Views)
+	}
+	// View-scoped request + its property survive (the lossy collector dropped both).
+	vr := corp.Views[0].Requests
+	if len(vr) != 1 || vr[0].Name != "CheckoutPayment" || len(vr[0].Properties) != 1 || vr[0].Properties[0].Field != "status" {
+		t.Errorf("view-scoped request/property: got %+v", vr)
+	}
+}
+
+func TestExport_ToURL_PostsCanonicalWire(t *testing.T) {
+	sdir := writeCorpus(t, exportCorpus)
+
+	var (
+		mu        sync.Mutex
+		gotBody   []byte
+		gotCT     string
+		gotAuth   string
+		gotMethod string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody, gotCT, gotAuth, gotMethod = body, r.Header.Get("Content-Type"), r.Header.Get("Authorization"), r.Method
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	if err := runExport([]string{"--sightmap-dir", sdir, "--url", srv.URL}); err != nil {
+		t.Fatalf("runExport --url: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty (no auth headers)", gotAuth)
+	}
+	var corp sightmap.Corpus
+	if err := json.Unmarshal(gotBody, &corp); err != nil {
+		t.Fatalf("POSTed body is not a canonical Corpus: %v", err)
+	}
+	if len(corp.Views) != 1 || len(corp.Messages) != 1 {
+		t.Errorf("POSTed corpus incomplete: views=%d messages=%d", len(corp.Views), len(corp.Messages))
+	}
+}
+
+func TestExport_NoCorpus_Errors(t *testing.T) {
+	empty := t.TempDir()
+	err := runExport([]string{empty})
+	if err == nil || !strings.Contains(err.Error(), "no .sightmap/ directory found") {
+		t.Fatalf("want no-corpus error, got %v", err)
+	}
+}
+
+func TestPush_FileAndStdin(t *testing.T) {
+	var got []byte
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		got = body
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// From a file.
+	f := filepath.Join(t.TempDir(), "c.json")
+	if err := os.WriteFile(f, []byte(`{"hello":"file"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runPush([]string{srv.URL, f}); err != nil {
+		t.Fatalf("push file: %v", err)
+	}
+	mu.Lock()
+	if string(got) != `{"hello":"file"}` {
+		t.Errorf("file body = %q", got)
+	}
+	mu.Unlock()
+
+	// From stdin.
+	withStdin(t, `{"hello":"stdin"}`, func() {
+		if err := runPush([]string{srv.URL}); err != nil {
+			t.Fatalf("push stdin: %v", err)
+		}
+	})
+	mu.Lock()
+	if string(got) != `{"hello":"stdin"}` {
+		t.Errorf("stdin body = %q", got)
+	}
+	mu.Unlock()
+}
+
+func TestPush_Non2xxErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad token", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	err := runPush([]string{srv.URL, "-"}) // "-" reads (empty) stdin
+	if err == nil || !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("want HTTP 401 error, got %v", err)
+	}
+}
+
+func TestPostJSON_RejectsNonHTTPScheme(t *testing.T) {
+	if err := postJSON("ftp://example.com/x", []byte("{}"), false); err == nil || !strings.Contains(err.Error(), "scheme") {
+		t.Fatalf("want scheme error, got %v", err)
+	}
+}
+
+func TestFindSightmapDir(t *testing.T) {
+	root := t.TempDir()
+	sdir := filepath.Join(root, ".sightmap")
+	nested := filepath.Join(root, "a", "b", "c")
+	for _, d := range []string{sdir, nested} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Upward walk from a deep descendant finds the ancestor .sightmap.
+	if got := findSightmapDir(nested); got != sdir {
+		t.Errorf("from nested: got %q, want %q", got, sdir)
+	}
+	// Passing the .sightmap dir itself returns it directly.
+	if got := findSightmapDir(sdir); got != sdir {
+		t.Errorf("from .sightmap: got %q, want %q", got, sdir)
+	}
+	// A tree with no .sightmap returns "".
+	if got := findSightmapDir(t.TempDir()); got != "" {
+		t.Errorf("no corpus: got %q, want empty", got)
+	}
+}
+
+func TestResolveExportDir_FlagWins(t *testing.T) {
+	dir, err := resolveExportDir("/explicit/.sightmap", []string{"/ignored"})
+	if err != nil || dir != "/explicit/.sightmap" {
+		t.Fatalf("explicit flag should win: got %q, %v", dir, err)
+	}
+}
+
+func TestIsLocalHost(t *testing.T) {
+	for _, h := range []string{"localhost", "127.0.0.1", "::1", "app.test", "foo.localhost"} {
+		if !isLocalHost(h) {
+			t.Errorf("isLocalHost(%q) = false, want true", h)
+		}
+	}
+	for _, h := range []string{"example.com", "sightmap.org", "10.0.0.1"} {
+		if isLocalHost(h) {
+			t.Errorf("isLocalHost(%q) = true, want false", h)
+		}
+	}
+}
+
+// withStdin swaps os.Stdin for a pipe carrying content for the duration of fn.
+func withStdin(t *testing.T, content string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig }()
+
+	go func() {
+		io.WriteString(w, content)
+		w.Close()
+	}()
+	fn()
+	r.Close()
+}

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -9,6 +9,7 @@
 //	sightmap sel-probe [flags] SEL  validate a CSS selector against the live page
 //	sightmap validate [flags]       check sightmap YAML for structural errors
 //	sightmap lint [flags]           check sightmap YAML for style issues
+//	sightmap export [dir]           emit the canonical Corpus wire (stdout, -o FILE, or --url)
 //	sightmap stats [flags]          corpus totals: views, components, requests, properties, memory
 //	sightmap coverage [flags]       recompute T1/T2/T3 coverage from saved snap files
 //	sightmap multi-coverage [flags] cross-page coverage matrix and promotion candidates
@@ -71,6 +72,10 @@ func main() {
 		err = runDiscover(args)
 	case "serve-sightmap", "serve_sightmap":
 		err = runServeSightmap(args)
+	case "export":
+		err = runExport(args)
+	case "push":
+		err = runPush(args)
 	case "report":
 		err = runReport(args)
 	case "stats":
@@ -132,6 +137,8 @@ Commands:
   search   [--field FIELD] PATTERN                           offline YAML content search
   discover [--all]                                           URL pattern discovery
   serve-sightmap [--port N] [--sightmap-dir DIR]             sightmap HTTP server for overlay extension
+  export   [dir] [-o FILE] [--url URL] [--sightmap-dir DIR]  emit the canonical Corpus wire (stdout, file, or POST)
+  push     URL [FILE]                                        POST a corpus JSON (file or stdin) to URL
 
   console  list [--level L] [--tab T] [--limit N]            captured console messages (needs a running session)
   console  get INDEX                                         one console message by index


### PR DESCRIPTION
Adds `sightmap export [dir]` — load a `.sightmap/` corpus and emit the **canonical Corpus wire** (the exact `json.Marshal(sightmap.Corpus)` shape a `go get`/library consumer reads: `selectors[]` arrays, components nested under each view, plus `requests` and `messages`) to:

- **stdout** (default),
- a **file** (`-o FILE`, atomic write), or
- an **HTTP endpoint** (`--url`), POSTed as `application/json` with **no auth headers** — the destination URL carries its own single-use token, so the tool needs zero knowledge of the consumer.

The `.sightmap/` dir is auto-detected by walking up from `[dir]` or the cwd (the upward walk the old Python collector did). TLS verification is skipped for local hosts (`localhost`, `127.0.0.1`, `::1`, `*.test`, `*.localhost`) or under an explicit `--insecure`.

A companion `sightmap push URL [FILE]` POSTs a corpus JSON (from a file or stdin) through the same shared transport, so the wire contract (no auth headers, local-host TLS skip) lives in exactly one place: `sightmap export -o corpus.json && sightmap push URL corpus.json`, or `sightmap export | sightmap push URL`.

## Why

Replaces the hand-rolled `collect_and_upload_sightmap.py` in the `subtext-sightmap` skill — a **second, lossy serializer** that flattened views into compound CSS selectors and dropped routes, requests, and messages (no `parentChain`). Routing the upload through the Go loader makes it the single source of truth, kills the PyYAML/python3 dependency (the `sightmap` CLI is already a hard prereq of the skills), and shares the exact `sightmap.Corpus` type with the server-side reader — the two ends cannot drift.

## Coordination

The live lidar reader currently only understands the legacy flat `{sightmap, memory}` shape. This lands the producer side; the consumer's structured dual-read reader lands alongside on the subtext/mn side (no `--format flat` shim is shipped here).

## Tests

`cmd_export_test.go` drives `export` end-to-end through the real loader: round-trips to a file and asserts the emitted bytes parse back into a canonical `sightmap.Corpus` with globals + global/view-scoped requests + a request property + messages all intact (the exact material the lossy collector dropped); POSTs via `httptest` asserting method/`Content-Type`/**no `Authorization`**; plus `push` (file + stdin), non-2xx surfacing, non-http scheme rejection, upward `.sightmap/` discovery, resolve-dir precedence, and local-host detection.

`go build/vet/test ./...` green; `gofmt` clean.

Tracks #160.
