### PR TITLE
fix(extension): fetch corpus directly on http origins so the overlay isn't stuck empty

### DIFF
--- a/.changeset/overlay-direct-fetch.md
+++ b/.changeset/overlay-direct-fetch.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix the browser overlay extension rendering **0 components** on pages whose corpus the sightmap server serves correctly. The content script proxied its `/sightmap` fetch through the background service worker, and on a cold/just-woken MV3 worker that round-trip intermittently delivered an empty corpus at page load; the empty result then stuck for the life of the page because the per-instance `version` never changes (so `pollVersion` never refetched) and an open side panel keeps the worker alive. `sightmap snapshot` was unaffected (it reads the corpus in-process over CDP). The content script now fetches the local server **directly** on http-origin pages — `host_permissions` already grants `http://localhost:*` and the server sends `Access-Control-Allow-Origin: *` — using the background proxy only as an https mixed-content fallback, and it treats an empty corpus as "not loaded yet" and keeps retrying instead of caching it.

--- a/go/cmd/sightmap/extension/content.js
+++ b/go/cmd/sightmap/extension/content.js
@@ -222,6 +222,54 @@ function activeComponents() {
 
 // ── Sightmap loading ──────────────────────────────────────────────────────────
 
+// The content script prefers a DIRECT fetch to the local sightmap server. On an
+// app served over http (the common dev case) the page can fetch http://localhost
+// directly, so we bypass the background service-worker proxy entirely: the MV3 SW
+// round-trip is unreliable on a cold/just-woken worker and was silently
+// delivering an empty corpus at page-load time. The SW proxy (bgFetch) remains a
+// fallback for https-origin pages, where mixed-content blocks a direct http
+// fetch. host_permissions grants http://localhost:*, and the server sends
+// Access-Control-Allow-Origin:*, so the cross-port fetch is allowed.
+let directServerBase = null; // cached resolved base, e.g. "http://localhost:7891"
+
+async function pingServer(base) {
+  try {
+    const r = await fetch(`${base}/sightmap/version`, {
+      signal: AbortSignal.timeout(400),
+    });
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Resolve the local server by direct probing: the hint from chrome.storage.local
+// (injected by `browser start`), then the 7891–7900 range. Returns null when
+// nothing responds or the page origin blocks the http fetch (https mixed
+// content) — callers then fall back to the SW proxy.
+async function discoverDirect() {
+  if (directServerBase && (await pingServer(directServerBase)))
+    return directServerBase;
+  directServerBase = null;
+  let hint = 7891;
+  try {
+    const s = await chrome.storage.local.get("serverPort");
+    if (s.serverPort) hint = s.serverPort;
+  } catch {
+    /* storage unavailable — use default hint */
+  }
+  const ports = [hint];
+  for (let p = 7891; p <= 7900; p++) if (p !== hint) ports.push(p);
+  for (const p of ports) {
+    const base = `http://localhost:${p}`;
+    if (await pingServer(base)) {
+      directServerBase = base;
+      return base;
+    }
+  }
+  return null;
+}
+
 // Proxy fetches through the background service worker to avoid mixed-content
 // blocks (content script on https:// cannot directly fetch http://localhost).
 function bgFetch(type) {
@@ -236,47 +284,85 @@ function bgFetch(type) {
   });
 }
 
-async function fetchSightmap() {
+// Fetch the full corpus. Prefers a direct fetch; falls back to the SW proxy
+// (https pages). Returns the parsed payload, or null on failure.
+async function fetchSightmapData() {
+  const base = await discoverDirect();
+  if (base) {
+    try {
+      const r = await fetch(`${base}/sightmap`);
+      if (r.ok) return await r.json();
+    } catch {
+      directServerBase = null; // direct path failed — fall through to the proxy
+    }
+  }
   try {
     const resp = await bgFetch("fetch-sightmap");
-    const data = resp.data;
-    const corpus = data.corpus ?? {};
-    state.globals = (corpus.globals ?? []).map(normalizeComp);
-    state.views = (corpus.views ?? []).map((v) => ({
-      name: v.name,
-      route: v.route,
-      components: (v.components ?? []).map(normalizeComp),
-    }));
-    state.version = data.version;
-    const total =
-      state.globals.length +
-      state.views.reduce((s, v) => s + v.components.length, 0);
-    console.log(
-      `[sightmap] loaded ${total} components from ${data.site} v${data.version}`,
-    );
-    chrome.runtime
-      .sendMessage({
-        type: "sightmap-loaded",
-        version: data.version,
-        site: data.site,
-        componentCount: total,
-      })
-      .catch(() => {});
-  } catch (err) {
-    // Server not running — silent; will retry on next poll
+    return resp.data;
+  } catch {
+    return null;
   }
 }
 
+// Fetch just the version string, same direct-then-proxy strategy.
+async function fetchVersionValue() {
+  const base = await discoverDirect();
+  if (base) {
+    try {
+      const r = await fetch(`${base}/sightmap/version`);
+      if (r.ok) return (await r.json()).version;
+    } catch {
+      directServerBase = null;
+    }
+  }
+  const resp = await bgFetch("fetch-sightmap-version");
+  return resp.version;
+}
+
+async function fetchSightmap() {
+  const data = await fetchSightmapData();
+  if (!data) return false; // server unreachable — retry on next poll
+  const corpus = data.corpus ?? {};
+  const globals = (corpus.globals ?? []).map(normalizeComp);
+  const views = (corpus.views ?? []).map((v) => ({
+    name: v.name,
+    route: v.route,
+    components: (v.components ?? []).map(normalizeComp),
+  }));
+  const total =
+    globals.length + views.reduce((s, v) => s + v.components.length, 0);
+  // An empty corpus means the server answered before its corpus finished loading
+  // (or a degraded proxy delivered a stripped payload). Do NOT cache it or record
+  // its version — leave state untouched so pollVersion keeps retrying instead of
+  // sticking on an empty overlay for the life of the page.
+  if (total === 0) return false;
+  state.globals = globals;
+  state.views = views;
+  state.version = data.version;
+  console.log(
+    `[sightmap] loaded ${total} components from ${data.site} v${data.version}`,
+  );
+  chrome.runtime
+    .sendMessage({
+      type: "sightmap-loaded",
+      version: data.version,
+      site: data.site,
+      componentCount: total,
+    })
+    .catch(() => {});
+  return true;
+}
+
 async function pollVersion() {
-  if (!state.version) {
-    // Initial fetch failed (server not yet ready, or service worker was sleeping).
-    // Retry until it succeeds.
+  // Keep retrying until we have a non-empty corpus. state.version is only set
+  // once a load succeeded WITH components, so this also covers the "server
+  // answered empty at startup" case that used to stick permanently.
+  if (!state.version || !state.globals.length) {
     await fetchSightmap();
     return;
   }
   try {
-    const resp = await bgFetch("fetch-sightmap-version");
-    const v = resp.version;
+    const v = await fetchVersionValue();
     if (v !== state.version) {
       console.log(
         `[sightmap] version changed (${state.version} → ${v}), reloading`,

--- a/go/cmd/sightmap/extension/manifest.json
+++ b/go/cmd/sightmap/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sightmap Overlay",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Component path overlay and structured event log for sightmap-instrumented pages.",
 
   "permissions": ["storage", "activeTab", "scripting", "devtools", "sidePanel"],


### PR DESCRIPTION
## Problem

The Sightmap Overlay extension renders **0 components** on pages whose corpus the sightmap server serves correctly. `sightmap snapshot` is unaffected.

Root cause, established by instrumenting every layer against a live app:

- In a **single correlated page load**, the extension's service worker **fetches `/sightmap` and receives the full corpus (18 globals + 10 view components)**, yet the content script logs `loaded 0 components` for that same load. The corpus is lost across the `chrome.runtime.sendMessage("fetch-sightmap")` round-trip between `background.js` and `content.js` on a cold / just-woken MV3 worker.
- The failure **sticks for the life of the page**: `version` is a constant per server-instance, so `pollVersion` never refetches, and an open side panel keeps the worker alive so nothing resets. Hard-refresh and extension-reload do not recover it.
- Ruled out: server race (cold tight-poll never saw an empty corpus; the SW itself receives the full corpus), HTTP cache (no cache headers; `no-store` identical), request origin/encoding, side-panel concurrency, foreign-corpus discovery, and content-script non-injection.

## Fix

- The content script now fetches `http://localhost:PORT/sightmap` **directly** on http-origin pages. `host_permissions` already grants `http://localhost:*` and the server sends `Access-Control-Allow-Origin: *`, so the cross-port fetch is allowed. The background service-worker proxy is kept only as an **https mixed-content fallback**.
- `fetchSightmap` treats an **empty corpus as "not loaded"**: it doesn't cache it or record its version, and `pollVersion` refetches while the corpus is empty — so a bad first fetch self-heals instead of sticking.
- Extension manifest bumped `0.1.18 → 0.1.19`.

## Verification

Against a local app, loading the extension from this branch:

- Content script now logs `loaded 28 components` (was `loaded 0`).
- Hovering a card renders the overlay boxes + tooltip with extracted properties (`[MenuCard itemName="…" price="…"]`).
- `prettier --check` clean; `go test ./cmd/sightmap` (Extension/Manifest/Snapshot) passes.
- Plain `sightmap browser start` (embedded extension) re-extracts `0.1.19` and loads the full corpus.

## Follow-ups (not in this PR)

Lower-priority hardening tracked separately: derive the corpus `version` from content/mtime (defense-in-depth), add a corpus-identity check to the extension's `7891–7900` server discovery, and reap leaked `browser start` daemons on abnormal exit.
