### PR TITLE
selectors: pierce shadow DOM consistently across live-DOM ops + formalize in spec

### DIFF
--- a/.changeset/selectors-through-shadow.md
+++ b/.changeset/selectors-through-shadow.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Make selectors behave consistently across shadow DOM. The captured component tree already flattens shadow roots (so offline matching, `sel-probe`'s offline count, and coverage pierce shadow), but every live-DOM operation re-found nodes with `document.querySelector`, which cannot cross shadow boundaries — so property extraction, interaction (click/fill/hover/value/scroll/wait-for), `bounds`, `sel-probe`'s live count, and `suggest`/`discover` were silently shadow-blind and disagreed with the corpus. A shared shadow-piercing resolver (`browser.DeepQueryJS`) now backs all of them, so live operations reach shadow-DOM content the same way matching does (property extraction on shadow-DOM leaves, interaction with shadow-DOM controls, and discovery of shadow-DOM links now work). `spec/v1/schema.md` formalizes the selector/tree model and its shadow-DOM semantics — a deliberate divergence from live `document.querySelector`, which does not cross shadow roots.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -128,6 +128,7 @@ See [SEP-0002](https://github.com/sightmap/sightmap/blob/main/spec/seps/0002-com
 - A list of strings is tried in order; the first selector that matches wins.
 - Selectors in `children` are evaluated **within** their parent's matched subtree, not globally. This scoping is how Sightmap avoids naming collisions between, say, two different card components that both contain a `button.primary`.
 - Selectors are not required to be unique at their level. If a selector matches multiple elements, all matches are named.
+- **Shadow DOM.** Selectors are matched against the captured component tree, which is a *flattened* representation: each shadow root's content is inlined as ordinary children of its host. Selectors therefore match **across shadow boundaries** — shadow-DOM content is addressed exactly like light-DOM content, and there is no piercing syntax (standard CSS has none: `>>>`/`/deep/` were removed, and `::part()`/`::slotted()` reach only explicitly-exposed nodes). `children` scoping and combinators operate over the flattened tree, where a shadow host → shadow child is an ordinary parent→child edge. This is a deliberate divergence from a live `document.querySelector`, which does **not** cross shadow roots: a tool re-implementing matching or property extraction against the live DOM MUST traverse shadow roots (walk each element's `shadowRoot`) to agree with the corpus. The same rule governs the `exists:`/sub-selector extract modes below — they resolve within the matched element's flattened subtree, including its shadow DOM.
 
 
 ### Component properties
@@ -149,8 +150,8 @@ A component may declare `properties: Property[]` — named values extracted from
 | `text_only` | `textContent` after removing `img`, `svg`, and `[alt]` descendants — use when icon alt-text bleeds into the label |
 | `inner_html` | `element.innerHTML` |
 | `attr=NAME` | `element.getAttribute(NAME)` |
-| `exists:SEL` | `"true"` if `element.querySelector(SEL)` matches; the property is **omitted** when it does not (boolean state flag) |
-| *any other string* | Treated as a CSS sub-selector: `element.querySelector(VALUE)?.textContent.trim()`; omitted when it matches nothing |
+| `exists:SEL` | `"true"` if `SEL` matches an element within the matched element's subtree — **including its shadow DOM** (see [Selector semantics](#selector-semantics)) — else **omitted** (boolean state flag) |
+| *any other string* | Treated as a CSS sub-selector resolved within the matched element's subtree, **including its shadow DOM**: the first match's `innerText` (falling back to `textContent`), trimmed; omitted when nothing matches |
 
 **Transforms.** When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1).
 

--- a/go/authoring/scan.go
+++ b/go/authoring/scan.go
@@ -49,7 +49,7 @@ func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Cand
     '[role="tabpanel"]',
   ];
   for (const sel of selectors) {
-    const els = document.querySelectorAll(sel);
+    const els = __smDeepQueryAll(document, sel);
     for (const el of els) {
       let candidate = '';
       const dt = el.getAttribute('data-testid');
@@ -76,7 +76,7 @@ func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Cand
   return Object.values(results).sort((a,b) => b.count - a.count).slice(0, max);
 })(%d)`, max)
 
-	raw, err := browser.EvalJSON(ctx, conn, script)
+	raw, err := browser.EvalJSON(ctx, conn, browser.DeepQueryJS+"\n"+script)
 	if err != nil {
 		return nil, fmt.Errorf("scan candidates: eval: %v", err)
 	}
@@ -94,7 +94,7 @@ func ScanLinks(ctx context.Context, conn *browser.CDPConn) ([]string, error) {
   const host = location.host;
   const seen = new Set();
   const links = [];
-  for (const a of document.querySelectorAll('a[href]')) {
+  for (const a of __smDeepQueryAll(document, 'a[href]')) {
     try {
       const u = new URL(a.href);
       if (u.host === host && !seen.has(u.pathname)) {
@@ -106,7 +106,7 @@ func ScanLinks(ctx context.Context, conn *browser.CDPConn) ([]string, error) {
   return links;
 })()`
 
-	raw, err := browser.EvalJSON(ctx, conn, linkScript)
+	raw, err := browser.EvalJSON(ctx, conn, browser.DeepQueryJS+"\n"+linkScript)
 	if err != nil {
 		return nil, fmt.Errorf("scan links: eval: %v", err)
 	}

--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -5,9 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"time"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // Navigate sends Page.navigate. Does NOT wait for load.
@@ -461,8 +462,9 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 // Returns an error when no element carries the id (the node was removed or the
 // page was re-probed since), so callers can prompt for a fresh snapshot.
 func ResolveBySightmapID(ctx context.Context, conn *CDPConn, id string) (*sightmap.ComponentNode, error) {
-	script := fmt.Sprintf(`(function(){
-  var el=document.querySelector('[data-sightmap-id=%q]');
+	script := DeepQueryJS + fmt.Sprintf(`
+(function(){
+  var el=__smDeepQuery(document,'[data-sightmap-id=%q]');
   if(!el) return null;
   var r=el.getBoundingClientRect();
   return {x:Math.round(r.left),y:Math.round(r.top),width:Math.round(r.width),height:Math.round(r.height)};
@@ -556,8 +558,9 @@ type clickTarget struct {
 // center is actually the top-most element there (so a target hidden behind an
 // overlay is reported as not-hit rather than clicked through).
 func locateForClick(ctx context.Context, conn *CDPConn, id string) (clickTarget, error) {
-	script := fmt.Sprintf(`(function(){
-  var el=document.querySelector('[data-sightmap-id=%q]');
+	script := DeepQueryJS + fmt.Sprintf(`
+(function(){
+  var el=__smDeepQuery(document,'[data-sightmap-id=%q]');
   if(!el) return {found:false};
   el.scrollIntoView({block:"center",inline:"center",behavior:"instant"});
   var r=el.getBoundingClientRect();
@@ -607,7 +610,7 @@ func Click(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) (in
 		if sel == "" {
 			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
-		_, err := EvalJSON(ctx, conn, fmt.Sprintf("document.querySelector(%q)?.click()", sel))
+		_, err := EvalJSON(ctx, conn, DeepQueryJS+fmt.Sprintf("\n__smDeepQuery(document,%q)?.click()", sel))
 		return -1, -1, err
 	}
 	x := node.Bounds.X + node.Bounds.Width/2
@@ -687,8 +690,8 @@ func readInputValue(ctx context.Context, conn *CDPConn, id string) (string, bool
 	if id == "" {
 		return "", false
 	}
-	raw, err := EvalJSON(ctx, conn, fmt.Sprintf(
-		`(function(){var el=document.querySelector('[data-sightmap-id=%q]');if(!el||el.value==null)return null;return String(el.value)})()`, id))
+	raw, err := EvalJSON(ctx, conn, DeepQueryJS+fmt.Sprintf(
+		"\n"+`(function(){var el=__smDeepQuery(document,'[data-sightmap-id=%q]');if(!el||el.value==null)return null;return String(el.value)})()`, id))
 	if err != nil || len(raw) == 0 || string(raw) == "null" {
 		return "", false
 	}
@@ -790,8 +793,8 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 // than surfacing as an EvalJSON JS exception.
 func ScrollIntoView(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) error {
 	if sel := node.Element.SelectorString(); sel != "" {
-		script := fmt.Sprintf(
-			`try{const el=document.querySelector(%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,
+		script := DeepQueryJS + fmt.Sprintf(
+			"\n"+`try{const el=__smDeepQuery(document,%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,
 			sel,
 		)
 		if _, err := EvalJSON(ctx, conn, script); err == nil {
@@ -845,7 +848,7 @@ func WaitForSelector(ctx context.Context, conn *CDPConn, selector string) error 
 			return ctx.Err()
 		default:
 		}
-		result, err := EvalJSON(ctx, conn, fmt.Sprintf("!!document.querySelector(%q)", selector))
+		result, err := EvalJSON(ctx, conn, DeepQueryJS+fmt.Sprintf("\n!!__smDeepQuery(document,%q)", selector))
 		if err == nil {
 			var found bool
 			if json.Unmarshal(result, &found) == nil && found {

--- a/go/browser/deepquery.go
+++ b/go/browser/deepquery.go
@@ -1,0 +1,47 @@
+package browser
+
+// DeepQueryJS defines shadow-piercing querySelector helpers, prepended to any
+// browser-eval that must locate a node the way the offline matcher does: across
+// shadow boundaries.
+//
+// Why this exists: capture is shadow-aware — probe.js walks node.shadowRoot and
+// stamps data-sightmap-id on live shadow nodes, and the extracted tree flattens
+// shadow subtrees in as ordinary children. So offline matching (and sel-probe's
+// offline count, coverage, component queries) matches ACROSS shadow boundaries.
+// A live document.querySelector does NOT cross shadow roots, so every live
+// lookup that re-finds a matched node (property extraction, interaction,
+// bounds, the sel-probe live count) was silently shadow-blind and disagreed
+// with the corpus. These helpers close that gap. See schema.md "Selector model
+// & shadow DOM".
+//
+//	__smDeepQueryAll(root, sel) — every element matching sel within root's tree
+//	  AND every shadow tree nested beneath it. root may be the document, a
+//	  shadow root, or an element; for an element the matches are its descendants
+//	  (mirroring Element.querySelectorAll) plus descendants inside its own or any
+//	  nested shadow root.
+//	__smDeepQuery(root, sel) — the first such element, or null.
+//
+// Prepend with: browser.DeepQueryJS + "\n" + script. The helpers are function
+// declarations, so the script's trailing expression stays the completion value.
+const DeepQueryJS = `
+function __smDeepQueryAll(root, sel) {
+  var out = [];
+  function walk(r) {
+    try {
+      var m = r.querySelectorAll(sel);
+      for (var i = 0; i < m.length; i++) out.push(m[i]);
+    } catch (e) { return; }
+    if (r.shadowRoot) walk(r.shadowRoot);
+    var all = r.querySelectorAll('*');
+    for (var j = 0; j < all.length; j++) {
+      if (all[j].shadowRoot) walk(all[j].shadowRoot);
+    }
+  }
+  walk(root);
+  return out;
+}
+function __smDeepQuery(root, sel) {
+  var a = __smDeepQueryAll(root, sel);
+  return a.length ? a[0] : null;
+}
+`

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -235,8 +235,9 @@ func boundsBySelector(
 ) ([]boundsResult, error) {
 	// Return the rects directly (not stringified) so EvalJSON gives us the
 	// object value rather than a JSON-encoded string.
-	script := fmt.Sprintf(`(function(){
-  var els = document.querySelectorAll(%s);
+	script := browser.DeepQueryJS + fmt.Sprintf(`
+(function(){
+  var els = __smDeepQueryAll(document, %s);
   var out = [];
   for (var i = 0; i < els.length; i++) {
     var r = els[i].getBoundingClientRect();

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -22,7 +22,7 @@ import (
 // Placeholders: %s = JSON-encoded selector, %d = max, %v = full (bool).
 const queryScript = `(function(sel, max, full) {
   try {
-    const els = [...document.querySelectorAll(sel)].slice(0, max);
+    const els = [...__smDeepQueryAll(document, sel)].slice(0, max);
     const interestingAttrs = new Set([
       'id','class','role','href','type','name','placeholder','aria-label',
       'aria-expanded','aria-haspopup','aria-controls','aria-selected',
@@ -246,8 +246,8 @@ func printOfflineCheck(ctx context.Context, conn *browser.CDPConn, selector stri
 // selector in the live page.
 func liveSelectorCount(ctx context.Context, conn *browser.CDPConn, selector string) (int, error) {
 	selJSON, _ := json.Marshal(selector)
-	raw, err := browser.EvalJSON(ctx, conn, fmt.Sprintf(
-		`(function(s){try{return document.querySelectorAll(s).length}catch(e){return -1}})(%s)`, string(selJSON)))
+	raw, err := browser.EvalJSON(ctx, conn, browser.DeepQueryJS+fmt.Sprintf(
+		"\n"+`(function(s){try{return __smDeepQueryAll(document,s).length}catch(e){return -1}})(%s)`, string(selJSON)))
 	if err != nil {
 		return 0, err
 	}
@@ -321,7 +321,7 @@ func queryElements(
 		return nil, fmt.Errorf("marshal selector: %w", err)
 	}
 
-	script := fmt.Sprintf(queryScript, string(selectorJSON), maxN, full)
+	script := browser.DeepQueryJS + "\n" + fmt.Sprintf(queryScript, string(selectorJSON), maxN, full)
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
@@ -517,9 +517,9 @@ func runSelProbeAll(args []string, sightmapDir, addr, tabID string, max int, ful
 		}
 		time.Sleep(time.Duration(w * float64(time.Second)))
 
-		script := fmt.Sprintf(`(function(sel,max){
+		script := browser.DeepQueryJS + fmt.Sprintf("\n"+`(function(sel,max){
             try {
-                var els = Array.from(document.querySelectorAll(sel)).slice(0,max);
+                var els = Array.from(__smDeepQueryAll(document,sel)).slice(0,max);
                 return els.length;
             } catch(e) { return -1; }
         })(%s, %d)`, string(selectorJSON), max)

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -78,9 +78,9 @@ func ExtractProperties(
     if (extract === 'inner_html') return el.innerHTML;
     if (extract.startsWith('attr=')) return el.getAttribute(extract.slice(5));
     if (extract.startsWith('exists:')) {
-      return el.querySelector(extract.slice(7)) ? 'true' : null;
+      return __smDeepQuery(el, extract.slice(7)) ? 'true' : null;
     }
-    const sub = el.querySelector(extract);
+    const sub = __smDeepQuery(el, extract);
     return sub ? (sub.innerText != null ? sub.innerText : sub.textContent) : null;
   }
   function applyTransform(val, transform) {
@@ -108,8 +108,8 @@ func ExtractProperties(
     // Anchor to the exact matched element via its sightmap ID attribute (set by
     // probe.js as data-sightmap-id). This ensures child components like
     // BreadcrumbLink get their own text, not the first match on the page.
-    const el = (id ? document.querySelector('[data-sightmap-id="' + id + '"]') : null)
-               || document.querySelector(selector);
+    const el = (id ? __smDeepQuery(document, '[data-sightmap-id="' + id + '"]') : null)
+               || __smDeepQuery(document, selector);
     if (!el) continue;
     const vals = {};
     for (const {name, extract, transform} of props) {
@@ -125,7 +125,7 @@ func ExtractProperties(
   return results;
 })(SPECS_JSON)`
 
-	script := strings.Replace(jsTemplate, "SPECS_JSON", string(specsJSON), 1)
+	script := browser.DeepQueryJS + "\n" + strings.Replace(jsTemplate, "SPECS_JSON", string(specsJSON), 1)
 
 	resultJSON, evalErr := browser.EvalJSON(ctx, conn, script)
 	if evalErr != nil {

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -120,6 +120,7 @@ See [SEP-0002](../seps/0002-component-ref.md) for the full proposal and rational
 - A list of strings is tried in order; the first selector that matches wins.
 - Selectors in `children` are evaluated **within** their parent's matched subtree, not globally. This scoping is how Sightmap avoids naming collisions between, say, two different card components that both contain a `button.primary`.
 - Selectors are not required to be unique at their level. If a selector matches multiple elements, all matches are named.
+- **Shadow DOM.** Selectors are matched against the captured component tree, which is a *flattened* representation: each shadow root's content is inlined as ordinary children of its host. Selectors therefore match **across shadow boundaries** — shadow-DOM content is addressed exactly like light-DOM content, and there is no piercing syntax (standard CSS has none: `>>>`/`/deep/` were removed, and `::part()`/`::slotted()` reach only explicitly-exposed nodes). `children` scoping and combinators operate over the flattened tree, where a shadow host → shadow child is an ordinary parent→child edge. This is a deliberate divergence from a live `document.querySelector`, which does **not** cross shadow roots: a tool re-implementing matching or property extraction against the live DOM MUST traverse shadow roots (walk each element's `shadowRoot`) to agree with the corpus. The same rule governs the `exists:`/sub-selector extract modes below — they resolve within the matched element's flattened subtree, including its shadow DOM.
 
 
 ### Component properties
@@ -141,8 +142,8 @@ A component may declare `properties: Property[]` — named values extracted from
 | `text_only` | `textContent` after removing `img`, `svg`, and `[alt]` descendants — use when icon alt-text bleeds into the label |
 | `inner_html` | `element.innerHTML` |
 | `attr=NAME` | `element.getAttribute(NAME)` |
-| `exists:SEL` | `"true"` if `element.querySelector(SEL)` matches; the property is **omitted** when it does not (boolean state flag) |
-| *any other string* | Treated as a CSS sub-selector: `element.querySelector(VALUE)?.textContent.trim()`; omitted when it matches nothing |
+| `exists:SEL` | `"true"` if `SEL` matches an element within the matched element's subtree — **including its shadow DOM** (see [Selector semantics](#selector-semantics)) — else **omitted** (boolean state flag) |
+| *any other string* | Treated as a CSS sub-selector resolved within the matched element's subtree, **including its shadow DOM**: the first match's `innerText` (falling back to `textContent`), trimmed; omitted when nothing matches |
 
 **Transforms.** When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1).
 


### PR DESCRIPTION
Selectors pierce shadow DOM when matched offline (the captured tree flattens
shadow roots), but every live-DOM op re-found nodes with `document.querySelector`,
which can't cross shadow boundaries — so property extraction, interaction, `bounds`,
`sel-probe`'s live count, and `suggest`/`discover` were silently shadow-blind and
disagreed with the corpus on shadow-heavy apps. The behavior was also unspecified.

### Fix
- **Shared shadow-piercing resolver** (`go/browser/deepquery.go`, `DeepQueryJS` →
  `__smDeepQuery`/`__smDeepQueryAll`) that walks `document` + all nested
  `shadowRoot`s. Adopted by:
  - property extraction (`observe/properties.go`) — node resolution + `exists:`/sub-selectors
  - interaction (`browser/actions.go`) — `ResolveBySightmapID`, click locator, click-by-selector, value-read, scroll, `wait-for`
  - `bounds` (`cmd_browser_bounds.go`), `sel-probe` live/count paths (`cmd_sel_probe.go`)
  - `suggest`/`discover` scans (`authoring/scan.go`)
- **Spec** (`spec/v1/schema.md`): a new shadow-DOM paragraph in *Selector semantics*
  formalizing that selectors match the flattened tree and cross shadow boundaries
  (a deliberate divergence from live `document.querySelector`), and the
  `exists:`/sub-selector extract rows reconciled to the same rule.

Because capture already stamps `data-sightmap-id` across shadow, the same ids and
selectors now resolve live — no re-capture needed.

### Verification
- Full `go test ./...`, `go vet`, `gofmt` clean.
- Live on a Salesforce Lightning app (shadow-heavy): components inside the
  `one-appnav`/LWC shadow trees that were bare before now extract their props,
  e.g. `[NavItem href="/lightning/o/Account/home" label="Accounts"]`,
  `[FlowInput fieldName="AccountName" type="text"]`.

### Deferred (follow-up)
The extension overlay's `content.js`/`resolver.js` resolve their target element
directly (already shadow-aware) but their `exists:`/sub-selector paths remain
light-DOM only. That separate in-browser runtime has duplicated extraction JS;
bringing it to parity pairs with de-duplicating that JS.

Closes #224
