### PR TITLE
sightmap: faithful Request records + RequestsForRecord property extraction (SEP-0005 runtime half)

### DIFF
--- a/.changeset/request-record-extraction.md
+++ b/.changeset/request-record-extraction.md
@@ -1,0 +1,17 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Observed `Request` records can now carry the payload a `RequestDef`'s
+`properties[]` addresses, and a new matcher resolves them — the runtime half of
+SEP-0005. `Request` gains optional (omitempty) `DurationMs`, `ReqHeaders` /
+`RspHeaders` (`[]Header`), and `ReqBody` / `RspBody` (`*Body`) fields, so a
+producer holding a full capture can populate them while a lazy producer leaves
+them nil and the wire stays lean. `Corpus.RequestsForRecord(rec) []RequestMatch`
+does route+method identity matching (via `RequestsForURL`) and then resolves each
+matched def's `properties[]` against the record — `source` → `field` (JSON
+dot-path with numeric array indexing for a `*.body`; case-insensitive header
+lookup for a `*.headers`) → optional RE2 `pattern` (capture group 1 else the whole
+match, or a scan of the raw source when `field` is absent) → optional
+`transform`. Unresolved values are omitted silently per the spec, so an
+incomplete record degrades to fewer properties rather than erroring.

--- a/go/sightmap/records.go
+++ b/go/sightmap/records.go
@@ -18,9 +18,16 @@ type Message struct {
 	Ts    int64  `json:"ts"` // unix milliseconds
 }
 
-// Request is one observed network request/response. Bodies are not included —
-// they are large and, for a live capture, fetched lazily by the tool that
-// observed the request. Status is 0 until the response is seen.
+// Request is one observed network request/response. Status is 0 until the
+// response is seen.
+//
+// Everything a RequestDef's properties[] can address (the SEP-0005 sources
+// req.body / rsp.body / req.headers / rsp.headers, plus the reserved identity
+// name duration) is carried here, so the record is faithful to what the def can
+// extract. But every such field is optional: a lazy or streaming producer may
+// leave them nil/empty — bodies are large and are often fetched on demand — and
+// property extraction then degrades to "value absent" (silent omission, per the
+// SEP) rather than erroring. A producer holding a full capture populates them.
 type Request struct {
 	Index        int    `json:"index"`
 	Tab          string `json:"tab"`
@@ -30,4 +37,31 @@ type Request struct {
 	StatusText   string `json:"statusText"`
 	ResourceType string `json:"resourceType"`
 	Ts           int64  `json:"ts"` // unix milliseconds
+
+	// Optional, fetch-on-demand payload material — the targets of properties[]
+	// extraction. Omitted from the wire when unpopulated.
+	DurationMs int64    `json:"durationMs,omitempty"` // request→response latency; the reserved "duration" identity
+	ReqHeaders []Header `json:"reqHeaders,omitempty"` // request headers, ordered, duplicate-preserving
+	RspHeaders []Header `json:"rspHeaders,omitempty"` // response headers, ordered, duplicate-preserving
+	ReqBody    *Body    `json:"reqBody,omitempty"`    // request body (raw)
+	RspBody    *Body    `json:"rspBody,omitempty"`    // response body (raw)
+}
+
+// Header is one observed HTTP header. Headers are stored as an ordered,
+// duplicate-preserving list rather than a map so repeated headers (Set-Cookie,
+// and the like) survive; a properties[] lookup by name is case-insensitive.
+type Header struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Body is an observed request or response body. Content is the raw text; the
+// matcher parses it (a properties[] field dot-path implies JSON at match time) —
+// parsing is deliberately kept out of the record. Truncated and Size let a
+// matcher tell "absent" from "absent because the capture truncated it".
+type Body struct {
+	Content     string `json:"content,omitempty"`
+	Size        int    `json:"size,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+	Truncated   bool   `json:"truncated,omitempty"`
 }

--- a/go/sightmap/request_extract.go
+++ b/go/sightmap/request_extract.go
@@ -1,0 +1,226 @@
+package sightmap
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// RequestMatch records which RequestDef classified an observed request, plus any
+// values its properties[] extracted from that request's live traffic. It is the
+// request-side analogue of ComponentMatch: a projection of the matched
+// definition carrying the fields a consumer needs to link a classification back
+// to what produced it (Name), the corpus context worth surfacing (Memory, Tags),
+// and the extracted content (Properties). Requests, like components, carry
+// live-extracted properties — unlike MessageMatch, which has none.
+type RequestMatch struct {
+	Name       string
+	Memory     []string
+	Tags       []string
+	Properties []PropertyValue
+}
+
+// RequestsForRecord returns every RequestDef that classifies the observed
+// request rec, as RequestMatch projections. Identity matching is delegated to
+// RequestsForURL (route glob + optional method) so there is one identity path;
+// each matched def then has its properties[] resolved against rec's live payload
+// (headers/bodies), and the resolved values are folded into the match.
+//
+// All matches apply, in the same order RequestsForURL returns them (global
+// requests first, then view-scoped). A def with no properties[] yields a match
+// with nil Properties; a property that doesn't resolve is silently omitted, per
+// SEP-0005 — so an incomplete record (bodies not captured) degrades to fewer
+// properties, never an error.
+func (c *Corpus) RequestsForRecord(rec Request) []RequestMatch {
+	defs := c.RequestsForURL(rec.URL, rec.Method)
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make([]RequestMatch, 0, len(defs))
+	for i := range defs {
+		out = append(out, RequestMatch{
+			Name:       defs[i].Name,
+			Memory:     defs[i].Memory,
+			Tags:       defs[i].Tags,
+			Properties: defs[i].ExtractProperties(rec),
+		})
+	}
+	return out
+}
+
+// ExtractProperties resolves d's declared properties[] against the observed
+// request rec, returning the values that resolved, in declaration order. A
+// property is silently omitted (never an error) when its source is unpopulated,
+// its field doesn't resolve, or its pattern finds no match — this is the SEP-0005
+// live-traffic contract, where whether a body or header is even available depends
+// on the capture layer.
+//
+// Resolution is source → field → pattern → transform: the source selects a body
+// or header block on rec; field selects within it (a JSON dot-path for a body, a
+// case-insensitive header name for a header block); an optional RE2 pattern
+// refines what field resolved (capture group 1 when present, else the whole
+// match) or scans the raw source text when field is absent; an optional transform
+// post-processes the string. The reserved identity names (status/method/duration)
+// are not handled here — they are a signal-layer concern and need no properties[]
+// declaration; a property that happens to be named after one still extracts from
+// its own source (the shadowing validation warns about).
+func (d *RequestDef) ExtractProperties(rec Request) []PropertyValue {
+	if len(d.Properties) == 0 {
+		return nil
+	}
+	var out []PropertyValue
+	for _, p := range d.Properties {
+		if v, ok := resolveRequestProperty(p, rec); ok {
+			out = append(out, PropertyValue{Name: p.Name, Value: v})
+		}
+	}
+	return out
+}
+
+// resolveRequestProperty applies one property definition to rec, returning the
+// extracted value and whether it resolved.
+func resolveRequestProperty(p RequestPropertyDef, rec Request) (string, bool) {
+	raw, ok := resolveSourceValue(p, rec)
+	if !ok {
+		return "", false
+	}
+	if p.Pattern != "" {
+		matched, ok := applyPattern(p.Pattern, raw)
+		if !ok {
+			return "", false
+		}
+		raw = matched
+	}
+	if raw == "" {
+		return "", false
+	}
+	return ApplyTransform(raw, p.Transform), true
+}
+
+// resolveSourceValue resolves the source+field half of a property to a raw
+// string (before pattern/transform). For a body source with a field it walks the
+// JSON dot-path; with no field it returns the whole raw body for a pattern to
+// scan. For a header source it looks up the (required) named header.
+func resolveSourceValue(p RequestPropertyDef, rec Request) (string, bool) {
+	switch p.Source {
+	case "req.body", "rsp.body":
+		body := rec.RspBody
+		if p.Source == "req.body" {
+			body = rec.ReqBody
+		}
+		if body == nil {
+			return "", false
+		}
+		if p.Field == "" {
+			// No field: the pattern (which validation requires when field is
+			// absent) scans the raw body text.
+			return body.Content, true
+		}
+		return walkJSONPath(body.Content, p.Field)
+	case "req.headers", "rsp.headers":
+		headers := rec.RspHeaders
+		if p.Source == "req.headers" {
+			headers = rec.ReqHeaders
+		}
+		return lookupHeader(headers, p.Field)
+	default:
+		return "", false
+	}
+}
+
+// lookupHeader returns the value of the header named name, matched
+// case-insensitively. Duplicate headers are joined with ", " (the RFC 7230 way
+// of combining repeated field values), so a pattern sees them all. Returns false
+// when no header matches or name is empty.
+func lookupHeader(headers []Header, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	var vals []string
+	for _, h := range headers {
+		if strings.EqualFold(h.Name, name) {
+			vals = append(vals, h.Value)
+		}
+	}
+	if len(vals) == 0 {
+		return "", false
+	}
+	return strings.Join(vals, ", "), true
+}
+
+// walkJSONPath parses content as JSON and walks a dot-separated path, returning
+// the addressed value as a string. An object key indexes a map; a numeric
+// segment indexes an array when the value at that level is one. A scalar leaf is
+// stringified plainly (numbers without a trailing ".0", booleans as true/false);
+// a non-scalar leaf (object/array) is re-encoded as JSON so a pattern can still
+// scan it. Returns false when the content isn't JSON, a segment doesn't resolve,
+// or the leaf is JSON null.
+func walkJSONPath(content, path string) (string, bool) {
+	var root any
+	if err := json.Unmarshal([]byte(content), &root); err != nil {
+		return "", false
+	}
+	cur := root
+	for _, seg := range strings.Split(path, ".") {
+		switch node := cur.(type) {
+		case map[string]any:
+			v, ok := node[seg]
+			if !ok {
+				return "", false
+			}
+			cur = v
+		case []any:
+			idx, err := strconv.Atoi(seg)
+			if err != nil || idx < 0 || idx >= len(node) {
+				return "", false
+			}
+			cur = node[idx]
+		default:
+			return "", false
+		}
+	}
+	return stringifyJSON(cur)
+}
+
+// stringifyJSON renders a JSON leaf value as a property string. Scalars stringify
+// plainly; a composite (object/array) is re-encoded so a pattern can scan it.
+// JSON null resolves to absent.
+func stringifyJSON(v any) (string, bool) {
+	switch val := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		return val, true
+	case bool:
+		return strconv.FormatBool(val), true
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64), true
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return "", false
+		}
+		return string(b), true
+	}
+}
+
+// applyPattern applies an RE2 regex to s, returning capture group 1 when the
+// pattern has one, else the whole match. A pattern that fails to compile (a
+// record built from an unvalidated corpus) or finds no match returns false —
+// matching stays silent the way value omission does; validation reports a
+// malformed pattern separately (request-property-pattern-invalid).
+func applyPattern(pattern, s string) (string, bool) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", false
+	}
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return "", false
+	}
+	if len(m) > 1 {
+		return m[1], true
+	}
+	return m[0], true
+}

--- a/go/sightmap/request_extract_test.go
+++ b/go/sightmap/request_extract_test.go
@@ -1,0 +1,226 @@
+package sightmap
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// jsonBody is a small helper for building a JSON *Body.
+func jsonBody(content string) *Body {
+	return &Body{Content: content, ContentType: "application/json", Size: len(content)}
+}
+
+func TestExtractProperties_BodyField(t *testing.T) {
+	d := &RequestDef{
+		Name: "CheckoutPayment", Route: "/api/checkout/pay", Method: "POST",
+		Properties: []RequestPropertyDef{
+			{Name: "outcome", Source: "rsp.body", Field: "status"},
+		},
+	}
+	rec := Request{RspBody: jsonBody(`{"status":"declined","amount":42}`)}
+
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "outcome", Value: "declined"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_BodyNestedAndArrayIndex(t *testing.T) {
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "first_item", Source: "rsp.body", Field: "items.0.name"},
+			{Name: "count", Source: "rsp.body", Field: "meta.count"},
+			{Name: "flag", Source: "rsp.body", Field: "meta.ok"},
+		},
+	}
+	rec := Request{RspBody: jsonBody(`{"items":[{"name":"widget"},{"name":"gadget"}],"meta":{"count":8,"ok":true}}`)}
+
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{
+		{Name: "first_item", Value: "widget"},
+		{Name: "count", Value: "8"}, // float64 8 must render "8", not "8.0"
+		{Name: "flag", Value: "true"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_HeaderWithPattern(t *testing.T) {
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "rate_limit_remaining", Source: "rsp.headers", Field: "X-RateLimit-Remaining", Pattern: `(\d+)`},
+		},
+	}
+	// Header name differs in case from the def — lookup is case-insensitive.
+	rec := Request{RspHeaders: []Header{{Name: "x-ratelimit-remaining", Value: "0"}}}
+
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "rate_limit_remaining", Value: "0"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_DuplicateHeadersJoined(t *testing.T) {
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "cookies", Source: "rsp.headers", Field: "Set-Cookie"},
+		},
+	}
+	rec := Request{RspHeaders: []Header{
+		{Name: "Set-Cookie", Value: "a=1"},
+		{Name: "set-cookie", Value: "b=2"},
+	}}
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "cookies", Value: "a=1, b=2"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_PatternNoFieldScansRawBody(t *testing.T) {
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			// Form-encoded body: no JSON to walk, pattern scans the raw text.
+			{Name: "legacy_outcome", Source: "rsp.body", Pattern: `(?:declined|approved|deferred)`},
+		},
+	}
+	rec := Request{RspBody: &Body{Content: "result=declined&code=51", ContentType: "application/x-www-form-urlencoded"}}
+
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "legacy_outcome", Value: "declined"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_Transform(t *testing.T) {
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "amount", Source: "rsp.body", Field: "total", Transform: "number"},
+		},
+	}
+	rec := Request{RspBody: jsonBody(`{"total":"$1,299.00"}`)}
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "amount", Value: "1299.00"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_SilentOmission(t *testing.T) {
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "missing_key", Source: "rsp.body", Field: "nope"},
+			{Name: "missing_body", Source: "req.body", Field: "x"}, // ReqBody nil
+			{Name: "missing_header", Source: "rsp.headers", Field: "X-Absent"},
+			{Name: "not_json", Source: "rsp.body", Field: "a.b"}, // body isn't JSON
+			{Name: "no_pattern_match", Source: "rsp.body", Field: "status", Pattern: `zzz`},
+			{Name: "null_leaf", Source: "rsp.body", Field: "maybe"}, // JSON null → absent
+			{Name: "resolved", Source: "rsp.body", Field: "status"}, // the one that should survive
+		},
+	}
+	rec := Request{RspBody: jsonBody(`{"status":"ok","maybe":null}`)}
+
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "resolved", Value: "ok"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v (omission should drop every unresolved property)", got, want)
+	}
+}
+
+func TestExtractProperties_CompositeLeafEncodedForPattern(t *testing.T) {
+	// A field resolving to an object, refined by a pattern scanning its JSON.
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "err_code", Source: "rsp.body", Field: "error", Pattern: `"code":"([A-Z0-9_]+)"`},
+		},
+	}
+	rec := Request{RspBody: jsonBody(`{"error":{"code":"CARD_DECLINED","msg":"no"}}`)}
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "err_code", Value: "CARD_DECLINED"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractProperties_InvalidPatternOmits(t *testing.T) {
+	// A record built from an unvalidated corpus may carry a bad pattern; it must
+	// omit silently, not panic.
+	d := &RequestDef{
+		Properties: []RequestPropertyDef{
+			{Name: "x", Source: "rsp.body", Field: "status", Pattern: `(unclosed`},
+		},
+	}
+	rec := Request{RspBody: jsonBody(`{"status":"ok"}`)}
+	if got := d.ExtractProperties(rec); got != nil {
+		t.Fatalf("bad pattern should omit, got %+v", got)
+	}
+}
+
+func TestRequestsForRecord_IdentityPlusExtraction(t *testing.T) {
+	c := &Corpus{
+		Requests: []RequestDef{
+			{
+				Name: "CheckoutPayment", Route: "/api/checkout/pay", Method: "POST",
+				Tags: []string{"defect-prone"}, Memory: []string{"declines look like 200s"},
+				Properties: []RequestPropertyDef{{Name: "outcome", Source: "rsp.body", Field: "status"}},
+			},
+			{Name: "GetUser", Route: "/api/me", Method: "GET"}, // different route, shouldn't match
+		},
+	}
+	rec := Request{
+		Method: "POST", URL: "https://shop.example.com/api/checkout/pay?ref=x",
+		Status: 200, RspBody: jsonBody(`{"status":"declined"}`),
+	}
+
+	got := c.RequestsForRecord(rec)
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d (%+v)", len(got), got)
+	}
+	m := got[0]
+	if m.Name != "CheckoutPayment" {
+		t.Errorf("name = %q", m.Name)
+	}
+	if !reflect.DeepEqual(m.Tags, []string{"defect-prone"}) || !reflect.DeepEqual(m.Memory, []string{"declines look like 200s"}) {
+		t.Errorf("memory/tags not carried: %+v", m)
+	}
+	if !reflect.DeepEqual(m.Properties, []PropertyValue{{Name: "outcome", Value: "declined"}}) {
+		t.Errorf("properties = %+v", m.Properties)
+	}
+}
+
+func TestRequestsForRecord_NoMatch(t *testing.T) {
+	c := &Corpus{Requests: []RequestDef{{Name: "X", Route: "/a", Method: "GET"}}}
+	if got := c.RequestsForRecord(Request{Method: "GET", URL: "https://h/b"}); got != nil {
+		t.Fatalf("want nil, got %+v", got)
+	}
+}
+
+func TestRequestsForRecord_MatchWithNoPropertiesHasNilProps(t *testing.T) {
+	c := &Corpus{Requests: []RequestDef{{Name: "Ping", Route: "/ping", Method: "GET"}}}
+	got := c.RequestsForRecord(Request{Method: "GET", URL: "https://h/ping"})
+	if len(got) != 1 || got[0].Properties != nil {
+		t.Fatalf("want one match with nil Properties, got %+v", got)
+	}
+}
+
+func TestRequest_WireStaysLeanWhenUnpopulated(t *testing.T) {
+	// A record with no captured payload must marshal without the optional
+	// fields — the #205 "faithful but optional" promise: a lazy producer's wire
+	// is unchanged from before the extension.
+	rec := Request{Index: 3, Method: "GET", URL: "https://h/x", Status: 200}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"durationMs", "reqHeaders", "rspHeaders", "reqBody", "rspBody"} {
+		if strings.Contains(string(b), f) {
+			t.Errorf("unpopulated %q leaked onto the wire: %s", f, b)
+		}
+	}
+}


### PR DESCRIPTION
Closes #205. The runtime (evaluation) half of SEP-0005 request `properties:`, at the library boundary — the surface a downstream consumer (FullStory/lidar) calls directly.

## Problem

A `RequestDef` can declare `properties[]` whose `source` is `req.body` / `rsp.body` / `req.headers` / `rsp.headers`, but the observed record it must run against —

```go
Request{Index, Tab, Method, URL, Status, StatusText, ResourceType, Ts}
```

carried neither bodies nor headers. The def surface had outgrown the record: a corpus could say "extract `outcome` from `rsp.body`," and nothing in the runtime record could supply it.

## Change

**Record (`records.go`), additive + all optional** — faithful to what a def can address, kept optional so a lazy/live producer may omit expensive fields and matching degrades to "property absent," while a full-capture producer populates them:

```go
Request{ …existing…
    DurationMs int64       // the reserved "duration" identity
    ReqHeaders []Header     // ordered, duplicate-preserving; case-insensitive lookup
    RspHeaders []Header
    ReqBody    *Body        // raw Content + ContentType; matcher parses
    RspBody    *Body
}
Header{ Name, Value string }
Body{ Content string; Size int; ContentType string; Truncated bool }
```

All `omitempty`, so an unpopulated record marshals byte-identically to before (regression-guarded by a test).

**Matcher (`request_extract.go`)** — `Corpus.RequestsForRecord(rec) []RequestMatch`: route+method identity via the existing `RequestsForURL` (one identity path), then per matched def resolves `properties[]` into a `RequestMatch{Name, Memory, Tags, Properties}` (the request-side analogue of `ComponentMatch`). Resolution is `source → field → pattern → transform`:

- `field` on a `*.body` walks a JSON dot-path (object keys; a numeric segment indexes an array — `items.0.name`); scalars stringify plainly (a JSON `8` → `"8"`, not `"8.0"`), a composite leaf re-encodes to JSON so a `pattern` can still scan it.
- `field` on a `*.headers` is a case-insensitive header name; duplicate headers join with `, ` (RFC 7230).
- optional RE2 `pattern` refines what `field` resolved (capture group 1 else whole match), or scans the raw body when `field` is absent.
- optional `transform` (reuses `ApplyTransform`, which gains its first non-test caller — the "dead mirror" #160 flagged).

Unresolved values are **silently omitted** per SEP-0005, so an incomplete record (bodies not captured) yields fewer properties, never an error. Reserved identity names (`status`/`method`/`duration`) are left to the signal layer and need no `properties:` declaration.

## Scope / follow-ups

- **Lib only** — this is exactly what Subtext pulls; it populates records from its own capture. No CLI/devtools wiring here.
- **Capture side** (populating headers/bodies from the sightmap collector's live CDP) is #130; **devtools wiring** to surface these in `network list|get` follows after.
- The message analogue (exception stacks on `Message` records) is #206.

## Tests

`request_extract_test.go`: body field / nested + array index / numeric stringification, header + pattern, duplicate-header join, pattern-scans-raw-body (form-encoded), transform, composite-leaf-encoded-for-pattern, invalid-pattern-omits, exhaustive silent-omission, `RequestsForRecord` identity+extraction / no-match / no-properties, and the lean-wire guard. `go build/vet/test ./...` green; `gofmt` clean.
