### PR TITLE
spec: scrub the product name from SEP prose

### DIFF
--- a/spec/seps/0004-component-tags.md
+++ b/spec/seps/0004-component-tags.md
@@ -431,7 +431,7 @@ merged-but-unimplemented spec change.
   offline, cross-language conformance suite has no live DOM or URL router to exercise, so it
   cannot test the union resolution rule itself (the same limitation SEP-0003's `properties`
   extraction ran into); that behavior is asserted by each SDK's own test suite instead.
-- Reference implementation: Fullstory's internal Subtext session-review signal pipeline (Go)
+- Reference implementation: an internal session-review signal pipeline (Go)
   implements and unit-tests the component case's union-across-levels resolution today (the
   view and request cases are new in this SEP, not yet implemented anywhere). Not a public
   repository — cited here for provenance, not as a checkable link.

--- a/spec/seps/0005-request-properties.md
+++ b/spec/seps/0005-request-properties.md
@@ -211,7 +211,7 @@ Existing SDKs that encounter a `properties:` entry under a `request:` MUST treat
 
 1. This SEP merges (status: Accepted).
 2. `sightmap/sightmap` implements request-property extraction in its network-capture pipeline. Bumped to a minor release.
-3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before adding `properties:` to a `requests:` entry.
+3. Consumers pin `github.com/sightmap/sightmap/go >= <new version>` before adding `properties:` to a `requests:` entry.
 
 ## Open questions
 

--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -135,7 +135,7 @@ Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-l
 
 1. This SEP merges (status: Accepted).
 2. `sightmap/sightmap` implements `messages:` parsing and matching. Bumped to a minor release.
-3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `messages:`.
+3. Consumers pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `messages:`.
 
 ## Open questions
 
@@ -145,4 +145,4 @@ Existing SDKs that encounter a `messages:` key MUST treat it as an unknown top-l
 
 ## References
 
-- Subtext (a sightmap consumer) folds uncaught exceptions into the same console-record stream under their own `exception` level (not `error`) — the real-world precedent behind this proposal's "one entity, not two" call in Semantics, and the reason a corpus that wants exceptions writes `level: EXCEPTION`.
+- A sightmap consumer folds uncaught exceptions into the same console-record stream under an `exception` level (not `error`) — the real-world precedent behind this proposal's "one entity, not two" call in Semantics, and the reason a corpus that wants exceptions writes `level: EXCEPTION`.

--- a/spec/seps/0007-signals.md
+++ b/spec/seps/0007-signals.md
@@ -225,7 +225,7 @@ Existing SDKs that encounter a `signals:` key MUST treat it as an unknown top-le
 
 1. This SEP merges (status: Accepted) — depends on [SEP-0005](0005-request-properties.md) and [SEP-0006](0006-message-entity.md) also being accepted, since this proposal's `Request`/`Message` examples assume both exist.
 2. `sightmap/sightmap` implements `signals:` parsing and `ref:`/`filter:` resolution. Bumped to a minor release.
-3. Consumers (e.g. Subtext) pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `signals:`.
+3. Consumers pin `github.com/sightmap/sightmap/go >= <new version>` before authoring `signals:`.
 
 ## Open questions
 


### PR DESCRIPTION
Keeps the product name out of the public spec (reviewer hygiene note). Neutralizes the five `Subtext` mentions in SEP prose — the release-playbook "Consumers (e.g. Subtext) pin …" lines (SEP-0005/0006/0007), the SEP-0006 exception-precedent reference, and the SEP-0004 reference-implementation line (which also named the company) — to consumer-neutral phrasing, preserving each argument's meaning.

Scope:
- **SEPs only.** The one normative-spec mention (`schema.md`, the `description`-never-surfaced conformance clause) is handled in #208 alongside the message-property work, so this PR and #208 touch disjoint files.
- **Left in place, flagged for a call:** two standalone `Fullstory` mentions that are substantive design rationale rather than incidental — SEP-0005's open-question comparison to `NetworkBodySelection.path` and SEP-0001's "empirical basis" audit citation. Scrubbing those changes the texture of the argument, so I left them; happy to neutralize in a follow-up if you'd rather no product names appear at all.

No package/behavior change — SEP prose isn't docs-synced, schema-validated, or part of the published package, so no changeset.
