### PR TITLE
browser: extract embedded eval scripts to real .js files, add Jest coverage

### DIFF
--- a/go/authoring/scan.go
+++ b/go/authoring/scan.go
@@ -7,11 +7,15 @@ package authoring
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 
 	"github.com/sightmap/sightmap/go/browser"
 )
+
+//go:embed scan.js
+var scanJS string
 
 // Candidate is one selector candidate found by ScanCandidates: a stable
 // data-attribute selector, how many elements it matched, and enough context
@@ -30,53 +34,9 @@ type Candidate struct {
 // candidate records the nearest [data-sightmap-id] ancestor so callers can group
 // candidates under the component that already covers their region.
 func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Candidate, error) {
-	script := fmt.Sprintf(`(function(max) {
-  const results = {};
-  const selectors = [
-    '[data-testid]',
-    '[data-component]',
-    '[aria-label][role]',
-    '[role="navigation"]',
-    '[role="search"]',
-    '[role="banner"]',
-    '[role="main"]',
-    '[role="complementary"]',
-    '[role="contentinfo"]',
-    '[role="dialog"]',
-    '[role="alertdialog"]',
-    '[role="tablist"]',
-    '[role="tab"]',
-    '[role="tabpanel"]',
-  ];
-  for (const sel of selectors) {
-    const els = __smDeepQueryAll(document, sel);
-    for (const el of els) {
-      let candidate = '';
-      const dt = el.getAttribute('data-testid');
-      const dc = el.getAttribute('data-component');
-      const role = el.getAttribute('role') || el.tagName.toLowerCase();
-      const tag = el.tagName.toLowerCase();
-      const text = el.textContent.trim().replace(/\s+/g, ' ').slice(0, 60);
-      if (dt) {
-        candidate = '[data-testid="' + dt + '"]';
-      } else if (dc) {
-        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, '');
-        candidate = '[data-component^="' + base + '"]';
-      } else {
-        continue;
-      }
-      if (!results[candidate]) {
-        const ancestorEl = el.closest('[data-sightmap-id]');
-        const ancestorId = ancestorEl ? ancestorEl.getAttribute('data-sightmap-id') : '';
-        results[candidate] = {sel: candidate, count: 0, role: role, tag: tag, sample: text, ancestorId: ancestorId};
-      }
-      results[candidate].count++;
-    }
-  }
-  return Object.values(results).sort((a,b) => b.count - a.count).slice(0, max);
-})(%d)`, max)
+	script := browser.DeepQueryJS + scanJS + fmt.Sprintf("\n__smScanCandidates(%d)", max)
 
-	raw, err := browser.EvalJSON(ctx, conn, browser.DeepQueryJS+"\n"+script)
+	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
 		return nil, fmt.Errorf("scan candidates: eval: %v", err)
 	}
@@ -90,23 +50,9 @@ func ScanCandidates(ctx context.Context, conn *browser.CDPConn, max int) ([]Cand
 // ScanLinks returns the distinct same-host link pathnames on the live page, in
 // document order. Callers normalize these into route patterns with NormalizePath.
 func ScanLinks(ctx context.Context, conn *browser.CDPConn) ([]string, error) {
-	const linkScript = `(function() {
-  const host = location.host;
-  const seen = new Set();
-  const links = [];
-  for (const a of __smDeepQueryAll(document, 'a[href]')) {
-    try {
-      const u = new URL(a.href);
-      if (u.host === host && !seen.has(u.pathname)) {
-        seen.add(u.pathname);
-        links.push(u.pathname);
-      }
-    } catch(e) {}
-  }
-  return links;
-})()`
+	script := browser.DeepQueryJS + scanJS + "\n__smScanLinks()"
 
-	raw, err := browser.EvalJSON(ctx, conn, browser.DeepQueryJS+"\n"+linkScript)
+	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
 		return nil, fmt.Errorf("scan links: eval: %v", err)
 	}

--- a/go/authoring/scan.js
+++ b/go/authoring/scan.js
@@ -1,0 +1,64 @@
+// Live-DOM discovery scans used while building a corpus. Depends on
+// __smDeepQueryAll from browser/deepquery.js being prepended.
+
+function __smScanCandidates(max) {
+  const results = {};
+  const selectors = [
+    '[data-testid]',
+    '[data-component]',
+    '[aria-label][role]',
+    '[role="navigation"]',
+    '[role="search"]',
+    '[role="banner"]',
+    '[role="main"]',
+    '[role="complementary"]',
+    '[role="contentinfo"]',
+    '[role="dialog"]',
+    '[role="alertdialog"]',
+    '[role="tablist"]',
+    '[role="tab"]',
+    '[role="tabpanel"]',
+  ];
+  for (const sel of selectors) {
+    const els = __smDeepQueryAll(document, sel);
+    for (const el of els) {
+      let candidate = '';
+      const dt = el.getAttribute('data-testid');
+      const dc = el.getAttribute('data-component');
+      const role = el.getAttribute('role') || el.tagName.toLowerCase();
+      const tag = el.tagName.toLowerCase();
+      const text = el.textContent.trim().replace(/\s+/g, ' ').slice(0, 60);
+      if (dt) {
+        candidate = '[data-testid="' + dt + '"]';
+      } else if (dc) {
+        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, '');
+        candidate = '[data-component^="' + base + '"]';
+      } else {
+        continue;
+      }
+      if (!results[candidate]) {
+        const ancestorEl = el.closest('[data-sightmap-id]');
+        const ancestorId = ancestorEl ? ancestorEl.getAttribute('data-sightmap-id') : '';
+        results[candidate] = {sel: candidate, count: 0, role, tag, sample: text, ancestorId};
+      }
+      results[candidate].count++;
+    }
+  }
+  return Object.values(results).sort((a, b) => b.count - a.count).slice(0, max);
+}
+
+function __smScanLinks() {
+  const host = location.host;
+  const seen = new Set();
+  const links = [];
+  for (const a of __smDeepQueryAll(document, 'a[href]')) {
+    try {
+      const u = new URL(a.href);
+      if (u.host === host && !seen.has(u.pathname)) {
+        seen.add(u.pathname);
+        links.push(u.pathname);
+      }
+    } catch (e) {}
+  }
+  return links;
+}

--- a/go/authoring/scan.test.js
+++ b/go/authoring/scan.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+// __smScanCandidates/__smScanLinks call __smDeepQueryAll, so load
+// deepquery.js first — the same prepend order Go uses (browser.DeepQueryJS +
+// scanJS). Both are loaded via indirect eval so the test exercises the exact
+// files that ship.
+(0, eval)(fs.readFileSync(path.join(__dirname, '..', 'browser', 'deepquery.js'), 'utf8'));
+(0, eval)(fs.readFileSync(path.join(__dirname, 'scan.js'), 'utf8'));
+
+describe('__smScanCandidates', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('ranks data-testid candidates by match count, most frequent first', () => {
+    document.body.innerHTML = `
+      <button data-testid="save"></button>
+      <button data-testid="save"></button>
+      <button data-testid="cancel"></button>
+    `;
+    const candidates = __smScanCandidates(10);
+    expect(candidates[0]).toMatchObject({sel: '[data-testid="save"]', count: 2});
+    expect(candidates[1]).toMatchObject({sel: '[data-testid="cancel"]', count: 1});
+  });
+
+  test('strips the version suffix from data-component before grouping', () => {
+    document.body.innerHTML = `
+      <div data-component="Card:v1.2.3-abcdef"></div>
+      <div data-component="Card:v1.2.4-fedcba"></div>
+    `;
+    const candidates = __smScanCandidates(10);
+    expect(candidates).toEqual([expect.objectContaining({sel: '[data-component^="Card"]', count: 2})]);
+  });
+
+  test('respects max and finds candidates inside shadow DOM', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    host.attachShadow({mode: 'open'}).innerHTML = '<button data-testid="shadow-btn"></button>';
+
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map(c => c.sel)).toContain('[data-testid="shadow-btn"]');
+  });
+
+  test('records the nearest [data-sightmap-id] ancestor', () => {
+    document.body.innerHTML = `
+      <div data-sightmap-id="42"><button data-testid="save"></button></div>
+    `;
+    const [candidate] = __smScanCandidates(10);
+    expect(candidate.ancestorId).toBe('42');
+  });
+});
+
+describe('__smScanLinks', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('returns distinct same-host pathnames in document order', () => {
+    document.body.innerHTML = `
+      <a href="${location.origin}/a">a</a>
+      <a href="${location.origin}/b">b</a>
+      <a href="${location.origin}/a">a again</a>
+    `;
+    expect(__smScanLinks()).toEqual(['/a', '/b']);
+  });
+
+  test('skips cross-host links', () => {
+    document.body.innerHTML = `
+      <a href="${location.origin}/same-host">same</a>
+      <a href="https://example.com/other-host">other</a>
+    `;
+    expect(__smScanLinks()).toEqual(['/same-host']);
+  });
+});

--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	_ "embed"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,9 @@ import (
 
 	"github.com/sightmap/sightmap/go/sightmap"
 )
+
+//go:embed actions.js
+var actionsJS string
 
 // Navigate sends Page.navigate. Does NOT wait for load.
 func Navigate(ctx context.Context, conn *CDPConn, url string) error {
@@ -373,7 +377,7 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 	// path for that combination that doesn't hang on cross-origin iframes).
 	fastPath := format == "jpeg" && opts.OptimizeForSpeed
 	if !fastPath {
-		if urlRaw, err := EvalJSON(ctx, conn, `JSON.stringify(location.protocol)`); err == nil {
+		if urlRaw, err := EvalJSON(ctx, conn, actionsJS+"\n__smLocationProtocol()"); err == nil {
 			var proto string
 			if json.Unmarshal(urlRaw, &proto) == nil && (proto == "http:" || proto == "https:") {
 				params["captureBeyondViewport"] = false
@@ -388,7 +392,7 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 	// above for HTTP(S) pages.
 	if opts.Clip != nil {
 		sx, sy := 0.0, 0.0
-		if raw, err := EvalJSON(ctx, conn, `({x: window.scrollX, y: window.scrollY})`); err == nil {
+		if raw, err := EvalJSON(ctx, conn, actionsJS+"\n__smScrollPosition()"); err == nil {
 			var s struct {
 				X float64 `json:"x"`
 				Y float64 `json:"y"`
@@ -462,13 +466,8 @@ func ScreenshotWithOptions(ctx context.Context, conn *CDPConn, opts ScreenshotOp
 // Returns an error when no element carries the id (the node was removed or the
 // page was re-probed since), so callers can prompt for a fresh snapshot.
 func ResolveBySightmapID(ctx context.Context, conn *CDPConn, id string) (*sightmap.ComponentNode, error) {
-	script := DeepQueryJS + fmt.Sprintf(`
-(function(){
-  var el=__smDeepQuery(document,'[data-sightmap-id=%q]');
-  if(!el) return null;
-  var r=el.getBoundingClientRect();
-  return {x:Math.round(r.left),y:Math.round(r.top),width:Math.round(r.width),height:Math.round(r.height)};
-})()`, id)
+	selJSON, _ := json.Marshal(fmt.Sprintf("[data-sightmap-id=%q]", id))
+	script := DeepQueryJS + actionsJS + fmt.Sprintf("\n__smBoundsBySelector(%s)", selJSON)
 	raw, err := EvalJSON(ctx, conn, script)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %q: %w", id, err)
@@ -558,18 +557,8 @@ type clickTarget struct {
 // center is actually the top-most element there (so a target hidden behind an
 // overlay is reported as not-hit rather than clicked through).
 func locateForClick(ctx context.Context, conn *CDPConn, id string) (clickTarget, error) {
-	script := DeepQueryJS + fmt.Sprintf(`
-(function(){
-  var el=__smDeepQuery(document,'[data-sightmap-id=%q]');
-  if(!el) return {found:false};
-  el.scrollIntoView({block:"center",inline:"center",behavior:"instant"});
-  var r=el.getBoundingClientRect();
-  var cx=Math.floor(r.left+r.width/2), cy=Math.floor(r.top+r.height/2);
-  var iv = r.width>0 && r.height>0 && cx>=0 && cy>=0 && cx<window.innerWidth && cy<window.innerHeight;
-  var hit=false;
-  if(iv){ var at=document.elementFromPoint(cx,cy); hit=!!at && (at===el||el.contains(at)||at.contains(el)); }
-  return {found:true,inViewport:iv,hit:hit,cx:cx,cy:cy};
-})()`, id)
+	selJSON, _ := json.Marshal(fmt.Sprintf("[data-sightmap-id=%q]", id))
+	script := DeepQueryJS + actionsJS + fmt.Sprintf("\n__smLocateForClick(%s)", selJSON)
 	raw, err := EvalJSON(ctx, conn, script)
 	if err != nil {
 		return clickTarget{}, err
@@ -610,7 +599,8 @@ func Click(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) (in
 		if sel == "" {
 			return -1, -1, fmt.Errorf("click: node %q has no bounds and no selector", node.Id)
 		}
-		_, err := EvalJSON(ctx, conn, DeepQueryJS+fmt.Sprintf("\n__smDeepQuery(document,%q)?.click()", sel))
+		selJSON, _ := json.Marshal(sel)
+		_, err := EvalJSON(ctx, conn, DeepQueryJS+actionsJS+fmt.Sprintf("\n__smClickBySelector(%s)", selJSON))
 		return -1, -1, err
 	}
 	x := node.Bounds.X + node.Bounds.Width/2
@@ -690,8 +680,8 @@ func readInputValue(ctx context.Context, conn *CDPConn, id string) (string, bool
 	if id == "" {
 		return "", false
 	}
-	raw, err := EvalJSON(ctx, conn, DeepQueryJS+fmt.Sprintf(
-		"\n"+`(function(){var el=__smDeepQuery(document,'[data-sightmap-id=%q]');if(!el||el.value==null)return null;return String(el.value)})()`, id))
+	selJSON, _ := json.Marshal(fmt.Sprintf("[data-sightmap-id=%q]", id))
+	raw, err := EvalJSON(ctx, conn, DeepQueryJS+actionsJS+fmt.Sprintf("\n__smReadValueBySelector(%s)", selJSON))
 	if err != nil || len(raw) == 0 || string(raw) == "null" {
 		return "", false
 	}
@@ -711,17 +701,8 @@ func ClearAndFill(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNo
 		return fmt.Errorf("ClearAndFill: click to focus: %w", err)
 	}
 	// Clear the field via JS native setter — works on React-controlled inputs.
-	clearJS := `(function(){
-		var el = document.activeElement;
-		if (!el) return;
-		var setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value') ||
-		             Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype,'value');
-		if (setter && setter.set) { setter.set.call(el,''); }
-		el.dispatchEvent(new Event('input',{bubbles:true}));
-		el.dispatchEvent(new Event('change',{bubbles:true}));
-	})()`
 	if _, err := conn.call(ctx, "Runtime.evaluate", map[string]interface{}{
-		"expression": clearJS,
+		"expression": actionsJS + "\n__smClearActiveElement()",
 	}); err != nil {
 		return fmt.Errorf("ClearAndFill: clear: %w", err)
 	}
@@ -793,10 +774,8 @@ func KeyPress(ctx context.Context, conn *CDPConn, key string) error {
 // than surfacing as an EvalJSON JS exception.
 func ScrollIntoView(ctx context.Context, conn *CDPConn, node *sightmap.ComponentNode) error {
 	if sel := node.Element.SelectorString(); sel != "" {
-		script := DeepQueryJS + fmt.Sprintf(
-			"\n"+`try{const el=__smDeepQuery(document,%q);if(el)el.scrollIntoView({block:"center",behavior:"instant"})}catch(_){}`,
-			sel,
-		)
+		selJSON, _ := json.Marshal(sel)
+		script := DeepQueryJS + actionsJS + fmt.Sprintf("\n__smScrollIntoViewBySelector(%s)", selJSON)
 		if _, err := EvalJSON(ctx, conn, script); err == nil {
 			return nil
 		}
@@ -805,8 +784,7 @@ func ScrollIntoView(ctx context.Context, conn *CDPConn, node *sightmap.Component
 	// Y position using its bounds.
 	if node.Bounds != nil {
 		y := int(node.Bounds.Y)
-		_, err := EvalJSON(ctx, conn,
-			fmt.Sprintf("window.scrollTo(0,Math.max(0,%d-Math.floor(window.innerHeight/2)))", y))
+		_, err := EvalJSON(ctx, conn, actionsJS+fmt.Sprintf("\n__smScrollToY(%d)", y))
 		return err
 	}
 	return fmt.Errorf("ScrollIntoView: node %q has no selector and no bounds", node.Id)
@@ -819,7 +797,7 @@ func ScrollIntoView(ctx context.Context, conn *CDPConn, node *sightmap.Component
 // "connection closed" errors. Runtime.evaluate is handled at the browser level
 // and is not affected by renderer lifecycle events.
 func ScrollBy(ctx context.Context, conn *CDPConn, deltaX, deltaY int) error {
-	_, err := EvalJSON(ctx, conn, fmt.Sprintf("window.scrollBy(%d,%d)", deltaX, deltaY))
+	_, err := EvalJSON(ctx, conn, actionsJS+fmt.Sprintf("\n__smScrollBy(%d,%d)", deltaX, deltaY))
 	return err
 }
 
@@ -848,7 +826,8 @@ func WaitForSelector(ctx context.Context, conn *CDPConn, selector string) error 
 			return ctx.Err()
 		default:
 		}
-		result, err := EvalJSON(ctx, conn, DeepQueryJS+fmt.Sprintf("\n!!__smDeepQuery(document,%q)", selector))
+		selJSON, _ := json.Marshal(selector)
+		result, err := EvalJSON(ctx, conn, DeepQueryJS+actionsJS+fmt.Sprintf("\n__smSelectorExists(%s)", selJSON))
 		if err == nil {
 			var found bool
 			if json.Unmarshal(result, &found) == nil && found {

--- a/go/browser/actions.js
+++ b/go/browser/actions.js
@@ -1,0 +1,80 @@
+// Live-DOM action helpers used by actions.go. Depends on
+// __smDeepQuery/__smDeepQueryAll from deepquery.js being prepended.
+
+function __smBoundsBySelector(sel) {
+  const el = __smDeepQuery(document, sel);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return {x: Math.round(r.left), y: Math.round(r.top), width: Math.round(r.width), height: Math.round(r.height)};
+}
+
+// __smLocateForClick scrolls the element to the center of the viewport and
+// reports whether its center is actually the top-most element there (so a
+// target hidden behind an overlay is reported as not-hit rather than clicked
+// through).
+function __smLocateForClick(sel) {
+  const el = __smDeepQuery(document, sel);
+  if (!el) return {found: false};
+  el.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
+  const r = el.getBoundingClientRect();
+  const cx = Math.floor(r.left + r.width / 2), cy = Math.floor(r.top + r.height / 2);
+  const inViewport = r.width > 0 && r.height > 0 && cx >= 0 && cy >= 0 && cx < window.innerWidth && cy < window.innerHeight;
+  let hit = false;
+  if (inViewport) {
+    const at = document.elementFromPoint(cx, cy);
+    hit = !!at && (at === el || el.contains(at) || at.contains(el));
+  }
+  return {found: true, inViewport, hit, cx, cy};
+}
+
+function __smClickBySelector(sel) {
+  __smDeepQuery(document, sel)?.click();
+}
+
+function __smReadValueBySelector(sel) {
+  const el = __smDeepQuery(document, sel);
+  if (!el || el.value == null) return null;
+  return String(el.value);
+}
+
+// __smScrollIntoViewBySelector is wrapped in try/catch so a syntactically
+// invalid selector (e.g. a bare numeric probe ID) degrades silently rather
+// than surfacing as an EvalJSON JS exception.
+function __smScrollIntoViewBySelector(sel) {
+  try {
+    const el = __smDeepQuery(document, sel);
+    if (el) el.scrollIntoView({block: 'center', behavior: 'instant'});
+  } catch (_) {}
+}
+
+function __smSelectorExists(sel) {
+  return !!__smDeepQuery(document, sel);
+}
+
+function __smLocationProtocol() {
+  return location.protocol;
+}
+
+function __smScrollPosition() {
+  return {x: window.scrollX, y: window.scrollY};
+}
+
+function __smScrollToY(y) {
+  window.scrollTo(0, Math.max(0, y - Math.floor(window.innerHeight / 2)));
+}
+
+function __smScrollBy(deltaX, deltaY) {
+  window.scrollBy(deltaX, deltaY);
+}
+
+// __smClearActiveElement clears document.activeElement's value via the native
+// JS setter — works on React-controlled inputs where Ctrl+A may not select.
+function __smClearActiveElement() {
+  const el = document.activeElement;
+  if (!el) return;
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value') ||
+                 Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
+  if (setter && setter.set) setter.set.call(el, '');
+  el.dispatchEvent(new Event('input', {bubbles: true}));
+  el.dispatchEvent(new Event('change', {bubbles: true}));
+}

--- a/go/browser/actions.test.js
+++ b/go/browser/actions.test.js
@@ -1,0 +1,183 @@
+const fs = require('fs');
+const path = require('path');
+
+(0, eval)(fs.readFileSync(path.join(__dirname, 'deepquery.js'), 'utf8'));
+(0, eval)(fs.readFileSync(path.join(__dirname, 'actions.js'), 'utf8'));
+
+describe('__smBoundsBySelector', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('returns rounded bounds for the matched element', () => {
+    document.body.innerHTML = '<div id="el"></div>';
+    const el = document.getElementById('el');
+    el.getBoundingClientRect = () => ({left: 1.4, top: 2.6, width: 10.5, height: 20.5});
+
+    expect(__smBoundsBySelector('#el')).toEqual({x: 1, y: 3, width: 11, height: 21});
+  });
+
+  test('returns null when nothing matches', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(__smBoundsBySelector('#missing')).toBeNull();
+  });
+});
+
+describe('__smLocateForClick', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  test('reports not-found when the selector matches nothing', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(__smLocateForClick('#missing')).toEqual({found: false});
+  });
+
+  test('reports hit:true when elementFromPoint returns the element itself', () => {
+    document.body.innerHTML = '<button id="btn"></button>';
+    const btn = document.getElementById('btn');
+    btn.scrollIntoView = jest.fn();
+    btn.getBoundingClientRect = () => ({left: 0, top: 0, width: 100, height: 20});
+    document.elementFromPoint = jest.fn().mockReturnValue(btn);
+    Object.defineProperty(window, 'innerWidth', {value: 800, configurable: true});
+    Object.defineProperty(window, 'innerHeight', {value: 600, configurable: true});
+
+    const result = __smLocateForClick('#btn');
+    expect(result).toMatchObject({found: true, inViewport: true, hit: true, cx: 50, cy: 10});
+  });
+
+  test('reports hit:false when something else is on top', () => {
+    document.body.innerHTML = '<button id="btn"></button><div id="overlay"></div>';
+    const btn = document.getElementById('btn');
+    const overlay = document.getElementById('overlay');
+    btn.scrollIntoView = jest.fn();
+    btn.getBoundingClientRect = () => ({left: 0, top: 0, width: 100, height: 20});
+    document.elementFromPoint = jest.fn().mockReturnValue(overlay);
+    Object.defineProperty(window, 'innerWidth', {value: 800, configurable: true});
+    Object.defineProperty(window, 'innerHeight', {value: 600, configurable: true});
+
+    expect(__smLocateForClick('#btn').hit).toBe(false);
+  });
+});
+
+describe('__smClickBySelector', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('clicks the matched element', () => {
+    document.body.innerHTML = '<button id="btn"></button>';
+    const btn = document.getElementById('btn');
+    const onClick = jest.fn();
+    btn.addEventListener('click', onClick);
+
+    __smClickBySelector('#btn');
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not throw when nothing matches', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(() => __smClickBySelector('#missing')).not.toThrow();
+  });
+});
+
+describe('__smReadValueBySelector', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('reads the current value of a form field', () => {
+    document.body.innerHTML = '<input id="in" value="hello" />';
+    expect(__smReadValueBySelector('#in')).toBe('hello');
+  });
+
+  test('returns null for an element with no value property', () => {
+    document.body.innerHTML = '<div id="el"></div>';
+    expect(__smReadValueBySelector('#el')).toBeNull();
+  });
+
+  test('returns null when nothing matches', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(__smReadValueBySelector('#missing')).toBeNull();
+  });
+});
+
+describe('__smScrollIntoViewBySelector', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('calls scrollIntoView on the matched element', () => {
+    document.body.innerHTML = '<div id="el"></div>';
+    const el = document.getElementById('el');
+    el.scrollIntoView = jest.fn();
+
+    __smScrollIntoViewBySelector('#el');
+    expect(el.scrollIntoView).toHaveBeenCalledWith({block: 'center', behavior: 'instant'});
+  });
+
+  test('fails soft on a syntactically invalid selector', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(() => __smScrollIntoViewBySelector('[')).not.toThrow();
+  });
+});
+
+describe('__smSelectorExists', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('true when the selector matches, false otherwise', () => {
+    document.body.innerHTML = '<div id="el"></div>';
+    expect(__smSelectorExists('#el')).toBe(true);
+    expect(__smSelectorExists('#missing')).toBe(false);
+  });
+});
+
+describe('scroll and location helpers', () => {
+  test('__smLocationProtocol reflects the current page', () => {
+    expect(__smLocationProtocol()).toBe(location.protocol);
+  });
+
+  test('__smScrollPosition reflects window scroll offsets', () => {
+    Object.defineProperty(window, 'scrollX', {value: 12, configurable: true});
+    Object.defineProperty(window, 'scrollY', {value: 34, configurable: true});
+    expect(__smScrollPosition()).toEqual({x: 12, y: 34});
+  });
+
+  test('__smScrollToY calls window.scrollTo centered on y', () => {
+    window.scrollTo = jest.fn();
+    Object.defineProperty(window, 'innerHeight', {value: 600, configurable: true});
+    __smScrollToY(1000);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 700);
+  });
+
+  test('__smScrollBy calls window.scrollBy with the given deltas', () => {
+    window.scrollBy = jest.fn();
+    __smScrollBy(5, -10);
+    expect(window.scrollBy).toHaveBeenCalledWith(5, -10);
+  });
+});
+
+describe('__smClearActiveElement', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test("clears the focused input's value and fires input/change events", () => {
+    document.body.innerHTML = '<input id="in" value="hello" />';
+    const input = document.getElementById('in');
+    input.focus();
+    const onInput = jest.fn();
+    const onChange = jest.fn();
+    input.addEventListener('input', onInput);
+    input.addEventListener('change', onChange);
+
+    __smClearActiveElement();
+
+    expect(input.value).toBe('');
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/go/browser/actions_test.go
+++ b/go/browser/actions_test.go
@@ -394,8 +394,8 @@ func TestResolveBySightmapID(t *testing.T) {
 	script := evalScript
 	mu.Unlock()
 
-	if !strings.Contains(script, `data-sightmap-id="805"`) {
-		t.Errorf("resolution should anchor to data-sightmap-id=\"805\", got: %s", script)
+	if !strings.Contains(script, "data-sightmap-id") || !strings.Contains(script, "805") {
+		t.Errorf("resolution should anchor to data-sightmap-id 805, got: %s", script)
 	}
 	if !strings.Contains(script, "getBoundingClientRect") {
 		t.Errorf("resolution should read live bounds via getBoundingClientRect, got: %s", script)

--- a/go/browser/click_verify_test.go
+++ b/go/browser/click_verify_test.go
@@ -72,9 +72,9 @@ func TestFill_DidNotStickErrors(t *testing.T) {
 	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
 		if method == "Runtime.evaluate" {
 			switch {
-			case strings.Contains(exprOf(params), "elementFromPoint"):
+			case strings.Contains(exprOf(params), "\n__smLocateForClick("):
 				return evalResult(`{"found":true,"inViewport":true,"hit":true,"cx":10,"cy":5}`)
-			case strings.Contains(exprOf(params), "el.value"):
+			case strings.Contains(exprOf(params), "\n__smReadValueBySelector("):
 				return evalResult(`""`) // field still empty → didn't stick
 			}
 		}
@@ -90,9 +90,9 @@ func TestFill_StuckSucceeds(t *testing.T) {
 	conn := newFakeCDP(t, func(method string, params json.RawMessage) json.RawMessage {
 		if method == "Runtime.evaluate" {
 			switch {
-			case strings.Contains(exprOf(params), "elementFromPoint"):
+			case strings.Contains(exprOf(params), "\n__smLocateForClick("):
 				return evalResult(`{"found":true,"inViewport":true,"hit":true,"cx":10,"cy":5}`)
-			case strings.Contains(exprOf(params), "el.value"):
+			case strings.Contains(exprOf(params), "\n__smReadValueBySelector("):
 				return evalResult(`"hello"`)
 			}
 		}

--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,6 +19,9 @@ import (
 	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
+
+//go:embed cmd_browser_bounds.js
+var boundsJS string
 
 // boundsResult is one emitted bounding box, in both viewport-% and raw px.
 type boundsResult struct {
@@ -233,20 +237,7 @@ func boundsBySelector(
 	selector string,
 	vw, vh int,
 ) ([]boundsResult, error) {
-	// Return the rects directly (not stringified) so EvalJSON gives us the
-	// object value rather than a JSON-encoded string.
-	script := browser.DeepQueryJS + fmt.Sprintf(`
-(function(){
-  var els = __smDeepQueryAll(document, %s);
-  var out = [];
-  for (var i = 0; i < els.length; i++) {
-    var r = els[i].getBoundingClientRect();
-    var label = (els[i].getAttribute('aria-label') || els[i].textContent || '').trim().replace(/\s+/g,' ');
-    if (label.length > 80) label = label.slice(0, 80);
-    out.push({x: r.left, y: r.top, width: r.width, height: r.height, label: label});
-  }
-  return out;
-})()`, jsString(selector))
+	script := browser.DeepQueryJS + boundsJS + fmt.Sprintf("\n__smBoundsBySelector(%s)", jsString(selector))
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
@@ -368,8 +359,7 @@ func intersectsViewport(b *sightmap.Bounds, vw, vh int) bool {
 
 // viewportSize reads window.innerWidth/innerHeight from the live page.
 func viewportSize(ctx context.Context, conn *browser.CDPConn) (int, int, error) {
-	raw, err := browser.EvalJSON(ctx, conn,
-		`({w: window.innerWidth, h: window.innerHeight})`)
+	raw, err := browser.EvalJSON(ctx, conn, boundsJS+"\n__smViewportSize()")
 	if err != nil {
 		return 0, 0, fmt.Errorf("bounds: read viewport: %w", err)
 	}

--- a/go/cmd/sightmap/cmd_browser_bounds.js
+++ b/go/cmd/sightmap/cmd_browser_bounds.js
@@ -1,0 +1,18 @@
+// Live-DOM helpers for the `bounds` subcommand. __smBoundsBySelector depends
+// on __smDeepQueryAll from browser/deepquery.js being prepended.
+
+function __smBoundsBySelector(sel) {
+  const els = __smDeepQueryAll(document, sel);
+  const out = [];
+  for (const el of els) {
+    const r = el.getBoundingClientRect();
+    let label = (el.getAttribute('aria-label') || el.textContent || '').trim().replace(/\s+/g, ' ');
+    if (label.length > 80) label = label.slice(0, 80);
+    out.push({x: r.left, y: r.top, width: r.width, height: r.height, label});
+  }
+  return out;
+}
+
+function __smViewportSize() {
+  return {w: window.innerWidth, h: window.innerHeight};
+}

--- a/go/cmd/sightmap/cmd_browser_bounds.test.js
+++ b/go/cmd/sightmap/cmd_browser_bounds.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+(0, eval)(fs.readFileSync(path.join(__dirname, '..', '..', 'browser', 'deepquery.js'), 'utf8'));
+(0, eval)(fs.readFileSync(path.join(__dirname, 'cmd_browser_bounds.js'), 'utf8'));
+
+describe('__smBoundsBySelector', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('returns a bounds+label entry per match, preferring aria-label over text', () => {
+    document.body.innerHTML = `
+      <button id="a" aria-label="Save changes">Save</button>
+      <button id="b">  Cancel   now  </button>
+    `;
+    document.getElementById('a').getBoundingClientRect = () => ({left: 0, top: 0, width: 10, height: 5});
+    document.getElementById('b').getBoundingClientRect = () => ({left: 1, top: 2, width: 3, height: 4});
+
+    const results = __smBoundsBySelector('button');
+    expect(results).toEqual([
+      {x: 0, y: 0, width: 10, height: 5, label: 'Save changes'},
+      {x: 1, y: 2, width: 3, height: 4, label: 'Cancel now'},
+    ]);
+  });
+
+  test('truncates an overlong label to 80 characters', () => {
+    document.body.innerHTML = `<button id="a">${'x'.repeat(200)}</button>`;
+    document.getElementById('a').getBoundingClientRect = () => ({left: 0, top: 0, width: 1, height: 1});
+
+    expect(__smBoundsBySelector('button')[0].label).toHaveLength(80);
+  });
+
+  test('finds matches inside shadow DOM', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const btn = document.createElement('button');
+    btn.getBoundingClientRect = () => ({left: 0, top: 0, width: 1, height: 1});
+    host.attachShadow({mode: 'open'}).appendChild(btn);
+
+    expect(__smBoundsBySelector('button')).toHaveLength(1);
+  });
+
+  test('returns an empty list when nothing matches', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(__smBoundsBySelector('button')).toEqual([]);
+  });
+});
+
+describe('__smViewportSize', () => {
+  test('reads window.innerWidth/innerHeight', () => {
+    Object.defineProperty(window, 'innerWidth', {value: 1024, configurable: true});
+    Object.defineProperty(window, 'innerHeight', {value: 768, configurable: true});
+    expect(__smViewportSize()).toEqual({w: 1024, h: 768});
+  });
+});

--- a/go/cmd/sightmap/cmd_sel_probe.go
+++ b/go/cmd/sightmap/cmd_sel_probe.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,48 +19,8 @@ import (
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
-// queryScript is the inline JS injected via EvalJSON.
-// Placeholders: %s = JSON-encoded selector, %d = max, %v = full (bool).
-const queryScript = `(function(sel, max, full) {
-  try {
-    const els = [...__smDeepQueryAll(document, sel)].slice(0, max);
-    const interestingAttrs = new Set([
-      'id','class','role','href','type','name','placeholder','aria-label',
-      'aria-expanded','aria-haspopup','aria-controls','aria-selected',
-      'data-testid','data-component','tabindex'
-    ]);
-    return els.map(el => {
-      const attrs = {};
-      for (const a of el.attributes) {
-        if (interestingAttrs.has(a.name) || a.name.startsWith('aria-') || a.name.startsWith('data-')) {
-          if (a.value !== '') attrs[a.name] = a.value;
-        }
-      }
-      const parents = [];
-      let p = el.parentElement;
-      for (let i = 0; i < 5 && p && p.tagName !== 'HTML'; i++, p = p.parentElement) {
-        parents.push({
-          tag: p.tagName.toLowerCase(),
-          id:  p.id || '',
-          cls: [...p.classList].slice(0, 4),
-          dt:  p.getAttribute('data-testid') || '',
-          dc:  p.getAttribute('data-component') || '',
-        });
-      }
-      return {
-        tag:     el.tagName.toLowerCase(),
-        id:      el.id || '',
-        cls:     [...el.classList],
-        role:    el.getAttribute('role') || '',
-        text:    full ? el.textContent.trim() : el.textContent.trim().slice(0, 80),
-        attrs:   attrs,
-        parents: parents,
-      };
-    });
-  } catch(e) {
-    return {error: e.message};
-  }
-})(%s, %d, %v)`
+//go:embed cmd_sel_probe.js
+var selProbeJS string
 
 // elementResult is the Go-side representation of one querySelectorAll hit.
 type elementResult struct {
@@ -246,8 +207,8 @@ func printOfflineCheck(ctx context.Context, conn *browser.CDPConn, selector stri
 // selector in the live page.
 func liveSelectorCount(ctx context.Context, conn *browser.CDPConn, selector string) (int, error) {
 	selJSON, _ := json.Marshal(selector)
-	raw, err := browser.EvalJSON(ctx, conn, browser.DeepQueryJS+fmt.Sprintf(
-		"\n"+`(function(s){try{return __smDeepQueryAll(document,s).length}catch(e){return -1}})(%s)`, string(selJSON)))
+	raw, err := browser.EvalJSON(ctx, conn,
+		browser.DeepQueryJS+selProbeJS+fmt.Sprintf("\n__smLiveSelectorCount(%s)", selJSON))
 	if err != nil {
 		return 0, err
 	}
@@ -321,7 +282,7 @@ func queryElements(
 		return nil, fmt.Errorf("marshal selector: %w", err)
 	}
 
-	script := browser.DeepQueryJS + "\n" + fmt.Sprintf(queryScript, string(selectorJSON), maxN, full)
+	script := browser.DeepQueryJS + selProbeJS + fmt.Sprintf("\n__smQueryElements(%s, %d, %v)", selectorJSON, maxN, full)
 
 	raw, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
@@ -517,12 +478,7 @@ func runSelProbeAll(args []string, sightmapDir, addr, tabID string, max int, ful
 		}
 		time.Sleep(time.Duration(w * float64(time.Second)))
 
-		script := browser.DeepQueryJS + fmt.Sprintf("\n"+`(function(sel,max){
-            try {
-                var els = Array.from(__smDeepQueryAll(document,sel)).slice(0,max);
-                return els.length;
-            } catch(e) { return -1; }
-        })(%s, %d)`, string(selectorJSON), max)
+		script := browser.DeepQueryJS + selProbeJS + fmt.Sprintf("\n__smSelProbeAllCount(%s, %d)", selectorJSON, max)
 
 		raw, evalErr := browser.EvalJSON(ctx, conn, script)
 		if evalErr != nil {

--- a/go/cmd/sightmap/cmd_sel_probe.js
+++ b/go/cmd/sightmap/cmd_sel_probe.js
@@ -1,0 +1,59 @@
+// Live-DOM helpers for the `sel-probe` subcommand. Depends on
+// __smDeepQueryAll from browser/deepquery.js being prepended.
+
+function __smQueryElements(sel, max, full) {
+  try {
+    const els = [...__smDeepQueryAll(document, sel)].slice(0, max);
+    const interestingAttrs = new Set([
+      'id', 'class', 'role', 'href', 'type', 'name', 'placeholder', 'aria-label',
+      'aria-expanded', 'aria-haspopup', 'aria-controls', 'aria-selected',
+      'data-testid', 'data-component', 'tabindex'
+    ]);
+    return els.map(el => {
+      const attrs = {};
+      for (const a of el.attributes) {
+        if (interestingAttrs.has(a.name) || a.name.startsWith('aria-') || a.name.startsWith('data-')) {
+          if (a.value !== '') attrs[a.name] = a.value;
+        }
+      }
+      const parents = [];
+      let p = el.parentElement;
+      for (let i = 0; i < 5 && p && p.tagName !== 'HTML'; i++, p = p.parentElement) {
+        parents.push({
+          tag: p.tagName.toLowerCase(),
+          id:  p.id || '',
+          cls: [...p.classList].slice(0, 4),
+          dt:  p.getAttribute('data-testid') || '',
+          dc:  p.getAttribute('data-component') || '',
+        });
+      }
+      return {
+        tag:     el.tagName.toLowerCase(),
+        id:      el.id || '',
+        cls:     [...el.classList],
+        role:    el.getAttribute('role') || '',
+        text:    full ? el.textContent.trim() : el.textContent.trim().slice(0, 80),
+        attrs,
+        parents,
+      };
+    });
+  } catch(e) {
+    return {error: e.message};
+  }
+}
+
+function __smLiveSelectorCount(sel) {
+  try {
+    return __smDeepQueryAll(document, sel).length;
+  } catch(e) {
+    return -1;
+  }
+}
+
+function __smSelProbeAllCount(sel, max) {
+  try {
+    return Array.from(__smDeepQueryAll(document, sel)).slice(0, max).length;
+  } catch(e) {
+    return -1;
+  }
+}

--- a/go/cmd/sightmap/cmd_sel_probe.test.js
+++ b/go/cmd/sightmap/cmd_sel_probe.test.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+
+(0, eval)(fs.readFileSync(path.join(__dirname, '..', '..', 'browser', 'deepquery.js'), 'utf8'));
+(0, eval)(fs.readFileSync(path.join(__dirname, 'cmd_sel_probe.js'), 'utf8'));
+
+describe('__smQueryElements', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('describes each match: tag, id, classes, role, text, attrs', () => {
+    document.body.innerHTML = `
+      <button id="save" class="btn primary" role="button" data-testid="save-btn">
+        Save now
+      </button>
+    `;
+    const [el] = __smQueryElements('button', 10, false);
+    expect(el).toMatchObject({
+      tag: 'button',
+      id: 'save',
+      cls: ['btn', 'primary'],
+      role: 'button',
+      text: 'Save now',
+      attrs: {'data-testid': 'save-btn'},
+    });
+  });
+
+  test('truncates text to 80 chars unless full is true', () => {
+    document.body.innerHTML = `<div id="d">${'x'.repeat(200)}</div>`;
+    expect(__smQueryElements('#d', 10, false)[0].text).toHaveLength(80);
+    expect(__smQueryElements('#d', 10, true)[0].text).toHaveLength(200);
+  });
+
+  test('caps results at max', () => {
+    document.body.innerHTML = '<i class="x"></i><i class="x"></i><i class="x"></i>';
+    expect(__smQueryElements('.x', 2, false)).toHaveLength(2);
+  });
+
+  test('collects ancestors up to 5 levels, stopping at html', () => {
+    document.body.innerHTML = '<div data-testid="root"><div><div><span id="leaf"></span></div></div></div>';
+    const [el] = __smQueryElements('#leaf', 10, false);
+    expect(el.parents.length).toBeGreaterThan(0);
+    expect(el.parents.some(p => p.dt === 'root')).toBe(true);
+    expect(el.parents.every(p => p.tag !== 'html')).toBe(true);
+  });
+
+  test('finds matches inside shadow DOM', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    host.attachShadow({mode: 'open'}).innerHTML = '<button id="shadow-btn"></button>';
+    expect(__smQueryElements('#shadow-btn', 10, false)).toHaveLength(1);
+  });
+
+  // deepquery.js's __smDeepQueryAll already fails soft on an invalid
+  // selector (returns [], doesn't throw), so this never reaches the
+  // {error} branch — it just sees zero matches, same as any other miss.
+  test('a bad selector yields no matches instead of throwing', () => {
+    expect(() => __smQueryElements('[', 10, false)).not.toThrow();
+    expect(__smQueryElements('[', 10, false)).toEqual([]);
+  });
+});
+
+describe('__smLiveSelectorCount', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('returns the true, uncapped match count', () => {
+    document.body.innerHTML = '<i class="x"></i><i class="x"></i><i class="x"></i>';
+    expect(__smLiveSelectorCount('.x')).toBe(3);
+  });
+
+  // Same fail-soft reasoning as __smQueryElements above: __smDeepQueryAll
+  // never throws on a bad selector, so this sees a length-0 result, not -1.
+  test('a bad selector yields 0, not -1 (deepquery already fails soft)', () => {
+    expect(__smLiveSelectorCount('[')).toBe(0);
+  });
+});
+
+describe('__smSelProbeAllCount', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('caps the count at max', () => {
+    document.body.innerHTML = '<i class="x"></i><i class="x"></i><i class="x"></i>';
+    expect(__smSelProbeAllCount('.x', 2)).toBe(2);
+  });
+
+  test('a bad selector yields 0, not -1 (deepquery already fails soft)', () => {
+    expect(__smSelProbeAllCount('[', 10)).toBe(0);
+  });
+});

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -2,14 +2,17 @@ package observe
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
+
+//go:embed properties.js
+var propertiesJS string
 
 // ExtractProperties runs a single batched JS evaluation against the live DOM to
 // extract property values for all matched nodes that have property definitions,
@@ -62,70 +65,7 @@ func ExtractProperties(
 		return
 	}
 
-	const jsTemplate = `(function(specs) {
-  // Canonical extractor — mirrored in cmd/sightmap/extension/{content,resolver}.js
-  // and (transforms only) sightmap/property.go. Returns the RAW value; the caller
-  // normalizes whitespace, applies the transform, and caps length uniformly.
-  function extractValue(el, extract) {
-    if (!extract) return null;
-    if (extract === 'text') return el.textContent;
-    if (extract === 'inner_text') return el.innerText;
-    if (extract === 'text_only') {
-      const clone = el.cloneNode(true);
-      clone.querySelectorAll('img,svg,[alt]').forEach(e => e.remove());
-      return clone.textContent;
-    }
-    if (extract === 'inner_html') return el.innerHTML;
-    if (extract.startsWith('attr=')) return el.getAttribute(extract.slice(5));
-    if (extract.startsWith('exists:')) {
-      return __smDeepQuery(el, extract.slice(7)) ? 'true' : null;
-    }
-    const sub = __smDeepQuery(el, extract);
-    return sub ? (sub.innerText != null ? sub.innerText : sub.textContent) : null;
-  }
-  function applyTransform(val, transform) {
-    if (!transform || !val) return val;
-    if (transform.indexOf('match:') === 0) {
-      try {
-        const m = val.match(new RegExp(transform.slice(6)));
-        if (!m) return val;
-        return m[1] != null ? m[1] : m[0];
-      } catch (e) { return val; }
-    }
-    const words = val.trim().split(/\s+/);
-    switch(transform) {
-      case 'first_word': return words[0] || val;
-      case 'last_word':  return words[words.length-1] || val;
-      case 'first_number': { const m = val.match(/\d[\d,.]*/); return m ? m[0] : val; }
-      case 'first_dollar': { const m = val.match(/\$[\d,.]+/); return m ? m[0] : val; }
-      case 'number':     return val.replace(/[^\d.]/g, '');
-      case 'slug':       return val.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-      default: return val;
-    }
-  }
-  const results = {};
-  for (const {id, selector, props} of specs) {
-    // Anchor to the exact matched element via its sightmap ID attribute (set by
-    // probe.js as data-sightmap-id). This ensures child components like
-    // BreadcrumbLink get their own text, not the first match on the page.
-    const el = (id ? __smDeepQuery(document, '[data-sightmap-id="' + id + '"]') : null)
-               || __smDeepQuery(document, selector);
-    if (!el) continue;
-    const vals = {};
-    for (const {name, extract, transform} of props) {
-      let val = extractValue(el, extract);
-      if (val == null) continue;
-      val = String(val).trim().replace(/\s+/g, ' ');
-      if (val === '') continue;
-      val = applyTransform(val, transform);
-      if (val) vals[name] = String(val).slice(0, 120);
-    }
-    if (Object.keys(vals).length > 0) results[id] = vals;
-  }
-  return results;
-})(SPECS_JSON)`
-
-	script := browser.DeepQueryJS + "\n" + strings.Replace(jsTemplate, "SPECS_JSON", string(specsJSON), 1)
+	script := browser.DeepQueryJS + propertiesJS + fmt.Sprintf("\n__smExtractProperties(%s)", string(specsJSON))
 
 	resultJSON, evalErr := browser.EvalJSON(ctx, conn, script)
 	if evalErr != nil {

--- a/go/observe/properties.js
+++ b/go/observe/properties.js
@@ -1,0 +1,65 @@
+// Canonical property extractor — mirrored in cmd/sightmap/extension/{content,resolver}.js
+// and (transforms only) sightmap/property.go. Depends on __smDeepQuery from
+// browser/deepquery.js being prepended.
+
+function __smExtractProperties(specs) {
+  // Returns the RAW value; the caller normalizes whitespace, applies the
+  // transform, and caps length uniformly.
+  function extractValue(el, extract) {
+    if (!extract) return null;
+    if (extract === 'text') return el.textContent;
+    if (extract === 'inner_text') return el.innerText;
+    if (extract === 'text_only') {
+      const clone = el.cloneNode(true);
+      clone.querySelectorAll('img,svg,[alt]').forEach(e => e.remove());
+      return clone.textContent;
+    }
+    if (extract === 'inner_html') return el.innerHTML;
+    if (extract.startsWith('attr=')) return el.getAttribute(extract.slice(5));
+    if (extract.startsWith('exists:')) {
+      return __smDeepQuery(el, extract.slice(7)) ? 'true' : null;
+    }
+    const sub = __smDeepQuery(el, extract);
+    return sub ? (sub.innerText != null ? sub.innerText : sub.textContent) : null;
+  }
+  function applyTransform(val, transform) {
+    if (!transform || !val) return val;
+    if (transform.indexOf('match:') === 0) {
+      try {
+        const m = val.match(new RegExp(transform.slice(6)));
+        if (!m) return val;
+        return m[1] != null ? m[1] : m[0];
+      } catch (e) { return val; }
+    }
+    const words = val.trim().split(/\s+/);
+    switch (transform) {
+      case 'first_word': return words[0] || val;
+      case 'last_word': return words[words.length - 1] || val;
+      case 'first_number': { const m = val.match(/\d[\d,.]*/); return m ? m[0] : val; }
+      case 'first_dollar': { const m = val.match(/\$[\d,.]+/); return m ? m[0] : val; }
+      case 'number': return val.replace(/[^\d.]/g, '');
+      case 'slug': return val.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      default: return val;
+    }
+  }
+  const results = {};
+  for (const {id, selector, props} of specs) {
+    // Anchor to the exact matched element via its sightmap ID attribute (set by
+    // probe.js as data-sightmap-id). This ensures child components like
+    // BreadcrumbLink get their own text, not the first match on the page.
+    const el = (id ? __smDeepQuery(document, '[data-sightmap-id="' + id + '"]') : null)
+               || __smDeepQuery(document, selector);
+    if (!el) continue;
+    const vals = {};
+    for (const {name, extract, transform} of props) {
+      let val = extractValue(el, extract);
+      if (val == null) continue;
+      val = String(val).trim().replace(/\s+/g, ' ');
+      if (val === '') continue;
+      val = applyTransform(val, transform);
+      if (val) vals[name] = String(val).slice(0, 120);
+    }
+    if (Object.keys(vals).length > 0) results[id] = vals;
+  }
+  return results;
+}

--- a/go/observe/properties.test.js
+++ b/go/observe/properties.test.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+(0, eval)(fs.readFileSync(path.join(__dirname, '..', 'browser', 'deepquery.js'), 'utf8'));
+(0, eval)(fs.readFileSync(path.join(__dirname, 'properties.js'), 'utf8'));
+
+describe('__smExtractProperties', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('extracts text by data-sightmap-id, anchoring to the exact matched element', () => {
+    document.body.innerHTML = `
+      <div class="card" data-sightmap-id="1">
+        <span class="label">outer</span>
+        <div class="card" data-sightmap-id="2"><span class="label">inner</span></div>
+      </div>
+    `;
+    const specs = [
+      {id: '2', selector: '.card', props: [{name: 'label', extract: 'text', transform: ''}]},
+    ];
+    expect(__smExtractProperties(specs)).toEqual({2: {label: 'inner'}});
+  });
+
+  test('falls back to the selector when id is empty', () => {
+    document.body.innerHTML = '<div class="card"><span class="label">hi</span></div>';
+    const specs = [{id: '', selector: '.card', props: [{name: 'label', extract: '.label'}]}];
+    expect(__smExtractProperties(specs)).toEqual({'': {label: 'hi'}});
+  });
+
+  test('exists: reports true only when the sub-selector matches, including inside shadow DOM', () => {
+    document.body.innerHTML = '<div class="card" data-sightmap-id="1"></div>';
+    const host = document.querySelector('.card');
+    host.attachShadow({mode: 'open'}).innerHTML = '<span class="icon"></span>';
+
+    const specs = [
+      {
+        id: '1',
+        selector: '.card',
+        props: [{name: 'hasIcon', extract: 'exists:.icon'}, {name: 'hasBadge', extract: 'exists:.badge'}],
+      },
+    ];
+    expect(__smExtractProperties(specs)).toEqual({1: {hasIcon: 'true'}});
+  });
+
+  test('attr= reads the named attribute', () => {
+    document.body.innerHTML = '<a class="link" href="/x" data-sightmap-id="1"></a>';
+    const specs = [{id: '1', selector: '.link', props: [{name: 'href', extract: 'attr=href'}]}];
+    expect(__smExtractProperties(specs)).toEqual({1: {href: '/x'}});
+  });
+
+  test('applies a transform to the extracted value', () => {
+    document.body.innerHTML = '<div class="price" data-sightmap-id="1">Total: $12.50 today</div>';
+    const specs = [
+      {id: '1', selector: '.price', props: [{name: 'price', extract: 'text', transform: 'first_dollar'}]},
+    ];
+    expect(__smExtractProperties(specs)).toEqual({1: {price: '$12.50'}});
+  });
+
+  test('omits a property when extraction yields nothing', () => {
+    document.body.innerHTML = '<div class="card" data-sightmap-id="1"></div>';
+    const specs = [{id: '1', selector: '.card', props: [{name: 'label', extract: '.missing'}]}];
+    expect(__smExtractProperties(specs)).toEqual({});
+  });
+
+  test('skips a spec whose element is not found', () => {
+    document.body.innerHTML = '<div></div>';
+    const specs = [{id: 'nope', selector: '.missing', props: [{name: 'label', extract: 'text'}]}];
+    expect(__smExtractProperties(specs)).toEqual({});
+  });
+});


### PR DESCRIPTION
> Replaces #236, which GitHub auto-closed when its base branch (`clint/deepquery-shadow-order`, #234) was deleted on merge. Same branch (`clint/embed-browser-js`) and commit — now retargeted directly onto `main`. Continues the stack: this → #237 → #238.

## What this changes

Extracts the browser-side JS embedded as Go string literals in `scan.go`, `actions.go`, `properties.go`, `cmd_browser_bounds.go`, and `cmd_sel_probe.go` into sibling `.js` files, embedded via `go:embed` (the `probe.js` precedent from `go/probe/`). Go call sites now pass dynamic values as JSON-encoded function arguments instead of splicing them into the script text via `fmt.Sprintf`/`strings.Replace`. Adds a Jest suite per extracted file, reusing the jsdom harness added for `deepquery.js` in #234.

## Why

These scripts (some with real loops/conditionals, e.g. `cmd_sel_probe.go`'s element-description walk) lived as unlintable, unformattable, untestable Go string literals — some built via multi-argument `fmt.Sprintf` with placeholders threaded through comments (`// Placeholders: %s = ..., %d = ..., %v = ...`). Moving them to real `.js` files makes them lintable/formattable JS and, paired with the Jest+jsdom harness from #234, actually testable — before this change, no JS in this repo (including `probe.js`) had any test coverage at all.

Two existing tests changed because their fake-CDP handlers distinguished calls by matching a substring against the raw script text (e.g. `"el.value"`, `"elementFromPoint"`) — substrings that used to be unique to one call's self-contained script. Now that each package's shared `.js` file is prepended in full to every call in that file, those substrings appear in every call's script regardless of which function actually runs. Both tests now match on the specific function invocation (e.g. `"\n__smReadValueBySelector("`) instead.

This PR is scoped to the mechanical move only — no JS logic changes, and no reformatting (a separate follow-up branch runs Prettier across everything once, so that diff is reviewable on its own).
