### PR TITLE
skills: cover runtime spec additions (requests/messages/properties) + route guidance

### DIFF
--- a/.changeset/skills-runtime-entities.md
+++ b/.changeset/skills-runtime-entities.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Expand the authoring and browser skills to cover the runtime spec additions.
+
+- **sightmap-authoring**: new "Requests and messages" section documenting `requests:` (route/method), request `properties:` extraction (SEP-0005 `source`/`field`/`pattern`/`transform`), and `messages:` (SEP-0006 `level`/`message` + `source: stack` stack-addressing properties); a new "Runtime activity" step in the per-page loop plus a runtime line in the "Done when" checklist so the loop routes authors to these entities; and view-route-generality guidance (a catch-all route that matches every page is a smell — carve specific routes).
+- **sightmap-browser**: reframe the `console`/`network` tooling as the runtime view of the corpus — each record leads with a `[Match]`/`[--]` slot and trails extracted `{name=value}` properties — with the observe-only "reproduce the traffic" note and `--url`-substring / SPA `wait-for` caveats.
+- Fix stale command references: `sel-probe -- 'selector'` (the bare `sel-probe 'selector'` form fails) and `gap --include-hidden` (the documented `--visible` flag does not exist).

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -89,7 +89,7 @@ other dependency.
 | `sightmap snapshot --coverage --url URL` | Observe: navigate + coverage + cluster hints, no tree. **Primary edit-loop tool.** |
 | `sightmap snapshot --url URL` | Observe: full annotated tree + coverage to stdout (add `--out FILE` / `--tree-out FILE` to save). |
 | `sightmap capture --url URL` | Persist a novelty-gated capture into the matched view's set. |
-| `sightmap sel-probe 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. |
+| `sightmap sel-probe -- 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. The selector goes **after** `--` (any flags before it): `sel-probe [flags] -- 'sel'`. |
 | `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; **warnings** — corpus conflicts + unknown/typo'd fields like `memroy:` — print but pass). No prepare step needed. |
 | `sightmap lint --warn-only` | Style checks (`--warn-only`; exits 0 always). |
 | `sightmap coverage --trace FILE.snap` | Offline T1/T2/T3 re-check on saved snap (requires `.snap.tree.json` companion). |
@@ -103,7 +103,7 @@ other dependency.
 | `sightmap search PATTERN` | Offline YAML regex search with hierarchy breadcrumbs. `--field name\|selector\|description\|memory` to narrow. |
 | `sightmap discover` | Crawl page links → ✓ mapped / ○ surveyed / ? unseen. `--all` shows surveyed. |
 | `sightmap suggest --exclude-known` | Candidate selectors not yet in sightmap (`--exclude-known` always on). |
-| `sightmap gap --visible` | Orphaned interactive nodes with selector hints (`--visible` always on). |
+| `sightmap gap` | Orphaned interactive nodes with selector hints. Add `--include-hidden` to also list hidden/off-screen nodes. |
 
 ### Session management
 
@@ -129,8 +129,8 @@ component still needs a disambiguating property.
 ## Hard rules
 
 **NEVER write YAML without first verifying selectors.**
-Run `sightmap sel-probe 'selector'` on every new selector before committing it to
-YAML. sel-probe queries the live DOM **and** cross-checks the offline matcher
+Run `sightmap sel-probe -- 'selector'` on every new selector before committing it
+to YAML (the selector goes after `--`, any flags before it). sel-probe queries the live DOM **and** cross-checks the offline matcher
 that `snapshot`/`coverage`/`capture` actually use — it prints both counts and a
 `⚠ offline/live divergence` warning when they disagree. Trust the **offline**
 count: that is what the corpus will see. Wrong match count = corrupt coverage.
@@ -303,6 +303,109 @@ this to your advantage — a well-named property makes the annotation clean.
 
 ---
 
+## Requests and messages
+
+Components and views describe the DOM. Two more top-level entities describe a
+page's *runtime activity*: the network it makes (`requests:`) and the
+console/exceptions it emits (`messages:`). Both are matched against **live
+traffic**, not the DOM tree — you author them from what you observe with the
+`sightmap-browser` skill's `network` and `console` tools, where each captured
+record leads with a `[MatchedName]` slot (or `[--]` when nothing matched). They
+live in their own top-level lists and can share any `.sightmap/*.yaml` file.
+
+### `requests:` — name an endpoint
+
+Name endpoints that *mean something* (an API action, an auth call, a data fetch)
+by route glob + method, so their traffic is classified instead of anonymous.
+Don't map static assets (JS/CSS/images/fonts).
+
+```yaml
+version: 1
+requests:
+  - name: AuraAction
+    route: /aura                 # glob matched against the request URL path
+    method: POST
+    description: Lightning Aura batched server actions.
+```
+
+In `sightmap network list`, traffic to it now reads `[AuraAction]`; unmapped
+traffic reads `[--]`.
+
+### Request `properties:` — extract a value from live traffic
+
+The HTTP status often lies: an endpoint returns `200 OK` while the real outcome
+lives inside the body. A request `properties:` entry pulls a named value out of
+the live request/response so a consumer can reason about it (the SEP-0005 "200 OK
+but the body says declined" case). Each property is resolved
+**source → field → pattern → transform**:
+
+- **`source:`** — which half to read: `rsp.body`, `req.body`, `rsp.headers`, or
+  `req.headers`.
+- **`field:`** — where inside it. For a body, a dot-path into the parsed JSON; a
+  numeric segment indexes an array (`actions.0.state`). For headers, the header
+  name (case-insensitive).
+- **`pattern:`** *(optional)* — an RE2 regex refining what `field` resolved (or
+  scanning the raw source when `field` is omitted). Capture group 1 is the value
+  when present, else the whole match.
+- **`transform:`** *(optional)* — same vocabulary as component properties.
+
+```yaml
+requests:
+  - name: AuraAction
+    route: /aura
+    method: POST
+    properties:
+      # Aura returns HTTP 200 even when an action fails; the real per-action
+      # outcome (SUCCESS | ERROR | INCOMPLETE) is inside the JSON body.
+      - name: first_action_state
+        source: rsp.body
+        field: actions.0.state
+```
+
+Live, matched requests carry the extracted value:
+`[AuraAction] POST /aura → 200 (XHR) {first_action_state=SUCCESS}` — and, on the
+one call that actually failed behind the same 200, `{first_action_state=ERROR}`.
+
+Extraction is **silently omitted** (never an error) when the source isn't
+present, the field doesn't resolve, or the pattern doesn't match — whether a body
+or header is even captured depends on the runtime layer. `status`, `method`, and
+`duration` are already-structured request identity and need no `properties:`
+declaration.
+
+### `messages:` — name a console/exception pattern
+
+A `messages:` entry classifies console output and runtime exceptions by `level`
+and/or a `message` regex. An exception folds in as an ERROR/`exception`-level
+record — there is no separate entity.
+
+```yaml
+version: 1
+messages:
+  - name: DeprecatedChartApi
+    level: WARN                    # exact, case-insensitive; omit to match any level
+    message: has been deprecated   # RE2 regex over the message text; omit to match any
+    description: Legacy chart JS deprecation warning.
+```
+
+In `sightmap console list`, a matched record reads `[DeprecatedChartApi]`;
+unmatched reads `[--]`. Declare at least one of `level`/`message` (an entry
+matching everything isn't useful).
+
+An exception's **stack frames** are addressable with message `properties:`
+(`source: stack` is the only source in v1):
+
+```yaml
+messages:
+  - name: CartSyncCrash
+    message: cart version mismatch
+    properties:
+      - name: origin_fn
+        source: stack
+        field: top.function       # <frame>.<attr>; frame = top|<index>, attr = function|file|line|column
+```
+
+---
+
 ## Seeding from the codebase
 
 When the app's source is available, use it to bootstrap components before you
@@ -375,6 +478,16 @@ views:
 ```
 
 Run `sightmap validate` before snapping.
+
+**Keep routes specific.** A `route:` glob should identify *this* view, not every
+page. A catch-all like `/lightning/**` or `/**` that matches every URL is a smell:
+as you map more pages they all collapse onto the one view, and — worse —
+`sightmap discover` marks those distinct URLs `✓ [ThatView]` (mapped) purely
+because the catch-all matched, hiding that they are actually uncovered. When a
+new page looks structurally different (its Guide is mostly *different*
+components), give it its own view with a narrower route and demote or drop the
+catch-all. Matching every page is the problem, not the goal — don't keep an
+over-general route just because it "matches."
 
 ### Step 1b — Snap and read coverage
 
@@ -464,6 +577,28 @@ sightmap browser navigate https://...
 sightmap snapshot --out PAGE.snap --tree-out PAGE.snap.tree.json
 ```
 
+### Step 1e — Runtime activity (requests & messages)
+
+DOM coverage isn't the whole page. Once components are done, classify what the
+page *does* at runtime — the network it makes and the console/exceptions it emits
+— with the `requests:` and `messages:` entities (see **Requests and messages**
+above; observe them with the `sightmap-browser` skill's `network`/`console`
+tools). Traffic from before the session started isn't captured, so **reproduce it
+first**: refresh the page (or re-trigger the action), then read the streams —
+matched records lead with a `[Name]` slot, unmapped ones with `[--]`:
+
+```bash
+sightmap network list --type XHR    # name meaningful endpoints; skip static assets
+sightmap console list               # name recurring console/exception patterns
+```
+
+- Add a `requests:` entry for endpoints that *mean something* (an API action, an
+  auth call, a data fetch). Add request `properties:` where a value inside the
+  body/headers is the real signal — the "200 OK but the body says failed" case.
+- Add a `messages:` entry for recurring console/exception patterns worth naming.
+- Requests/messages are often global; promote cross-page ones like components
+  (Phase 2). Skip it only when the page makes no meaningful traffic.
+
 ---
 
 ## Phase 2: Cross-page promotion
@@ -491,6 +626,7 @@ sightmap lint --warn-only   # deep-nesting warnings are expected; watch for new 
 - [ ] Every page at 0 orphaned ✓
 - [ ] Quality self-review passed for all pages
 - [ ] `sightmap multi-coverage` shows no unaddressed global candidates
+- [ ] Runtime activity classified — meaningful `network`/`console` records lead with a `[Name]`, not `[--]` (or are deliberately left unmapped)
 
 ---
 

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -119,24 +119,48 @@ so nothing goes stale. Prefer queries on dynamic pages.
   addressable (see the `sightmap-authoring` skill).
 - `--sightmap-dir` (default `.sightmap`) controls which corpus resolves a query.
 
-## Debugging: console & network
+## Console & network — the runtime view of the corpus
 
 The `browser start` daemon owns the session and runs a **collector** that buffers
 console messages and network requests from every tab for the life of the session
 (bounded ring buffers, ~1000 of each). Read them with thin query commands — no
-re-attaching to Chrome, and history the transient page commands never saw:
+re-attaching to Chrome, and with history the transient page commands never saw.
+
+These are not just raw debug streams. Each captured record is matched against the
+corpus's `requests:` and `messages:` entries (see the `sightmap-authoring`
+skill), so every line **leads with a `[MatchedName]` slot** — or `[--]` when
+nothing in the corpus classified it — the way a snapshot foregrounds a node's
+`[Component]`. Matched records also **trail their extracted `{name=value}`
+properties**.
 
 | Command | What it does |
 |---------|-------------|
-| `sightmap console list [--level error] [--tab ID] [--limit N]` | Captured console messages (uncaught exceptions fold in as `level=exception`). |
-| `sightmap console get <index>` | One console message by index. |
-| `sightmap network list [--type XHR] [--url /api] [--tab ID] [--limit N]` | Captured requests: `method url → status (type)`. |
-| `sightmap network get <index> [--response-file F]` | One request + its response body (fetched on demand; save with `--response-file`). |
+| `sightmap console list [--level error] [--tab ID] [--limit N]` | Console messages, each led by its `messages:` match (uncaught exceptions fold in as `level=exception`). |
+| `sightmap console get <index>` | One console message + any extracted stack `properties:`. |
+| `sightmap network list [--type XHR] [--url /api] [--tab ID] [--limit N]` | Requests: `[Match] method url → status (type) {prop=value}`. |
+| `sightmap network get <index> [--response-file F]` | One request + its `requests:` match, a `Properties:` block, and response body (save with `--response-file`). |
+
+Reading the slot:
+```
+[AuraAction]         POST /aura → 200 (XHR) {first_action_state=SUCCESS}   # matched a requests: entry + extracted a body value
+[AuraAction]         POST /aura → 200 (XHR) {first_action_state=ERROR}     # 200 OK, but the body says it failed — the payoff of request properties:
+[--]                 GET  /favicon.ico → 200 (Image)                       # unmatched: no corpus entry, unstructured
+[DeprecatedChartApi] warn  ...stackhbar.js has been deprecated             # matched a messages: entry
+```
+The `[--]` slot is deliberately quiet — it marks a record unclassified without
+drowning the matched ones.
 
 - These need a running `browser start` session — that's where the collector
-  lives. Entries from before the session started aren't available.
-- Reproduce the issue (navigate/click), then read `console list --level error`
-  and `network list` to see what failed; `network get <index>` pulls the body.
+  lives. Records from **before** the session started aren't captured, so in an
+  attached/degraded session (or right after `start`) **reproduce the traffic**:
+  refresh the page or re-trigger the action, then read. (A SPA may never reach
+  `wait-for --load`; prefer `wait-for --url`/`--selector`, or just re-read after
+  a short pause.)
+- `--url` is a substring match, not a path anchor (`--url /aura` also catches
+  `.../auraFW/...`) — narrow it when a route is noisy.
+- To find failures: reproduce, then scan the `[...]` slots in `console list`
+  (`--level error`) and `network list`; `network get <index>` pulls the body +
+  properties.
 
 ## Gotchas
 

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -89,7 +89,7 @@ other dependency.
 | `sightmap snapshot --coverage --url URL` | Observe: navigate + coverage + cluster hints, no tree. **Primary edit-loop tool.** |
 | `sightmap snapshot --url URL` | Observe: full annotated tree + coverage to stdout (add `--out FILE` / `--tree-out FILE` to save). |
 | `sightmap capture --url URL` | Persist a novelty-gated capture into the matched view's set. |
-| `sightmap sel-probe 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. |
+| `sightmap sel-probe -- 'selector'` | Verify a selector: match count + parent chain. Run before writing any YAML. The selector goes **after** `--` (any flags before it): `sel-probe [flags] -- 'sel'`. |
 | `sightmap validate` | Spec-validate `.sightmap/` YAML (errors fail; **warnings** — corpus conflicts + unknown/typo'd fields like `memroy:` — print but pass). No prepare step needed. |
 | `sightmap lint --warn-only` | Style checks (`--warn-only`; exits 0 always). |
 | `sightmap coverage --trace FILE.snap` | Offline T1/T2/T3 re-check on saved snap (requires `.snap.tree.json` companion). |
@@ -103,7 +103,7 @@ other dependency.
 | `sightmap search PATTERN` | Offline YAML regex search with hierarchy breadcrumbs. `--field name\|selector\|description\|memory` to narrow. |
 | `sightmap discover` | Crawl page links → ✓ mapped / ○ surveyed / ? unseen. `--all` shows surveyed. |
 | `sightmap suggest --exclude-known` | Candidate selectors not yet in sightmap (`--exclude-known` always on). |
-| `sightmap gap --visible` | Orphaned interactive nodes with selector hints (`--visible` always on). |
+| `sightmap gap` | Orphaned interactive nodes with selector hints. Add `--include-hidden` to also list hidden/off-screen nodes. |
 
 ### Session management
 
@@ -129,8 +129,8 @@ component still needs a disambiguating property.
 ## Hard rules
 
 **NEVER write YAML without first verifying selectors.**
-Run `sightmap sel-probe 'selector'` on every new selector before committing it to
-YAML. sel-probe queries the live DOM **and** cross-checks the offline matcher
+Run `sightmap sel-probe -- 'selector'` on every new selector before committing it
+to YAML (the selector goes after `--`, any flags before it). sel-probe queries the live DOM **and** cross-checks the offline matcher
 that `snapshot`/`coverage`/`capture` actually use — it prints both counts and a
 `⚠ offline/live divergence` warning when they disagree. Trust the **offline**
 count: that is what the corpus will see. Wrong match count = corrupt coverage.
@@ -303,6 +303,109 @@ this to your advantage — a well-named property makes the annotation clean.
 
 ---
 
+## Requests and messages
+
+Components and views describe the DOM. Two more top-level entities describe a
+page's *runtime activity*: the network it makes (`requests:`) and the
+console/exceptions it emits (`messages:`). Both are matched against **live
+traffic**, not the DOM tree — you author them from what you observe with the
+`sightmap-browser` skill's `network` and `console` tools, where each captured
+record leads with a `[MatchedName]` slot (or `[--]` when nothing matched). They
+live in their own top-level lists and can share any `.sightmap/*.yaml` file.
+
+### `requests:` — name an endpoint
+
+Name endpoints that *mean something* (an API action, an auth call, a data fetch)
+by route glob + method, so their traffic is classified instead of anonymous.
+Don't map static assets (JS/CSS/images/fonts).
+
+```yaml
+version: 1
+requests:
+  - name: AuraAction
+    route: /aura                 # glob matched against the request URL path
+    method: POST
+    description: Lightning Aura batched server actions.
+```
+
+In `sightmap network list`, traffic to it now reads `[AuraAction]`; unmapped
+traffic reads `[--]`.
+
+### Request `properties:` — extract a value from live traffic
+
+The HTTP status often lies: an endpoint returns `200 OK` while the real outcome
+lives inside the body. A request `properties:` entry pulls a named value out of
+the live request/response so a consumer can reason about it (the SEP-0005 "200 OK
+but the body says declined" case). Each property is resolved
+**source → field → pattern → transform**:
+
+- **`source:`** — which half to read: `rsp.body`, `req.body`, `rsp.headers`, or
+  `req.headers`.
+- **`field:`** — where inside it. For a body, a dot-path into the parsed JSON; a
+  numeric segment indexes an array (`actions.0.state`). For headers, the header
+  name (case-insensitive).
+- **`pattern:`** *(optional)* — an RE2 regex refining what `field` resolved (or
+  scanning the raw source when `field` is omitted). Capture group 1 is the value
+  when present, else the whole match.
+- **`transform:`** *(optional)* — same vocabulary as component properties.
+
+```yaml
+requests:
+  - name: AuraAction
+    route: /aura
+    method: POST
+    properties:
+      # Aura returns HTTP 200 even when an action fails; the real per-action
+      # outcome (SUCCESS | ERROR | INCOMPLETE) is inside the JSON body.
+      - name: first_action_state
+        source: rsp.body
+        field: actions.0.state
+```
+
+Live, matched requests carry the extracted value:
+`[AuraAction] POST /aura → 200 (XHR) {first_action_state=SUCCESS}` — and, on the
+one call that actually failed behind the same 200, `{first_action_state=ERROR}`.
+
+Extraction is **silently omitted** (never an error) when the source isn't
+present, the field doesn't resolve, or the pattern doesn't match — whether a body
+or header is even captured depends on the runtime layer. `status`, `method`, and
+`duration` are already-structured request identity and need no `properties:`
+declaration.
+
+### `messages:` — name a console/exception pattern
+
+A `messages:` entry classifies console output and runtime exceptions by `level`
+and/or a `message` regex. An exception folds in as an ERROR/`exception`-level
+record — there is no separate entity.
+
+```yaml
+version: 1
+messages:
+  - name: DeprecatedChartApi
+    level: WARN                    # exact, case-insensitive; omit to match any level
+    message: has been deprecated   # RE2 regex over the message text; omit to match any
+    description: Legacy chart JS deprecation warning.
+```
+
+In `sightmap console list`, a matched record reads `[DeprecatedChartApi]`;
+unmatched reads `[--]`. Declare at least one of `level`/`message` (an entry
+matching everything isn't useful).
+
+An exception's **stack frames** are addressable with message `properties:`
+(`source: stack` is the only source in v1):
+
+```yaml
+messages:
+  - name: CartSyncCrash
+    message: cart version mismatch
+    properties:
+      - name: origin_fn
+        source: stack
+        field: top.function       # <frame>.<attr>; frame = top|<index>, attr = function|file|line|column
+```
+
+---
+
 ## Seeding from the codebase
 
 When the app's source is available, use it to bootstrap components before you
@@ -375,6 +478,16 @@ views:
 ```
 
 Run `sightmap validate` before snapping.
+
+**Keep routes specific.** A `route:` glob should identify *this* view, not every
+page. A catch-all like `/lightning/**` or `/**` that matches every URL is a smell:
+as you map more pages they all collapse onto the one view, and — worse —
+`sightmap discover` marks those distinct URLs `✓ [ThatView]` (mapped) purely
+because the catch-all matched, hiding that they are actually uncovered. When a
+new page looks structurally different (its Guide is mostly *different*
+components), give it its own view with a narrower route and demote or drop the
+catch-all. Matching every page is the problem, not the goal — don't keep an
+over-general route just because it "matches."
 
 ### Step 1b — Snap and read coverage
 
@@ -464,6 +577,28 @@ sightmap browser navigate https://...
 sightmap snapshot --out PAGE.snap --tree-out PAGE.snap.tree.json
 ```
 
+### Step 1e — Runtime activity (requests & messages)
+
+DOM coverage isn't the whole page. Once components are done, classify what the
+page *does* at runtime — the network it makes and the console/exceptions it emits
+— with the `requests:` and `messages:` entities (see **Requests and messages**
+above; observe them with the `sightmap-browser` skill's `network`/`console`
+tools). Traffic from before the session started isn't captured, so **reproduce it
+first**: refresh the page (or re-trigger the action), then read the streams —
+matched records lead with a `[Name]` slot, unmapped ones with `[--]`:
+
+```bash
+sightmap network list --type XHR    # name meaningful endpoints; skip static assets
+sightmap console list               # name recurring console/exception patterns
+```
+
+- Add a `requests:` entry for endpoints that *mean something* (an API action, an
+  auth call, a data fetch). Add request `properties:` where a value inside the
+  body/headers is the real signal — the "200 OK but the body says failed" case.
+- Add a `messages:` entry for recurring console/exception patterns worth naming.
+- Requests/messages are often global; promote cross-page ones like components
+  (Phase 2). Skip it only when the page makes no meaningful traffic.
+
 ---
 
 ## Phase 2: Cross-page promotion
@@ -491,6 +626,7 @@ sightmap lint --warn-only   # deep-nesting warnings are expected; watch for new 
 - [ ] Every page at 0 orphaned ✓
 - [ ] Quality self-review passed for all pages
 - [ ] `sightmap multi-coverage` shows no unaddressed global candidates
+- [ ] Runtime activity classified — meaningful `network`/`console` records lead with a `[Name]`, not `[--]` (or are deliberately left unmapped)
 
 ---
 

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -119,24 +119,48 @@ so nothing goes stale. Prefer queries on dynamic pages.
   addressable (see the `sightmap-authoring` skill).
 - `--sightmap-dir` (default `.sightmap`) controls which corpus resolves a query.
 
-## Debugging: console & network
+## Console & network — the runtime view of the corpus
 
 The `browser start` daemon owns the session and runs a **collector** that buffers
 console messages and network requests from every tab for the life of the session
 (bounded ring buffers, ~1000 of each). Read them with thin query commands — no
-re-attaching to Chrome, and history the transient page commands never saw:
+re-attaching to Chrome, and with history the transient page commands never saw.
+
+These are not just raw debug streams. Each captured record is matched against the
+corpus's `requests:` and `messages:` entries (see the `sightmap-authoring`
+skill), so every line **leads with a `[MatchedName]` slot** — or `[--]` when
+nothing in the corpus classified it — the way a snapshot foregrounds a node's
+`[Component]`. Matched records also **trail their extracted `{name=value}`
+properties**.
 
 | Command | What it does |
 |---------|-------------|
-| `sightmap console list [--level error] [--tab ID] [--limit N]` | Captured console messages (uncaught exceptions fold in as `level=exception`). |
-| `sightmap console get <index>` | One console message by index. |
-| `sightmap network list [--type XHR] [--url /api] [--tab ID] [--limit N]` | Captured requests: `method url → status (type)`. |
-| `sightmap network get <index> [--response-file F]` | One request + its response body (fetched on demand; save with `--response-file`). |
+| `sightmap console list [--level error] [--tab ID] [--limit N]` | Console messages, each led by its `messages:` match (uncaught exceptions fold in as `level=exception`). |
+| `sightmap console get <index>` | One console message + any extracted stack `properties:`. |
+| `sightmap network list [--type XHR] [--url /api] [--tab ID] [--limit N]` | Requests: `[Match] method url → status (type) {prop=value}`. |
+| `sightmap network get <index> [--response-file F]` | One request + its `requests:` match, a `Properties:` block, and response body (save with `--response-file`). |
+
+Reading the slot:
+```
+[AuraAction]         POST /aura → 200 (XHR) {first_action_state=SUCCESS}   # matched a requests: entry + extracted a body value
+[AuraAction]         POST /aura → 200 (XHR) {first_action_state=ERROR}     # 200 OK, but the body says it failed — the payoff of request properties:
+[--]                 GET  /favicon.ico → 200 (Image)                       # unmatched: no corpus entry, unstructured
+[DeprecatedChartApi] warn  ...stackhbar.js has been deprecated             # matched a messages: entry
+```
+The `[--]` slot is deliberately quiet — it marks a record unclassified without
+drowning the matched ones.
 
 - These need a running `browser start` session — that's where the collector
-  lives. Entries from before the session started aren't available.
-- Reproduce the issue (navigate/click), then read `console list --level error`
-  and `network list` to see what failed; `network get <index>` pulls the body.
+  lives. Records from **before** the session started aren't captured, so in an
+  attached/degraded session (or right after `start`) **reproduce the traffic**:
+  refresh the page or re-trigger the action, then read. (A SPA may never reach
+  `wait-for --load`; prefer `wait-for --url`/`--selector`, or just re-read after
+  a short pause.)
+- `--url` is a substring match, not a path anchor (`--url /aura` also catches
+  `.../auraFW/...`) — narrow it when a route is noisy.
+- To find failures: reproduce, then scan the `[...]` slots in `console list`
+  (`--level error`) and `network list`; `network get <index>` pulls the body +
+  properties.
 
 ## Gotchas
 


### PR DESCRIPTION
Expand the authoring & browser skills to cover the runtime spec additions
(SEP-0005 request `properties:`, SEP-0006 `messages:`), which they predated.

### sightmap-authoring
- New **"Requests and messages"** section: `requests:` (route/method), request
  `properties:` extraction (`source` = `req.body`/`rsp.body`/`req.headers`/
  `rsp.headers`; dot-path `field` with array indexing; RE2 `pattern`; `transform`),
  and `messages:` (`level`/`message` + `source: stack` stack-addressing properties).
- New **"Step 1e — Runtime activity"** in the per-page loop and a runtime line in
  the **"Done when"** checklist, so the loop routes authors to these entities
  instead of stopping at DOM coverage.
- **Route-generality guidance**: a catch-all `route:` matching every page is a
  smell (and `discover` will falsely mark such pages mapped) — carve specific
  routes.

### sightmap-browser
- Reframe `console`/`network` as the **runtime view of the corpus**: each record
  leads with a `[Match]`/`[--]` slot and trails extracted `{name=value}`
  properties; observe-only "reproduce the traffic" note; `--url`-substring and
  SPA `wait-for` caveats.

### Doc fixes
- `sel-probe -- 'selector'` (the bare `sel-probe 'selector'` form errors out).
- `gap --include-hidden` (the documented `--visible` flag does not exist).

Every example is grounded in output verified live against a real app on the
current build. Changeset: `minor`.

Closes #222
