### PR TITLE
feat(web): link the Atlas from the footer

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -10,6 +10,7 @@ export default function Footer() {
             sightmap · open-source spec by <a href="https://subtext.fullstory.com" target="_blank" rel="noreferrer">Subtext</a>
           </div>
           <div className="footer-links">
+            <a href="/atlas">Atlas</a>
             <a href="/blog">Blog</a>
             <a href="https://docs.sightmap.org">Docs</a>
             <a href="https://docs.sightmap.org/start/quickstart">Quickstart</a>


### PR DESCRIPTION
Navigation links to `/atlas`; the footer does not. The route is real and prerendered, so the Atlas was reachable from the header and from nowhere else on the way out of a page.

Placed first in the footer link list to match the header's order.

## Why this PR exists now

It is also the first real test of the Netlify curation extension. This is the kind of change the extension is built for: it touches `web/src/**` and adds an interactive node, so merging it should produce an agent run that re-crawls the site and updates `web/.sightmap/app.yaml` — a real corpus update rather than a no-op.

The previous end-to-end run rebuilt an unchanged tree, so the agent correctly stopped early and never exercised the curation path itself. This merge exercises the parts that run only found: the crawl, the coverage arithmetic, the scope checks against a genuine diff, and the loop guard that must drop the agent's own end-of-session deploy.

Merge only after #217, which removes the old CI curation workflow. Merging this first would fire both and bill two overlapping runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAw3ummLzV4CBkeqwCkB2P