### PR TITLE
render: keep visible descendants of an invisible ancestor (fix empty tree)

### DIFF
--- a/.changeset/render-invisible-subtree.md
+++ b/.changeset/render-invisible-subtree.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `snapshot`/`capture` rendering an empty component tree when the page root (or any ancestor) is reported invisible. `render.Filter` dropped an entire subtree at the first `IsVisible=false` node, but a zero-size or `visibility:hidden` ancestor — notably the document `<html>` root, which reports height 0 / ignored — can have fully visible descendants, so the whole annotated tree vanished even though coverage still counted the visible nodes. Invisible nodes are now made transparent (the node itself is omitted, visible descendants survive); a genuinely hidden `display:none` subtree still renders nothing, keeping render in lockstep with coverage.

--- a/go/render/render.go
+++ b/go/render/render.go
@@ -174,12 +174,19 @@ func decide(node *sightmap.ComponentNode, matched bool) disposition {
 		}
 	}
 
-	// Drop invisible subtrees entirely. IsVisible is effective visibility
-	// (probe.js consults the browser's style engine, so ancestor-hidden nodes
-	// like a closed opacity:0 menu's items are already false), so this keeps the
-	// rendered tree in lockstep with coverage, which skips the same nodes.
+	// An invisible node doesn't render itself, but must NOT drop its subtree:
+	// visibility is overridable (a `visibility:hidden` ancestor can hold
+	// `visibility:visible` descendants) and a zero-size wrapper — notably the
+	// document <html> root, which probe.js reports as height 0 / ignored — has
+	// fully visible content beneath it. `display:none` is the case the old
+	// dropNode was really guarding, and probe.js already propagates that to
+	// descendants as effective invisibility, so they arrive here invisible too.
+	// Making the node transparent (recurse, drop only the node itself) handles
+	// both: a genuinely hidden subtree renders nothing (every node transparent),
+	// while visible descendants of an invisible ancestor survive — which keeps the
+	// tree in lockstep with coverage, which counts those same visible nodes.
 	if !node.IsVisible {
-		return dropNode
+		return makeTransparent
 	}
 
 	// Transparent: structural "none" role wrapper without sightmap identity.

--- a/go/render/render_test.go
+++ b/go/render/render_test.go
@@ -2,9 +2,10 @@ package render
 
 import (
 	"bytes"
-	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // node builds a ComponentNode for use in tests.
@@ -40,15 +41,37 @@ func TestFilter_Drop_Invisible(t *testing.T) {
 	}
 }
 
-// Invisible subtrees are dropped regardless of interactivity, so the rendered
-// tree stays in lockstep with coverage (which skips the same nodes). probe.js
-// reports effective visibility, so an interactive control hidden by an ancestor
-// (e.g. a closed opacity:0 menu's item) arrives here as invisible and must not
-// appear.
+// An invisible node with no visible descendants renders nothing: it is made
+// transparent (the node itself is dropped) and has nothing to promote. probe.js
+// reports effective visibility, so an interactive control hidden by display:none
+// (e.g. a closed menu's item) arrives here invisible with invisible children and
+// must not appear — keeping the tree in lockstep with coverage, which skips the
+// same nodes. (Contrast TestFilter_InvisibleAncestor_KeepsVisibleDescendant,
+// where an invisible ancestor DOES have visible descendants.)
 func TestFilter_Drop_InvisibleInteractive(t *testing.T) {
 	root := node("1", "button", "Hidden", false /* visible */, true /* interactive */, false)
 	if comp := Filter(root, nil); comp != nil {
-		t.Errorf("expected nil for invisible interactive node, got role=%q", comp.Role)
+		t.Errorf("expected nil for invisible interactive leaf, got role=%q", comp.Role)
+	}
+}
+
+// TestFilter_InvisibleAncestor_KeepsVisibleDescendant guards the fix for an
+// invisible ancestor that nonetheless has VISIBLE descendants — the zero-height
+// <html> document root (probe.js reports it height 0 / ignored), or a
+// visibility:hidden wrapper whose child overrides it with visibility:visible.
+// The ancestor is made transparent (dropped as a node), but its visible child
+// must survive; the whole subtree must NOT vanish (the bug this fixes: an
+// invisible root dropped the entire rendered tree while coverage still counted
+// the visible descendants).
+func TestFilter_InvisibleAncestor_KeepsVisibleDescendant(t *testing.T) {
+	child := node("2", "button", "Add", true /* visible */, true /* interactive */, false)
+	root := node("1", "none", "", false /* visible */, false, false, child)
+	comp := Filter(root, nil)
+	if comp == nil {
+		t.Fatal("expected the visible descendant to survive an invisible ancestor, got nil")
+	}
+	if comp.Role != "button" || comp.Name != "Add" {
+		t.Errorf("expected surviving role=button name=Add, got role=%q name=%q", comp.Role, comp.Name)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes `snapshot`/`capture` rendering an **empty component tree** when the page root (or any ancestor) is reported invisible. `render.Filter`'s `decide()` dropped the entire subtree at the first `IsVisible=false` node — but a zero-size or `visibility:hidden` ancestor (notably the document `<html>` root, which probe.js reports as height 0 / ignored) can have fully visible descendants. So the whole annotated tree vanished even though `[Coverage]` still counted the visible nodes.

Invisible nodes are now made **transparent** (the node itself is omitted; visible descendants survive). A genuinely hidden `display:none` subtree still renders nothing (probe.js already propagates that to descendants as effective invisibility), keeping render in lockstep with coverage.

## Why

On Salesforce Lightning the `<html>`/shell wrappers report invisible, so the annotated tree came back blank for every matched view — the authoring loop's most-used output was unusable (authors had to QA property values through repeated `wait-for --component` probes instead of reading them inline).

## Notes

- Recovered work: this is the fix originally authored as `1e47e30` that landed on an internal integration branch but never reached `main`.
- `render_test.go` updated; `go test ./render/...` green. Changeset included (`patch`).
