### PR TITLE
perf(web): cache hashed assets immutably

### DIFF
--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -7,6 +7,23 @@
   to = "/index.html"
   status = 200
 
+# Vite writes a content hash into every filename under /assets/, so a changed
+# file is always a new URL and the old one is safe to keep forever. Without
+# this the Netlify default applies (`max-age=0, must-revalidate`), and every
+# page view revalidates the bundle: a 304 saves the bytes but still costs a
+# round trip per asset. This site is prerendered, so every internal link is a
+# full page load rather than a client-side route change — that round trip is
+# paid on each one.
+#
+# Scoped to /assets/ deliberately. Nothing else in dist/ is content-hashed:
+# /atlas/ alone is ~4.7MB of generated screenshots and archives written to
+# stable paths, and marking those immutable would pin a removed entry — a
+# takedown — in caches for a year.
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
 # Inject the visitor's consent region into app HTML (replaces <!--CC_REGION-->).
 # The function guards on content-type, so non-HTML responses pass through;
 # assets are excluded outright to avoid pointless invocations.


### PR DESCRIPTION
## What this changes

Adds one `[[headers]]` rule to `web/netlify.toml` so files under `/assets/` are served `public, max-age=31536000, immutable`.

## Why

Measured on production:

```
$ curl -I https://sightmap.org/assets/index-BgPzi9Wa.js
cache-control: public,max-age=0,must-revalidate
```

That's Netlify's default — `web/netlify.toml` had no `[[headers]]` block at all. Every page view revalidates the bundle. It returns 304, so the bytes are saved, but it still costs a round trip per asset. This site is prerendered, so every internal link is a full page load rather than a client-side route change; that round trip is paid on each one.

Vite writes a content hash into every `/assets/` filename, so a changed file is always a new URL and the old one is safe to keep forever. The Subtext marketing site already carries this exact rule, and it's live there:

```
$ curl -I https://subtext.fullstory.com/assets/index-Cg-Wf-sO.js
cache-control: public,max-age=31536000,immutable
```

## Why only /assets/

Nothing else in `dist/` is content-hashed. Counted from a real build:

| Path | Files | Content-hashed | Size |
|---|---|---|---|
| `/assets/` | 3 | **3** | 513 KB |
| `/atlas/` | 76 | 0 | 4.7 MB |
| `/blog/` | 4 | 0 | 770 KB |

`/atlas/` is generated screenshots and archives written to stable paths. Marking those immutable would pin a removed entry — a takedown — in caches for a year.

## Context

This came out of the Replay QA finding on #220, which flagged the bundle as a 463,748-char eager load. Worth noting for anyone reading that report: the wire cost is **119 KB**, not 464 KB — Netlify already serves `content-encoding: br` — and the script is `<script type="module">`, which is deferred and never blocks rendering on a prerendered page.

Code-splitting is a separate question. Measured from the source map, splitting the atlas manifest and the blog-only syntax highlighter out of the initial chunk would save 32 KB brotli (27%), but on a prerendered site that means hydration waits on a second chunk, so it needs its own change. Not attempted here.

## Follow-up not taken here

`/atlas/` (4.7 MB) and `/blog/images/` (one 634 KB PNG) are also revalidated on every view. They can't be `immutable`, but a short `max-age` would help — Subtext uses `max-age=300, stale-while-revalidate=86400` for `/blog/*`. Left out to keep this to one concern.

## Verification

- `netlify.toml` parses; the rule resolves to `/assets/*` → `public, max-age=31536000, immutable`
- No redirect or edge-function rules touched

## Area

- [x] Marketing site (`web/`)

## Type of change

- [x] Bug fix

## Checklist

- [x] I read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] Every commit on this branch is signed off (`git commit -s`) per [DCO](../CONTRIBUTING.md#developer-certificate-of-origin)
- [x] I kept this PR focused on a single concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKkT88AzDor1ZisdJAGNCZ