### PR TITLE
browser: add --attach degraded mode (attach to a running Chrome) + fix Collector.Stop deadlock

### DIFF
--- a/.changeset/browser-attach.md
+++ b/.changeset/browser-attach.md
@@ -1,0 +1,19 @@
+---
+"@sightmap/sightmap": minor
+---
+
+`browser start --attach host:port` attaches the daemon (devtools server +
+console/network collector) to an already-running Chrome's CDP endpoint instead
+of launching and owning its own. It is a deliberately degraded mode: no owned
+profile or extension guarantees, capture is complete only from attach onward
+(pre-attach network/console history can't be recovered — `Network.enable`
+replays nothing), and `browser stop` detaches rather than killing the
+caller-owned browser. The collector and devtools query surface are unchanged —
+the collector only ever needed a CDP address — so live console/exception and
+request matching work identically once attached.
+
+Also fixes a latent shutdown-order bug in the collector surfaced by attach mode:
+`Collector.Stop` cancelled the per-tab drain contexts *after* `wg.Wait()`, which
+deadlocked whenever the CDP connections were still healthy at stop time (the norm
+when a consumer stops the collector without tearing down the browser). Stop now
+cancels the drains first and refuses new tab attachments during teardown.

--- a/.changeset/browser-attach.md
+++ b/.changeset/browser-attach.md
@@ -17,3 +17,12 @@ Also fixes a latent shutdown-order bug in the collector surfaced by attach mode:
 deadlocked whenever the CDP connections were still healthy at stop time (the norm
 when a consumer stops the collector without tearing down the browser). Stop now
 cancels the drains first and refuses new tab attachments during teardown.
+
+And fixes extension-server-port injection under attach: `findExtensionSWWS` took
+the *first* extension service worker it found, so in a real browser with several
+extensions installed (the attach case) it injected the port hint into the wrong
+one and the sightmap overlay never learned the server port — falling back to
+probing 7891–7900 and latching onto whatever sightmap server answered first
+(often a different session). It now identifies the sightmap extension by its
+manifest name before injecting, so the correct overlay gets the hint. An owned
+launch never hit this: its isolated profile contains only the sightmap extension.

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -50,8 +50,9 @@ type Collector struct {
 	consoleDropped int
 	networkDropped int
 
-	tabsMu sync.Mutex
-	tabs   map[string]*tabColl
+	tabsMu   sync.Mutex
+	tabs     map[string]*tabColl
+	stopping bool // set under tabsMu in Stop; blocks new tab attachments during teardown
 
 	stop chan struct{}
 	wg   sync.WaitGroup
@@ -81,13 +82,28 @@ func (c *Collector) Start() {
 }
 
 // Stop halts capture and closes every per-tab connection.
+//
+// Order matters: each drain goroutine only returns on its ctx being cancelled,
+// so the per-tab contexts MUST be cancelled BEFORE wg.Wait(). Cancelling after
+// the wait would deadlock whenever the CDP connections are still healthy at Stop
+// time (i.e. the browser is still running — the norm when a caller stops the
+// collector without tearing down the browser, as in --attach mode). The owned
+// path happened to avoid this only because it kills Chrome first, breaking the
+// connections out from under the drains.
 func (c *Collector) Stop() {
 	close(c.stop)
+	c.tabsMu.Lock()
+	c.stopping = true // stop syncTabs from attaching a fresh (uncancelled) drain
+	for _, tc := range c.tabs {
+		tc.cancel()
+	}
+	c.tabsMu.Unlock()
 	c.wg.Wait()
 	c.tabsMu.Lock()
 	for id, tc := range c.tabs {
-		tc.cancel()
-		tc.conn.Close()
+		if tc.conn != nil {
+			tc.conn.Close()
+		}
 		delete(c.tabs, id)
 	}
 	c.tabsMu.Unlock()
@@ -160,10 +176,18 @@ func (c *Collector) attachTab(tabID string) {
 	}
 
 	c.tabsMu.Lock()
+	if c.stopping {
+		// Teardown is in progress; don't start a drain that Stop's wg.Wait would
+		// then block on. Cancel and drop this connection instead.
+		c.tabsMu.Unlock()
+		cancel()
+		conn.Close()
+		return
+	}
 	c.tabs[tabID] = &tabColl{conn: conn, cancel: cancel}
+	c.wg.Add(1)
 	c.tabsMu.Unlock()
 
-	c.wg.Add(1)
 	go c.drain(ctx, tabID, conn, consoleCh, excCh, reqCh, respCh, finishedCh)
 }
 

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -50,12 +50,24 @@ type Collector struct {
 	consoleDropped int
 	networkDropped int
 
-	tabsMu   sync.Mutex
-	tabs     map[string]*tabColl
-	stopping bool // set under tabsMu in Stop; blocks new tab attachments during teardown
+	tabsMu sync.Mutex
+	tabs   map[string]*tabColl
 
-	stop chan struct{}
-	wg   sync.WaitGroup
+	// ctx spans the collector's entire capture lifetime and is cancelled by Stop.
+	// Every per-tab context derives from it, so a single cancel stops every drain
+	// and interrupts any in-flight tab poll or dial.
+	//
+	// Holding a context in a struct is a deliberate deviation from the usual
+	// "pass it as the first argument" rule. The scope here is this object's
+	// lifetime rather than one request, and fixing both fields at construction
+	// keeps that lifetime immutable: Start and Stop then need no locking, no nil
+	// check, and no guard against a second Start replacing the first cancel func
+	// and stranding wg.Wait forever. Long-lived clients hold the same pair for
+	// the same reason (e.g. grpc.ClientConn).
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	wg sync.WaitGroup
 }
 
 type tabColl struct {
@@ -66,11 +78,13 @@ type tabColl struct {
 // NewCollector creates a collector for the Chrome session at addr (host:port).
 // Call Start to begin capturing and Stop to tear down.
 func NewCollector(addr string) *Collector {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Collector{
 		addr:       addr,
 		maxEntries: DefaultMaxEntries,
 		tabs:       make(map[string]*tabColl),
-		stop:       make(chan struct{}),
+		ctx:        ctx,
+		cancel:     cancel,
 	}
 }
 
@@ -81,23 +95,25 @@ func (c *Collector) Start() {
 	go c.attachLoop()
 }
 
-// Stop halts capture and closes every per-tab connection.
+// Stop halts capture and closes every per-tab connection. It is safe to call
+// more than once.
 //
-// Order matters: each drain goroutine only returns on its ctx being cancelled,
-// so the per-tab contexts MUST be cancelled BEFORE wg.Wait(). Cancelling after
-// the wait would deadlock whenever the CDP connections are still healthy at Stop
-// time (i.e. the browser is still running — the norm when a caller stops the
-// collector without tearing down the browser, as in --attach mode). The owned
-// path happened to avoid this only because it kills Chrome first, breaking the
-// connections out from under the drains.
+// Order matters: a drain goroutine returns only once its context is cancelled,
+// so cancellation MUST precede wg.Wait(). Waiting first deadlocks whenever the
+// CDP connections are still healthy at Stop time, which is the normal case
+// whenever the caller owns the browser and it outlives the collector, as under
+// --attach. One cancel covers every tab, since all tab contexts descend from
+// c.ctx.
+//
+// A tab attaching concurrently with Stop is safe on three counts: its context
+// descends from c.ctx, so it is born cancelled and its drain returns on its
+// first select; its conn is registered in c.tabs before that drain is counted,
+// so the sweep below still closes it; and its wg.Add cannot race wg.Wait,
+// because attachTab runs only on the attachLoop goroutine, which holds a count
+// of its own until it returns, keeping the counter above zero for as long as a
+// further Add is possible.
 func (c *Collector) Stop() {
-	close(c.stop)
-	c.tabsMu.Lock()
-	c.stopping = true // stop syncTabs from attaching a fresh (uncancelled) drain
-	for _, tc := range c.tabs {
-		tc.cancel()
-	}
-	c.tabsMu.Unlock()
+	c.cancel()
 	c.wg.Wait()
 	c.tabsMu.Lock()
 	for id, tc := range c.tabs {
@@ -119,7 +135,7 @@ func (c *Collector) attachLoop() {
 	defer t.Stop()
 	for {
 		select {
-		case <-c.stop:
+		case <-c.ctx.Done():
 			return
 		case <-t.C:
 			c.syncTabs()
@@ -128,7 +144,10 @@ func (c *Collector) attachLoop() {
 }
 
 func (c *Collector) syncTabs() {
-	tabs, err := ListTabs(context.Background(), c.addr)
+	// Neither this poll nor the ConnectTab below sets a client timeout, so the
+	// collector context is the only thing bounding them: a browser that accepts
+	// the socket and then never answers would otherwise block Stop indefinitely.
+	tabs, err := ListTabs(c.ctx, c.addr)
 	if err != nil {
 		return
 	}
@@ -155,11 +174,11 @@ func (c *Collector) syncTabs() {
 }
 
 func (c *Collector) attachTab(tabID string) {
-	conn, err := ConnectTab(context.Background(), c.addr, tabID)
+	conn, err := ConnectTab(c.ctx, c.addr, tabID)
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.ctx)
 
 	consoleCh := conn.Subscribe("Runtime.consoleAPICalled")
 	excCh := conn.Subscribe("Runtime.exceptionThrown")
@@ -176,14 +195,6 @@ func (c *Collector) attachTab(tabID string) {
 	}
 
 	c.tabsMu.Lock()
-	if c.stopping {
-		// Teardown is in progress; don't start a drain that Stop's wg.Wait would
-		// then block on. Cancel and drop this connection instead.
-		c.tabsMu.Unlock()
-		cancel()
-		conn.Close()
-		return
-	}
 	c.tabs[tabID] = &tabColl{conn: conn, cancel: cancel}
 	c.wg.Add(1)
 	c.tabsMu.Unlock()

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -3,8 +3,13 @@ package browser
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -178,14 +183,15 @@ func TestDecodeBody(t *testing.T) {
 	}
 }
 
-// TestCollectorStop_NoDeadlockWhileConnected guards the shutdown-order fix: a
-// drain goroutine only returns on its ctx being cancelled, so Stop must cancel
-// the per-tab contexts BEFORE wg.Wait(). Simulate a still-attached tab whose
-// drain is blocked (a healthy CDP connection, i.e. the browser is still alive —
-// the --attach case) and assert Stop returns promptly instead of deadlocking.
+// TestCollectorStop_NoDeadlockWhileConnected pins Stop's shutdown ordering: a
+// drain returns only once its context is cancelled, so Stop must cancel every
+// tab context, via the shared parent c.ctx, before wg.Wait. Simulates a
+// still-attached tab whose drain is blocked on a healthy CDP connection, the
+// case where the browser outlives the collector, and asserts Stop returns
+// promptly rather than deadlocking.
 func TestCollectorStop_NoDeadlockWhileConnected(t *testing.T) {
 	c := NewCollector("unused")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.ctx)
 	c.tabsMu.Lock()
 	c.tabs["t1"] = &tabColl{conn: nil, cancel: cancel}
 	c.tabsMu.Unlock()
@@ -201,5 +207,148 @@ func TestCollectorStop_NoDeadlockWhileConnected(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Collector.Stop deadlocked with a healthy (uncancelled) drain")
+	}
+}
+
+// newFakeBrowser starts a fake Chrome CDP endpoint exposing a single page target
+// and returns its host:port. The websocket answers every command with an empty
+// result, which is all attachTab's Runtime.enable and Network.enable require.
+// onList, when non-nil, runs at the head of each /json/list request, letting a
+// test stall the tab poll.
+func newFakeBrowser(t *testing.T, onList func(r *http.Request)) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewUnstartedServer(mux)
+
+	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
+		if onList != nil {
+			onList(r)
+		}
+		targets := []map[string]string{{
+			"id":                   "tab-1",
+			"type":                 "page",
+			"url":                  "http://fake.test/",
+			"webSocketDebuggerUrl": "ws://" + r.Host + "/ws",
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(targets); err != nil {
+			t.Logf("newFakeBrowser: encode targets: %v", err)
+		}
+	})
+
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		wsConn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("newFakeBrowser: ws upgrade: %v", err)
+			return
+		}
+		var wsMu sync.Mutex
+		go func() {
+			for {
+				_, raw, readErr := wsConn.ReadMessage()
+				if readErr != nil {
+					return
+				}
+				var req struct {
+					ID int64 `json:"id"`
+				}
+				if json.Unmarshal(raw, &req) != nil {
+					continue
+				}
+				reply, _ := json.Marshal(map[string]any{"id": req.ID, "result": map[string]any{}})
+				wsMu.Lock()
+				err := wsConn.WriteMessage(websocket.TextMessage, reply)
+				wsMu.Unlock()
+				if err != nil {
+					return
+				}
+			}
+		}()
+	})
+
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
+}
+
+// waitForTabs blocks until the collector has exactly n tabs registered.
+func waitForTabs(t *testing.T, c *Collector, n int, why string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		c.tabsMu.Lock()
+		got := len(c.tabs)
+		c.tabsMu.Unlock()
+		if got == n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: %d tabs registered, want %d", why, got, n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestCollectorStop_LiveTabNoDeadlock drives the real attach path against a fake
+// browser and stops the collector while the CDP connection is still healthy, the
+// case where the caller owns the browser and it outlives the collector. Stop must
+// return promptly and leave no tab registered.
+func TestCollectorStop_LiveTabNoDeadlock(t *testing.T) {
+	c := NewCollector(newFakeBrowser(t, nil))
+	c.Start()
+	t.Cleanup(c.Stop) // idempotent; covers the early-Fatal paths below
+	waitForTabs(t, c, 1, "collector never attached the fake tab")
+
+	done := make(chan struct{})
+	go func() { c.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Collector.Stop deadlocked with a live, healthy tab connection")
+	}
+
+	c.tabsMu.Lock()
+	remaining := len(c.tabs)
+	c.tabsMu.Unlock()
+	if remaining != 0 {
+		t.Errorf("after Stop: %d tabs still registered, want 0", remaining)
+	}
+}
+
+// TestCollectorStop_DuringStalledPoll covers the other route to a hung Stop: a
+// browser that accepts the connection and then never answers the tab poll.
+// ListTabs sets no client timeout, so attachLoop escapes the poll only because it
+// runs on the collector context that Stop cancels.
+func TestCollectorStop_DuringStalledPoll(t *testing.T) {
+	polled := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	addr := newFakeBrowser(t, func(r *http.Request) {
+		once.Do(func() { close(polled) })
+		select {
+		case <-r.Context().Done(): // the collector gave up on the request
+		case <-release:
+		}
+	})
+	// Runs before the server's own cleanup, so a stalled handler cannot wedge it.
+	t.Cleanup(func() { close(release) })
+
+	c := NewCollector(addr)
+	c.Start()
+	t.Cleanup(c.Stop)
+
+	select {
+	case <-polled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("collector never polled the fake browser")
+	}
+
+	done := make(chan struct{})
+	go func() { c.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Collector.Stop deadlocked while the tab poll was stalled")
 	}
 }

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -174,5 +175,31 @@ func TestDecodeBody(t *testing.T) {
 	enc, err := decodeBody(json.RawMessage(`{"body":"aGk=","base64Encoded":true}`))
 	if err != nil || string(enc) != "hi" {
 		t.Errorf("base64 body = %q, %v", enc, err)
+	}
+}
+
+// TestCollectorStop_NoDeadlockWhileConnected guards the shutdown-order fix: a
+// drain goroutine only returns on its ctx being cancelled, so Stop must cancel
+// the per-tab contexts BEFORE wg.Wait(). Simulate a still-attached tab whose
+// drain is blocked (a healthy CDP connection, i.e. the browser is still alive —
+// the --attach case) and assert Stop returns promptly instead of deadlocking.
+func TestCollectorStop_NoDeadlockWhileConnected(t *testing.T) {
+	c := NewCollector("unused")
+	ctx, cancel := context.WithCancel(context.Background())
+	c.tabsMu.Lock()
+	c.tabs["t1"] = &tabColl{conn: nil, cancel: cancel}
+	c.tabsMu.Unlock()
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		<-ctx.Done() // exits only when Stop cancels the tab's context
+	}()
+
+	done := make(chan struct{})
+	go func() { c.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Collector.Stop deadlocked with a healthy (uncancelled) drain")
 	}
 }

--- a/go/browser/extension.go
+++ b/go/browser/extension.go
@@ -50,12 +50,11 @@ func InjectExtensionServerPort(ctx context.Context, addr string, serverPort int)
 // extension's service worker, retrying for up to 5 seconds while it starts.
 // Returns "" if no sightmap extension service worker is found.
 //
-// It must not just take the first extension service worker it sees: a real
-// browser (the --attach case) commonly has several extensions installed, so the
-// candidate is confirmed by evaluating its manifest `name` and matching
-// sightmapExtensionMarker. (An owned launch has an isolated profile with only
-// the sightmap extension, so this only ever mattered once attach let us point at
-// a user's everyday browser.)
+// Taking the first extension service worker found is not enough: a browser the
+// caller owns (the --attach case) commonly has several extensions installed, so
+// each candidate is confirmed by evaluating its manifest `name` against
+// sightmapExtensionMarker. An owned launch has an isolated profile holding only
+// the sightmap extension, where the first candidate always matches.
 func findExtensionSWWS(ctx context.Context, addr string) (string, error) {
 	type target struct {
 		Type  string `json:"type"`

--- a/go/browser/extension.go
+++ b/go/browser/extension.go
@@ -11,6 +11,14 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// sightmapExtensionMarker is matched (case-insensitively, as a substring)
+// against a candidate extension's manifest `name` to identify the sightmap
+// overlay extension among any others installed in the browser. Matching the
+// manifest name — rather than a hardcoded extension ID — is what lets this work
+// across both the published extension and an unpacked `--load-extension` build,
+// whose IDs differ.
+const sightmapExtensionMarker = "sightmap"
+
 // InjectExtensionServerPort finds the sightmap extension's service worker
 // target via the Chrome DevTools Protocol and injects the sightmap HTTP server
 // port into chrome.storage.local. Each Chrome profile has its own isolated
@@ -18,61 +26,36 @@ import (
 // approach without any file-system races.
 //
 // The function retries for up to 5 seconds to allow the service worker to
-// finish starting. Returns nil if no extension service worker is found — the
-// extension will fall back to port-range probing.
+// finish starting. Returns nil if the sightmap extension's service worker is not
+// found — the extension will fall back to port-range probing.
 func InjectExtensionServerPort(ctx context.Context, addr string, serverPort int) error {
 	swWSURL, err := findExtensionSWWS(ctx, addr)
 	if err != nil {
 		return fmt.Errorf("inject extension port: %w", err)
 	}
 	if swWSURL == "" {
-		// No extension service worker found — non-fatal; extension will probe ports.
+		// Sightmap extension service worker not found — non-fatal; the extension
+		// will fall back to port-range probing.
 		return nil
 	}
 
-	// Connect directly to the service worker's debugger endpoint.
-	dialer := websocket.Dialer{}
-	ws, _, err := dialer.DialContext(ctx, swWSURL, nil)
-	if err != nil {
-		return fmt.Errorf("inject extension port: dial service worker: %w", err)
-	}
-	defer ws.Close()
-
-	type cdpReq struct {
-		ID     int    `json:"id"`
-		Method string `json:"method"`
-		Params any    `json:"params"`
-	}
 	expr := fmt.Sprintf("chrome.storage.local.set({serverPort: %d})", serverPort)
-	if err := ws.WriteJSON(cdpReq{
-		ID:     1,
-		Method: "Runtime.evaluate",
-		Params: map[string]any{
-			"expression":   expr,
-			"awaitPromise": true,
-		},
-	}); err != nil {
-		return fmt.Errorf("inject extension port: send evaluate: %w", err)
-	}
-
-	// Read and discard the response (we only care that the call succeeded).
-	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
-	_, raw, err := ws.ReadMessage()
-	if err != nil {
-		return fmt.Errorf("inject extension port: read response: %w", err)
-	}
-	var resp struct {
-		Error *struct{ Message string } `json:"error"`
-	}
-	if json.Unmarshal(raw, &resp) == nil && resp.Error != nil {
-		return fmt.Errorf("inject extension port: CDP error: %s", resp.Error.Message)
+	if _, err := swEval(ctx, swWSURL, expr); err != nil {
+		return fmt.Errorf("inject extension port: %w", err)
 	}
 	return nil
 }
 
-// findExtensionSWWS returns the WebSocket debugger URL of the sightmap extension's
-// service worker, retrying for up to 5 seconds while it starts. Returns "" if no
-// extension service worker is found.
+// findExtensionSWWS returns the WebSocket debugger URL of the *sightmap*
+// extension's service worker, retrying for up to 5 seconds while it starts.
+// Returns "" if no sightmap extension service worker is found.
+//
+// It must not just take the first extension service worker it sees: a real
+// browser (the --attach case) commonly has several extensions installed, so the
+// candidate is confirmed by evaluating its manifest `name` and matching
+// sightmapExtensionMarker. (An owned launch has an isolated profile with only
+// the sightmap extension, so this only ever mattered once attach let us point at
+// a user's everyday browser.)
 func findExtensionSWWS(ctx context.Context, addr string) (string, error) {
 	type target struct {
 		Type  string `json:"type"`
@@ -94,7 +77,10 @@ func findExtensionSWWS(ctx context.Context, addr string) (string, error) {
 			return "", err
 		}
 		for _, t := range targets {
-			if t.Type == "service_worker" && strings.HasPrefix(t.URL, "chrome-extension://") {
+			if t.Type != "service_worker" || !strings.HasPrefix(t.URL, "chrome-extension://") || t.WSURL == "" {
+				continue
+			}
+			if isSightmapSW(ctx, t.WSURL) {
 				return t.WSURL, nil
 			}
 		}
@@ -116,4 +102,81 @@ func findExtensionSWWS(ctx context.Context, addr string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+// isSightmapSW reports whether the extension service worker at wsURL belongs to
+// the sightmap extension, by reading its manifest name over CDP. Any dial/eval
+// error is treated as "not it" so an unrelated or uncooperative extension is
+// simply skipped.
+func isSightmapSW(ctx context.Context, wsURL string) bool {
+	val, err := swEval(ctx, wsURL, "chrome.runtime.getManifest().name")
+	if err != nil {
+		return false
+	}
+	var name string
+	if json.Unmarshal(val, &name) != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(name), sightmapExtensionMarker)
+}
+
+// swEval dials a service-worker debugger endpoint, runs Runtime.evaluate for
+// expr (awaiting promises, returning the value by value), and returns the raw
+// JSON of the result value. Shared by the extension-identity check and the
+// server-port injection.
+func swEval(ctx context.Context, wsURL, expr string) (json.RawMessage, error) {
+	dialer := websocket.Dialer{}
+	ws, _, err := dialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial service worker: %w", err)
+	}
+	defer ws.Close()
+
+	type cdpReq struct {
+		ID     int    `json:"id"`
+		Method string `json:"method"`
+		Params any    `json:"params"`
+	}
+	if err := ws.WriteJSON(cdpReq{
+		ID:     1,
+		Method: "Runtime.evaluate",
+		Params: map[string]any{
+			"expression":    expr,
+			"awaitPromise":  true,
+			"returnByValue": true,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("send evaluate: %w", err)
+	}
+
+	// Bound the read by the caller's deadline when it has one, else a short
+	// default. Loop until our command reply (id==1) arrives, skipping any
+	// protocol events the worker emits first.
+	if dl, ok := ctx.Deadline(); ok {
+		_ = ws.SetReadDeadline(dl)
+	} else {
+		_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+	}
+	for {
+		_, raw, err := ws.ReadMessage()
+		if err != nil {
+			return nil, fmt.Errorf("read response: %w", err)
+		}
+		var resp struct {
+			ID     int `json:"id"`
+			Result struct {
+				Result struct {
+					Value json.RawMessage `json:"value"`
+				} `json:"result"`
+			} `json:"result"`
+			Error *struct{ Message string } `json:"error"`
+		}
+		if json.Unmarshal(raw, &resp) != nil || resp.ID != 1 {
+			continue // malformed, or an event rather than our reply
+		}
+		if resp.Error != nil {
+			return nil, fmt.Errorf("CDP error: %s", resp.Error.Message)
+		}
+		return resp.Result.Result.Value, nil
+	}
 }

--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -25,11 +25,16 @@ const DefaultCDPPort = 7892
 // ServerPort is the sightmap HTTP server port (default 7891). It is recorded
 // here so callers can display it and so the extension config can be validated.
 type SessionInfo struct {
-	Port       int    `json:"port"`
-	PID        int    `json:"pid"`                  // 0 if Chrome reused an existing process
+	Port       int    `json:"port"`                 // Chrome CDP (remote-debugging) port
+	PID        int    `json:"pid"`                  // 0 if Chrome reused an existing process; the DAEMON's own pid in attach mode
 	Pgid       int    `json:"pgid,omitempty"`       // process-group id (unix) for group-kill on stop
-	Profile    string `json:"profile"`              // user-data-dir used for this session
+	Profile    string `json:"profile"`              // user-data-dir used for this session (empty in attach mode)
 	ServerPort int    `json:"serverPort,omitempty"` // sightmap HTTP server port (0 = unknown/legacy)
+	// Attached is true when the daemon attached to a caller-launched Chrome via
+	// --attach rather than launching (and owning) its own. In that mode stop must
+	// NOT kill the browser — it only signals the daemon to detach. PID then holds
+	// the daemon's own pid, not Chrome's, and Profile is empty.
+	Attached bool `json:"attached,omitempty"`
 	// TargetID removed — use --tab flag on individual commands instead
 }
 

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -184,6 +184,21 @@ func runStop(args []string) error {
 	info, infoErr := browser.ReadSessionInfo(sightmapDir)
 	hasSession := infoErr == nil && (info.Port > 0 || info.PID > 0 || info.Pgid > 0)
 
+	// Attached session: the browser is caller-owned, so never kill it. Signal the
+	// daemon (info.PID is the daemon's own pid in attach mode) to detach, and drop
+	// the session file. The daemon's own signal handler also tears down; both
+	// removing the file is harmless.
+	if hasSession && info.Attached {
+		if info.PID > 0 {
+			if proc, perr := os.FindProcess(info.PID); perr == nil {
+				_ = proc.Signal(syscall.SIGTERM)
+			}
+		}
+		_ = browser.RemoveSessionFile(sightmapDir)
+		fmt.Fprintln(os.Stderr, "detached (browser left running)")
+		return nil
+	}
+
 	profile := ""
 	if hasSession {
 		profile = info.Profile

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -366,8 +366,8 @@ func startDevtoolsServer(sightmapDir, siteName string, serverPort int) (*http.Se
 // deliberately degraded mode (see the --attach flag help): no owned profile or
 // extension guarantees, capture is complete only from attach onward, and the
 // browser is left running when the daemon stops. The collector and devtools
-// server are identical to the owned-launch path — the collector only ever needed
-// a CDP address.
+// server are identical to the owned-launch path, since the collector needs
+// nothing but a CDP address.
 func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlFlag string) error {
 	// Normalize the endpoint. A bare ":port" or "port" is treated as localhost.
 	host, port, err := net.SplitHostPort(attachAddr)
@@ -422,16 +422,23 @@ func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlF
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	gone := make(chan struct{})
-	stopPoll := make(chan struct{})
+	pollCtx, pollCancel := context.WithCancel(context.Background())
+	defer pollCancel()
 	go func() {
 		t := time.NewTicker(2 * time.Second)
 		defer t.Stop()
 		for {
 			select {
-			case <-stopPoll:
+			case <-pollCtx.Done():
 				return
 			case <-t.C:
-				if !cdpVersionAlive(context.Background(), cdpAddr) {
+				// The probe sets no client timeout of its own, so pollCtx is what
+				// bounds it: a browser that accepts the socket and never answers
+				// would otherwise wedge this loop and never report the browser gone.
+				if !cdpVersionAlive(pollCtx, cdpAddr) {
+					if pollCtx.Err() != nil {
+						return // shutting down, not a dead browser
+					}
 					close(gone)
 					return
 				}
@@ -478,7 +485,6 @@ func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlF
 	case <-gone:
 		fmt.Fprintln(os.Stderr, "\nattached browser went away — detaching")
 	}
-	close(stopPoll)
 
 	// Stop HTTP server and drop the session file. The browser is NOT touched.
 	shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,7 @@ func runBrowserStart(args []string) error {
 	fset := flag.NewFlagSet("start", flag.ContinueOnError)
 	portFlag := fset.Int("port", 7891, "Sightmap HTTP server port (0 = auto-allocate)")
 	cdpPortFlag := fset.Int("cdp-port", browser.DefaultCDPPort, "Chrome remote debugging port (0 = auto-allocate)")
+	attachFlag := fset.String("attach", "", "Attach to an already-running Chrome's CDP endpoint (host:port) instead of launching one (degraded mode: no owned profile, capture is complete only from attach onward, browser is left running on stop)")
 	sightmapDir := fset.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir")
 	extensionsFlag := fset.String("extensions", "", "Comma-separated extension paths to load")
 	urlFlag := fset.String("url", "", "Navigate here after launch")
@@ -49,6 +51,13 @@ func runBrowserStart(args []string) error {
 		if !explicit["port"] && cfg.Browser.Port > 0 {
 			*portFlag = cfg.Browser.Port
 		}
+	}
+
+	// Attach mode: hand off to the degraded, browser-not-owned path. It shares the
+	// devtools server + collector with the owned-launch path below but skips the
+	// launch/profile/extension machinery entirely.
+	if *attachFlag != "" {
+		return runAttachedSession(*attachFlag, *sightmapDir, *portFlag, *urlFlag)
 	}
 
 	// Resolve profile early so the existing-Chrome check can match it.
@@ -109,73 +118,9 @@ func runBrowserStart(args []string) error {
 
 	// ── Start sightmap HTTP server in background ──────────────────────────────
 	siteName := filepath.Base(cwd())
-	compiled, err := loadServedSightmap(*sightmapDir, siteName)
+	srv, collectorPtr, err := startDevtoolsServer(*sightmapDir, siteName, resolvedServerPort)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "start: sightmap load warning: %v\n", err)
-		// non-fatal: continue without corpus
-	}
-
-	var mu sync.RWMutex
-	current := compiled
-
-	reload := func() {
-		c, loadErr := loadServedSightmap(*sightmapDir, siteName)
-		if loadErr != nil {
-			fmt.Fprintf(os.Stderr, "[serve-sightmap] load error: %v\n", loadErr)
-			return
-		}
-		mu.Lock()
-		current = c
-		mu.Unlock()
-		fmt.Fprintf(os.Stderr, "[serve-sightmap] reloaded (v%s)\n", c.Version)
-	}
-
-	go watchSightmapDir(*sightmapDir, reload)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/sightmap/version", func(w http.ResponseWriter, r *http.Request) {
-		mu.RLock()
-		v := current.Version
-		mu.RUnlock()
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"version":%q}`, v)
-	})
-	mux.HandleFunc("/sightmap", func(w http.ResponseWriter, r *http.Request) {
-		mu.RLock()
-		c := current
-		mu.RUnlock()
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(c)
-	})
-
-	// Devtools query surface. The collector is created after Chrome is ready
-	// (below); the handlers return 503 until then.
-	var collectorPtr atomic.Pointer[browser.Collector]
-	registerDevtoolsHandlers(mux, &collectorPtr, *sightmapDir)
-
-	// Bind the sightmap server on the IPv4 loopback (not the ":port" wildcard) so
-	// it shares an address family with Chrome's CDP and with FindFreePort's probe.
-	// This keeps concurrent daemons from landing one daemon's server on another's
-	// CDP port, and keeps the server local-only.
-	srvAddr := fmt.Sprintf("127.0.0.1:%d", resolvedServerPort)
-	srv := &http.Server{Addr: srvAddr, Handler: mux}
-	srvReady := make(chan error, 1)
-	go func() {
-		ln, listenErr := net.Listen("tcp", srvAddr)
-		if listenErr != nil {
-			srvReady <- listenErr
-			return
-		}
-		srvReady <- nil
-		fmt.Fprintf(os.Stderr, "[serve-sightmap] listening on http://%s\n", srvAddr)
-		_ = srv.Serve(ln)
-	}()
-	if srvErr := <-srvReady; srvErr != nil {
-		// This shouldn't happen since we pre-allocated via FindFreePort,
-		// but handle the unlikely race gracefully.
-		return fmt.Errorf("start: sightmap server could not bind port %d: %w", resolvedServerPort, srvErr)
+		return fmt.Errorf("start: %w", err)
 	}
 
 	// ── Launch Chrome ─────────────────────────────────────────────────────────
@@ -337,5 +282,208 @@ func runBrowserStart(args []string) error {
 	// Remove session file.
 	os.Remove(browser.SessionFilePath(*sightmapDir))
 
+	return nil
+}
+
+// startDevtoolsServer builds and starts the sightmap HTTP server for a browser
+// session on serverPort: it serves the live corpus (/sightmap, /sightmap/version,
+// hot-reloaded from sightmapDir) and the devtools query surface (network/console).
+// It returns the running server plus the collector pointer the devtools handlers
+// read from — the caller Stores the live collector into it once the CDP session
+// is ready. Both the owned-launch and --attach paths share this.
+func startDevtoolsServer(sightmapDir, siteName string, serverPort int) (*http.Server, *atomic.Pointer[browser.Collector], error) {
+	compiled, err := loadServedSightmap(sightmapDir, siteName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start: sightmap load warning: %v\n", err)
+		// non-fatal: continue without corpus
+	}
+
+	var mu sync.RWMutex
+	current := compiled
+
+	reload := func() {
+		c, loadErr := loadServedSightmap(sightmapDir, siteName)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "[serve-sightmap] load error: %v\n", loadErr)
+			return
+		}
+		mu.Lock()
+		current = c
+		mu.Unlock()
+		fmt.Fprintf(os.Stderr, "[serve-sightmap] reloaded (v%s)\n", c.Version)
+	}
+
+	go watchSightmapDir(sightmapDir, reload)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sightmap/version", func(w http.ResponseWriter, r *http.Request) {
+		mu.RLock()
+		v := current.Version
+		mu.RUnlock()
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"version":%q}`, v)
+	})
+	mux.HandleFunc("/sightmap", func(w http.ResponseWriter, r *http.Request) {
+		mu.RLock()
+		c := current
+		mu.RUnlock()
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(c)
+	})
+
+	// Devtools query surface. The collector is created after the CDP session is
+	// ready; the handlers return 503 until then.
+	collectorPtr := &atomic.Pointer[browser.Collector]{}
+	registerDevtoolsHandlers(mux, collectorPtr, sightmapDir)
+
+	// Bind the sightmap server on the IPv4 loopback (not the ":port" wildcard) so
+	// it shares an address family with Chrome's CDP and with FindFreePort's probe.
+	// This keeps concurrent daemons from landing one daemon's server on another's
+	// CDP port, and keeps the server local-only.
+	srvAddr := fmt.Sprintf("127.0.0.1:%d", serverPort)
+	srv := &http.Server{Addr: srvAddr, Handler: mux}
+	srvReady := make(chan error, 1)
+	go func() {
+		ln, listenErr := net.Listen("tcp", srvAddr)
+		if listenErr != nil {
+			srvReady <- listenErr
+			return
+		}
+		srvReady <- nil
+		fmt.Fprintf(os.Stderr, "[serve-sightmap] listening on http://%s\n", srvAddr)
+		_ = srv.Serve(ln)
+	}()
+	if srvErr := <-srvReady; srvErr != nil {
+		return nil, nil, fmt.Errorf("sightmap server could not bind port %d: %w", serverPort, srvErr)
+	}
+	return srv, collectorPtr, nil
+}
+
+// runAttachedSession runs the daemon against a caller-launched Chrome reached at
+// attachAddr (host:port CDP endpoint) instead of launching its own. It is a
+// deliberately degraded mode (see the --attach flag help): no owned profile or
+// extension guarantees, capture is complete only from attach onward, and the
+// browser is left running when the daemon stops. The collector and devtools
+// server are identical to the owned-launch path — the collector only ever needed
+// a CDP address.
+func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlFlag string) error {
+	// Normalize the endpoint. A bare ":port" or "port" is treated as localhost.
+	host, port, err := net.SplitHostPort(attachAddr)
+	if err != nil {
+		// Allow a bare port number.
+		if p, perr := strconv.Atoi(strings.TrimSpace(attachAddr)); perr == nil && p > 0 {
+			host, port = "", strconv.Itoa(p)
+		} else {
+			return fmt.Errorf("start --attach: invalid CDP endpoint %q (want host:port)", attachAddr)
+		}
+	}
+	if host == "" {
+		host = "localhost"
+	}
+	cdpPort, err := strconv.Atoi(port)
+	if err != nil || cdpPort <= 0 || cdpPort > 65535 {
+		return fmt.Errorf("start --attach: invalid CDP port in %q", attachAddr)
+	}
+	cdpAddr := net.JoinHostPort(host, port)
+
+	// Verify the endpoint is actually reachable before we advertise a session.
+	if !cdpVersionAlive(context.Background(), cdpAddr) {
+		return fmt.Errorf("start --attach: no Chrome CDP endpoint answering at %s\n"+
+			"  Launch Chrome with --remote-debugging-port=%d first, then retry.", cdpAddr, cdpPort)
+	}
+
+	resolvedServerPort, err := browser.FindFreePort(serverPortFlag)
+	if err != nil {
+		return fmt.Errorf("start --attach: sightmap server: %w", err)
+	}
+
+	siteName := filepath.Base(cwd())
+	srv, collectorPtr, err := startDevtoolsServer(sightmapDir, siteName, resolvedServerPort)
+	if err != nil {
+		return fmt.Errorf("start --attach: %w", err)
+	}
+
+	collector := browser.NewCollector(cdpAddr)
+	collector.Start()
+	collectorPtr.Store(collector)
+	defer collector.Stop()
+
+	// Record the session. PID is the DAEMON's pid (there is no owned Chrome), and
+	// Attached tells stop to detach rather than kill. Profile is empty.
+	_ = browser.WriteSessionInfo(sightmapDir, browser.SessionInfo{
+		Port: cdpPort, PID: os.Getpid(), ServerPort: resolvedServerPort, Attached: true,
+	})
+
+	// Install signal handling and liveness polling up front, so the daemon is
+	// always interruptible even while the best-effort setup below is still running.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	gone := make(chan struct{})
+	stopPoll := make(chan struct{})
+	go func() {
+		t := time.NewTicker(2 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-stopPoll:
+				return
+			case <-t.C:
+				if !cdpVersionAlive(context.Background(), cdpAddr) {
+					close(gone)
+					return
+				}
+			}
+		}
+	}()
+
+	ctx := context.Background()
+	// Best-effort extension port injection, off the main path: on a browser without
+	// the sightmap extension (common in attach mode) the service-worker lookup
+	// retries for several seconds, which must not delay readiness or block stop.
+	go func() {
+		injCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if injErr := browser.InjectExtensionServerPort(injCtx, cdpAddr, resolvedServerPort); injErr != nil {
+			fmt.Fprintf(os.Stderr, "start --attach: note: could not inject extension port: %v\n", injErr)
+		}
+	}()
+
+	var tabID string
+	if urlFlag != "" {
+		// Open our own tab rather than disturbing the caller's existing tabs.
+		id, conn, tabErr := browser.CreateTab(ctx, cdpAddr, urlFlag)
+		if tabErr != nil {
+			fmt.Fprintf(os.Stderr, "start --attach: warning: could not open tab for %s: %v\n", urlFlag, tabErr)
+		} else {
+			tabID = id
+			loadCtx, loadCancel := context.WithTimeout(ctx, 15*time.Second)
+			_ = browser.WaitForLoad(loadCtx, conn)
+			loadCancel()
+			conn.Close()
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "● attached  cdp=%s  server=%d  tab=%s\n", cdpAddr, resolvedServerPort, tabID)
+	fmt.Fprintf(os.Stderr, "  Addr: --addr %s\n", cdpAddr)
+	fmt.Fprintf(os.Stderr, "  Degraded mode: browser is caller-owned; console/network capture is live from now on.\n")
+	fmt.Fprintf(os.Stderr, "  Press Ctrl-C (or 'browser stop') to detach — the browser is left running.\n")
+
+	// Block until a signal, or until the attached browser goes away.
+	select {
+	case <-sigCh:
+		fmt.Fprintln(os.Stderr, "\ndetaching (browser left running)...")
+	case <-gone:
+		fmt.Fprintln(os.Stderr, "\nattached browser went away — detaching")
+	}
+	close(stopPoll)
+
+	// Stop HTTP server and drop the session file. The browser is NOT touched.
+	shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	srv.Shutdown(shutCtx)
+	os.Remove(browser.SessionFilePath(sightmapDir))
 	return nil
 }


### PR DESCRIPTION
## What

Adds `browser start --attach host:port`: the daemon attaches to an
already-running Chrome's CDP endpoint instead of launching (and owning) its own.
This is the basic, opt-in **degraded mode** from the e463/#70 discussion.

- `runAttachedSession` shares the devtools HTTP server + console/network
  collector with the owned-launch path (extracted into a new `startDevtoolsServer`
  helper) but skips the launch/profile/extension/sandbox machinery. The collector
  only ever needed a CDP address, so live console/exception + request matching
  work identically once attached.
- The session is recorded with `Attached: true` and `PID` = the daemon's own pid;
  `browser stop` **detaches** an attached session (SIGTERM the daemon) and
  **never kills** the caller-owned browser.
- Best-effort extension port injection runs off the main path (a browser without
  the sightmap extension makes the service-worker lookup retry for several
  seconds), so it can't delay readiness or block stop.

## What you give up (documented in the flag help + changeset)

- **Pre-attach history** — capture is complete only from attach onward.
  `Network.enable` replays nothing, so traffic/exceptions that fired before the
  daemon attached are gone (`Runtime.enable` does replay buffered console).
- **Profile isolation / clean-tab guarantees** — the browser is caller-owned.
- **Extension** — assumed handled out-of-band; injection is best-effort and may
  no-op if a manually-installed extension has a different ID.

## Drive-by fix: `Collector.Stop` deadlock

Attach surfaced a latent bug: `Stop` cancelled the per-tab drain contexts
*after* `wg.Wait()`. A drain only returns on ctx cancellation, so `Stop` only
ever returned because the owned path kills Chrome first (breaking the CDP
connections out from under the drains). With the browser still alive — exactly
the attach-stop case — the drains never exit and `Stop` deadlocks. `Stop` now
cancels drains *before* waiting and refuses new tab attachments during teardown;
`conn.Close` is nil-guarded. This matters for any library consumer that stops a
collector without tearing down the browser. Regression test added
(`TestCollectorStop_NoDeadlockWhileConnected`).

## Test

- `go test ./...` green; `go vet` + `gofmt -l` clean.
- **E2E** (headless Chrome launched externally on `:9333`, static fixture):
  `--attach localhost:9333` connects and prints its banner immediately; a tab
  opened post-attach yields `console list` → matched `[CheckoutBoom]` exception
  (with stack) and, after a post-attach fetch, `network list` →
  `[CheckoutPayment] GET …/pay.json → 200 OK (Fetch)`. The per-attach limitation
  is visible exactly as predicted: a page-load fetch that beats the 2s tab-poll
  is missed (console survives via replay, network does not). `browser stop` →
  `detached (browser left running)`, daemon exits cleanly (no deadlock), Chrome
  stays up.

Property-*value* annotation (`{outcome=declined}`) still depends on eager body
retention (#212, in review) and is orthogonal to attach.

## Notes

- Standalone PR off `main` (not part of the #209 stack). `minor` changeset.
- Basic scope per the design discussion: assumes a local CDP endpoint; the
  session file's `Port` is the external CDP port (other commands assume
  `localhost:PORT`).


## Testing against an enterprise / SSO app (verified against Salesforce)

The motivating use case: apps behind enterprise SSO / device-trust that
**reject Chrome for Testing**, so you can't log in under the sightmap-managed
CfT. `--attach` solves this — point it at your own branded Chrome, logged in
normally.

macOS gotchas that shape the recipe:
- `--remote-debugging-port` is **launch-time only** (no runtime toggle), and
  Chrome 136+ **silently ignores it on the *default* user-data-dir** — so you
  need a non-default dir.
- CfT can't decrypt branded Chrome's cookies (per-binary macOS Keychain key), so
  copying a profile into CfT logs you out. Use branded Chrome instead.

Working recipe (log in once in a dedicated dir — no copy, no Keychain issues,
doesn't disturb your everyday Chrome):

```sh
# 1. Launch YOUR branded Chrome with CDP on a dedicated, non-default profile dir
"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
  --remote-debugging-port=9999 \
  --user-data-dir="$HOME/.sightmap/profiles/work-debug" &
# 2. Log into the app once in that window (SSO/2FA); it persists across relaunches
# 3. Attach
curl -s http://localhost:9999/json/version   # confirm CDP is actually up
sightmap browser start --attach localhost:9999 --sightmap-dir .sightmap
```

To reuse an existing profile instead of logging in fresh: point `--user-data-dir`
at the **user-data-dir root** (not the profile subfolder — that silently makes a
new empty profile) and select the profile with `--profile-directory="Default"`.

Verified end-to-end against a live `*.lightning.force.com` session: attach
connected, console streamed (buffered messages replayed via `Runtime.enable`),
and post-attach navigation produced Lightning `/aura` XHRs that matched request
defs live; `browser stop` detached and left the Salesforce session untouched.
The pre-attach limitation was visible as designed — the tab loaded before attach
had console (replayed) but no network (`Network.enable` replays nothing).
