### PR TITLE
refactor(browser): scope collector capture to one cancellable context

### DIFF
--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -49,12 +49,24 @@ type Collector struct {
 	consoleDropped int
 	networkDropped int
 
-	tabsMu   sync.Mutex
-	tabs     map[string]*tabColl
-	stopping bool // set under tabsMu in Stop; blocks new tab attachments during teardown
+	tabsMu sync.Mutex
+	tabs   map[string]*tabColl
 
-	stop chan struct{}
-	wg   sync.WaitGroup
+	// ctx spans the collector's entire capture lifetime and is cancelled by Stop.
+	// Every per-tab context derives from it, so a single cancel stops every drain
+	// and interrupts any in-flight tab poll or dial.
+	//
+	// Holding a context in a struct is a deliberate deviation from the usual
+	// "pass it as the first argument" rule. The scope here is this object's
+	// lifetime rather than one request, and fixing both fields at construction
+	// keeps that lifetime immutable: Start and Stop then need no locking, no nil
+	// check, and no guard against a second Start replacing the first cancel func
+	// and stranding wg.Wait forever. Long-lived clients hold the same pair for
+	// the same reason (e.g. grpc.ClientConn).
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	wg sync.WaitGroup
 }
 
 type tabColl struct {
@@ -65,11 +77,13 @@ type tabColl struct {
 // NewCollector creates a collector for the Chrome session at addr (host:port).
 // Call Start to begin capturing and Stop to tear down.
 func NewCollector(addr string) *Collector {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Collector{
 		addr:       addr,
 		maxEntries: DefaultMaxEntries,
 		tabs:       make(map[string]*tabColl),
-		stop:       make(chan struct{}),
+		ctx:        ctx,
+		cancel:     cancel,
 	}
 }
 
@@ -80,23 +94,25 @@ func (c *Collector) Start() {
 	go c.attachLoop()
 }
 
-// Stop halts capture and closes every per-tab connection.
+// Stop halts capture and closes every per-tab connection. It is safe to call
+// more than once.
 //
-// Order matters: each drain goroutine only returns on its ctx being cancelled,
-// so the per-tab contexts MUST be cancelled BEFORE wg.Wait(). Cancelling after
-// the wait would deadlock whenever the CDP connections are still healthy at Stop
-// time (i.e. the browser is still running — the norm when a caller stops the
-// collector without tearing down the browser, as in --attach mode). The owned
-// path happened to avoid this only because it kills Chrome first, breaking the
-// connections out from under the drains.
+// Order matters: a drain goroutine returns only once its context is cancelled,
+// so cancellation MUST precede wg.Wait(). Waiting first deadlocks whenever the
+// CDP connections are still healthy at Stop time, which is the normal case
+// whenever the caller owns the browser and it outlives the collector, as under
+// --attach. One cancel covers every tab, since all tab contexts descend from
+// c.ctx.
+//
+// A tab attaching concurrently with Stop is safe on three counts: its context
+// descends from c.ctx, so it is born cancelled and its drain returns on its
+// first select; its conn is registered in c.tabs before that drain is counted,
+// so the sweep below still closes it; and its wg.Add cannot race wg.Wait,
+// because attachTab runs only on the attachLoop goroutine, which holds a count
+// of its own until it returns, keeping the counter above zero for as long as a
+// further Add is possible.
 func (c *Collector) Stop() {
-	close(c.stop)
-	c.tabsMu.Lock()
-	c.stopping = true // stop syncTabs from attaching a fresh (uncancelled) drain
-	for _, tc := range c.tabs {
-		tc.cancel()
-	}
-	c.tabsMu.Unlock()
+	c.cancel()
 	c.wg.Wait()
 	c.tabsMu.Lock()
 	for id, tc := range c.tabs {
@@ -118,7 +134,7 @@ func (c *Collector) attachLoop() {
 	defer t.Stop()
 	for {
 		select {
-		case <-c.stop:
+		case <-c.ctx.Done():
 			return
 		case <-t.C:
 			c.syncTabs()
@@ -127,7 +143,10 @@ func (c *Collector) attachLoop() {
 }
 
 func (c *Collector) syncTabs() {
-	tabs, err := ListTabs(context.Background(), c.addr)
+	// Neither this poll nor the ConnectTab below sets a client timeout, so the
+	// collector context is the only thing bounding them: a browser that accepts
+	// the socket and then never answers would otherwise block Stop indefinitely.
+	tabs, err := ListTabs(c.ctx, c.addr)
 	if err != nil {
 		return
 	}
@@ -154,11 +173,11 @@ func (c *Collector) syncTabs() {
 }
 
 func (c *Collector) attachTab(tabID string) {
-	conn, err := ConnectTab(context.Background(), c.addr, tabID)
+	conn, err := ConnectTab(c.ctx, c.addr, tabID)
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.ctx)
 
 	consoleCh := conn.Subscribe("Runtime.consoleAPICalled")
 	excCh := conn.Subscribe("Runtime.exceptionThrown")
@@ -174,14 +193,6 @@ func (c *Collector) attachTab(tabID string) {
 	}
 
 	c.tabsMu.Lock()
-	if c.stopping {
-		// Teardown is in progress; don't start a drain that Stop's wg.Wait would
-		// then block on. Cancel and drop this connection instead.
-		c.tabsMu.Unlock()
-		cancel()
-		conn.Close()
-		return
-	}
 	c.tabs[tabID] = &tabColl{conn: conn, cancel: cancel}
 	c.wg.Add(1)
 	c.tabsMu.Unlock()

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -3,8 +3,13 @@ package browser
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 
 	"github.com/sightmap/sightmap/go/sightmap"
 )
@@ -123,14 +128,15 @@ func TestDecodeBody(t *testing.T) {
 	}
 }
 
-// TestCollectorStop_NoDeadlockWhileConnected guards the shutdown-order fix: a
-// drain goroutine only returns on its ctx being cancelled, so Stop must cancel
-// the per-tab contexts BEFORE wg.Wait(). Simulate a still-attached tab whose
-// drain is blocked (a healthy CDP connection, i.e. the browser is still alive —
-// the --attach case) and assert Stop returns promptly instead of deadlocking.
+// TestCollectorStop_NoDeadlockWhileConnected pins Stop's shutdown ordering: a
+// drain returns only once its context is cancelled, so Stop must cancel every
+// tab context, via the shared parent c.ctx, before wg.Wait. Simulates a
+// still-attached tab whose drain is blocked on a healthy CDP connection, the
+// case where the browser outlives the collector, and asserts Stop returns
+// promptly rather than deadlocking.
 func TestCollectorStop_NoDeadlockWhileConnected(t *testing.T) {
 	c := NewCollector("unused")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.ctx)
 	c.tabsMu.Lock()
 	c.tabs["t1"] = &tabColl{conn: nil, cancel: cancel}
 	c.tabsMu.Unlock()
@@ -146,5 +152,148 @@ func TestCollectorStop_NoDeadlockWhileConnected(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Collector.Stop deadlocked with a healthy (uncancelled) drain")
+	}
+}
+
+// newFakeBrowser starts a fake Chrome CDP endpoint exposing a single page target
+// and returns its host:port. The websocket answers every command with an empty
+// result, which is all attachTab's Runtime.enable and Network.enable require.
+// onList, when non-nil, runs at the head of each /json/list request, letting a
+// test stall the tab poll.
+func newFakeBrowser(t *testing.T, onList func(r *http.Request)) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewUnstartedServer(mux)
+
+	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
+		if onList != nil {
+			onList(r)
+		}
+		targets := []map[string]string{{
+			"id":                   "tab-1",
+			"type":                 "page",
+			"url":                  "http://fake.test/",
+			"webSocketDebuggerUrl": "ws://" + r.Host + "/ws",
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(targets); err != nil {
+			t.Logf("newFakeBrowser: encode targets: %v", err)
+		}
+	})
+
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		wsConn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("newFakeBrowser: ws upgrade: %v", err)
+			return
+		}
+		var wsMu sync.Mutex
+		go func() {
+			for {
+				_, raw, readErr := wsConn.ReadMessage()
+				if readErr != nil {
+					return
+				}
+				var req struct {
+					ID int64 `json:"id"`
+				}
+				if json.Unmarshal(raw, &req) != nil {
+					continue
+				}
+				reply, _ := json.Marshal(map[string]any{"id": req.ID, "result": map[string]any{}})
+				wsMu.Lock()
+				err := wsConn.WriteMessage(websocket.TextMessage, reply)
+				wsMu.Unlock()
+				if err != nil {
+					return
+				}
+			}
+		}()
+	})
+
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
+}
+
+// waitForTabs blocks until the collector has exactly n tabs registered.
+func waitForTabs(t *testing.T, c *Collector, n int, why string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		c.tabsMu.Lock()
+		got := len(c.tabs)
+		c.tabsMu.Unlock()
+		if got == n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: %d tabs registered, want %d", why, got, n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestCollectorStop_LiveTabNoDeadlock drives the real attach path against a fake
+// browser and stops the collector while the CDP connection is still healthy, the
+// case where the caller owns the browser and it outlives the collector. Stop must
+// return promptly and leave no tab registered.
+func TestCollectorStop_LiveTabNoDeadlock(t *testing.T) {
+	c := NewCollector(newFakeBrowser(t, nil))
+	c.Start()
+	t.Cleanup(c.Stop) // idempotent; covers the early-Fatal paths below
+	waitForTabs(t, c, 1, "collector never attached the fake tab")
+
+	done := make(chan struct{})
+	go func() { c.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Collector.Stop deadlocked with a live, healthy tab connection")
+	}
+
+	c.tabsMu.Lock()
+	remaining := len(c.tabs)
+	c.tabsMu.Unlock()
+	if remaining != 0 {
+		t.Errorf("after Stop: %d tabs still registered, want 0", remaining)
+	}
+}
+
+// TestCollectorStop_DuringStalledPoll covers the other route to a hung Stop: a
+// browser that accepts the connection and then never answers the tab poll.
+// ListTabs sets no client timeout, so attachLoop escapes the poll only because it
+// runs on the collector context that Stop cancels.
+func TestCollectorStop_DuringStalledPoll(t *testing.T) {
+	polled := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	addr := newFakeBrowser(t, func(r *http.Request) {
+		once.Do(func() { close(polled) })
+		select {
+		case <-r.Context().Done(): // the collector gave up on the request
+		case <-release:
+		}
+	})
+	// Runs before the server's own cleanup, so a stalled handler cannot wedge it.
+	t.Cleanup(func() { close(release) })
+
+	c := NewCollector(addr)
+	c.Start()
+	t.Cleanup(c.Stop)
+
+	select {
+	case <-polled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("collector never polled the fake browser")
+	}
+
+	done := make(chan struct{})
+	go func() { c.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Collector.Stop deadlocked while the tab poll was stalled")
 	}
 }

--- a/go/browser/extension.go
+++ b/go/browser/extension.go
@@ -50,12 +50,11 @@ func InjectExtensionServerPort(ctx context.Context, addr string, serverPort int)
 // extension's service worker, retrying for up to 5 seconds while it starts.
 // Returns "" if no sightmap extension service worker is found.
 //
-// It must not just take the first extension service worker it sees: a real
-// browser (the --attach case) commonly has several extensions installed, so the
-// candidate is confirmed by evaluating its manifest `name` and matching
-// sightmapExtensionMarker. (An owned launch has an isolated profile with only
-// the sightmap extension, so this only ever mattered once attach let us point at
-// a user's everyday browser.)
+// Taking the first extension service worker found is not enough: a browser the
+// caller owns (the --attach case) commonly has several extensions installed, so
+// each candidate is confirmed by evaluating its manifest `name` against
+// sightmapExtensionMarker. An owned launch has an isolated profile holding only
+// the sightmap extension, where the first candidate always matches.
 func findExtensionSWWS(ctx context.Context, addr string) (string, error) {
 	type target struct {
 		Type  string `json:"type"`

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -366,8 +366,8 @@ func startDevtoolsServer(sightmapDir, siteName string, serverPort int) (*http.Se
 // deliberately degraded mode (see the --attach flag help): no owned profile or
 // extension guarantees, capture is complete only from attach onward, and the
 // browser is left running when the daemon stops. The collector and devtools
-// server are identical to the owned-launch path — the collector only ever needed
-// a CDP address.
+// server are identical to the owned-launch path, since the collector needs
+// nothing but a CDP address.
 func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlFlag string) error {
 	// Normalize the endpoint. A bare ":port" or "port" is treated as localhost.
 	host, port, err := net.SplitHostPort(attachAddr)
@@ -422,16 +422,23 @@ func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlF
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	gone := make(chan struct{})
-	stopPoll := make(chan struct{})
+	pollCtx, pollCancel := context.WithCancel(context.Background())
+	defer pollCancel()
 	go func() {
 		t := time.NewTicker(2 * time.Second)
 		defer t.Stop()
 		for {
 			select {
-			case <-stopPoll:
+			case <-pollCtx.Done():
 				return
 			case <-t.C:
-				if !cdpVersionAlive(context.Background(), cdpAddr) {
+				// The probe sets no client timeout of its own, so pollCtx is what
+				// bounds it: a browser that accepts the socket and never answers
+				// would otherwise wedge this loop and never report the browser gone.
+				if !cdpVersionAlive(pollCtx, cdpAddr) {
+					if pollCtx.Err() != nil {
+						return // shutting down, not a dead browser
+					}
 					close(gone)
 					return
 				}
@@ -478,7 +485,6 @@ func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlF
 	case <-gone:
 		fmt.Fprintln(os.Stderr, "\nattached browser went away — detaching")
 	}
-	close(stopPoll)
 
 	// Stop HTTP server and drop the session file. The browser is NOT touched.
 	shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
Stacked on #216.

The collector's teardown carried three mechanisms: a stop channel, a per-tab cancel loop in `Stop`, and a `stopping` flag that kept `syncTabs` from registering a fresh drain that `Stop`'s `wg.Wait` would then block on. Deriving every per-tab context from one collector-lifetime context collapses all three into a single cancel, since a tab attaching concurrently is then born cancelled and its drain returns on its first select. `Stop` also becomes idempotent, where closing the stop channel twice panicked.

That same context replaces the `context.Background()` passed to the tab poll and dial. Neither sets a client timeout, so a browser that accepts the socket and never answers could wedge `attachLoop` and hang `Stop` regardless of when the drains were cancelled, which is a hole the `stopping` flag could not close. The attach daemon's liveness probe had the same gap and is fixed alongside it.

Two regression tests drive the real attach path against a fake CDP endpoint, one stopping the collector with a healthy tab connection and one with the tab poll stalled. Each was confirmed to fail without its corresponding fix. Also rewords a few comments that described the change rather than the code, so they read for someone seeing the file for the first time.
