### PR TITLE
browser: compose each embedded script's DeepQueryJS dependency once

### DIFF
--- a/go/authoring/scan.go
+++ b/go/authoring/scan.go
@@ -15,7 +15,12 @@ import (
 )
 
 //go:embed scan.js
-var scanJS string
+var scanJSSource string
+
+// scanJS is scanJSSource with its __smDeepQueryAll dependency (deepquery.js)
+// composed in once here, so every call site below just does scanJS+<call> --
+// there's no "did I remember to prepend DeepQueryJS" to get wrong.
+var scanJS = browser.DeepQueryJS + "\n" + scanJSSource
 
 // Candidate is one selector candidate found by ScanCandidates: a stable
 // data-attribute selector, how many elements it matched, and enough context
@@ -34,7 +39,7 @@ type Candidate struct {
 // candidate records the nearest [data-sightmap-id] ancestor so callers can group
 // candidates under the component that already covers their region.
 func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Candidate, error) {
-	script := browser.DeepQueryJS + scanJS + fmt.Sprintf("\n__smScanCandidates(%d)", max)
+	script := scanJS + fmt.Sprintf("\n__smScanCandidates(%d)", max)
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
@@ -50,7 +55,7 @@ func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Cand
 // ScanLinks returns the distinct same-host link pathnames on the live page, in
 // document order. Callers normalize these into route patterns with NormalizePath.
 func ScanLinks(ctx context.Context, conn *browser.CDPConn) ([]string, error) {
-	script := browser.DeepQueryJS + scanJS + "\n__smScanLinks()"
+	script := scanJS + "\n__smScanLinks()"
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {

--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -13,7 +13,12 @@ import (
 )
 
 //go:embed actions.js
-var actionsJS string
+var actionsJSSource string
+
+// actionsJS is actionsJSSource with its __smDeepQuery dependency (deepquery.js)
+// composed in once here, so every call site below just does actionsJS+<call>
+// -- there's no "did I remember to prepend DeepQueryJS" to get wrong.
+var actionsJS = DeepQueryJS + "\n" + actionsJSSource
 
 // Navigate sends Page.navigate. Does NOT wait for load.
 func Navigate(ctx context.Context, conn *CDPConn, url string) error {
@@ -467,7 +472,7 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 // page was re-probed since), so callers can prompt for a fresh snapshot.
 func ResolveBySightmapID(ctx context.Context, conn *CDPConn, id string) (*sightmap.ComponentNode, error) {
 	selJSON, _ := json.Marshal(fmt.Sprintf("[data-sightmap-id=%q]", id))
-	script := DeepQueryJS + actionsJS + fmt.Sprintf("\n__smBoundsBySelector(%s)", selJSON)
+	script := actionsJS + fmt.Sprintf("\n__smBoundsBySelector(%s)", selJSON)
 	raw, err := EvalJSON(ctx, conn, script)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %q: %w", id, err)
@@ -558,7 +563,7 @@ type clickTarget struct {
 // overlay is reported as not-hit rather than clicked through).
 func locateForClick(ctx context.Context, conn *CDPConn, id string) (clickTarget, error) {
 	selJSON, _ := json.Marshal(fmt.Sprintf("[data-sightmap-id=%q]", id))
-	script := DeepQueryJS + actionsJS + fmt.Sprintf("\n__smLocateForClick(%s)", selJSON)
+	script := actionsJS + fmt.Sprintf("\n__smLocateForClick(%s)", selJSON)
 	raw, err := EvalJSON(ctx, conn, script)
 	if err != nil {
 		return clickTarget{}, err
@@ -600,7 +605,7 @@ func Click(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) (in
 			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
 		selJSON, _ := json.Marshal(sel)
-		_, err := EvalJSON(ctx, conn, DeepQueryJS+actionsJS+fmt.Sprintf("\n__smClickBySelector(%s)", selJSON))
+		_, err := EvalJSON(ctx, conn, actionsJS+fmt.Sprintf("\n__smClickBySelector(%s)", selJSON))
 		return -1, -1, err
 	}
 	x := node.Bounds.X + node.Bounds.Width/2
@@ -681,7 +686,7 @@ func readInputValue(ctx context.Context, conn *CDPConn, id string) (string, bool
 		return "", false
 	}
 	selJSON, _ := json.Marshal(fmt.Sprintf("[data-sightmap-id=%q]", id))
-	raw, err := EvalJSON(ctx, conn, DeepQueryJS+actionsJS+fmt.Sprintf("\n__smReadValueBySelector(%s)", selJSON))
+	raw, err := EvalJSON(ctx, conn, actionsJS+fmt.Sprintf("\n__smReadValueBySelector(%s)", selJSON))
 	if err != nil || len(raw) == 0 || string(raw) == "null" {
 		return "", false
 	}
@@ -775,7 +780,7 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 func ScrollIntoView(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) error {
 	if sel := node.Element.SelectorString(); sel != "" {
 		selJSON, _ := json.Marshal(sel)
-		script := DeepQueryJS + actionsJS + fmt.Sprintf("\n__smScrollIntoViewBySelector(%s)", selJSON)
+		script := actionsJS + fmt.Sprintf("\n__smScrollIntoViewBySelector(%s)", selJSON)
 		if _, err := EvalJSON(ctx, conn, script); err == nil {
 			return nil
 		}
@@ -827,7 +832,7 @@ func WaitForSelector(ctx context.Context, conn *CDPConn, selector string) error 
 		default:
 		}
 		selJSON, _ := json.Marshal(selector)
-		result, err := EvalJSON(ctx, conn, DeepQueryJS+actionsJS+fmt.Sprintf("\n__smSelectorExists(%s)", selJSON))
+		result, err := EvalJSON(ctx, conn, actionsJS+fmt.Sprintf("\n__smSelectorExists(%s)", selJSON))
 		if err == nil {
 			var found bool
 			if json.Unmarshal(result, &found) == nil && found {

--- a/go/browser/deepquery.go
+++ b/go/browser/deepquery.go
@@ -28,8 +28,11 @@ import _ "embed"
 //	  nested shadow root.
 //	__smDeepQuery(root, sel) — the first such element, or null.
 //
-// Prepend with: browser.DeepQueryJS + "\n" + script. The helpers are function
-// declarations, so the script's trailing expression stays the completion value.
+// Compose it once into any other embedded .js source that calls
+// __smDeepQuery/__smDeepQueryAll (see e.g. actions.go's actionsJS), rather
+// than prepending it again at each eval call site. The helpers are function
+// declarations, so the script's trailing expression stays the completion
+// value.
 //
 //go:embed deepquery.js
 var DeepQueryJS string

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -21,7 +21,13 @@ import (
 )
 
 //go:embed cmd_browser_bounds.js
-var boundsJS string
+var boundsJSSource string
+
+// boundsJS is boundsJSSource with its __smDeepQueryAll dependency
+// (deepquery.js) composed in once here, so the call site below just does
+// boundsJS+<call> -- there's no "did I remember to prepend DeepQueryJS" to
+// get wrong.
+var boundsJS = browser.DeepQueryJS + "\n" + boundsJSSource
 
 // boundsResult is one emitted bounding box, in both viewport-% and raw px.
 type boundsResult struct {
@@ -237,7 +243,7 @@ func boundsBySelector(
 	selector string,
 	vw, vh int,
 ) ([]boundsResult, error) {
-	script := browser.DeepQueryJS + boundsJS + fmt.Sprintf("\n__smBoundsBySelector(%s)", jsString(selector))
+	script := boundsJS + fmt.Sprintf("\n__smBoundsBySelector(%s)", jsString(selector))
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -20,7 +20,13 @@ import (
 )
 
 //go:embed cmd_sel_probe.js
-var selProbeJS string
+var selProbeJSSource string
+
+// selProbeJS is selProbeJSSource with its __smDeepQueryAll dependency
+// (deepquery.js) composed in once here, so every call site below just does
+// selProbeJS+<call> -- there's no "did I remember to prepend DeepQueryJS" to
+// get wrong.
+var selProbeJS = browser.DeepQueryJS + "\n" + selProbeJSSource
 
 // elementResult is the Go-side representation of one querySelectorAll hit.
 type elementResult struct {
@@ -207,8 +213,7 @@ func printOfflineCheck(ctx context.Context, conn *browser.CDPConn, selector stri
 // selector in the live page.
 func liveSelectorCount(ctx context.Context, conn *browser.CDPConn, selector string) (int, error) {
 	selJSON, _ := json.Marshal(selector)
-	raw, err := browser.EvalJSON(ctx, conn,
-		browser.DeepQueryJS+selProbeJS+fmt.Sprintf("\n__smLiveSelectorCount(%s)", selJSON))
+	raw, err := browser.EvalJSON(ctx, conn, selProbeJS+fmt.Sprintf("\n__smLiveSelectorCount(%s)", selJSON))
 	if err != nil {
 		return 0, err
 	}
@@ -282,7 +287,7 @@ func queryElements(
 		return nil, fmt.Errorf("marshal selector: %w", err)
 	}
 
-	script := browser.DeepQueryJS + selProbeJS + fmt.Sprintf("\n__smQueryElements(%s, %d, %v)", selectorJSON, maxN, full)
+	script := selProbeJS + fmt.Sprintf("\n__smQueryElements(%s, %d, %v)", selectorJSON, maxN, full)
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
@@ -478,7 +483,7 @@ func runSelProbeAll(args []string, sightmapDir, addr, tabID string, max int, ful
 		}
 		time.Sleep(time.Duration(w * float64(time.Second)))
 
-		script := browser.DeepQueryJS + selProbeJS + fmt.Sprintf("\n__smSelProbeAllCount(%s, %d)", selectorJSON, max)
+		script := selProbeJS + fmt.Sprintf("\n__smSelProbeAllCount(%s, %d)", selectorJSON, max)
 
 		raw, evalErr := browser.EvalJSON(ctx, conn, script)
 		if evalErr != nil {

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -12,7 +12,13 @@ import (
 )
 
 //go:embed properties.js
-var propertiesJS string
+var propertiesJSSource string
+
+// propertiesJS is propertiesJSSource with its __smDeepQuery dependency
+// (deepquery.js) composed in once here, so the call site below just does
+// propertiesJS+<call> -- there's no "did I remember to prepend DeepQueryJS"
+// to get wrong.
+var propertiesJS = browser.DeepQueryJS + "\n" + propertiesJSSource
 
 // ExtractProperties runs a single batched JS evaluation against the live DOM to
 // extract property values for all matched nodes that have property definitions,
@@ -65,7 +71,7 @@ func ExtractProperties(
 		return
 	}
 
-	script := browser.DeepQueryJS + propertiesJS + fmt.Sprintf("\n__smExtractProperties(%s)", string(specsJSON))
+	script := propertiesJS + fmt.Sprintf("\n__smExtractProperties(%s)", string(specsJSON))
 
 	resultJSON, evalErr := browser.EvalJSON(ctx, conn, script)
 	if evalErr != nil {


### PR DESCRIPTION
## What this changes

Composes each embedded script's `DeepQueryJS` dependency once, at its `go:embed` site, instead of at every call site. `scanJS`, `actionsJS`, `propertiesJS`, `boundsJS`, and `selProbeJS` now already include `DeepQueryJS` — every call site downstream is just `xJS + "\n" + <call>`, not `DeepQueryJS + xJS + "\n" + <call>`.

## Why

#236 left every call site that used `__smDeepQuery`/`__smDeepQueryAll` repeating `DeepQueryJS+xJS+<call>` by hand — five files, a dozen-plus call sites, each one a chance to forget the prepend and ship a silent `ReferenceError` at eval time (or to redundantly double-prepend it). Composing it once, next to the `go:embed` directive, removes the footgun entirely: there's nothing left to remember at a call site.

No JS or behavior changes — this only touches how the Go string constants are assembled.
