### PR TITLE
browser: capture req/rsp headers, duration, and exception stack frames

### DIFF
--- a/.changeset/collector-capture-headers-stack.md
+++ b/.changeset/collector-capture-headers-stack.md
@@ -1,0 +1,13 @@
+---
+"@sightmap/sightmap": patch
+---
+
+The reference network/console collector now populates the faithful-record fields
+added for SEP-0005/0006 runtime matching. Observed `Request` records carry
+request/response headers (from the CDP `requestWillBeSent`/`responseReceived`
+events — cheap, no extra round-trip) and an observed `DurationMs`; observed
+exception `Message` records carry the `Stack` (from `exceptionThrown`
+`stackTrace.callFrames`, throwing frame first, with 0-based line/column
+preserved). Bodies remain fetched on demand. This is what lets
+`RequestsForRecord` extract body/header properties and `MessagesForRecord`
+resolve stack properties against traffic the reference tooling captured.

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -191,8 +192,8 @@ func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, cons
 				c.addNetwork(e)
 			}
 		case raw := <-respCh:
-			if reqID, st, stText, rtype, ok := parseResponse(raw); ok {
-				c.applyResponse(reqID, st, stText, rtype)
+			if info, ok := parseResponse(raw); ok {
+				c.applyResponse(info)
 			}
 		}
 	}
@@ -223,16 +224,21 @@ func (c *Collector) addNetwork(e networkRecord) {
 }
 
 // applyResponse matches a response back to its pending request (scanning from
-// the tail, where the request almost always is) and fills in status + type.
-func (c *Collector) applyResponse(reqID string, status int, statusText, rtype string) {
+// the tail, where the request almost always is) and fills in status, type,
+// response headers, and the observed request→response duration.
+func (c *Collector) applyResponse(info responseInfo) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for i := len(c.network) - 1; i >= 0; i-- {
-		if c.network[i].requestID == reqID {
-			c.network[i].Status = status
-			c.network[i].StatusText = statusText
-			if rtype != "" {
-				c.network[i].ResourceType = rtype
+		if c.network[i].requestID == info.reqID {
+			c.network[i].Status = info.status
+			c.network[i].StatusText = info.statusText
+			if info.rtype != "" {
+				c.network[i].ResourceType = info.rtype
+			}
+			c.network[i].RspHeaders = info.headers
+			if ts := c.network[i].Ts; ts > 0 {
+				c.network[i].DurationMs = time.Now().UnixMilli() - ts
 			}
 			return
 		}
@@ -365,6 +371,14 @@ func parseConsoleAPI(raw json.RawMessage) (sightmap.Message, bool) {
 	}, true
 }
 
+// cdpCallFrame is one CDP Runtime.CallFrame (0-based line/column).
+type cdpCallFrame struct {
+	FunctionName string `json:"functionName"`
+	URL          string `json:"url"`
+	LineNumber   int    `json:"lineNumber"`
+	ColumnNumber int    `json:"columnNumber"`
+}
+
 func parseException(raw json.RawMessage) (sightmap.Message, bool) {
 	var ev struct {
 		Timestamp        float64 `json:"timestamp"`
@@ -373,6 +387,9 @@ func parseException(raw json.RawMessage) (sightmap.Message, bool) {
 			Exception struct {
 				Description string `json:"description"`
 			} `json:"exception"`
+			StackTrace struct {
+				CallFrames []cdpCallFrame `json:"callFrames"`
+			} `json:"stackTrace"`
 		} `json:"exceptionDetails"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil {
@@ -382,7 +399,33 @@ func parseException(raw json.RawMessage) (sightmap.Message, bool) {
 	if text == "" {
 		text = ev.ExceptionDetails.Text
 	}
-	return sightmap.Message{Level: "exception", Text: text, Ts: int64(ev.Timestamp)}, true
+	return sightmap.Message{
+		Level: "exception",
+		Text:  text,
+		Ts:    int64(ev.Timestamp),
+		Stack: framesFromCallFrames(ev.ExceptionDetails.StackTrace.CallFrames),
+	}, true
+}
+
+// framesFromCallFrames converts CDP stackTrace.callFrames into sightmap.Frame
+// records, throwing frame first. lineNumber/columnNumber are always present on a
+// CDP call frame and are 0-based, so they are captured as pointers (never nil
+// here); a downstream producer that lacks them leaves the pointer nil instead.
+func framesFromCallFrames(cfs []cdpCallFrame) []sightmap.Frame {
+	if len(cfs) == 0 {
+		return nil
+	}
+	out := make([]sightmap.Frame, 0, len(cfs))
+	for _, cf := range cfs {
+		line, col := cf.LineNumber, cf.ColumnNumber
+		out = append(out, sightmap.Frame{
+			Function: cf.FunctionName,
+			File:     cf.URL,
+			Line:     &line,
+			Column:   &col,
+		})
+	}
+	return out
 }
 
 func parseRequest(raw json.RawMessage) (networkRecord, bool) {
@@ -390,8 +433,9 @@ func parseRequest(raw json.RawMessage) (networkRecord, bool) {
 		RequestID string `json:"requestId"`
 		Type      string `json:"type"`
 		Request   struct {
-			URL    string `json:"url"`
-			Method string `json:"method"`
+			URL     string            `json:"url"`
+			Method  string            `json:"method"`
+			Headers map[string]string `json:"headers"`
 		} `json:"request"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
@@ -403,24 +447,59 @@ func parseRequest(raw json.RawMessage) (networkRecord, bool) {
 			URL:          ev.Request.URL,
 			ResourceType: ev.Type,
 			Ts:           time.Now().UnixMilli(),
+			ReqHeaders:   headersFromMap(ev.Request.Headers),
 		},
 		requestID: ev.RequestID,
 	}, true
 }
 
-func parseResponse(raw json.RawMessage) (reqID string, status int, statusText, rtype string, ok bool) {
+// responseInfo is the parsed Network.responseReceived event, applied back onto
+// the pending request record by applyResponse.
+type responseInfo struct {
+	reqID      string
+	status     int
+	statusText string
+	rtype      string
+	headers    []sightmap.Header
+}
+
+func parseResponse(raw json.RawMessage) (responseInfo, bool) {
 	var ev struct {
 		RequestID string `json:"requestId"`
 		Type      string `json:"type"`
 		Response  struct {
-			Status     int    `json:"status"`
-			StatusText string `json:"statusText"`
+			Status     int               `json:"status"`
+			StatusText string            `json:"statusText"`
+			Headers    map[string]string `json:"headers"`
 		} `json:"response"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
-		return "", 0, "", "", false
+		return responseInfo{}, false
 	}
-	return ev.RequestID, ev.Response.Status, ev.Response.StatusText, ev.Type, true
+	return responseInfo{
+		reqID:      ev.RequestID,
+		status:     ev.Response.Status,
+		statusText: ev.Response.StatusText,
+		rtype:      ev.Type,
+		headers:    headersFromMap(ev.Response.Headers),
+	}, true
+}
+
+// headersFromMap converts CDP's header object into an ordered Header slice,
+// sorted by name for determinism. CDP delivers headers as a JSON object, so
+// duplicates are already collapsed and order is not preserved — a producer with
+// the raw header text (e.g. a different capture layer) can populate duplicates,
+// which the []Header type supports.
+func headersFromMap(m map[string]string) []sightmap.Header {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]sightmap.Header, 0, len(m))
+	for k, v := range m {
+		out = append(out, sightmap.Header{Name: k, Value: v})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
 }
 
 // renderArg turns one console argument into display text: the JSON value when

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -25,7 +25,7 @@ func TestParseConsoleAPI(t *testing.T) {
 }
 
 func TestParseException(t *testing.T) {
-	raw := json.RawMessage(`{"timestamp":1785015495306,"exceptionDetails":{"text":"Uncaught","exception":{"description":"TypeError: x is not a function"}}}`)
+	raw := json.RawMessage(`{"timestamp":1785015495306,"exceptionDetails":{"text":"Uncaught","exception":{"description":"TypeError: x is not a function"},"stackTrace":{"callFrames":[{"functionName":"syncCart","url":"https://x/cart.js","lineNumber":41,"columnNumber":8},{"functionName":"","url":"https://x/main.js","lineNumber":0,"columnNumber":0}]}}}`)
 	e, ok := parseException(raw)
 	if !ok {
 		t.Fatal("parseException returned ok=false")
@@ -36,10 +36,22 @@ func TestParseException(t *testing.T) {
 	if e.Text != "TypeError: x is not a function" {
 		t.Errorf("text = %q", e.Text)
 	}
+	// The stack is captured, throwing frame first, with 0-based line/column as
+	// non-nil pointers (a captured 0 is a real location).
+	if len(e.Stack) != 2 {
+		t.Fatalf("stack frames = %d, want 2", len(e.Stack))
+	}
+	top := e.Stack[0]
+	if top.Function != "syncCart" || top.File != "https://x/cart.js" || top.Line == nil || *top.Line != 41 {
+		t.Errorf("top frame = %+v", top)
+	}
+	if f2 := e.Stack[1]; f2.Line == nil || *f2.Line != 0 || f2.Column == nil || *f2.Column != 0 {
+		t.Errorf("second frame captured-zero line/column not preserved: %+v", f2)
+	}
 }
 
 func TestParseRequestResponse(t *testing.T) {
-	req := json.RawMessage(`{"requestId":"R1","type":"XHR","request":{"url":"https://x/api","method":"POST"}}`)
+	req := json.RawMessage(`{"requestId":"R1","type":"XHR","request":{"url":"https://x/api","method":"POST","headers":{"Authorization":"Bearer t"}}}`)
 	e, ok := parseRequest(req)
 	if !ok {
 		t.Fatal("parseRequest ok=false")
@@ -47,11 +59,18 @@ func TestParseRequestResponse(t *testing.T) {
 	if e.Method != "POST" || e.URL != "https://x/api" || e.ResourceType != "XHR" || e.requestID != "R1" {
 		t.Errorf("request parse = %+v", e)
 	}
+	if len(e.ReqHeaders) != 1 || e.ReqHeaders[0].Name != "Authorization" || e.ReqHeaders[0].Value != "Bearer t" {
+		t.Errorf("request headers = %+v", e.ReqHeaders)
+	}
 
-	resp := json.RawMessage(`{"requestId":"R1","type":"XHR","response":{"status":201,"statusText":"Created"}}`)
-	id, st, stText, rtype, ok := parseResponse(resp)
-	if !ok || id != "R1" || st != 201 || stText != "Created" || rtype != "XHR" {
-		t.Errorf("response parse = %s %d %s %s %v", id, st, stText, rtype, ok)
+	resp := json.RawMessage(`{"requestId":"R1","type":"XHR","response":{"status":201,"statusText":"Created","headers":{"Content-Type":"application/json","X-RateLimit-Remaining":"0"}}}`)
+	info, ok := parseResponse(resp)
+	if !ok || info.reqID != "R1" || info.status != 201 || info.statusText != "Created" || info.rtype != "XHR" {
+		t.Errorf("response parse = %+v %v", info, ok)
+	}
+	// Response headers are captured, sorted by name for determinism.
+	if len(info.headers) != 2 || info.headers[0].Name != "Content-Type" || info.headers[1].Value != "0" {
+		t.Errorf("response headers = %+v", info.headers)
 	}
 }
 
@@ -98,7 +117,7 @@ func TestNetworkFilterAndResponseMatch(t *testing.T) {
 	c := NewCollector("localhost:0")
 	c.addNetwork(networkRecord{Request: sightmap.Request{Method: "GET", URL: "https://x/style.css", ResourceType: "Stylesheet"}, requestID: "A"})
 	c.addNetwork(networkRecord{Request: sightmap.Request{Method: "POST", URL: "https://x/api/cart", ResourceType: "XHR"}, requestID: "B"})
-	c.applyResponse("B", 500, "Server Error", "XHR")
+	c.applyResponse(responseInfo{reqID: "B", status: 500, statusText: "Server Error", rtype: "XHR"})
 
 	xhr, _ := c.Network(NetworkFilter{ResourceType: "xhr"})
 	if len(xhr) != 1 || xhr[0].Status != 500 || xhr[0].StatusText != "Server Error" {


### PR DESCRIPTION
Part of #226 / #170. Stacked on #208 (base `feat/message-stack-extraction`). The **capture side** of the record-faithfulness pair: the reference collector now populates the optional record fields that #207 (Request headers/bodies) and #208 (Message stack) added, so `RequestsForRecord`/`MessagesForRecord` have something to extract from when the reference tooling is the producer.

## Change (`go/browser/collector.go`)

- **Request headers** — `parseRequest`/`parseResponse` now read `request.headers` / `response.headers` off the CDP events (already in hand — no extra round-trip) into `Request.ReqHeaders` / `RspHeaders`. Headers arrive as a CDP object, so they're emitted as a `[]Header` sorted by name (deduped/unordered — the `[]Header` type still supports duplicates for a producer that has the raw header text).
- **Duration** — `applyResponse` sets `DurationMs` to the observed request→response latency.
- **Exception stack** — `parseException` reads `exceptionDetails.stackTrace.callFrames` into `Message.Stack`, throwing frame first; CDP `lineNumber`/`columnNumber` are 0-based and always present, so they're captured as non-nil pointers (a genuine line 0 is preserved, distinct from "not captured").
- `parseResponse` now returns a `responseInfo` struct rather than a 5-value tuple (it was growing a 6th/7th return).

Bodies stay **fetched on demand** (the existing `ResponseBody`/`RequestBody` lazy fetchers) — the handler-side wiring that assembles a full record and renders extracted values is the next slice.

## No output change

The CLI renders selected text fields (`network list`: `method url → status`; `console`: `level text`), not a raw record dump, so `list`/`get` output is unchanged — the new fields ride in the record silently until they're consumed. The follow-up wiring PR surfaces extracted `name=value` pairs.

## Tests

`collector_test.go`: request-header capture, response-header capture (sorted), and exception stack-frame capture including the **captured-zero line/column** case (0-based CDP → preserved as `*0`, not dropped). Full Go suite + `gofmt` green.

Leaves open: eager body retention + surfacing headers in `network get` (#226 — this PR only lands the header/timing *capture*); WebSocket visibility (#130).
