### PR TITLE
devtools: serve retained req/rsp bodies + surface headers in network get

### DIFF
--- a/.changeset/devtools-body-headers.md
+++ b/.changeset/devtools-body-headers.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Make `network get` reliable and header-aware. The devtools body endpoint now serves the response/request body eagerly retained on the record (captured at `loadingFinished`) instead of always re-fetching it from Chrome via `getResponseBody`, which failed once the browser had evicted the body ("response body no longer available"). And `network get` now renders the captured request/response headers (they were already on the record from the collector but never surfaced). This closes the HTTP response header/body residual split out of the network-collector gaps.

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -316,9 +316,12 @@ func (c *Collector) Network(f NetworkFilter) ([]sightmap.Request, int) {
 // index, from the collector connection that observed it. Returns (body, found,
 // err); found is false when no such entry is buffered.
 func (c *Collector) ResponseBody(ctx context.Context, index int) ([]byte, bool, error) {
-	reqID, conn, ok := c.lookupRequest(index)
-	if !ok {
+	retained, reqID, conn, found := c.bodyLookup(index, func(r networkRecord) *sightmap.Body { return r.RspBody })
+	if !found {
 		return nil, false, nil
+	}
+	if retained != nil {
+		return retained, true, nil
 	}
 	body, err := getResponseBody(ctx, conn, reqID)
 	return body, true, err
@@ -327,12 +330,36 @@ func (c *Collector) ResponseBody(ctx context.Context, index int) ([]byte, bool, 
 // RequestBody fetches the request post-data for the network entry with the given
 // index. Returns (body, found, err).
 func (c *Collector) RequestBody(ctx context.Context, index int) ([]byte, bool, error) {
-	reqID, conn, ok := c.lookupRequest(index)
-	if !ok {
+	retained, reqID, conn, found := c.bodyLookup(index, func(r networkRecord) *sightmap.Body { return r.ReqBody })
+	if !found {
 		return nil, false, nil
+	}
+	if retained != nil {
+		return retained, true, nil
 	}
 	body, err := getRequestPostData(ctx, conn, reqID)
 	return body, true, err
+}
+
+// bodyLookup finds the buffered record for index and returns EITHER the body
+// already retained on it (pick selects ReqBody/RspBody) or the reqID+conn to
+// fetch it live. Preferring the retained copy is what makes `network get`
+// reliable: the eager loadingFinished capture keeps the body in memory, so a
+// query after Chrome has evicted it from its own network cache still succeeds
+// (a live getResponseBody would fail). Falls back to a live fetch only when
+// nothing was retained (e.g. a non-XHR/Fetch type, which wantsBody skips).
+func (c *Collector) bodyLookup(index int, pick func(networkRecord) *sightmap.Body) (retained []byte, reqID string, conn *CDPConn, found bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range c.network {
+		if c.network[i].Index == index {
+			if b := pick(c.network[i]); b != nil {
+				return []byte(b.Content), "", nil, true
+			}
+			return nil, c.network[i].requestID, c.network[i].conn, true
+		}
+	}
+	return nil, "", nil, false
 }
 
 // retainResponseBody fetches a finished response's body and stores it on the

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -1,11 +1,48 @@
 package browser
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/sightmap/sightmap/go/sightmap"
 )
+
+// A retained body must be served without a live CDP fetch. These records carry a
+// zero-value conn, so a live getResponseBody/getRequestPostData would fail — a
+// pass proves the eagerly-retained copy was used (the #226 reliability fix).
+func TestResponseBody_PrefersRetained(t *testing.T) {
+	c := &Collector{network: []networkRecord{{
+		Request: sightmap.Request{Index: 1, RspBody: &sightmap.Body{Content: "retained-rsp"}},
+	}}}
+	body, found, err := c.ResponseBody(context.Background(), 1)
+	if err != nil || !found {
+		t.Fatalf("ResponseBody: found=%v err=%v", found, err)
+	}
+	if string(body) != "retained-rsp" {
+		t.Errorf("ResponseBody = %q, want retained-rsp", body)
+	}
+}
+
+func TestRequestBody_PrefersRetained(t *testing.T) {
+	c := &Collector{network: []networkRecord{{
+		Request: sightmap.Request{Index: 2, ReqBody: &sightmap.Body{Content: "retained-req"}},
+	}}}
+	body, found, err := c.RequestBody(context.Background(), 2)
+	if err != nil || !found {
+		t.Fatalf("RequestBody: found=%v err=%v", found, err)
+	}
+	if string(body) != "retained-req" {
+		t.Errorf("RequestBody = %q, want retained-req", body)
+	}
+}
+
+func TestResponseBody_NotFound(t *testing.T) {
+	c := &Collector{}
+	if _, found, err := c.ResponseBody(context.Background(), 99); found || err != nil {
+		t.Errorf("ResponseBody(absent) = found=%v err=%v, want found=false, nil", found, err)
+	}
+}
 
 func TestParseConsoleAPI(t *testing.T) {
 	raw := json.RawMessage(`{"type":"warning","timestamp":1785015495306,"args":[{"type":"string","value":"hello"},{"type":"number","value":42}]}`)

--- a/go/cmd/sightmap/cmd_devtools.go
+++ b/go/cmd/sightmap/cmd_devtools.go
@@ -143,6 +143,24 @@ func printProps(props []sightmap.PropertyValue) {
 	}
 }
 
+// printHeaders renders a captured header block (request or response) for
+// `network get`. Headers ride on the record from the collector (no extra
+// round-trip); long values are truncated so a token/cookie doesn't flood the
+// output while a marker header stays readable.
+func printHeaders(label string, hs []sightmap.Header) {
+	if len(hs) == 0 {
+		return
+	}
+	fmt.Printf("%s:\n", label)
+	for _, h := range hs {
+		v := h.Value
+		if len(v) > 512 {
+			v = v[:512] + "…(truncated)"
+		}
+		fmt.Printf("  %s: %s\n", h.Name, v)
+	}
+}
+
 // matchSlot renders the leading corpus-match token for a list line: the matched
 // def name(s) in brackets, or "[--]" when unmatched. It leads the line (before
 // the record's own payload) so an agent reads the classification first, mirroring
@@ -336,6 +354,8 @@ func runNetworkGet(args []string) error {
 		fmt.Printf("Matches: %s\n", strings.Join(entry.Matches, ", "))
 	}
 	printProps(entry.Props)
+	printHeaders("Request Headers", entry.ReqHeaders)
+	printHeaders("Response Headers", entry.RspHeaders)
 
 	if *reqFile != "" {
 		if err := saveBody(*sightmapDir, idx, "request", *reqFile); err != nil {


### PR DESCRIPTION
Completes the HTTP header/body half of the network-collector work (#226),
stacked on #212.

### Fixes
- **Reliable body reads.** `Collector.ResponseBody`/`RequestBody` now return the
  body eagerly retained on the record at `loadingFinished`, instead of always
  re-fetching via `Network.getResponseBody` — which fails once Chrome has evicted
  the body (`network get` → "response body no longer available" / broken pipe).
  Falls back to a live fetch only when nothing was retained (non-XHR/Fetch types,
  which the eager path skips by design).
- **Surface headers.** `network get` now renders the captured request/response
  headers (already on the record from #211; previously never shown), long values
  truncated.

### Tests
`collector_test.go`: `ResponseBody`/`RequestBody` serve the retained body without
a live fetch (the records carry a zero conn, so a live fetch would fail — a pass
proves the retained copy is used) + a not-found case. `go test`/`vet`/`gofmt`
green.

### Verified
`network get` on a live capture now prints full Request/Response Headers blocks
(confirmed against a running session). The retained-body path is unit-tested.

Closes #226. Stacked on #212 (base `feat/devtools-property-annotation`).
