### PR TITLE
chore(js): add prettier, format the extracted browser scripts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules/
+go/npm/
+
+# Not yet brought under prettier -- pre-existing JS with its own history and
+# conventions. Reformatting either is a deliberate follow-up, not a side
+# effect of `npm run fmt` picking up every go/**/*.js file.
+go/probe/probe.js
+go/cmd/sightmap/extension/

--- a/go/authoring/scan.js
+++ b/go/authoring/scan.js
@@ -4,9 +4,9 @@
 function __smScanCandidates(max) {
   const results = {};
   const selectors = [
-    '[data-testid]',
-    '[data-component]',
-    '[aria-label][role]',
+    "[data-testid]",
+    "[data-component]",
+    "[aria-label][role]",
     '[role="navigation"]',
     '[role="search"]',
     '[role="banner"]',
@@ -22,36 +22,47 @@ function __smScanCandidates(max) {
   for (const sel of selectors) {
     const els = __smDeepQueryAll(document, sel);
     for (const el of els) {
-      let candidate = '';
-      const dt = el.getAttribute('data-testid');
-      const dc = el.getAttribute('data-component');
-      const role = el.getAttribute('role') || el.tagName.toLowerCase();
+      let candidate = "";
+      const dt = el.getAttribute("data-testid");
+      const dc = el.getAttribute("data-component");
+      const role = el.getAttribute("role") || el.tagName.toLowerCase();
       const tag = el.tagName.toLowerCase();
-      const text = el.textContent.trim().replace(/\s+/g, ' ').slice(0, 60);
+      const text = el.textContent.trim().replace(/\s+/g, " ").slice(0, 60);
       if (dt) {
         candidate = '[data-testid="' + dt + '"]';
       } else if (dc) {
-        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, '');
+        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, "");
         candidate = '[data-component^="' + base + '"]';
       } else {
         continue;
       }
       if (!results[candidate]) {
-        const ancestorEl = el.closest('[data-sightmap-id]');
-        const ancestorId = ancestorEl ? ancestorEl.getAttribute('data-sightmap-id') : '';
-        results[candidate] = {sel: candidate, count: 0, role, tag, sample: text, ancestorId};
+        const ancestorEl = el.closest("[data-sightmap-id]");
+        const ancestorId = ancestorEl
+          ? ancestorEl.getAttribute("data-sightmap-id")
+          : "";
+        results[candidate] = {
+          sel: candidate,
+          count: 0,
+          role,
+          tag,
+          sample: text,
+          ancestorId,
+        };
       }
       results[candidate].count++;
     }
   }
-  return Object.values(results).sort((a, b) => b.count - a.count).slice(0, max);
+  return Object.values(results)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, max);
 }
 
 function __smScanLinks() {
   const host = location.host;
   const seen = new Set();
   const links = [];
-  for (const a of __smDeepQueryAll(document, 'a[href]')) {
+  for (const a of __smDeepQueryAll(document, "a[href]")) {
     try {
       const u = new URL(a.href);
       if (u.host === host && !seen.has(u.pathname)) {

--- a/go/authoring/scan.test.js
+++ b/go/authoring/scan.test.js
@@ -1,75 +1,91 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 // __smScanCandidates/__smScanLinks call __smDeepQueryAll, so load
 // deepquery.js first — the same prepend order Go uses (browser.DeepQueryJS +
 // scanJS). Both are loaded via indirect eval so the test exercises the exact
 // files that ship.
-(0, eval)(fs.readFileSync(path.join(__dirname, '..', 'browser', 'deepquery.js'), 'utf8'));
-(0, eval)(fs.readFileSync(path.join(__dirname, 'scan.js'), 'utf8'));
+(0, eval)(
+  fs.readFileSync(
+    path.join(__dirname, "..", "browser", "deepquery.js"),
+    "utf8",
+  ),
+);
+(0, eval)(fs.readFileSync(path.join(__dirname, "scan.js"), "utf8"));
 
-describe('__smScanCandidates', () => {
+describe("__smScanCandidates", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('ranks data-testid candidates by match count, most frequent first', () => {
+  test("ranks data-testid candidates by match count, most frequent first", () => {
     document.body.innerHTML = `
       <button data-testid="save"></button>
       <button data-testid="save"></button>
       <button data-testid="cancel"></button>
     `;
     const candidates = __smScanCandidates(10);
-    expect(candidates[0]).toMatchObject({sel: '[data-testid="save"]', count: 2});
-    expect(candidates[1]).toMatchObject({sel: '[data-testid="cancel"]', count: 1});
+    expect(candidates[0]).toMatchObject({
+      sel: '[data-testid="save"]',
+      count: 2,
+    });
+    expect(candidates[1]).toMatchObject({
+      sel: '[data-testid="cancel"]',
+      count: 1,
+    });
   });
 
-  test('strips the version suffix from data-component before grouping', () => {
+  test("strips the version suffix from data-component before grouping", () => {
     document.body.innerHTML = `
       <div data-component="Card:v1.2.3-abcdef"></div>
       <div data-component="Card:v1.2.4-fedcba"></div>
     `;
     const candidates = __smScanCandidates(10);
-    expect(candidates).toEqual([expect.objectContaining({sel: '[data-component^="Card"]', count: 2})]);
+    expect(candidates).toEqual([
+      expect.objectContaining({ sel: '[data-component^="Card"]', count: 2 }),
+    ]);
   });
 
-  test('respects max and finds candidates inside shadow DOM', () => {
-    const host = document.createElement('div');
+  test("respects max and finds candidates inside shadow DOM", () => {
+    const host = document.createElement("div");
     document.body.appendChild(host);
-    host.attachShadow({mode: 'open'}).innerHTML = '<button data-testid="shadow-btn"></button>';
+    host.attachShadow({ mode: "open" }).innerHTML =
+      '<button data-testid="shadow-btn"></button>';
 
     const candidates = __smScanCandidates(10);
-    expect(candidates.map(c => c.sel)).toContain('[data-testid="shadow-btn"]');
+    expect(candidates.map((c) => c.sel)).toContain(
+      '[data-testid="shadow-btn"]',
+    );
   });
 
-  test('records the nearest [data-sightmap-id] ancestor', () => {
+  test("records the nearest [data-sightmap-id] ancestor", () => {
     document.body.innerHTML = `
       <div data-sightmap-id="42"><button data-testid="save"></button></div>
     `;
     const [candidate] = __smScanCandidates(10);
-    expect(candidate.ancestorId).toBe('42');
+    expect(candidate.ancestorId).toBe("42");
   });
 });
 
-describe('__smScanLinks', () => {
+describe("__smScanLinks", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('returns distinct same-host pathnames in document order', () => {
+  test("returns distinct same-host pathnames in document order", () => {
     document.body.innerHTML = `
       <a href="${location.origin}/a">a</a>
       <a href="${location.origin}/b">b</a>
       <a href="${location.origin}/a">a again</a>
     `;
-    expect(__smScanLinks()).toEqual(['/a', '/b']);
+    expect(__smScanLinks()).toEqual(["/a", "/b"]);
   });
 
-  test('skips cross-host links', () => {
+  test("skips cross-host links", () => {
     document.body.innerHTML = `
       <a href="${location.origin}/same-host">same</a>
       <a href="https://example.com/other-host">other</a>
     `;
-    expect(__smScanLinks()).toEqual(['/same-host']);
+    expect(__smScanLinks()).toEqual(["/same-host"]);
   });
 });

--- a/go/browser/actions.js
+++ b/go/browser/actions.js
@@ -5,7 +5,12 @@ function __smBoundsBySelector(sel) {
   const el = __smDeepQuery(document, sel);
   if (!el) return null;
   const r = el.getBoundingClientRect();
-  return {x: Math.round(r.left), y: Math.round(r.top), width: Math.round(r.width), height: Math.round(r.height)};
+  return {
+    x: Math.round(r.left),
+    y: Math.round(r.top),
+    width: Math.round(r.width),
+    height: Math.round(r.height),
+  };
 }
 
 // __smLocateForClick scrolls the element to the center of the viewport and
@@ -14,17 +19,24 @@ function __smBoundsBySelector(sel) {
 // through).
 function __smLocateForClick(sel) {
   const el = __smDeepQuery(document, sel);
-  if (!el) return {found: false};
-  el.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
+  if (!el) return { found: false };
+  el.scrollIntoView({ block: "center", inline: "center", behavior: "instant" });
   const r = el.getBoundingClientRect();
-  const cx = Math.floor(r.left + r.width / 2), cy = Math.floor(r.top + r.height / 2);
-  const inViewport = r.width > 0 && r.height > 0 && cx >= 0 && cy >= 0 && cx < window.innerWidth && cy < window.innerHeight;
+  const cx = Math.floor(r.left + r.width / 2),
+    cy = Math.floor(r.top + r.height / 2);
+  const inViewport =
+    r.width > 0 &&
+    r.height > 0 &&
+    cx >= 0 &&
+    cy >= 0 &&
+    cx < window.innerWidth &&
+    cy < window.innerHeight;
   let hit = false;
   if (inViewport) {
     const at = document.elementFromPoint(cx, cy);
     hit = !!at && (at === el || el.contains(at) || at.contains(el));
   }
-  return {found: true, inViewport, hit, cx, cy};
+  return { found: true, inViewport, hit, cx, cy };
 }
 
 function __smClickBySelector(sel) {
@@ -43,7 +55,7 @@ function __smReadValueBySelector(sel) {
 function __smScrollIntoViewBySelector(sel) {
   try {
     const el = __smDeepQuery(document, sel);
-    if (el) el.scrollIntoView({block: 'center', behavior: 'instant'});
+    if (el) el.scrollIntoView({ block: "center", behavior: "instant" });
   } catch (_) {}
 }
 
@@ -56,7 +68,7 @@ function __smLocationProtocol() {
 }
 
 function __smScrollPosition() {
-  return {x: window.scrollX, y: window.scrollY};
+  return { x: window.scrollX, y: window.scrollY };
 }
 
 function __smScrollToY(y) {
@@ -72,9 +84,10 @@ function __smScrollBy(deltaX, deltaY) {
 function __smClearActiveElement() {
   const el = document.activeElement;
   if (!el) return;
-  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value') ||
-                 Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
-  if (setter && setter.set) setter.set.call(el, '');
-  el.dispatchEvent(new Event('input', {bubbles: true}));
-  el.dispatchEvent(new Event('change', {bubbles: true}));
+  const setter =
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
+  if (setter && setter.set) setter.set.call(el, "");
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
 }

--- a/go/browser/actions.test.js
+++ b/go/browser/actions.test.js
@@ -1,182 +1,227 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-(0, eval)(fs.readFileSync(path.join(__dirname, 'deepquery.js'), 'utf8'));
-(0, eval)(fs.readFileSync(path.join(__dirname, 'actions.js'), 'utf8'));
+(0, eval)(fs.readFileSync(path.join(__dirname, "deepquery.js"), "utf8"));
+(0, eval)(fs.readFileSync(path.join(__dirname, "actions.js"), "utf8"));
 
-describe('__smBoundsBySelector', () => {
+describe("__smBoundsBySelector", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('returns rounded bounds for the matched element', () => {
+  test("returns rounded bounds for the matched element", () => {
     document.body.innerHTML = '<div id="el"></div>';
-    const el = document.getElementById('el');
-    el.getBoundingClientRect = () => ({left: 1.4, top: 2.6, width: 10.5, height: 20.5});
+    const el = document.getElementById("el");
+    el.getBoundingClientRect = () => ({
+      left: 1.4,
+      top: 2.6,
+      width: 10.5,
+      height: 20.5,
+    });
 
-    expect(__smBoundsBySelector('#el')).toEqual({x: 1, y: 3, width: 11, height: 21});
+    expect(__smBoundsBySelector("#el")).toEqual({
+      x: 1,
+      y: 3,
+      width: 11,
+      height: 21,
+    });
   });
 
-  test('returns null when nothing matches', () => {
-    document.body.innerHTML = '<div></div>';
-    expect(__smBoundsBySelector('#missing')).toBeNull();
+  test("returns null when nothing matches", () => {
+    document.body.innerHTML = "<div></div>";
+    expect(__smBoundsBySelector("#missing")).toBeNull();
   });
 });
 
-describe('__smLocateForClick', () => {
+describe("__smLocateForClick", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
     jest.restoreAllMocks();
   });
 
-  test('reports not-found when the selector matches nothing', () => {
-    document.body.innerHTML = '<div></div>';
-    expect(__smLocateForClick('#missing')).toEqual({found: false});
+  test("reports not-found when the selector matches nothing", () => {
+    document.body.innerHTML = "<div></div>";
+    expect(__smLocateForClick("#missing")).toEqual({ found: false });
   });
 
-  test('reports hit:true when elementFromPoint returns the element itself', () => {
+  test("reports hit:true when elementFromPoint returns the element itself", () => {
     document.body.innerHTML = '<button id="btn"></button>';
-    const btn = document.getElementById('btn');
+    const btn = document.getElementById("btn");
     btn.scrollIntoView = jest.fn();
-    btn.getBoundingClientRect = () => ({left: 0, top: 0, width: 100, height: 20});
+    btn.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 20,
+    });
     document.elementFromPoint = jest.fn().mockReturnValue(btn);
-    Object.defineProperty(window, 'innerWidth', {value: 800, configurable: true});
-    Object.defineProperty(window, 'innerHeight', {value: 600, configurable: true});
+    Object.defineProperty(window, "innerWidth", {
+      value: 800,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 600,
+      configurable: true,
+    });
 
-    const result = __smLocateForClick('#btn');
-    expect(result).toMatchObject({found: true, inViewport: true, hit: true, cx: 50, cy: 10});
+    const result = __smLocateForClick("#btn");
+    expect(result).toMatchObject({
+      found: true,
+      inViewport: true,
+      hit: true,
+      cx: 50,
+      cy: 10,
+    });
   });
 
-  test('reports hit:false when something else is on top', () => {
-    document.body.innerHTML = '<button id="btn"></button><div id="overlay"></div>';
-    const btn = document.getElementById('btn');
-    const overlay = document.getElementById('overlay');
+  test("reports hit:false when something else is on top", () => {
+    document.body.innerHTML =
+      '<button id="btn"></button><div id="overlay"></div>';
+    const btn = document.getElementById("btn");
+    const overlay = document.getElementById("overlay");
     btn.scrollIntoView = jest.fn();
-    btn.getBoundingClientRect = () => ({left: 0, top: 0, width: 100, height: 20});
+    btn.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 20,
+    });
     document.elementFromPoint = jest.fn().mockReturnValue(overlay);
-    Object.defineProperty(window, 'innerWidth', {value: 800, configurable: true});
-    Object.defineProperty(window, 'innerHeight', {value: 600, configurable: true});
+    Object.defineProperty(window, "innerWidth", {
+      value: 800,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 600,
+      configurable: true,
+    });
 
-    expect(__smLocateForClick('#btn').hit).toBe(false);
+    expect(__smLocateForClick("#btn").hit).toBe(false);
   });
 });
 
-describe('__smClickBySelector', () => {
+describe("__smClickBySelector", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('clicks the matched element', () => {
+  test("clicks the matched element", () => {
     document.body.innerHTML = '<button id="btn"></button>';
-    const btn = document.getElementById('btn');
+    const btn = document.getElementById("btn");
     const onClick = jest.fn();
-    btn.addEventListener('click', onClick);
+    btn.addEventListener("click", onClick);
 
-    __smClickBySelector('#btn');
+    __smClickBySelector("#btn");
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  test('does not throw when nothing matches', () => {
-    document.body.innerHTML = '<div></div>';
-    expect(() => __smClickBySelector('#missing')).not.toThrow();
+  test("does not throw when nothing matches", () => {
+    document.body.innerHTML = "<div></div>";
+    expect(() => __smClickBySelector("#missing")).not.toThrow();
   });
 });
 
-describe('__smReadValueBySelector', () => {
+describe("__smReadValueBySelector", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('reads the current value of a form field', () => {
+  test("reads the current value of a form field", () => {
     document.body.innerHTML = '<input id="in" value="hello" />';
-    expect(__smReadValueBySelector('#in')).toBe('hello');
+    expect(__smReadValueBySelector("#in")).toBe("hello");
   });
 
-  test('returns null for an element with no value property', () => {
+  test("returns null for an element with no value property", () => {
     document.body.innerHTML = '<div id="el"></div>';
-    expect(__smReadValueBySelector('#el')).toBeNull();
+    expect(__smReadValueBySelector("#el")).toBeNull();
   });
 
-  test('returns null when nothing matches', () => {
-    document.body.innerHTML = '<div></div>';
-    expect(__smReadValueBySelector('#missing')).toBeNull();
+  test("returns null when nothing matches", () => {
+    document.body.innerHTML = "<div></div>";
+    expect(__smReadValueBySelector("#missing")).toBeNull();
   });
 });
 
-describe('__smScrollIntoViewBySelector', () => {
+describe("__smScrollIntoViewBySelector", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('calls scrollIntoView on the matched element', () => {
+  test("calls scrollIntoView on the matched element", () => {
     document.body.innerHTML = '<div id="el"></div>';
-    const el = document.getElementById('el');
+    const el = document.getElementById("el");
     el.scrollIntoView = jest.fn();
 
-    __smScrollIntoViewBySelector('#el');
-    expect(el.scrollIntoView).toHaveBeenCalledWith({block: 'center', behavior: 'instant'});
+    __smScrollIntoViewBySelector("#el");
+    expect(el.scrollIntoView).toHaveBeenCalledWith({
+      block: "center",
+      behavior: "instant",
+    });
   });
 
-  test('fails soft on a syntactically invalid selector', () => {
-    document.body.innerHTML = '<div></div>';
-    expect(() => __smScrollIntoViewBySelector('[')).not.toThrow();
+  test("fails soft on a syntactically invalid selector", () => {
+    document.body.innerHTML = "<div></div>";
+    expect(() => __smScrollIntoViewBySelector("[")).not.toThrow();
   });
 });
 
-describe('__smSelectorExists', () => {
+describe("__smSelectorExists", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('true when the selector matches, false otherwise', () => {
+  test("true when the selector matches, false otherwise", () => {
     document.body.innerHTML = '<div id="el"></div>';
-    expect(__smSelectorExists('#el')).toBe(true);
-    expect(__smSelectorExists('#missing')).toBe(false);
+    expect(__smSelectorExists("#el")).toBe(true);
+    expect(__smSelectorExists("#missing")).toBe(false);
   });
 });
 
-describe('scroll and location helpers', () => {
-  test('__smLocationProtocol reflects the current page', () => {
+describe("scroll and location helpers", () => {
+  test("__smLocationProtocol reflects the current page", () => {
     expect(__smLocationProtocol()).toBe(location.protocol);
   });
 
-  test('__smScrollPosition reflects window scroll offsets', () => {
-    Object.defineProperty(window, 'scrollX', {value: 12, configurable: true});
-    Object.defineProperty(window, 'scrollY', {value: 34, configurable: true});
-    expect(__smScrollPosition()).toEqual({x: 12, y: 34});
+  test("__smScrollPosition reflects window scroll offsets", () => {
+    Object.defineProperty(window, "scrollX", { value: 12, configurable: true });
+    Object.defineProperty(window, "scrollY", { value: 34, configurable: true });
+    expect(__smScrollPosition()).toEqual({ x: 12, y: 34 });
   });
 
-  test('__smScrollToY calls window.scrollTo centered on y', () => {
+  test("__smScrollToY calls window.scrollTo centered on y", () => {
     window.scrollTo = jest.fn();
-    Object.defineProperty(window, 'innerHeight', {value: 600, configurable: true});
+    Object.defineProperty(window, "innerHeight", {
+      value: 600,
+      configurable: true,
+    });
     __smScrollToY(1000);
     expect(window.scrollTo).toHaveBeenCalledWith(0, 700);
   });
 
-  test('__smScrollBy calls window.scrollBy with the given deltas', () => {
+  test("__smScrollBy calls window.scrollBy with the given deltas", () => {
     window.scrollBy = jest.fn();
     __smScrollBy(5, -10);
     expect(window.scrollBy).toHaveBeenCalledWith(5, -10);
   });
 });
 
-describe('__smClearActiveElement', () => {
+describe("__smClearActiveElement", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
   test("clears the focused input's value and fires input/change events", () => {
     document.body.innerHTML = '<input id="in" value="hello" />';
-    const input = document.getElementById('in');
+    const input = document.getElementById("in");
     input.focus();
     const onInput = jest.fn();
     const onChange = jest.fn();
-    input.addEventListener('input', onInput);
-    input.addEventListener('change', onChange);
+    input.addEventListener("input", onInput);
+    input.addEventListener("change", onChange);
 
     __smClearActiveElement();
 
-    expect(input.value).toBe('');
+    expect(input.value).toBe("");
     expect(onInput).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledTimes(1);
   });

--- a/go/cmd/sightmap/cmd_browser_bounds.js
+++ b/go/cmd/sightmap/cmd_browser_bounds.js
@@ -6,13 +6,15 @@ function __smBoundsBySelector(sel) {
   const out = [];
   for (const el of els) {
     const r = el.getBoundingClientRect();
-    let label = (el.getAttribute('aria-label') || el.textContent || '').trim().replace(/\s+/g, ' ');
+    let label = (el.getAttribute("aria-label") || el.textContent || "")
+      .trim()
+      .replace(/\s+/g, " ");
     if (label.length > 80) label = label.slice(0, 80);
-    out.push({x: r.left, y: r.top, width: r.width, height: r.height, label});
+    out.push({ x: r.left, y: r.top, width: r.width, height: r.height, label });
   }
   return out;
 }
 
 function __smViewportSize() {
-  return {w: window.innerWidth, h: window.innerHeight};
+  return { w: window.innerWidth, h: window.innerHeight };
 }

--- a/go/cmd/sightmap/cmd_browser_bounds.test.js
+++ b/go/cmd/sightmap/cmd_browser_bounds.test.js
@@ -1,56 +1,89 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-(0, eval)(fs.readFileSync(path.join(__dirname, '..', '..', 'browser', 'deepquery.js'), 'utf8'));
-(0, eval)(fs.readFileSync(path.join(__dirname, 'cmd_browser_bounds.js'), 'utf8'));
+(0, eval)(
+  fs.readFileSync(
+    path.join(__dirname, "..", "..", "browser", "deepquery.js"),
+    "utf8",
+  ),
+);
+(0, eval)(
+  fs.readFileSync(path.join(__dirname, "cmd_browser_bounds.js"), "utf8"),
+);
 
-describe('__smBoundsBySelector', () => {
+describe("__smBoundsBySelector", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('returns a bounds+label entry per match, preferring aria-label over text', () => {
+  test("returns a bounds+label entry per match, preferring aria-label over text", () => {
     document.body.innerHTML = `
       <button id="a" aria-label="Save changes">Save</button>
       <button id="b">  Cancel   now  </button>
     `;
-    document.getElementById('a').getBoundingClientRect = () => ({left: 0, top: 0, width: 10, height: 5});
-    document.getElementById('b').getBoundingClientRect = () => ({left: 1, top: 2, width: 3, height: 4});
+    document.getElementById("a").getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 10,
+      height: 5,
+    });
+    document.getElementById("b").getBoundingClientRect = () => ({
+      left: 1,
+      top: 2,
+      width: 3,
+      height: 4,
+    });
 
-    const results = __smBoundsBySelector('button');
+    const results = __smBoundsBySelector("button");
     expect(results).toEqual([
-      {x: 0, y: 0, width: 10, height: 5, label: 'Save changes'},
-      {x: 1, y: 2, width: 3, height: 4, label: 'Cancel now'},
+      { x: 0, y: 0, width: 10, height: 5, label: "Save changes" },
+      { x: 1, y: 2, width: 3, height: 4, label: "Cancel now" },
     ]);
   });
 
-  test('truncates an overlong label to 80 characters', () => {
-    document.body.innerHTML = `<button id="a">${'x'.repeat(200)}</button>`;
-    document.getElementById('a').getBoundingClientRect = () => ({left: 0, top: 0, width: 1, height: 1});
+  test("truncates an overlong label to 80 characters", () => {
+    document.body.innerHTML = `<button id="a">${"x".repeat(200)}</button>`;
+    document.getElementById("a").getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 1,
+      height: 1,
+    });
 
-    expect(__smBoundsBySelector('button')[0].label).toHaveLength(80);
+    expect(__smBoundsBySelector("button")[0].label).toHaveLength(80);
   });
 
-  test('finds matches inside shadow DOM', () => {
-    const host = document.createElement('div');
+  test("finds matches inside shadow DOM", () => {
+    const host = document.createElement("div");
     document.body.appendChild(host);
-    const btn = document.createElement('button');
-    btn.getBoundingClientRect = () => ({left: 0, top: 0, width: 1, height: 1});
-    host.attachShadow({mode: 'open'}).appendChild(btn);
+    const btn = document.createElement("button");
+    btn.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 1,
+      height: 1,
+    });
+    host.attachShadow({ mode: "open" }).appendChild(btn);
 
-    expect(__smBoundsBySelector('button')).toHaveLength(1);
+    expect(__smBoundsBySelector("button")).toHaveLength(1);
   });
 
-  test('returns an empty list when nothing matches', () => {
-    document.body.innerHTML = '<div></div>';
-    expect(__smBoundsBySelector('button')).toEqual([]);
+  test("returns an empty list when nothing matches", () => {
+    document.body.innerHTML = "<div></div>";
+    expect(__smBoundsBySelector("button")).toEqual([]);
   });
 });
 
-describe('__smViewportSize', () => {
-  test('reads window.innerWidth/innerHeight', () => {
-    Object.defineProperty(window, 'innerWidth', {value: 1024, configurable: true});
-    Object.defineProperty(window, 'innerHeight', {value: 768, configurable: true});
-    expect(__smViewportSize()).toEqual({w: 1024, h: 768});
+describe("__smViewportSize", () => {
+  test("reads window.innerWidth/innerHeight", () => {
+    Object.defineProperty(window, "innerWidth", {
+      value: 1024,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 768,
+      configurable: true,
+    });
+    expect(__smViewportSize()).toEqual({ w: 1024, h: 768 });
   });
 });

--- a/go/cmd/sightmap/cmd_sel_probe.js
+++ b/go/cmd/sightmap/cmd_sel_probe.js
@@ -5,47 +5,67 @@ function __smQueryElements(sel, max, full) {
   try {
     const els = [...__smDeepQueryAll(document, sel)].slice(0, max);
     const interestingAttrs = new Set([
-      'id', 'class', 'role', 'href', 'type', 'name', 'placeholder', 'aria-label',
-      'aria-expanded', 'aria-haspopup', 'aria-controls', 'aria-selected',
-      'data-testid', 'data-component', 'tabindex'
+      "id",
+      "class",
+      "role",
+      "href",
+      "type",
+      "name",
+      "placeholder",
+      "aria-label",
+      "aria-expanded",
+      "aria-haspopup",
+      "aria-controls",
+      "aria-selected",
+      "data-testid",
+      "data-component",
+      "tabindex",
     ]);
-    return els.map(el => {
+    return els.map((el) => {
       const attrs = {};
       for (const a of el.attributes) {
-        if (interestingAttrs.has(a.name) || a.name.startsWith('aria-') || a.name.startsWith('data-')) {
-          if (a.value !== '') attrs[a.name] = a.value;
+        if (
+          interestingAttrs.has(a.name) ||
+          a.name.startsWith("aria-") ||
+          a.name.startsWith("data-")
+        ) {
+          if (a.value !== "") attrs[a.name] = a.value;
         }
       }
       const parents = [];
       let p = el.parentElement;
-      for (let i = 0; i < 5 && p && p.tagName !== 'HTML'; i++, p = p.parentElement) {
+      for (
+        let i = 0;
+        i < 5 && p && p.tagName !== "HTML";
+        i++, p = p.parentElement
+      ) {
         parents.push({
           tag: p.tagName.toLowerCase(),
-          id:  p.id || '',
+          id: p.id || "",
           cls: [...p.classList].slice(0, 4),
-          dt:  p.getAttribute('data-testid') || '',
-          dc:  p.getAttribute('data-component') || '',
+          dt: p.getAttribute("data-testid") || "",
+          dc: p.getAttribute("data-component") || "",
         });
       }
       return {
-        tag:     el.tagName.toLowerCase(),
-        id:      el.id || '',
-        cls:     [...el.classList],
-        role:    el.getAttribute('role') || '',
-        text:    full ? el.textContent.trim() : el.textContent.trim().slice(0, 80),
+        tag: el.tagName.toLowerCase(),
+        id: el.id || "",
+        cls: [...el.classList],
+        role: el.getAttribute("role") || "",
+        text: full ? el.textContent.trim() : el.textContent.trim().slice(0, 80),
         attrs,
         parents,
       };
     });
-  } catch(e) {
-    return {error: e.message};
+  } catch (e) {
+    return { error: e.message };
   }
 }
 
 function __smLiveSelectorCount(sel) {
   try {
     return __smDeepQueryAll(document, sel).length;
-  } catch(e) {
+  } catch (e) {
     return -1;
   }
 }
@@ -53,7 +73,7 @@ function __smLiveSelectorCount(sel) {
 function __smSelProbeAllCount(sel, max) {
   try {
     return Array.from(__smDeepQueryAll(document, sel)).slice(0, max).length;
-  } catch(e) {
+  } catch (e) {
     return -1;
   }
 }

--- a/go/cmd/sightmap/cmd_sel_probe.test.js
+++ b/go/cmd/sightmap/cmd_sel_probe.test.js
@@ -1,94 +1,104 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-(0, eval)(fs.readFileSync(path.join(__dirname, '..', '..', 'browser', 'deepquery.js'), 'utf8'));
-(0, eval)(fs.readFileSync(path.join(__dirname, 'cmd_sel_probe.js'), 'utf8'));
+(0, eval)(
+  fs.readFileSync(
+    path.join(__dirname, "..", "..", "browser", "deepquery.js"),
+    "utf8",
+  ),
+);
+(0, eval)(fs.readFileSync(path.join(__dirname, "cmd_sel_probe.js"), "utf8"));
 
-describe('__smQueryElements', () => {
+describe("__smQueryElements", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('describes each match: tag, id, classes, role, text, attrs', () => {
+  test("describes each match: tag, id, classes, role, text, attrs", () => {
     document.body.innerHTML = `
       <button id="save" class="btn primary" role="button" data-testid="save-btn">
         Save now
       </button>
     `;
-    const [el] = __smQueryElements('button', 10, false);
+    const [el] = __smQueryElements("button", 10, false);
     expect(el).toMatchObject({
-      tag: 'button',
-      id: 'save',
-      cls: ['btn', 'primary'],
-      role: 'button',
-      text: 'Save now',
-      attrs: {'data-testid': 'save-btn'},
+      tag: "button",
+      id: "save",
+      cls: ["btn", "primary"],
+      role: "button",
+      text: "Save now",
+      attrs: { "data-testid": "save-btn" },
     });
   });
 
-  test('truncates text to 80 chars unless full is true', () => {
-    document.body.innerHTML = `<div id="d">${'x'.repeat(200)}</div>`;
-    expect(__smQueryElements('#d', 10, false)[0].text).toHaveLength(80);
-    expect(__smQueryElements('#d', 10, true)[0].text).toHaveLength(200);
+  test("truncates text to 80 chars unless full is true", () => {
+    document.body.innerHTML = `<div id="d">${"x".repeat(200)}</div>`;
+    expect(__smQueryElements("#d", 10, false)[0].text).toHaveLength(80);
+    expect(__smQueryElements("#d", 10, true)[0].text).toHaveLength(200);
   });
 
-  test('caps results at max', () => {
-    document.body.innerHTML = '<i class="x"></i><i class="x"></i><i class="x"></i>';
-    expect(__smQueryElements('.x', 2, false)).toHaveLength(2);
+  test("caps results at max", () => {
+    document.body.innerHTML =
+      '<i class="x"></i><i class="x"></i><i class="x"></i>';
+    expect(__smQueryElements(".x", 2, false)).toHaveLength(2);
   });
 
-  test('collects ancestors up to 5 levels, stopping at html', () => {
-    document.body.innerHTML = '<div data-testid="root"><div><div><span id="leaf"></span></div></div></div>';
-    const [el] = __smQueryElements('#leaf', 10, false);
+  test("collects ancestors up to 5 levels, stopping at html", () => {
+    document.body.innerHTML =
+      '<div data-testid="root"><div><div><span id="leaf"></span></div></div></div>';
+    const [el] = __smQueryElements("#leaf", 10, false);
     expect(el.parents.length).toBeGreaterThan(0);
-    expect(el.parents.some(p => p.dt === 'root')).toBe(true);
-    expect(el.parents.every(p => p.tag !== 'html')).toBe(true);
+    expect(el.parents.some((p) => p.dt === "root")).toBe(true);
+    expect(el.parents.every((p) => p.tag !== "html")).toBe(true);
   });
 
-  test('finds matches inside shadow DOM', () => {
-    const host = document.createElement('div');
+  test("finds matches inside shadow DOM", () => {
+    const host = document.createElement("div");
     document.body.appendChild(host);
-    host.attachShadow({mode: 'open'}).innerHTML = '<button id="shadow-btn"></button>';
-    expect(__smQueryElements('#shadow-btn', 10, false)).toHaveLength(1);
+    host.attachShadow({ mode: "open" }).innerHTML =
+      '<button id="shadow-btn"></button>';
+    expect(__smQueryElements("#shadow-btn", 10, false)).toHaveLength(1);
   });
 
   // deepquery.js's __smDeepQueryAll already fails soft on an invalid
   // selector (returns [], doesn't throw), so this never reaches the
   // {error} branch — it just sees zero matches, same as any other miss.
-  test('a bad selector yields no matches instead of throwing', () => {
-    expect(() => __smQueryElements('[', 10, false)).not.toThrow();
-    expect(__smQueryElements('[', 10, false)).toEqual([]);
+  test("a bad selector yields no matches instead of throwing", () => {
+    expect(() => __smQueryElements("[", 10, false)).not.toThrow();
+    expect(__smQueryElements("[", 10, false)).toEqual([]);
   });
 });
 
-describe('__smLiveSelectorCount', () => {
+describe("__smLiveSelectorCount", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('returns the true, uncapped match count', () => {
-    document.body.innerHTML = '<i class="x"></i><i class="x"></i><i class="x"></i>';
-    expect(__smLiveSelectorCount('.x')).toBe(3);
+  test("returns the true, uncapped match count", () => {
+    document.body.innerHTML =
+      '<i class="x"></i><i class="x"></i><i class="x"></i>';
+    expect(__smLiveSelectorCount(".x")).toBe(3);
   });
 
   // Same fail-soft reasoning as __smQueryElements above: __smDeepQueryAll
   // never throws on a bad selector, so this sees a length-0 result, not -1.
-  test('a bad selector yields 0, not -1 (deepquery already fails soft)', () => {
-    expect(__smLiveSelectorCount('[')).toBe(0);
+  test("a bad selector yields 0, not -1 (deepquery already fails soft)", () => {
+    expect(__smLiveSelectorCount("[")).toBe(0);
   });
 });
 
-describe('__smSelProbeAllCount', () => {
+describe("__smSelProbeAllCount", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('caps the count at max', () => {
-    document.body.innerHTML = '<i class="x"></i><i class="x"></i><i class="x"></i>';
-    expect(__smSelProbeAllCount('.x', 2)).toBe(2);
+  test("caps the count at max", () => {
+    document.body.innerHTML =
+      '<i class="x"></i><i class="x"></i><i class="x"></i>';
+    expect(__smSelProbeAllCount(".x", 2)).toBe(2);
   });
 
-  test('a bad selector yields 0, not -1 (deepquery already fails soft)', () => {
-    expect(__smSelProbeAllCount('[', 10)).toBe(0);
+  test("a bad selector yields 0, not -1 (deepquery already fails soft)", () => {
+    expect(__smSelProbeAllCount("[", 10)).toBe(0);
   });
 });

--- a/go/observe/properties.js
+++ b/go/observe/properties.js
@@ -7,55 +7,77 @@ function __smExtractProperties(specs) {
   // transform, and caps length uniformly.
   function extractValue(el, extract) {
     if (!extract) return null;
-    if (extract === 'text') return el.textContent;
-    if (extract === 'inner_text') return el.innerText;
-    if (extract === 'text_only') {
+    if (extract === "text") return el.textContent;
+    if (extract === "inner_text") return el.innerText;
+    if (extract === "text_only") {
       const clone = el.cloneNode(true);
-      clone.querySelectorAll('img,svg,[alt]').forEach(e => e.remove());
+      clone.querySelectorAll("img,svg,[alt]").forEach((e) => e.remove());
       return clone.textContent;
     }
-    if (extract === 'inner_html') return el.innerHTML;
-    if (extract.startsWith('attr=')) return el.getAttribute(extract.slice(5));
-    if (extract.startsWith('exists:')) {
-      return __smDeepQuery(el, extract.slice(7)) ? 'true' : null;
+    if (extract === "inner_html") return el.innerHTML;
+    if (extract.startsWith("attr=")) return el.getAttribute(extract.slice(5));
+    if (extract.startsWith("exists:")) {
+      return __smDeepQuery(el, extract.slice(7)) ? "true" : null;
     }
     const sub = __smDeepQuery(el, extract);
-    return sub ? (sub.innerText != null ? sub.innerText : sub.textContent) : null;
+    return sub
+      ? sub.innerText != null
+        ? sub.innerText
+        : sub.textContent
+      : null;
   }
   function applyTransform(val, transform) {
     if (!transform || !val) return val;
-    if (transform.indexOf('match:') === 0) {
+    if (transform.indexOf("match:") === 0) {
       try {
         const m = val.match(new RegExp(transform.slice(6)));
         if (!m) return val;
         return m[1] != null ? m[1] : m[0];
-      } catch (e) { return val; }
+      } catch (e) {
+        return val;
+      }
     }
     const words = val.trim().split(/\s+/);
     switch (transform) {
-      case 'first_word': return words[0] || val;
-      case 'last_word': return words[words.length - 1] || val;
-      case 'first_number': { const m = val.match(/\d[\d,.]*/); return m ? m[0] : val; }
-      case 'first_dollar': { const m = val.match(/\$[\d,.]+/); return m ? m[0] : val; }
-      case 'number': return val.replace(/[^\d.]/g, '');
-      case 'slug': return val.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-      default: return val;
+      case "first_word":
+        return words[0] || val;
+      case "last_word":
+        return words[words.length - 1] || val;
+      case "first_number": {
+        const m = val.match(/\d[\d,.]*/);
+        return m ? m[0] : val;
+      }
+      case "first_dollar": {
+        const m = val.match(/\$[\d,.]+/);
+        return m ? m[0] : val;
+      }
+      case "number":
+        return val.replace(/[^\d.]/g, "");
+      case "slug":
+        return val
+          .toLowerCase()
+          .replace(/\s+/g, "-")
+          .replace(/[^a-z0-9-]/g, "");
+      default:
+        return val;
     }
   }
   const results = {};
-  for (const {id, selector, props} of specs) {
+  for (const { id, selector, props } of specs) {
     // Anchor to the exact matched element via its sightmap ID attribute (set by
     // probe.js as data-sightmap-id). This ensures child components like
     // BreadcrumbLink get their own text, not the first match on the page.
-    const el = (id ? __smDeepQuery(document, '[data-sightmap-id="' + id + '"]') : null)
-               || __smDeepQuery(document, selector);
+    const el =
+      (id
+        ? __smDeepQuery(document, '[data-sightmap-id="' + id + '"]')
+        : null) || __smDeepQuery(document, selector);
     if (!el) continue;
     const vals = {};
-    for (const {name, extract, transform} of props) {
+    for (const { name, extract, transform } of props) {
       let val = extractValue(el, extract);
       if (val == null) continue;
-      val = String(val).trim().replace(/\s+/g, ' ');
-      if (val === '') continue;
+      val = String(val).trim().replace(/\s+/g, " ");
+      if (val === "") continue;
       val = applyTransform(val, transform);
       if (val) vals[name] = String(val).slice(0, 120);
     }

--- a/go/observe/properties.test.js
+++ b/go/observe/properties.test.js
@@ -1,15 +1,20 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-(0, eval)(fs.readFileSync(path.join(__dirname, '..', 'browser', 'deepquery.js'), 'utf8'));
-(0, eval)(fs.readFileSync(path.join(__dirname, 'properties.js'), 'utf8'));
+(0, eval)(
+  fs.readFileSync(
+    path.join(__dirname, "..", "browser", "deepquery.js"),
+    "utf8",
+  ),
+);
+(0, eval)(fs.readFileSync(path.join(__dirname, "properties.js"), "utf8"));
 
-describe('__smExtractProperties', () => {
+describe("__smExtractProperties", () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
-  test('extracts text by data-sightmap-id, anchoring to the exact matched element', () => {
+  test("extracts text by data-sightmap-id, anchoring to the exact matched element", () => {
     document.body.innerHTML = `
       <div class="card" data-sightmap-id="1">
         <span class="label">outer</span>
@@ -17,55 +22,94 @@ describe('__smExtractProperties', () => {
       </div>
     `;
     const specs = [
-      {id: '2', selector: '.card', props: [{name: 'label', extract: 'text', transform: ''}]},
+      {
+        id: "2",
+        selector: ".card",
+        props: [{ name: "label", extract: "text", transform: "" }],
+      },
     ];
-    expect(__smExtractProperties(specs)).toEqual({2: {label: 'inner'}});
+    expect(__smExtractProperties(specs)).toEqual({ 2: { label: "inner" } });
   });
 
-  test('falls back to the selector when id is empty', () => {
-    document.body.innerHTML = '<div class="card"><span class="label">hi</span></div>';
-    const specs = [{id: '', selector: '.card', props: [{name: 'label', extract: '.label'}]}];
-    expect(__smExtractProperties(specs)).toEqual({'': {label: 'hi'}});
+  test("falls back to the selector when id is empty", () => {
+    document.body.innerHTML =
+      '<div class="card"><span class="label">hi</span></div>';
+    const specs = [
+      {
+        id: "",
+        selector: ".card",
+        props: [{ name: "label", extract: ".label" }],
+      },
+    ];
+    expect(__smExtractProperties(specs)).toEqual({ "": { label: "hi" } });
   });
 
-  test('exists: reports true only when the sub-selector matches, including inside shadow DOM', () => {
+  test("exists: reports true only when the sub-selector matches, including inside shadow DOM", () => {
     document.body.innerHTML = '<div class="card" data-sightmap-id="1"></div>';
-    const host = document.querySelector('.card');
-    host.attachShadow({mode: 'open'}).innerHTML = '<span class="icon"></span>';
+    const host = document.querySelector(".card");
+    host.attachShadow({ mode: "open" }).innerHTML =
+      '<span class="icon"></span>';
 
     const specs = [
       {
-        id: '1',
-        selector: '.card',
-        props: [{name: 'hasIcon', extract: 'exists:.icon'}, {name: 'hasBadge', extract: 'exists:.badge'}],
+        id: "1",
+        selector: ".card",
+        props: [
+          { name: "hasIcon", extract: "exists:.icon" },
+          { name: "hasBadge", extract: "exists:.badge" },
+        ],
       },
     ];
-    expect(__smExtractProperties(specs)).toEqual({1: {hasIcon: 'true'}});
+    expect(__smExtractProperties(specs)).toEqual({ 1: { hasIcon: "true" } });
   });
 
-  test('attr= reads the named attribute', () => {
-    document.body.innerHTML = '<a class="link" href="/x" data-sightmap-id="1"></a>';
-    const specs = [{id: '1', selector: '.link', props: [{name: 'href', extract: 'attr=href'}]}];
-    expect(__smExtractProperties(specs)).toEqual({1: {href: '/x'}});
-  });
-
-  test('applies a transform to the extracted value', () => {
-    document.body.innerHTML = '<div class="price" data-sightmap-id="1">Total: $12.50 today</div>';
+  test("attr= reads the named attribute", () => {
+    document.body.innerHTML =
+      '<a class="link" href="/x" data-sightmap-id="1"></a>';
     const specs = [
-      {id: '1', selector: '.price', props: [{name: 'price', extract: 'text', transform: 'first_dollar'}]},
+      {
+        id: "1",
+        selector: ".link",
+        props: [{ name: "href", extract: "attr=href" }],
+      },
     ];
-    expect(__smExtractProperties(specs)).toEqual({1: {price: '$12.50'}});
+    expect(__smExtractProperties(specs)).toEqual({ 1: { href: "/x" } });
   });
 
-  test('omits a property when extraction yields nothing', () => {
+  test("applies a transform to the extracted value", () => {
+    document.body.innerHTML =
+      '<div class="price" data-sightmap-id="1">Total: $12.50 today</div>';
+    const specs = [
+      {
+        id: "1",
+        selector: ".price",
+        props: [{ name: "price", extract: "text", transform: "first_dollar" }],
+      },
+    ];
+    expect(__smExtractProperties(specs)).toEqual({ 1: { price: "$12.50" } });
+  });
+
+  test("omits a property when extraction yields nothing", () => {
     document.body.innerHTML = '<div class="card" data-sightmap-id="1"></div>';
-    const specs = [{id: '1', selector: '.card', props: [{name: 'label', extract: '.missing'}]}];
+    const specs = [
+      {
+        id: "1",
+        selector: ".card",
+        props: [{ name: "label", extract: ".missing" }],
+      },
+    ];
     expect(__smExtractProperties(specs)).toEqual({});
   });
 
-  test('skips a spec whose element is not found', () => {
-    document.body.innerHTML = '<div></div>';
-    const specs = [{id: 'nope', selector: '.missing', props: [{name: 'label', extract: 'text'}]}];
+  test("skips a spec whose element is not found", () => {
+    document.body.innerHTML = "<div></div>";
+    const specs = [
+      {
+        id: "nope",
+        selector: ".missing",
+        props: [{ name: "label", extract: "text" }],
+      },
+    ];
     expect(__smExtractProperties(specs)).toEqual({});
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       ],
       "devDependencies": {
         "jest": "29.7.0",
-        "jest-environment-jsdom": "29.7.0"
+        "jest-environment-jsdom": "29.7.0",
+        "prettier": "3.9.6"
       }
     },
     "go/npm": {
@@ -3789,6 +3790,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
     "changeset": "npx --yes @changesets/cli@^2.27.0",
     "version-packages": "npx --yes @changesets/cli@^2.27.0 version && node scripts/sync-manifest-versions.mjs && node scripts/changelog-entry.mjs && node docs/scripts/build-changelog.mjs",
     "sync-docs": "node docs/scripts/sync-spec.mjs",
-    "test": "jest"
+    "test": "jest",
+    "fmt": "prettier --write \"go/**/*.js\" \"*.js\"",
+    "fmt:check": "prettier --check \"go/**/*.js\" \"*.js\""
   },
   "devDependencies": {
     "jest": "29.7.0",
-    "jest-environment-jsdom": "29.7.0"
+    "jest-environment-jsdom": "29.7.0",
+    "prettier": "3.9.6"
   }
 }


### PR DESCRIPTION
## What this changes

Pins `prettier` as a devDependency and adds `fmt`/`fmt:check` npm scripts, then runs it once over the `.js`/`.test.js` files added by the extraction (#236) and composition-refactor (#237) commits. Pure formatting — no logic changes.

## Why

#236's PR description raised "can we lint them etc" for the newly-extracted JS. This is the other half of that: a real formatter wired up as an npm script, not just a one-off `npx prettier` run. Isolated into its own PR so the formatting-only diff (quote style, wrapping) doesn't mix with the extraction or refactor diffs.

`go/probe/probe.js` and `go/cmd/sightmap/extension/` are pre-existing JS this pass deliberately doesn't touch — excluded via `.prettierignore` so `npm run fmt`'s `go/**/*.js` glob doesn't pick them up as an unreviewed side effect. Bringing them under prettier is a separate follow-up.