### PR TITLE
sightmap: exception stack matching/extraction on messages (SEP-0006 addendum)

### DIFF
--- a/.changeset/message-stack-extraction.md
+++ b/.changeset/message-stack-extraction.md
@@ -1,0 +1,17 @@
+---
+"@sightmap/sightmap": minor
+---
+
+`messages:` can now match and extract on exception **stack traces** (a SEP-0006
+follow-on). An observed `Message` gains an optional `Stack []Frame` (throwing
+frame first; `Frame{Function, File, Line, Column}`), empty for a plain console
+record. A `MessageDef` gains a stack-addressing `properties[]` mirroring
+SEP-0005's `source`/`field`/`pattern`/`transform`: the one source is `stack`,
+`field` names a frame and attribute (`top.file`, `top.function`, `1.line`, where
+`top` aliases frame `0`), an optional RE2 `pattern` refines the resolved value,
+and `transform` post-processes it. `Corpus.MessagesForRecord` now folds the
+extracted values into each `MessageMatch.Properties`, bringing it to parity with
+`ComponentMatch`/`RequestMatch`; unresolved values are omitted silently, so a
+plain console record (no stack) simply extracts nothing. The reference CLI
+validates the new declarations (`message-property-invalid-name` /
+`-source-invalid` / `-no-field` / `-pattern-invalid`).

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -557,7 +557,7 @@ A conforming SDK:
 - MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - MUST reject a `MessageProperty` with a `source` other than `stack`, or one that omits `field`, or whose `pattern` is not a valid RE2 regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
-- MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
+- MAY ignore fields it doesn't use (e.g. a consumer that never surfaces `description` at runtime)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
 
 An SDK that also **evaluates live activity** (observed network requests, console records, DOM state) additionally:

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -341,8 +341,43 @@ messages:
 | `message` | string | no | [RE2](#regular-expressions) regex matched against the record's text. Match-any if omitted. |
 | `description` | string | no | What this pattern means, for a human reading the corpus. |
 | `source` | string | no | Relative path to the source most likely to emit this. |
+| `properties` | [MessageProperty](#message-properties)[] | no | Values to extract from an exception's stack. |
 
 A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful. `message` is an [RE2 regular expression](#regular-expressions).
+
+### Message properties
+
+`properties:` declares named values to pull out of an uncaught exception's **stack trace**, so a corpus can classify an exception by where it came from and extract the failing location — the message-side analogue of a request's [`properties:`](#request-properties). It reuses that mechanism's `source` / `field` / `pattern` / `transform` shape.
+
+```yaml
+messages:
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+    message: 'Cannot read propert(y|ies) .* of (null|undefined)'
+    properties:
+      # The throwing frame's source file and function.
+      - name: origin_file
+        source: stack
+        field: top.file
+      - name: origin_fn
+        source: stack
+        field: top.function
+      # A specific frame by index, refined by a pattern to just the basename.
+      - name: caller_base
+        source: stack
+        field: 1.file
+        pattern: '([^/]+)$'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
+| `source` | string | yes | Which root to read from. The only value in v1 is `stack` (the exception's call stack). |
+| `field` | string | yes | The frame and attribute to select, `<frame>.<attribute>`: `<frame>` is `top` (an alias for `0`) or a non-negative frame index (`0`, `1`, …), throwing frame first; `<attribute>` is one of `function`, `file`, `line`, or `column`. Required — a `stack` source has no meaningful bare-regex scan, the same reasoning that requires `field` for a request's headers source. |
+| `pattern` | string | no | An [RE2](#regular-expressions) regex applied to whatever `field` resolved. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
+| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+
+Extraction requires **live traffic** and **value omission is silent**, exactly as for [request properties](#request-properties): a property that doesn't resolve (a plain console record with no stack, a frame index out of range, an unknown attribute, no pattern match) is simply absent, never an error. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
 
 ### Message levels
 
@@ -367,7 +402,7 @@ A consumer evaluating live records MUST surface an ambiguity when a record match
 
 ## Regular expressions
 
-Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)) and a message's `message` ([Message](#message)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
+Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)), a message's `message` ([Message](#message)), and a message property's `pattern` ([Message properties](#message-properties)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
 
 A conforming SDK MUST reject a regular expression that is not valid RE2; the reference CLI reports `request-property-pattern-invalid` for a `pattern` and `message-regex-invalid` for a `message`.
 
@@ -520,6 +555,7 @@ A conforming SDK:
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
+- MUST reject a `MessageProperty` with a `source` other than `stack`, or one that omits `field`, or whose `pattern` is not a valid RE2 regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -532,6 +568,7 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
+- MUST resolve a `MessageProperty` only from a live record's stack, omitting the value silently when the record has no stack or the addressed frame/attribute doesn't resolve
 
 **Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -49,11 +49,20 @@ type rawFile struct {
 }
 
 type rawMessage struct {
-	Name        string `yaml:"name"`
-	Level       string `yaml:"level"`
-	Message     string `yaml:"message"`
-	Description string `yaml:"description"`
-	Source      string `yaml:"source"`
+	Name        string               `yaml:"name"`
+	Level       string               `yaml:"level"`
+	Message     string               `yaml:"message"`
+	Description string               `yaml:"description"`
+	Source      string               `yaml:"source"`
+	Properties  []rawMessageProperty `yaml:"properties"`
+}
+
+type rawMessageProperty struct {
+	Name      string `yaml:"name"`
+	Source    string `yaml:"source"`
+	Field     string `yaml:"field"`
+	Pattern   string `yaml:"pattern"`
+	Transform string `yaml:"transform"`
 }
 
 type rawSnapshot struct {
@@ -390,9 +399,31 @@ func toMessageDefs(rms []rawMessage) []MessageDef {
 			Message:     rm.Message,
 			Description: rm.Description,
 			Source:      rm.Source,
+			Properties:  toMessageProperties(rm.Properties),
 		}
 		md.precompile() // cache the compiled pattern once, at load time
 		out = append(out, md)
+	}
+	return out
+}
+
+// toMessageProperties converts raw stack-addressing property declarations
+// (SEP-0006 follow-on). Shape problems (a bad name, a wrong source, a missing
+// field) are reported by checkMessageProperties at validation time rather than
+// dropped here, so an author sees every problem at once.
+func toMessageProperties(rps []rawMessageProperty) []MessagePropertyDef {
+	if len(rps) == 0 {
+		return nil
+	}
+	out := make([]MessagePropertyDef, 0, len(rps))
+	for _, rp := range rps {
+		out = append(out, MessagePropertyDef{
+			Name:      rp.Name,
+			Source:    rp.Source,
+			Field:     rp.Field,
+			Pattern:   rp.Pattern,
+			Transform: rp.Transform,
+		})
 	}
 	return out
 }

--- a/go/sightmap/message.go
+++ b/go/sightmap/message.go
@@ -35,6 +35,11 @@ type MessageDef struct {
 	Description string `json:"description,omitempty"`
 	Source      string `json:"source,omitempty"`
 
+	// Properties declares named values to extract from an exception record's
+	// stack (the SEP-0006 stack-addressing follow-on, mirroring SEP-0005's
+	// request properties). Resolved by ExtractProperties against Message.Stack.
+	Properties []MessagePropertyDef `json:"properties,omitempty"`
+
 	// re is the compiled Message pattern, cached by the loader (precompile) so
 	// MessagesForRecord doesn't recompile per record. Nil when Message is empty,
 	// the pattern is invalid (validation reports that), or the def was built in
@@ -42,6 +47,32 @@ type MessageDef struct {
 	// fly in that last case. Unexported, so it never serializes.
 	re *regexp.Regexp
 }
+
+// MessagePropertyDef declares a named value to extract from an observed
+// exception's stack (SEP-0006 stack-addressing follow-on). It mirrors
+// RequestPropertyDef's source/field/pattern/transform shape, but the only source
+// is "stack": Field addresses a frame ("top" or a numeric index) and one of its
+// attributes (function/file/line/column) — e.g. "top.file" or "1.function";
+// Pattern optionally refines the resolved string; Transform post-processes it.
+type MessagePropertyDef struct {
+	Name string `json:"name"`
+	// Source is the extraction root; the only value in v1 is "stack".
+	Source string `json:"source"`
+	// Field addresses a stack frame and attribute: "<frame>.<attribute>" where
+	// <frame> is "top" (alias for 0) or a non-negative index, and <attribute> is
+	// one of function/file/line/column. Required for a stack source.
+	Field string `json:"field,omitempty"`
+	// Pattern is an RE2 regex applied to what Field resolved. Capture group 1 is
+	// the value when present, else the entire match.
+	Pattern string `json:"pattern,omitempty"`
+	// Transform is optional post-processing, sharing componentProperty's
+	// vocabulary (SEP-0003).
+	Transform string `json:"transform,omitempty"`
+}
+
+// MessagePropertySources is the closed set of roots a MessagePropertyDef.Source
+// may name. Only the exception stack is addressable in v1.
+var MessagePropertySources = []string{"stack"}
 
 // precompile caches the compiled Message pattern on the def. The loader calls it
 // as each MessageDef is built, so a corpus loaded once and matched against many
@@ -84,12 +115,15 @@ var KnownMessageLevels = []string{
 // MessageMatch records which MessageDef classified an observed Message. It is
 // the message-side analogue of ComponentMatch: a projection of the matched
 // definition carrying the fields a consumer needs to link a classification back
-// to what produced it. Messages have no live-extracted properties, so — unlike
-// ComponentMatch — it carries no property values.
+// to what produced it. Properties carries any values the def's stack-addressing
+// properties[] extracted from an exception record (nil for a plain console
+// match or a def declaring none), bringing MessageMatch to parity with
+// ComponentMatch and RequestMatch.
 type MessageMatch struct {
 	Name        string
 	Description string
 	Source      string
+	Properties  []PropertyValue
 }
 
 // MessagesForRecord returns every MessageDef that classifies the observed record
@@ -133,6 +167,7 @@ func (c *Corpus) MessagesForRecord(rec Message) []MessageMatch {
 			Name:        m.Name,
 			Description: m.Description,
 			Source:      m.Source,
+			Properties:  m.ExtractProperties(rec),
 		})
 	}
 	return out

--- a/go/sightmap/message_extract.go
+++ b/go/sightmap/message_extract.go
@@ -83,9 +83,15 @@ func resolveStackField(frames []Frame, field string) (string, bool) {
 	case "file":
 		return f.File, f.File != ""
 	case "line":
-		return strconv.Itoa(f.Line), true
+		if f.Line == nil {
+			return "", false
+		}
+		return strconv.Itoa(*f.Line), true
 	case "column":
-		return strconv.Itoa(f.Column), true
+		if f.Column == nil {
+			return "", false
+		}
+		return strconv.Itoa(*f.Column), true
 	default:
 		return "", false
 	}

--- a/go/sightmap/message_extract.go
+++ b/go/sightmap/message_extract.go
@@ -1,0 +1,92 @@
+package sightmap
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ExtractProperties resolves d's stack-addressing properties[] against the
+// observed message rec, returning the values that resolved, in declaration
+// order. A property is silently omitted (never an error) when rec has no stack,
+// the addressed frame or attribute doesn't resolve, or a pattern finds no
+// match — the same live-traffic contract as request-property extraction: a plain
+// console record (empty Stack) simply yields nothing.
+//
+// Resolution is source → field → pattern → transform. The only source is
+// "stack"; field addresses a frame and attribute ("top.file", "1.function"),
+// pattern optionally refines the resolved string (capture group 1 else the whole
+// match), and transform post-processes it.
+func (d *MessageDef) ExtractProperties(rec Message) []PropertyValue {
+	if len(d.Properties) == 0 {
+		return nil
+	}
+	var out []PropertyValue
+	for _, p := range d.Properties {
+		if v, ok := resolveMessageProperty(p, rec); ok {
+			out = append(out, PropertyValue{Name: p.Name, Value: v})
+		}
+	}
+	return out
+}
+
+// resolveMessageProperty applies one property definition to rec.
+func resolveMessageProperty(p MessagePropertyDef, rec Message) (string, bool) {
+	var raw string
+	var ok bool
+	switch p.Source {
+	case "stack":
+		raw, ok = resolveStackField(rec.Stack, p.Field)
+	default:
+		return "", false
+	}
+	if !ok {
+		return "", false
+	}
+	if p.Pattern != "" {
+		matched, ok := applyPattern(p.Pattern, raw)
+		if !ok {
+			return "", false
+		}
+		raw = matched
+	}
+	if raw == "" {
+		return "", false
+	}
+	return ApplyTransform(raw, p.Transform), true
+}
+
+// resolveStackField resolves a "<frame>.<attribute>" field against a call stack.
+// <frame> is "top" (alias for index 0) or a non-negative integer index;
+// <attribute> is one of function/file/line/column. Returns false when the field
+// is malformed, the frame index is out of range, or the attribute is unknown —
+// so a bad field omits silently rather than erroring, per the SEP.
+func resolveStackField(frames []Frame, field string) (string, bool) {
+	sel, attr, found := strings.Cut(field, ".")
+	if !found {
+		return "", false
+	}
+	idx := 0
+	if sel != "top" {
+		n, err := strconv.Atoi(sel)
+		if err != nil || n < 0 {
+			return "", false
+		}
+		idx = n
+	}
+	if idx >= len(frames) {
+		return "", false
+	}
+	f := frames[idx]
+	switch attr {
+	case "function":
+		return f.Function, f.Function != ""
+	case "file":
+		return f.File, f.File != ""
+	case "line":
+		return strconv.Itoa(f.Line), true
+	case "column":
+		return strconv.Itoa(f.Column), true
+	default:
+		return "", false
+	}
+}

--- a/go/sightmap/message_extract_test.go
+++ b/go/sightmap/message_extract_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 )
 
+func intp(n int) *int { return &n }
+
 func excStack() []Frame {
 	return []Frame{
-		{Function: "syncCart", File: "src/cart/sync.ts", Line: 42, Column: 9},
-		{Function: "onClick", File: "src/checkout/pay.ts", Line: 118, Column: 4},
+		{Function: "syncCart", File: "src/cart/sync.ts", Line: intp(42), Column: intp(9)},
+		{Function: "onClick", File: "src/checkout/pay.ts", Line: intp(118), Column: intp(4)},
 	}
 }
 
@@ -76,6 +78,31 @@ func TestMessageExtract_SilentOmission(t *testing.T) {
 	rec := Message{Stack: []Frame{{File: "a.ts"}}}
 	if got := d.ExtractProperties(rec); got != nil {
 		t.Fatalf("want nil (all omitted), got %+v", got)
+	}
+}
+
+func TestMessageExtract_CapturedZeroLineIsValueNotAbsent(t *testing.T) {
+	// CDP line numbers are 0-based, so a captured line 0 is a real location and
+	// must resolve to "0" — not be treated as absent.
+	d := &MessageDef{Properties: []MessagePropertyDef{{Name: "ln", Source: "stack", Field: "top.line"}}}
+	rec := Message{Stack: []Frame{{File: "a.ts", Line: intp(0)}}}
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{{Name: "ln", Value: "0"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("captured line 0 should resolve to \"0\", got %+v", got)
+	}
+}
+
+func TestMessageExtract_UnsetLineOmits(t *testing.T) {
+	// A frame whose Line/Column the capture didn't supply (nil) omits, distinct
+	// from a captured 0.
+	d := &MessageDef{Properties: []MessagePropertyDef{
+		{Name: "ln", Source: "stack", Field: "top.line"},
+		{Name: "col", Source: "stack", Field: "top.column"},
+	}}
+	rec := Message{Stack: []Frame{{File: "a.ts"}}} // Line/Column nil
+	if got := d.ExtractProperties(rec); got != nil {
+		t.Fatalf("unset line/column should omit, got %+v", got)
 	}
 }
 

--- a/go/sightmap/message_extract_test.go
+++ b/go/sightmap/message_extract_test.go
@@ -1,0 +1,140 @@
+package sightmap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func excStack() []Frame {
+	return []Frame{
+		{Function: "syncCart", File: "src/cart/sync.ts", Line: 42, Column: 9},
+		{Function: "onClick", File: "src/checkout/pay.ts", Line: 118, Column: 4},
+	}
+}
+
+func TestMessageExtract_TopFrameAttributes(t *testing.T) {
+	d := &MessageDef{
+		Name: "UncaughtCheckoutError", Level: "exception",
+		Properties: []MessagePropertyDef{
+			{Name: "origin_file", Source: "stack", Field: "top.file"},
+			{Name: "origin_fn", Source: "stack", Field: "top.function"},
+			{Name: "origin_line", Source: "stack", Field: "top.line"},
+		},
+	}
+	rec := Message{Level: "exception", Text: "boom", Stack: excStack()}
+
+	got := d.ExtractProperties(rec)
+	want := []PropertyValue{
+		{Name: "origin_file", Value: "src/cart/sync.ts"},
+		{Name: "origin_fn", Value: "syncCart"},
+		{Name: "origin_line", Value: "42"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestMessageExtract_NumericFrameIndex(t *testing.T) {
+	d := &MessageDef{
+		Properties: []MessagePropertyDef{
+			{Name: "caller_file", Source: "stack", Field: "1.file"},
+		},
+	}
+	got := d.ExtractProperties(Message{Stack: excStack()})
+	want := []PropertyValue{{Name: "caller_file", Value: "src/checkout/pay.ts"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestMessageExtract_Pattern(t *testing.T) {
+	// Extract just the basename via a pattern's capture group.
+	d := &MessageDef{
+		Properties: []MessagePropertyDef{
+			{Name: "file_base", Source: "stack", Field: "top.file", Pattern: `([^/]+)$`},
+		},
+	}
+	got := d.ExtractProperties(Message{Stack: excStack()})
+	want := []PropertyValue{{Name: "file_base", Value: "sync.ts"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestMessageExtract_SilentOmission(t *testing.T) {
+	d := &MessageDef{
+		Properties: []MessagePropertyDef{
+			{Name: "oob_frame", Source: "stack", Field: "9.file"},      // index out of range
+			{Name: "bad_attr", Source: "stack", Field: "top.garbage"},  // unknown attribute
+			{Name: "malformed", Source: "stack", Field: "topfile"},     // no "." separator
+			{Name: "empty_fn", Source: "stack", Field: "top.function"}, // frame has no function name
+			{Name: "no_match", Source: "stack", Field: "top.file", Pattern: `zzz`},
+		},
+	}
+	// A single frame with only a file — no function, so empty_fn omits; every
+	// other property is out-of-range / malformed / non-matching.
+	rec := Message{Stack: []Frame{{File: "a.ts"}}}
+	if got := d.ExtractProperties(rec); got != nil {
+		t.Fatalf("want nil (all omitted), got %+v", got)
+	}
+}
+
+func TestMessageExtract_PlainConsoleRecordNoStack(t *testing.T) {
+	d := &MessageDef{Properties: []MessagePropertyDef{{Name: "x", Source: "stack", Field: "top.file"}}}
+	if got := d.ExtractProperties(Message{Level: "error", Text: "plain log"}); got != nil {
+		t.Fatalf("plain console record should extract nothing, got %+v", got)
+	}
+}
+
+func TestMessagesForRecord_FoldsStackProperties(t *testing.T) {
+	c := &Corpus{Messages: []MessageDef{
+		{
+			Name: "UncaughtCheckoutError", Level: "exception",
+			Message:     `Cannot read propert`,
+			Description: "null deref in checkout",
+			Properties:  []MessagePropertyDef{{Name: "origin_file", Source: "stack", Field: "top.file"}},
+		},
+	}}
+	c.Messages[0].precompile()
+
+	rec := Message{Level: "exception", Text: "Cannot read property 'x' of undefined", Stack: excStack()}
+	got := c.MessagesForRecord(rec)
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d", len(got))
+	}
+	if got[0].Name != "UncaughtCheckoutError" || got[0].Description != "null deref in checkout" {
+		t.Errorf("projection wrong: %+v", got[0])
+	}
+	if !reflect.DeepEqual(got[0].Properties, []PropertyValue{{Name: "origin_file", Value: "src/cart/sync.ts"}}) {
+		t.Errorf("stack properties = %+v", got[0].Properties)
+	}
+}
+
+func TestMessageProperties_Validation(t *testing.T) {
+	c := &Corpus{Messages: []MessageDef{
+		{Name: "M", Level: "exception", Properties: []MessagePropertyDef{
+			{Name: "Bad-Name", Source: "stack", Field: "top.file"},    // invalid name
+			{Name: "wrong_src", Source: "console", Field: "top.file"}, // bad source
+			{Name: "no_field", Source: "stack"},                       // stack requires field
+			{Name: "bad_re", Source: "stack", Field: "top.file", Pattern: `(unclosed`},
+		}},
+	}}
+	diags := Validate(c)
+
+	want := map[string]bool{
+		"message-property-invalid-name":    false,
+		"message-property-source-invalid":  false,
+		"message-property-no-field":        false,
+		"message-property-pattern-invalid": false,
+	}
+	for _, d := range diags {
+		if _, ok := want[d.Code]; ok {
+			want[d.Code] = true
+		}
+	}
+	for code, seen := range want {
+		if !seen {
+			t.Errorf("expected diagnostic %q, not emitted; got %+v", code, diags)
+		}
+	}
+}

--- a/go/sightmap/records.go
+++ b/go/sightmap/records.go
@@ -26,12 +26,16 @@ type Message struct {
 
 // Frame is one call-stack frame of an exception Message, as the reference
 // capture derives it from CDP Runtime.exceptionThrown stackTrace.callFrames.
-// Line and Column are 0 when the capture didn't supply them.
+//
+// Line and Column are pointers so "not captured" (nil) is distinguishable from a
+// genuine zero: CDP callFrames.lineNumber is 0-based, so line 0 is a real
+// location, not a missing one. A property addressing an unset Line/Column omits
+// silently (per the SEP), while one addressing a captured 0 resolves to "0".
 type Frame struct {
 	Function string `json:"function,omitempty"`
 	File     string `json:"file,omitempty"`
-	Line     int    `json:"line,omitempty"`
-	Column   int    `json:"column,omitempty"`
+	Line     *int   `json:"line,omitempty"`
+	Column   *int   `json:"column,omitempty"`
 }
 
 // Request is one observed network request/response. Status is 0 until the

--- a/go/sightmap/records.go
+++ b/go/sightmap/records.go
@@ -16,6 +16,22 @@ type Message struct {
 	Level string `json:"level"`
 	Text  string `json:"text"`
 	Ts    int64  `json:"ts"` // unix milliseconds
+
+	// Stack is the call stack of an uncaught exception, throwing frame first
+	// (frame 0 == "top"). Empty for a plain console record. Optional and
+	// omitempty, like the Request payload fields: a producer that didn't capture
+	// frames leaves it nil and stack extraction degrades to "absent".
+	Stack []Frame `json:"stack,omitempty"`
+}
+
+// Frame is one call-stack frame of an exception Message, as the reference
+// capture derives it from CDP Runtime.exceptionThrown stackTrace.callFrames.
+// Line and Column are 0 when the capture didn't supply them.
+type Frame struct {
+	Function string `json:"function,omitempty"`
+	File     string `json:"file,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Column   int    `json:"column,omitempty"`
 }
 
 // Request is one observed network request/response. Status is 0 until the

--- a/go/sightmap/spec_conformance_test.go
+++ b/go/sightmap/spec_conformance_test.go
@@ -32,6 +32,10 @@ func TestSpecConformance_MessageFixtures(t *testing.T) {
 	runSpecValidateFixtures(t, "*-messages.fixture")
 }
 
+func TestSpecConformance_MessagePropertyFixtures(t *testing.T) {
+	runSpecValidateFixtures(t, "*-message-properties.fixture")
+}
+
 func runSpecValidateFixtures(t *testing.T, glob string) {
 	t.Helper()
 	const root = "../../spec/conformance"

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -34,7 +34,8 @@ var (
 	snapshotFields  = set("name", "notes", "url")
 
 	requestPropertyFields = set("name", "source", "field", "pattern", "transform")
-	messageFields         = set("name", "level", "message", "description", "source")
+	messageFields         = set("name", "level", "message", "description", "source", "properties")
+	messagePropertyFields = set("name", "source", "field", "pattern", "transform")
 )
 
 func set(keys ...string) map[string]bool {
@@ -260,6 +261,10 @@ func walkMessage(node *yaml.Node, file string, out *[]ValidationError) {
 	// write a pattern for an HTTP-status console error, and the JSON Schema
 	// rejects it.
 	checkStringScalars(v, []string{"name", "level", "message", "description", "source"}, file, out)
+	forEachItem(v["properties"], func(n *yaml.Node) {
+		pv := checkKeys(n, messagePropertyFields, file, out)
+		checkStringScalars(pv, []string{"name", "source", "field", "pattern", "transform"}, file, out)
+	})
 }
 
 func walkPayload(node *yaml.Node, file string, out *[]ValidationError) {

--- a/go/sightmap/validate_message.go
+++ b/go/sightmap/validate_message.go
@@ -3,6 +3,7 @@ package sightmap
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -42,8 +43,78 @@ func checkMessages(msgs []MessageDef) []ValidationError {
 		}
 	}
 
+	errs = append(errs, checkMessageProperties(msgs)...)
 	errs = append(errs, checkMessageNameCollisions(msgs)...)
 	errs = append(errs, checkMessageConflicts(msgs)...)
+	return errs
+}
+
+// checkMessageProperties validates the shape of every stack-addressing message
+// property (the SEP-0006 follow-on). Like checkRequestProperties, these
+// constraints also live in the JSON Schema, but the Go CLI never validates
+// against it, so without this a corpus with a bad property name, an unknown
+// source, or a stack source missing its field would pass `sightmap validate`
+// while `npm run validate:conformance` rejects it.
+func checkMessageProperties(msgs []MessageDef) []ValidationError {
+	var errs []ValidationError
+	for _, m := range msgs {
+		for _, p := range m.Properties {
+			errs = append(errs, validateMessageProperty(m.Name, p)...)
+		}
+	}
+	return errs
+}
+
+func validateMessageProperty(msgName string, p MessagePropertyDef) []ValidationError {
+	var errs []ValidationError
+
+	// name reuses the identifier rule shared with request/component properties.
+	if !requestPropertyNamePattern.MatchString(p.Name) {
+		errs = append(errs, ValidationError{
+			Component: msgName,
+			Code:      "message-property-invalid-name",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("message %q declares a property named %q; names must match %s",
+				msgName, p.Name, requestPropertyNamePattern),
+		})
+	}
+
+	validSource := slices.Contains(MessagePropertySources, p.Source)
+	if !validSource {
+		errs = append(errs, ValidationError{
+			Component: msgName,
+			Code:      "message-property-source-invalid",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("message %q property %q has source %q; must be one of %s",
+				msgName, p.Name, p.Source, strings.Join(MessagePropertySources, ", ")),
+		})
+	}
+
+	// A stack source addresses a specific frame+attribute, so field is required —
+	// there is no meaningful bare-regex scan over a structured call stack (the
+	// same reasoning that requires field for a headers source in SEP-0005).
+	if validSource && p.Field == "" {
+		errs = append(errs, ValidationError{
+			Component: msgName,
+			Code:      "message-property-no-field",
+			Severity:  SeverityError,
+			Message: fmt.Sprintf("message %q property %q reads from %q but omits field; name a frame and attribute, e.g. field: top.file",
+				msgName, p.Name, p.Source),
+		})
+	}
+
+	if p.Pattern != "" {
+		if _, err := regexp.Compile(p.Pattern); err != nil {
+			errs = append(errs, ValidationError{
+				Component: msgName,
+				Code:      "message-property-pattern-invalid",
+				Severity:  SeverityError,
+				Message: fmt.Sprintf("message %q property %q: pattern regex parse error: %v",
+					msgName, p.Name, err),
+			})
+		}
+	}
+
 	return errs
 }
 

--- a/spec/conformance/020-message-properties.fixture/expected.json
+++ b/spec/conformance/020-message-properties.fixture/expected.json
@@ -1,0 +1,12 @@
+{
+  "cases": [
+    {
+      "command": "validate",
+      "args": {},
+      "expected": {
+        "ok": true,
+        "diagnostics": []
+      }
+    }
+  ]
+}

--- a/spec/conformance/020-message-properties.fixture/sightmap/app.yaml
+++ b/spec/conformance/020-message-properties.fixture/sightmap/app.yaml
@@ -1,0 +1,18 @@
+version: 1
+messages:
+  # An exception classified by origin, extracting the throwing frame's file and
+  # function plus a specific caller frame refined by a pattern.
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+    message: 'Cannot read propert(y|ies) .* of (null|undefined)'
+    properties:
+      - name: origin_file
+        source: stack
+        field: top.file
+      - name: origin_fn
+        source: stack
+        field: top.function
+      - name: caller_base
+        source: stack
+        field: 1.file
+        pattern: '([^/]+)$'

--- a/spec/seps/0004-component-tags.md
+++ b/spec/seps/0004-component-tags.md
@@ -431,7 +431,7 @@ merged-but-unimplemented spec change.
   offline, cross-language conformance suite has no live DOM or URL router to exercise, so it
   cannot test the union resolution rule itself (the same limitation SEP-0003's `properties`
   extraction ran into); that behavior is asserted by each SDK's own test suite instead.
-- Reference implementation: Fullstory's internal Subtext session-review signal pipeline (Go)
+- Reference implementation: an internal session-review signal pipeline (Go)
   implements and unit-tests the component case's union-across-levels resolution today (the
   view and request cases are new in this SEP, not yet implemented anywhere). Not a public
   repository — cited here for provenance, not as a checkable link.

--- a/spec/seps/0005-request-properties.md
+++ b/spec/seps/0005-request-properties.md
@@ -211,7 +211,7 @@ Existing SDKs that encounter a `properties:` entry under a `request:` MUST treat
 
 1. This SEP merges (status: Accepted).
 2. `sightmap/sightmap` implements request-property extraction in its network-capture pipeline. Bumped to a minor release.
-3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before adding `properties:` to a `requests:` entry.
+3. Consumers pin `github.com/sightmap/sightmap/go >= <new version>` before adding `properties:` to a `requests:` entry.
 
 ## Open questions
 

--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -135,7 +135,7 @@ Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-l
 
 1. This SEP merges (status: Accepted).
 2. `sightmap/sightmap` implements `messages:` parsing and matching. Bumped to a minor release.
-3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `messages:`.
+3. Consumers pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `messages:`.
 
 ## Open questions
 
@@ -145,4 +145,4 @@ Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-l
 
 ## References
 
-- Subtext (a sightmap consumer) folds uncaught exceptions into the same console-record stream under their own `exception` level (not `error`) — the real-world precedent behind this proposal's "one entity, not two" call in Semantics, and the reason a corpus that wants exceptions writes `level: EXCEPTION`.
+- A sightmap consumer folds uncaught exceptions into the same console-record stream under an `exception` level (not `error`) — the real-world precedent behind this proposal's "one entity, not two" call in Semantics, and the reason a corpus that wants exceptions writes `level: EXCEPTION`.

--- a/spec/seps/0007-signals.md
+++ b/spec/seps/0007-signals.md
@@ -225,7 +225,7 @@ Existing SDKs that encounter a `signals:` key MUST treat it as an unknown top-le
 
 1. This SEP merges (status: Accepted) — depends on [SEP-0005](0005-request-properties.md) and [SEP-0006](0006-message-entity.md) also being accepted, since this proposal's `Request`/`Message` examples assume both exist.
 2. `sightmap/sightmap` implements `signals:` parsing and `ref:`/`filter:` resolution. Bumped to a minor release.
-3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `signals:`.
+3. Consumers pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `signals:`.
 
 ## Open questions
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -333,8 +333,43 @@ messages:
 | `message` | string | no | [RE2](#regular-expressions) regex matched against the record's text. Match-any if omitted. |
 | `description` | string | no | What this pattern means, for a human reading the corpus. |
 | `source` | string | no | Relative path to the source most likely to emit this. |
+| `properties` | [MessageProperty](#message-properties)[] | no | Values to extract from an exception's stack. |
 
 A record matches when every declared constraint holds. Declaring neither `level` nor `message` matches every record, which is legal but rarely useful. `message` is an [RE2 regular expression](#regular-expressions).
+
+### Message properties
+
+`properties:` declares named values to pull out of an uncaught exception's **stack trace**, so a corpus can classify an exception by where it came from and extract the failing location — the message-side analogue of a request's [`properties:`](#request-properties). It reuses that mechanism's `source` / `field` / `pattern` / `transform` shape.
+
+```yaml
+messages:
+  - name: UncaughtCheckoutError
+    level: EXCEPTION
+    message: 'Cannot read propert(y|ies) .* of (null|undefined)'
+    properties:
+      # The throwing frame's source file and function.
+      - name: origin_file
+        source: stack
+        field: top.file
+      - name: origin_fn
+        source: stack
+        field: top.function
+      # A specific frame by index, refined by a pattern to just the basename.
+      - name: caller_base
+        source: stack
+        field: 1.file
+        pattern: '([^/]+)$'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Key a consumer refers to this value by. Must match `^[a-z][a-z0-9_]*$`. |
+| `source` | string | yes | Which root to read from. The only value in v1 is `stack` (the exception's call stack). |
+| `field` | string | yes | The frame and attribute to select, `<frame>.<attribute>`: `<frame>` is `top` (an alias for `0`) or a non-negative frame index (`0`, `1`, …), throwing frame first; `<attribute>` is one of `function`, `file`, `line`, or `column`. Required — a `stack` source has no meaningful bare-regex scan, the same reasoning that requires `field` for a request's headers source. |
+| `pattern` | string | no | An [RE2](#regular-expressions) regex applied to whatever `field` resolved. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
+| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+
+Extraction requires **live traffic** and **value omission is silent**, exactly as for [request properties](#request-properties): a property that doesn't resolve (a plain console record with no stack, a frame index out of range, an unknown attribute, no pattern match) is simply absent, never an error. See [SEP-0006](../seps/0006-message-entity.md).
 
 ### Message levels
 
@@ -359,7 +394,7 @@ A consumer evaluating live records MUST surface an ambiguity when a record match
 
 ## Regular expressions
 
-Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)) and a message's `message` ([Message](#message)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
+Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)), a message's `message` ([Message](#message)), and a message property's `pattern` ([Message properties](#message-properties)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.
 
 A conforming SDK MUST reject a regular expression that is not valid RE2; the reference CLI reports `request-property-pattern-invalid` for a `pattern` and `message-regex-invalid` for a `message`.
 
@@ -512,6 +547,7 @@ A conforming SDK:
 - MUST reject a `RequestProperty` whose `source` is a headers source but omits `field`
 - MUST reject a `RequestProperty` whose `pattern` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
+- MUST reject a `MessageProperty` with a `source` other than `stack`, or one that omits `field`, or whose `pattern` is not a valid RE2 regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
 - MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
@@ -524,6 +560,7 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
+- MUST resolve a `MessageProperty` only from a live record's stack, omitting the value silently when the record has no stack or the addressed frame/attribute doesn't resolve
 
 **Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -549,7 +549,7 @@ A conforming SDK:
 - MUST reject a `messages:` entry whose `message` is not a valid RE2 regular expression (see [Regular expressions](#regular-expressions))
 - MUST reject a `MessageProperty` with a `source` other than `stack`, or one that omits `field`, or whose `pattern` is not a valid RE2 regular expression
 - SHOULD surface `memory` entries to the agent when the parent definition is active
-- MAY ignore fields it doesn't use (e.g. `description` is never surfaced at runtime by Subtext today)
+- MAY ignore fields it doesn't use (e.g. a consumer that never surfaces `description` at runtime)
 - MAY implement additional, non-standard behavior as long as it doesn't change the meaning of conforming inputs
 
 An SDK that also **evaluates live activity** (observed network requests, console records, DOM state) additionally:

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -296,6 +296,44 @@
         "source": {
           "type": "string",
           "description": "Relative path to the source most likely to emit this pattern."
+        },
+        "properties": {
+          "type": "array",
+          "description": "Ordered list of stack-addressing value extractions for an exception record. See SEP-0006.",
+          "items": { "$ref": "#/$defs/messageProperty" }
+        }
+      }
+    },
+    "messageProperty": {
+      "type": "object",
+      "description": "A named value extracted from an observed exception's stack. See SEP-0006.",
+      "required": ["name", "source", "field"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Key a consumer refers to this value by."
+        },
+        "source": {
+          "type": "string",
+          "enum": ["stack"],
+          "description": "Which root to read from. Only the exception stack is addressable in v1."
+        },
+        "field": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Frame and attribute to select: \"<frame>.<attribute>\" where <frame> is \"top\" (alias for 0) or a non-negative index and <attribute> is one of function/file/line/column. Required."
+        },
+        "pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "RE2 regex (no backreferences or lookaround) applied to what field resolved. Capture group 1 is the value if present, else the full match."
+        },
+        "transform": {
+          "type": "string",
+          "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
+          "description": "Optional post-processing applied to the extracted string. Same vocabulary as componentProperty.transform (SEP-0003)."
         }
       }
     },


### PR DESCRIPTION
Closes #206. Stacked on #207 (base `feat/request-record-extraction`) — reuses that PR's `applyPattern` + transform tail. The message analogue of #205's request-body gap, and a small SEP-0006 addendum (no new SEP — it reuses SEP-0005's exact `source`/`field`/`pattern`/`transform` vocabulary).

## Problem

`MessageDef` matched on `level` + a regex over `text`, and the observed record was `Message{Index, Tab, Level, Text, Ts}`. An uncaught exception's stack — its throwing origin and frames — was dropped, so a corpus couldn't classify an exception by where it came from, nor extract the failing location.

## Change

**Record (`records.go`)** — additive, optional:
```go
Message{ …existing… Stack []Frame `json:"stack,omitempty"` }   // empty for a plain console record
Frame{ Function, File string; Line, Column int }
```

**Def + spec (SEP-0006 addendum)** — `MessageDef` gains a stack-addressing `properties[]` mirroring SEP-0005:
- `source: stack` (the only source in v1),
- `field: <frame>.<attribute>` — `<frame>` is `top` (alias for `0`) or a non-negative index, throwing frame first; `<attribute>` is `function`/`file`/`line`/`column`. Required (a structured stack has no meaningful bare-regex scan — the same reasoning that requires `field` for a headers source),
- optional RE2 `pattern` (capture group 1 else whole match) and `transform`.

`schema.md` gets a **Message properties** subsection + the `properties` row + conformance clauses; `sightmap.schema.json` gets a `messageProperty` `$def` (surgical 38-line insertion, style-matched); `docs/reference/schema.md` regenerated.

**Matching (`message_extract.go`)** — `MessageDef.ExtractProperties(rec)` resolves the stack properties, and `Corpus.MessagesForRecord` folds them into `MessageMatch.Properties` — bringing `MessageMatch` to parity with `ComponentMatch`/`RequestMatch` (it previously carried no properties). Unresolved values omit silently, so a plain console record (no stack) extracts nothing.

**Validation (`validate_message.go`)** — `message-property-invalid-name` / `-source-invalid` / `-no-field` / `-pattern-invalid`, mirroring the request-property diagnostics. New conformance fixture `020-message-properties` (ajv + the Go validate harness via a new glob).

## Scope / follow-ups

- **Lib + spec only** — this is what Subtext pulls. Populating `Stack` from the collector's `Runtime.exceptionThrown` `callFrames` (which it already receives and drops) is the capture side, #130.

## Tests

`message_extract_test.go`: top-frame attributes, numeric frame index, pattern (basename capture), exhaustive silent-omission (OOB frame / unknown attr / malformed field / empty function / no pattern match), plain-console-record-no-stack, `MessagesForRecord` folding, and the four validation diagnostics. Full Go suite + `gofmt` clean; `spec` `validate:conformance` + `validate:examples` green.
