### PR TITLE
match: chain-matching entry point (MatchChain/NamesForChain/TagsForChain)

### DIFF
--- a/.changeset/match-chain.md
+++ b/.changeset/match-chain.md
@@ -1,0 +1,16 @@
+---
+"@sightmap/sightmap": minor
+---
+
+`match.Matcher` gains a chain-matching entry point for consumers that classify a
+stream of individual observed elements rather than a full component tree. Each
+observed element carries only its own root→leaf ancestor chain, so there was no
+first-class API for it — a consumer had to reimplement the spec's component
+identity/tag resolution by hand (and route-blind). `MatchChain(chain, pageURL)`
+runs the shared NFA matcher over a single-branch spine built from the chain and
+returns depth-annotated `ChainMatch` values; `NamesForChain` applies the
+nearest-enclosing identity rule and `TagsForChain` the tag-union rule (deduped,
+sorted), so the spec's resolution lives once in the shared library. Matching is
+route-aware, so view-scoped components apply on the chain exactly as in a
+full-tree match. Purely additive packaging over already-exported pieces — no new
+matching semantics.

--- a/go/match/chain.go
+++ b/go/match/chain.go
@@ -1,0 +1,131 @@
+package match
+
+import (
+	"sort"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// ChainMatch is a single component definition matched at a specific depth along
+// an observed element's ancestor chain. Depth is the 0-based index into the
+// chain passed to MatchChain: 0 is the root, len(chain)-1 is the observed leaf.
+// A chain node may appear in more than one ChainMatch when several component
+// definitions match it.
+type ChainMatch struct {
+	Depth  int
+	Name   string
+	Tags   []string
+	Memory []string
+}
+
+// MatchChain resolves the component definitions that apply along a single
+// observed element's ancestor chain, root-first (chain[0] is the root, the last
+// entry is the observed leaf). It is the streaming-element analogue of Match:
+// where Match walks a full component tree, MatchChain evaluates one branch in
+// isolation, which is what a consumer classifying a stream of individual
+// observed elements has on hand.
+//
+// Matching is route-aware: pageURL selects the same view-scoped-plus-global
+// component set Match would use, so a view-scoped definition applies on the
+// chain exactly as it would in a full-tree match. Returns nil when chain is
+// empty or no component definitions apply for pageURL.
+//
+// Each returned ChainMatch is annotated with the Depth of the chain node that
+// completed the selector. Results are ordered by ascending depth (root toward
+// leaf); within a depth they follow component-definition order. Callers wanting
+// the spec's two resolution policies directly should reach for NamesForChain
+// (nearest-enclosing) and TagsForChain (union) rather than re-deriving them.
+//
+// Because the caller supplies only the ancestor chain and not the leaf's own
+// subtree, a relational selector that inspects descendants (:has()) on the leaf
+// cannot be satisfied here — the same inherent limitation any ancestor-only
+// view carries.
+func (m *Matcher) MatchChain(chain []sightmap.Element, pageURL string) []ChainMatch {
+	entry := m.entryFor(pageURL)
+	if len(chain) == 0 || len(entry.queries) == 0 {
+		return nil
+	}
+
+	// Build a single-branch spine (root -> leaf) of ComponentNodes so the shared
+	// NFA matcher can run over it unchanged. Each node aliases the caller's
+	// Element identity; matching only reads it.
+	nodes := make([]*sightmap.ComponentNode, len(chain))
+	for i := range chain {
+		nodes[i] = &sightmap.ComponentNode{Element: &chain[i]}
+	}
+	depthOf := make(map[*sightmap.ComponentNode]int, len(nodes))
+	for i, n := range nodes {
+		depthOf[n] = i
+		if i+1 < len(nodes) {
+			n.Children = []*sightmap.ComponentNode{nodes[i+1]}
+		}
+	}
+
+	byName := make(map[string]*sightmap.ComponentDef, len(entry.components))
+	for i := range entry.components {
+		byName[entry.components[i].Name] = &entry.components[i]
+	}
+
+	var out []ChainMatch
+	FindAllMatches(nodes[0], entry.queries, func(node *sightmap.ComponentNode, q *MatchQuery) {
+		cm := ChainMatch{Depth: depthOf[node], Name: q.Name}
+		if def := byName[q.Name]; def != nil {
+			cm.Tags = def.Tags
+			cm.Memory = def.Memory
+		}
+		out = append(out, cm)
+	})
+	// FindAllMatches visits the linear spine depth-first, so out already runs
+	// root -> leaf; a defensive stable sort keeps the contract explicit without
+	// disturbing within-depth (definition) order.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Depth < out[j].Depth })
+	return out
+}
+
+// NamesForChain returns the component name(s) that identify the observed leaf
+// element, applying the spec's nearest-enclosing rule: the name resolved from
+// the deepest chain level that matched. It is almost always a single name;
+// more than one is returned only when several definitions match that same
+// deepest level (a genuine identity conflict the caller may want to see, rather
+// than a silently-picked winner). Names are deduplicated and returned in
+// component-definition order. Returns nil when nothing along the chain matched.
+func (m *Matcher) NamesForChain(chain []sightmap.Element, pageURL string) []string {
+	matches := m.MatchChain(chain, pageURL)
+	if len(matches) == 0 {
+		return nil
+	}
+	deepest := matches[len(matches)-1].Depth // sorted ascending by depth
+	var names []string
+	seen := make(map[string]bool)
+	for _, cm := range matches {
+		if cm.Depth == deepest && !seen[cm.Name] {
+			seen[cm.Name] = true
+			names = append(names, cm.Name)
+		}
+	}
+	return names
+}
+
+// TagsForChain returns the tags that apply to the observed leaf element,
+// applying the spec's tag-union rule: the union of tags across every matching
+// level of the chain, never narrowed by the nearest-enclosing identity rule. The
+// result is deduplicated and lexicographically sorted, per the spec's Tags
+// resolution requirement. Returns nil when no matching level carries a tag.
+func (m *Matcher) TagsForChain(chain []sightmap.Element, pageURL string) []string {
+	matches := m.MatchChain(chain, pageURL)
+	set := make(map[string]bool)
+	for _, cm := range matches {
+		for _, t := range cm.Tags {
+			set[t] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	tags := make([]string, 0, len(set))
+	for t := range set {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	return tags
+}

--- a/go/match/chain_test.go
+++ b/go/match/chain_test.go
@@ -1,0 +1,194 @@
+package match_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// el is a shorthand for an observed element identity.
+func el(tag string, classes ...string) sightmap.Element {
+	return sightmap.Element{Tag: tag, Classes: classes}
+}
+
+// chainMatcher builds a Matcher over global defs.
+func chainMatcher(defs ...sightmap.ComponentDef) *match.Matcher {
+	return match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs})
+}
+
+func TestMatchChain_NearestEnclosingName(t *testing.T) {
+	// CheckoutForm encloses an untagged SubmitButton child; a "click" on the
+	// button resolves the nearest-enclosing name (SubmitButton), per spec.
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "CheckoutForm", Selectors: []string{"form.checkout"}},
+		sightmap.ComponentDef{Name: "SubmitButton", Selectors: []string{"button.submit"}},
+	)
+	chain := []sightmap.Element{
+		el("form", "checkout"),
+		el("button", "submit"),
+	}
+	got := m.NamesForChain(chain, "")
+	if want := []string{"SubmitButton"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("NamesForChain = %v, want %v", got, want)
+	}
+}
+
+func TestMatchChain_NearestEnclosingFallsBackToAncestor(t *testing.T) {
+	// The leaf itself matches nothing; the nearest enclosing match is an
+	// ancestor. Nearest-enclosing therefore resolves the ancestor's name.
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "CheckoutForm", Selectors: []string{"form.checkout"}},
+	)
+	chain := []sightmap.Element{
+		el("form", "checkout"),
+		el("div", "row"),
+		el("span"),
+	}
+	got := m.NamesForChain(chain, "")
+	if want := []string{"CheckoutForm"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("NamesForChain = %v, want %v", got, want)
+	}
+}
+
+func TestMatchChain_TagUnionAcrossLevels(t *testing.T) {
+	// Tagged CheckoutForm ancestor, untagged SubmitButton leaf: identity is the
+	// nearest (SubmitButton) but tags union the tagged ancestor in.
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "CheckoutForm", Selectors: []string{"form.checkout"}, Tags: []string{"defect"}},
+		sightmap.ComponentDef{Name: "SubmitButton", Selectors: []string{"button.submit"}},
+	)
+	chain := []sightmap.Element{
+		el("form", "checkout"),
+		el("button", "submit"),
+	}
+	if got, want := m.NamesForChain(chain, ""), []string{"SubmitButton"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("NamesForChain = %v, want %v", got, want)
+	}
+	if got, want := m.TagsForChain(chain, ""), []string{"defect"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("TagsForChain = %v, want %v", got, want)
+	}
+}
+
+func TestMatchChain_TagUnionDedupedAndSorted(t *testing.T) {
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "Outer", Selectors: []string{"div.outer"}, Tags: []string{"flaky", "defect"}},
+		sightmap.ComponentDef{Name: "Inner", Selectors: []string{"button"}, Tags: []string{"defect", "slow"}},
+	)
+	chain := []sightmap.Element{
+		el("div", "outer"),
+		el("button"),
+	}
+	got := m.TagsForChain(chain, "")
+	// Union {flaky,defect,slow}, deduplicated, lexicographically sorted.
+	if want := []string{"defect", "flaky", "slow"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("TagsForChain = %v, want %v", got, want)
+	}
+}
+
+func TestMatchChain_DepthAnnotation(t *testing.T) {
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "Outer", Selectors: []string{"div.outer"}},
+		sightmap.ComponentDef{Name: "Inner", Selectors: []string{"button.submit"}},
+	)
+	chain := []sightmap.Element{
+		el("div", "outer"),     // depth 0
+		el("section"),          // depth 1 (matches nothing)
+		el("button", "submit"), // depth 2
+	}
+	got := m.MatchChain(chain, "")
+	want := []match.ChainMatch{
+		{Depth: 0, Name: "Outer"},
+		{Depth: 2, Name: "Inner"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MatchChain = %+v, want %+v", got, want)
+	}
+}
+
+func TestMatchChain_DescendantSelectorAttributesToLeaf(t *testing.T) {
+	// A descendant selector "nav a.link" completes at the anchor (depth 2), so
+	// the match is attributed to that deepest node, not the nav.
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "NavLink", Selectors: []string{"nav a.link"}},
+	)
+	chain := []sightmap.Element{
+		el("nav"),
+		el("ul"),
+		el("a", "link"),
+	}
+	got := m.MatchChain(chain, "")
+	want := []match.ChainMatch{{Depth: 2, Name: "NavLink"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MatchChain = %+v, want %+v", got, want)
+	}
+}
+
+func TestMatchChain_SameDepthConflictReturnsBothNames(t *testing.T) {
+	// Two definitions match the leaf at the same (deepest) level: both surface,
+	// rather than one being silently picked, so a caller can see the conflict.
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "Primary", Selectors: []string{"button.primary"}},
+		sightmap.ComponentDef{Name: "Submit", Selectors: []string{"button.submit"}},
+	)
+	chain := []sightmap.Element{el("button", "primary", "submit")}
+	got := m.NamesForChain(chain, "")
+	if want := []string{"Primary", "Submit"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("NamesForChain = %v, want %v", got, want)
+	}
+}
+
+func TestMatchChain_RouteAwareViewScoped(t *testing.T) {
+	// A view-scoped component applies on the chain only under its route.
+	corpus := &sightmap.Corpus{
+		Views: []sightmap.ViewDef{
+			{
+				Name:  "Checkout",
+				Route: "/checkout",
+				Components: []sightmap.ComponentDef{
+					{Name: "PayButton", Selectors: []string{"button.pay"}},
+				},
+			},
+		},
+	}
+	m := match.NewMatcher(corpus)
+	chain := []sightmap.Element{el("button", "pay")}
+
+	if got, want := m.NamesForChain(chain, "https://x.test/checkout"), []string{"PayButton"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("on-route NamesForChain = %v, want %v", got, want)
+	}
+	if got := m.NamesForChain(chain, "https://x.test/other"); got != nil {
+		t.Errorf("off-route NamesForChain = %v, want nil", got)
+	}
+}
+
+func TestMatchChain_NoMatch(t *testing.T) {
+	m := chainMatcher(
+		sightmap.ComponentDef{Name: "Btn", Selectors: []string{"button"}},
+	)
+	chain := []sightmap.Element{el("div"), el("span")}
+	if got := m.MatchChain(chain, ""); got != nil {
+		t.Errorf("MatchChain = %v, want nil", got)
+	}
+	if got := m.NamesForChain(chain, ""); got != nil {
+		t.Errorf("NamesForChain = %v, want nil", got)
+	}
+	if got := m.TagsForChain(chain, ""); got != nil {
+		t.Errorf("TagsForChain = %v, want nil", got)
+	}
+}
+
+func TestMatchChain_EmptyChain(t *testing.T) {
+	m := chainMatcher(sightmap.ComponentDef{Name: "Btn", Selectors: []string{"button"}})
+	if got := m.MatchChain(nil, ""); got != nil {
+		t.Errorf("MatchChain(nil) = %v, want nil", got)
+	}
+}
+
+func TestMatchChain_NoDefs(t *testing.T) {
+	m := match.NewMatcher(&sightmap.Corpus{})
+	if got := m.MatchChain([]sightmap.Element{el("button")}, ""); got != nil {
+		t.Errorf("MatchChain = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a chain-matching entry point to `match.Matcher`, for consumers that
classify a **stream of individual observed elements** rather than a full
component tree. Each observed element carries only its own root→leaf ancestor
chain (not a tree), so today there is no first-class API for it — a consumer
reimplements the spec's component identity/tag resolution by hand, and
route-blind.

Three additions on `*match.Matcher`:

- `MatchChain(chain []sightmap.Element, pageURL string) []ChainMatch` — the
  primitive. Builds a single-branch `ComponentNode` spine from the chain, runs
  the existing NFA matcher (`FindAllMatches`) over it, and returns every match
  annotated with the `Depth` of the chain node that completed the selector,
  ordered root→leaf.
- `NamesForChain(...) []string` — the spec's **nearest-enclosing** identity rule
  (schema.md §Tags): the name(s) at the deepest matching level. Almost always a
  single name; returns more than one only on a genuine same-depth identity
  conflict, so the caller sees it rather than a silently-picked winner.
- `TagsForChain(...) []string` — the spec's **tag-union** rule: union of tags
  across every matching level, deduplicated and lexicographically sorted.

Matching is **route-aware** — `pageURL` selects the same view-scoped-plus-global
set `Match` uses, so a view-scoped component applies on the chain exactly as it
would in a full-tree match. This is what makes the downstream consumer's
signal-path naming route-aware in the process.

## Why

Lifts the spec's two component resolution rules into the shared library so they
live once, and unblocks retiring a downstream consumer's parallel single-chain
matcher (FullStory/lidar signal path). Purely **additive packaging** over
already-exported pieces (`ParseQueries` / `Components` / `FindAllMatches`) — no
new matching semantics.

## Notes

- Because the caller supplies only the ancestor chain and not the leaf's own
  subtree, a relational `:has()` on the leaf cannot be satisfied here — the
  inherent limitation of any ancestor-only view. Documented on `MatchChain`.
- Standalone PR off `main` (not part of the #209 stack); `minor` changeset.

## Test

`go test ./match/` — new `chain_test.go` covers nearest-enclosing (incl.
ancestor fallback), tag union (dedup + sort), depth annotation, descendant
selectors attributing to the deepest node, same-depth conflicts, route-aware
view scoping, and the empty/no-match/no-def edges. Full `go test ./...` and
`gofmt -l` clean.
