### PR TITLE
cmd/sightmap: surface extracted request/message properties in devtools

### DIFF
--- a/.changeset/devtools-property-annotation.md
+++ b/.changeset/devtools-property-annotation.md
@@ -1,0 +1,15 @@
+---
+"@sightmap/sightmap": minor
+---
+
+The `browser start` devtools now surface extracted property values, not just
+matched-def names. The collector eagerly retains request/response bodies for
+XHR/Fetch traffic (request bodies inline from `requestWillBeSent`; response
+bodies fetched on `Network.loadingFinished`, off the event loop), so a buffered
+`Request` record is complete. `sightmap network list|get` annotate via
+`RequestsForRecord` — resolving each matched request's `properties[]` against the
+live headers/body — and `sightmap console list|get` surface a matched message's
+stack `properties[]`. Extracted values render as a trailing `{name=value, …}`
+token on list lines and a `Properties:` block in `get` detail, e.g.
+`GET /api/checkout/pay → 200 OK (Fetch) {outcome=declined}` — the "200 OK but the
+body says declined" case, now visible.

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -149,6 +149,7 @@ func (c *Collector) attachTab(tabID string) {
 	excCh := conn.Subscribe("Runtime.exceptionThrown")
 	reqCh := conn.Subscribe("Network.requestWillBeSent")
 	respCh := conn.Subscribe("Network.responseReceived")
+	finishedCh := conn.Subscribe("Network.loadingFinished")
 
 	// Enable the domains after subscribing so buffered replays aren't missed.
 	if err := conn.EnableDomain(ctx, "Runtime"); err != nil {
@@ -163,13 +164,13 @@ func (c *Collector) attachTab(tabID string) {
 	c.tabsMu.Unlock()
 
 	c.wg.Add(1)
-	go c.drain(ctx, tabID, conn, consoleCh, excCh, reqCh, respCh)
+	go c.drain(ctx, tabID, conn, consoleCh, excCh, reqCh, respCh, finishedCh)
 }
 
 // drain funnels one tab's CDP events into the shared buffers until ctx is
 // cancelled. It does minimal work per event so the cap-8 subscription channels
 // don't drop during bursts.
-func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, consoleCh, excCh, reqCh, respCh <-chan json.RawMessage) {
+func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, consoleCh, excCh, reqCh, respCh, finishedCh <-chan json.RawMessage) {
 	defer c.wg.Done()
 	for {
 		select {
@@ -194,6 +195,14 @@ func (c *Collector) drain(ctx context.Context, tabID string, conn *CDPConn, cons
 		case raw := <-respCh:
 			if info, ok := parseResponse(raw); ok {
 				c.applyResponse(info)
+			}
+		case raw := <-finishedCh:
+			// The response body is reliably fetchable only once loading finished.
+			// Fetch it OFF the drain loop (a getResponseBody round-trip would
+			// otherwise stall these cap-8 channels and drop events).
+			if reqID := parseLoadingFinished(raw); reqID != "" {
+				c.wg.Add(1)
+				go c.retainResponseBody(ctx, conn, reqID)
 			}
 		}
 	}
@@ -326,6 +335,81 @@ func (c *Collector) RequestBody(ctx context.Context, index int) ([]byte, bool, e
 	return body, true, err
 }
 
+// retainResponseBody fetches a finished response's body and stores it on the
+// buffered record, so property extraction runs against a complete record without
+// the query path making its own CDP round-trip. Only XHR/Fetch bodies are
+// retained — the API-call types a request property addresses — so page assets
+// (images, fonts, stylesheets) aren't pulled into memory. Best-effort: a body
+// that can't be fetched (evicted, no body, a redirect) is simply left absent,
+// matching the SEP's silent omission.
+func (c *Collector) retainResponseBody(ctx context.Context, conn *CDPConn, reqID string) {
+	defer c.wg.Done()
+
+	c.mu.Lock()
+	var rtype, ctype string
+	found := false
+	for i := range c.network {
+		if c.network[i].requestID == reqID {
+			rtype = c.network[i].ResourceType
+			ctype = contentTypeFromHeaders(c.network[i].RspHeaders)
+			found = true
+			break
+		}
+	}
+	c.mu.Unlock()
+	if !found || !wantsBody(rtype) {
+		return
+	}
+
+	body, err := getResponseBody(ctx, conn, reqID)
+	if err != nil || len(body) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	for i := range c.network {
+		if c.network[i].requestID == reqID {
+			c.network[i].RspBody = &sightmap.Body{
+				Content:     string(body),
+				Size:        len(body),
+				ContentType: ctype,
+			}
+			break
+		}
+	}
+	c.mu.Unlock()
+}
+
+// wantsBody reports whether a response body is worth retaining for a given CDP
+// resource type: the API-call types whose bodies a request property extracts.
+func wantsBody(resourceType string) bool {
+	switch strings.ToLower(resourceType) {
+	case "xhr", "fetch":
+		return true
+	}
+	return false
+}
+
+// contentTypeFromMap / contentTypeFromHeaders read the Content-Type header
+// (case-insensitive) from CDP's header map and from a captured Header slice.
+func contentTypeFromMap(m map[string]string) string {
+	for k, v := range m {
+		if strings.EqualFold(k, "content-type") {
+			return v
+		}
+	}
+	return ""
+}
+
+func contentTypeFromHeaders(hs []sightmap.Header) string {
+	for _, h := range hs {
+		if strings.EqualFold(h.Name, "content-type") {
+			return h.Value
+		}
+	}
+	return ""
+}
+
 func (c *Collector) lookupRequest(index int) (string, *CDPConn, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -433,15 +517,16 @@ func parseRequest(raw json.RawMessage) (networkRecord, bool) {
 		RequestID string `json:"requestId"`
 		Type      string `json:"type"`
 		Request   struct {
-			URL     string            `json:"url"`
-			Method  string            `json:"method"`
-			Headers map[string]string `json:"headers"`
+			URL      string            `json:"url"`
+			Method   string            `json:"method"`
+			Headers  map[string]string `json:"headers"`
+			PostData string            `json:"postData"`
 		} `json:"request"`
 	}
 	if err := json.Unmarshal(raw, &ev); err != nil || ev.RequestID == "" {
 		return networkRecord{}, false
 	}
-	return networkRecord{
+	rec := networkRecord{
 		Request: sightmap.Request{
 			Method:       ev.Request.Method,
 			URL:          ev.Request.URL,
@@ -450,7 +535,30 @@ func parseRequest(raw json.RawMessage) (networkRecord, bool) {
 			ReqHeaders:   headersFromMap(ev.Request.Headers),
 		},
 		requestID: ev.RequestID,
-	}, true
+	}
+	// The request body is delivered inline on requestWillBeSent (no round-trip),
+	// so retain it directly. The response body is not — it's fetched on
+	// loadingFinished (retainResponseBody).
+	if ev.Request.PostData != "" {
+		rec.ReqBody = &sightmap.Body{
+			Content:     ev.Request.PostData,
+			Size:        len(ev.Request.PostData),
+			ContentType: contentTypeFromMap(ev.Request.Headers),
+		}
+	}
+	return rec, true
+}
+
+// parseLoadingFinished extracts the requestId from a Network.loadingFinished
+// event, or "" if it doesn't parse.
+func parseLoadingFinished(raw json.RawMessage) string {
+	var ev struct {
+		RequestID string `json:"requestId"`
+	}
+	if json.Unmarshal(raw, &ev) != nil {
+		return ""
+	}
+	return ev.RequestID
 }
 
 // responseInfo is the parsed Network.responseReceived event, applied back onto

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -58,12 +58,14 @@ func devtoolsGet(sightmapDir, path string, query url.Values) ([]byte, error) {
 // fields to the top level, so the wire shape is the record plus "matches".
 type consoleEntry struct {
 	sightmap.Message
-	Matches []string `json:"matches,omitempty"`
+	Matches []string                 `json:"matches,omitempty"`
+	Props   []sightmap.PropertyValue `json:"props,omitempty"`
 }
 
 type networkEntry struct {
 	sightmap.Request
-	Matches []string `json:"matches,omitempty"`
+	Matches []string                 `json:"matches,omitempty"`
+	Props   []sightmap.PropertyValue `json:"props,omitempty"`
 }
 
 type consoleResult struct {
@@ -88,6 +90,7 @@ func annotateConsole(c *sightmap.Corpus, msgs []sightmap.Message) []consoleEntry
 		if c != nil {
 			for _, mm := range c.MessagesForRecord(m) {
 				e.Matches = append(e.Matches, mm.Name)
+				e.Props = append(e.Props, mm.Properties...)
 			}
 		}
 		out[i] = e
@@ -100,13 +103,44 @@ func annotateNetwork(c *sightmap.Corpus, reqs []sightmap.Request) []networkEntry
 	for i, r := range reqs {
 		e := networkEntry{Request: r}
 		if c != nil {
-			for _, rd := range c.RequestsForURL(r.URL, r.Method) {
-				e.Matches = append(e.Matches, rd.Name)
+			// RequestsForRecord does route+method identity AND resolves each
+			// matched def's properties[] against the record's live headers/body
+			// (populated by the collector). RequestsForURL gave names only.
+			for _, rm := range c.RequestsForRecord(r) {
+				e.Matches = append(e.Matches, rm.Name)
+				e.Props = append(e.Props, rm.Properties...)
 			}
 		}
 		out[i] = e
 	}
 	return out
+}
+
+// propsSlot renders extracted property values as a trailing `{name=value, …}`
+// token for a list line, or "" when none. It follows the record's own payload —
+// the classification (matchSlot) leads, the extracted content trails — mirroring
+// how a snapshot shows `[Component attr="value"]`.
+func propsSlot(props []sightmap.PropertyValue) string {
+	if len(props) == 0 {
+		return ""
+	}
+	parts := make([]string, len(props))
+	for i, p := range props {
+		parts[i] = fmt.Sprintf("%s=%s", p.Name, p.Value)
+	}
+	return " {" + strings.Join(parts, ", ") + "}"
+}
+
+// printProps writes an extracted-property block for a `get` detail view, one
+// `name = value` per line under a "Properties:" header. No-op when empty.
+func printProps(props []sightmap.PropertyValue) {
+	if len(props) == 0 {
+		return
+	}
+	fmt.Println("Properties:")
+	for _, p := range props {
+		fmt.Printf("  %s = %s\n", p.Name, p.Value)
+	}
 }
 
 // matchSlot renders the leading corpus-match token for a list line: the matched
@@ -168,9 +202,9 @@ func runConsoleList(args []string) error {
 		multiTab := spansMultipleTabs(res.Entries)
 		for _, e := range res.Entries {
 			if multiTab {
-				fmt.Printf("[%d] %s %-9s [%s] %s\n", e.Index, matchSlot(e.Matches), e.Level, shortTab(e.Tab), e.Text)
+				fmt.Printf("[%d] %s %-9s [%s] %s%s\n", e.Index, matchSlot(e.Matches), e.Level, shortTab(e.Tab), e.Text, propsSlot(e.Props))
 			} else {
-				fmt.Printf("[%d] %s %-9s %s\n", e.Index, matchSlot(e.Matches), e.Level, e.Text)
+				fmt.Printf("[%d] %s %-9s %s%s\n", e.Index, matchSlot(e.Matches), e.Level, e.Text, propsSlot(e.Props))
 			}
 		}
 	}
@@ -202,6 +236,7 @@ func runConsoleGet(args []string) error {
 			if len(e.Matches) > 0 {
 				fmt.Printf("Matches: %s\n", strings.Join(e.Matches, ", "))
 			}
+			printProps(e.Props)
 			return nil
 		}
 	}
@@ -253,7 +288,7 @@ func runNetworkList(args []string) error {
 		fmt.Println("No network requests captured.")
 	} else {
 		for _, e := range res.Entries {
-			fmt.Printf("[%d] %s %s %s → %s (%s)\n", e.Index, matchSlot(e.Matches), e.Method, e.URL, statusStr(e.Request), e.ResourceType)
+			fmt.Printf("[%d] %s %s %s → %s (%s)%s\n", e.Index, matchSlot(e.Matches), e.Method, e.URL, statusStr(e.Request), e.ResourceType, propsSlot(e.Props))
 		}
 	}
 	reportDropped(res.Dropped, "network")
@@ -300,6 +335,7 @@ func runNetworkGet(args []string) error {
 	if len(entry.Matches) > 0 {
 		fmt.Printf("Matches: %s\n", strings.Join(entry.Matches, ", "))
 	}
+	printProps(entry.Props)
 
 	if *reqFile != "" {
 		if err := saveBody(*sightmapDir, idx, "request", *reqFile); err != nil {

--- a/go/cmd/sightmap/cmd_devtools_test.go
+++ b/go/cmd/sightmap/cmd_devtools_test.go
@@ -55,6 +55,56 @@ func TestAnnotateNetwork(t *testing.T) {
 	}
 }
 
+func TestAnnotateNetwork_ExtractsProperties(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Requests: []sightmap.RequestDef{{
+			Name: "CheckoutPayment", Route: "/api/checkout/pay", Method: "POST",
+			Properties: []sightmap.RequestPropertyDef{
+				{Name: "outcome", Source: "rsp.body", Field: "status"},
+			},
+		}},
+	}
+	reqs := []sightmap.Request{{
+		Index: 1, Method: "POST", URL: "https://x.test/api/checkout/pay", Status: 200,
+		RspBody: &sightmap.Body{Content: `{"status":"declined"}`, ContentType: "application/json"},
+	}}
+	got := annotateNetwork(corpus, reqs)
+
+	if !reflect.DeepEqual(got[0].Matches, []string{"CheckoutPayment"}) {
+		t.Errorf("matches = %+v", got[0].Matches)
+	}
+	if !reflect.DeepEqual(got[0].Props, []sightmap.PropertyValue{{Name: "outcome", Value: "declined"}}) {
+		t.Errorf("props = %+v (want outcome=declined extracted from the 200 body)", got[0].Props)
+	}
+	if slot := propsSlot(got[0].Props); slot != " {outcome=declined}" {
+		t.Errorf("propsSlot = %q", slot)
+	}
+}
+
+func TestAnnotateConsole_ExtractsStackProperties(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		Messages: []sightmap.MessageDef{{
+			Name: "UncaughtCheckoutError", Level: "exception",
+			Properties: []sightmap.MessagePropertyDef{
+				{Name: "origin_file", Source: "stack", Field: "top.file"},
+			},
+		}},
+	}
+	line := 42
+	msgs := []sightmap.Message{{
+		Index: 1, Level: "exception", Text: "boom",
+		Stack: []sightmap.Frame{{Function: "syncCart", File: "src/cart/sync.ts", Line: &line}},
+	}}
+	got := annotateConsole(corpus, msgs)
+
+	if !reflect.DeepEqual(got[0].Matches, []string{"UncaughtCheckoutError"}) {
+		t.Errorf("matches = %+v", got[0].Matches)
+	}
+	if !reflect.DeepEqual(got[0].Props, []sightmap.PropertyValue{{Name: "origin_file", Value: "src/cart/sync.ts"}}) {
+		t.Errorf("props = %+v", got[0].Props)
+	}
+}
+
 func TestMatchSlot(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
Closes the runtime-matching pile: the devtools now **surface extracted property values**, end-to-end. Stacked on #211 (base `feat/collector-capture-headers-stack`).

## Change

**Collector — eager body retention.** Per the "memory isn't a concern here, keep it simple" call, bodies are now coupled to the record rather than fetched lazily at query time:
- request bodies come inline off `requestWillBeSent` (`request.postData`, no round-trip);
- response bodies are fetched on `Network.loadingFinished` — when they're reliably available — in a goroutine **off** the drain loop (a `getResponseBody` round-trip there would stall the cap-8 event channels), gated to XHR/Fetch so page assets (images/fonts/CSS) aren't pulled into memory.

So a buffered `Request` now carries headers (#211) + bodies, and extraction runs against a complete record.

**Handler + render.** `annotateNetwork` switches from `RequestsForURL` (names only) to `RequestsForRecord` (identity + `properties[]` resolved against the live record); `annotateConsole` already gets `MessageMatch.Properties` (stack extraction from #208). Both flow into the entry DTO, and render as:
- a trailing `{name=value, …}` token on `network list` / `console list` lines (classification leads via the `[match]` slot, extracted content trails — mirroring a snapshot's `[Component attr="value"]`);
- a `Properties:` block in `network get` / `console get` detail.

## End-to-end (headless Chrome, local fixture)

A page fetches `/pay.json` (`200 OK`, body `{"status":"declined","amount":42}`) and throws an async exception:

```
network list
[1] [CheckoutPayment]      GET http://localhost:8199/pay.json → 200 OK (Fetch) {outcome=declined, amount=42}

console list
[4] [CheckoutBoom]         exception Error: boom in checkout
    at boomTrigger (<anonymous>:1:118) {origin_fn=boomTrigger}
```

The 200-OK-body-says-declined case is visible; the body was retained from live Chrome and resolved by `RequestsForRecord`. (`origin_file` correctly omitted for the eval'd frame — an anonymous `<anonymous>` URL → empty file → silent omission — while `origin_fn` resolved.) `get` detail shows the `Properties:` block + the retained response body.

## Tests

Unit: `annotateNetwork`/`annotateConsole` extract properties and render (`propsSlot`); existing identity/nil-corpus tests unchanged. Plus the live E2E above. Full Go suite + `gofmt` green; `minor` changeset.

Leaves open under #130: WebSocket visibility.

---

Closes #227 (this PR implements it).
Partially addresses #226 (eager XHR/Fetch response-body retention).
#130 is now scoped to WebSocket visibility only; the HTTP header/body residual was split out to #226.
