### PR TITLE
Authoring efficacy: generalized discovery, explain, honest coverage

### DIFF
--- a/.changeset/authoring-efficacy.md
+++ b/.changeset/authoring-efficacy.md
@@ -1,0 +1,10 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Authoring efficacy on hook-poor DOMs (Salesforce Lightning, Angular, framework-generated markup):
+
+- **Generalized selector-candidate generation.** `gap` and `suggest` no longer dead-end when a DOM has no `data-testid`/`data-component`. Candidate generation now ranks custom-element tags, design-system classes, ids, other stable `data-*`, and `name`/`href`/`aria` hooks (data-attributes remain the top-ranked input, not an override), dropping only clearly machine-generated tokens. `gap` also emits a container hook on the hook-poor path.
+- **New `explain` command.** Node-first inspection: pick nodes by selector, `--id`, or `--grep` (role/name) — live or offline via `--snap` — and dump each node's facts, ranked selector candidates, coverage tier + owning component, and ancestor hooks. Shadow-transparent (matches the offline matcher), so authors no longer hand-read `*.snap.tree.json`.
+- **Honest coverage.** `snapshot --coverage` and `gap` now warn when a clean "0 orphaned" pass is carried entirely by global (chrome) components — i.e. the current view modeled nothing and the pass reflects a global backstop rather than a real view.
+- **Authoring skill:** a second mandatory property rule requires a per-instance discriminator on any component whose selector matches more than one instance, so repeated cards/rows/tabs stay individually addressable; plus `explain` documentation.

--- a/go/authoring/scan.js
+++ b/go/authoring/scan.js
@@ -54,10 +54,25 @@ function __smCandidateWorthy(el) {
   return ["a", "button", "input", "select", "textarea"].includes(tag);
 }
 
+// __smHrefSuffix mirrors coverage.hrefSuffix (Go): the portable, stable
+// trailing path segment of an href, "" when the tail is dynamic/hashed.
+function __smHrefSuffix(href) {
+  let h = href;
+  const cut = h.search(/[?#]/);
+  if (cut >= 0) h = h.slice(0, cut);
+  h = h.replace(/\/+$/, "");
+  const slash = h.lastIndexOf("/");
+  if (slash < 0) return "";
+  const seg = h.slice(slash + 1);
+  if (!seg || __smLooksHashed(seg)) return "";
+  return "/" + seg;
+}
+
 // __smBestHook returns the single strongest stable selector for el, or "".
-// Priority mirrors coverage.SelectorCandidates (Go): data-* hooks lead but are
-// one input, not an override — a custom-element tag, stable id, form name, or
-// design-system class is surfaced when no data-attr exists.
+// A best-effort single pick, not the full ranked list coverage.SelectorCandidates
+// (Go) returns — but the same hooks, roughly by the same priority: data-* leads
+// but is one input, falling through to custom-element tag, stable id, form name,
+// other stable data-*, design-system class, href, then aria-label.
 function __smBestHook(el) {
   const tag = el.tagName.toLowerCase();
   const dt = el.getAttribute("data-testid");
@@ -70,6 +85,17 @@ function __smBestHook(el) {
   if (id && !__smLooksHashed(id) && !/\d+$/.test(id)) return "#" + id;
   const name = el.getAttribute("name");
   if (name && !__smLooksHashed(name)) return tag + '[name="' + name + '"]';
+  for (const attr of el.attributes) {
+    if (
+      attr.name.startsWith("data-") &&
+      attr.name !== "data-testid" &&
+      attr.name !== "data-component" &&
+      attr.value &&
+      !__smLooksHashed(attr.value)
+    ) {
+      return "[" + attr.name + '="' + attr.value + '"]';
+    }
+  }
   let utility = "";
   for (const cls of el.classList) {
     if (!cls || __smLooksHashed(cls)) continue;
@@ -80,6 +106,11 @@ function __smBestHook(el) {
     return tag + "." + cls; // first specific class wins
   }
   if (utility) return utility;
+  const href = el.getAttribute("href");
+  if (href) {
+    const suf = __smHrefSuffix(href);
+    if (suf) return 'a[href$="' + suf + '"]';
+  }
   const al = el.getAttribute("aria-label");
   if (al && !__smLooksHashed(al) && al.length <= 40)
     return tag + '[aria-label="' + al + '"]';

--- a/go/authoring/scan.js
+++ b/go/authoring/scan.js
@@ -1,57 +1,115 @@
 // Live-DOM discovery scans used while building a corpus. Depends on
 // __smDeepQueryAll from browser/deepquery.js being prepended.
 
+// __smLooksHashed mirrors coverage.looksHashed (Go): a token is machine-generated
+// / per-instance (aura ids, hashed classnames, uuids, emotion/styled suffixes)
+// rather than a stable authored hook. Keep the two in sync.
+function __smLooksHashed(tok) {
+  if (!tok) return true;
+  if (/[:;$]/.test(tok)) return true; // aura ids "1:1;a", scoped "$x"
+  if (/[0-9]{4,}/.test(tok)) return true; // counters/timestamps
+  if (/[0-9a-fA-F]{8,}/.test(tok)) return true; // hashes/uuids
+  for (const seg of tok.split(/[-_]/)) {
+    // word-<hash>: >=6 chars mixing letters with several digits
+    if (
+      seg.length >= 6 &&
+      /[a-zA-Z]/.test(seg) &&
+      (seg.match(/[0-9]/g) || []).length >= 2
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const __smUtilityClasses = new Set([
+  "active",
+  "open",
+  "closed",
+  "hidden",
+  "show",
+  "hide",
+  "selected",
+  "disabled",
+  "visible",
+  "container",
+  "row",
+  "col",
+  "wrapper",
+  "content",
+  "clearfix",
+  "sr-only",
+]);
+
+// __smCandidateWorthy limits the scan to elements likely to be a nameable
+// component — controls, landmarks, custom elements, or data-attr-bearing nodes —
+// so pure layout wrappers don't flood the output.
+function __smCandidateWorthy(el) {
+  const tag = el.tagName.toLowerCase();
+  if (el.hasAttribute("data-testid") || el.hasAttribute("data-component"))
+    return true;
+  if (tag.includes("-")) return true; // custom element
+  if (el.hasAttribute("role")) return true;
+  if (el.hasAttribute("aria-label")) return true;
+  return ["a", "button", "input", "select", "textarea"].includes(tag);
+}
+
+// __smBestHook returns the single strongest stable selector for el, or "".
+// Priority mirrors coverage.SelectorCandidates (Go): data-* hooks lead but are
+// one input, not an override — a custom-element tag, stable id, form name, or
+// design-system class is surfaced when no data-attr exists.
+function __smBestHook(el) {
+  const tag = el.tagName.toLowerCase();
+  const dt = el.getAttribute("data-testid");
+  if (dt && !__smLooksHashed(dt)) return '[data-testid="' + dt + '"]';
+  const dc = el.getAttribute("data-component");
+  if (dc)
+    return '[data-component^="' + dc.replace(/:v\d+\.\d+\.\d+.*$/, "") + '"]';
+  if (tag.includes("-")) return tag; // custom element — stable and semantic
+  const id = el.id;
+  if (id && !__smLooksHashed(id) && !/\d+$/.test(id)) return "#" + id;
+  const name = el.getAttribute("name");
+  if (name && !__smLooksHashed(name)) return tag + '[name="' + name + '"]';
+  let utility = "";
+  for (const cls of el.classList) {
+    if (!cls || __smLooksHashed(cls)) continue;
+    if (__smUtilityClasses.has(cls)) {
+      if (!utility) utility = tag + "." + cls;
+      continue;
+    }
+    return tag + "." + cls; // first specific class wins
+  }
+  if (utility) return utility;
+  const al = el.getAttribute("aria-label");
+  if (al && !__smLooksHashed(al) && al.length <= 40)
+    return tag + '[aria-label="' + al + '"]';
+  return "";
+}
+
 function __smScanCandidates(max) {
   const results = {};
-  const selectors = [
-    "[data-testid]",
-    "[data-component]",
-    "[aria-label][role]",
-    '[role="navigation"]',
-    '[role="search"]',
-    '[role="banner"]',
-    '[role="main"]',
-    '[role="complementary"]',
-    '[role="contentinfo"]',
-    '[role="dialog"]',
-    '[role="alertdialog"]',
-    '[role="tablist"]',
-    '[role="tab"]',
-    '[role="tabpanel"]',
-  ];
-  for (const sel of selectors) {
-    const els = __smDeepQueryAll(document, sel);
-    for (const el of els) {
-      let candidate = "";
-      const dt = el.getAttribute("data-testid");
-      const dc = el.getAttribute("data-component");
-      const role = el.getAttribute("role") || el.tagName.toLowerCase();
-      const tag = el.tagName.toLowerCase();
-      const text = el.textContent.trim().replace(/\s+/g, " ").slice(0, 60);
-      if (dt) {
-        candidate = '[data-testid="' + dt + '"]';
-      } else if (dc) {
-        const base = dc.replace(/:v\d+\.\d+\.\d+.*$/, "");
-        candidate = '[data-component^="' + base + '"]';
-      } else {
-        continue;
-      }
-      if (!results[candidate]) {
-        const ancestorEl = el.closest("[data-sightmap-id]");
-        const ancestorId = ancestorEl
-          ? ancestorEl.getAttribute("data-sightmap-id")
-          : "";
-        results[candidate] = {
-          sel: candidate,
-          count: 0,
-          role,
-          tag,
-          sample: text,
-          ancestorId,
-        };
-      }
-      results[candidate].count++;
+  for (const el of __smDeepQueryAll(document, "*")) {
+    if (!__smCandidateWorthy(el)) continue;
+    const candidate = __smBestHook(el);
+    if (!candidate) continue;
+    const role = el.getAttribute("role") || el.tagName.toLowerCase();
+    const tag = el.tagName.toLowerCase();
+    const text = el.textContent.trim().replace(/\s+/g, " ").slice(0, 60);
+    if (!results[candidate]) {
+      const ancestorEl = el.closest("[data-sightmap-id]");
+      const ancestorId = ancestorEl
+        ? ancestorEl.getAttribute("data-sightmap-id")
+        : "";
+      results[candidate] = {
+        sel: candidate,
+        count: 0,
+        role,
+        tag,
+        sample: text,
+        ancestorId,
+      };
     }
+    results[candidate].count++;
   }
   return Object.values(results)
     .sort((a, b) => b.count - a.count)

--- a/go/authoring/scan.test.js
+++ b/go/authoring/scan.test.js
@@ -97,6 +97,26 @@ describe("__smScanCandidates", () => {
     const candidates = __smScanCandidates(10);
     expect(candidates).toEqual([]);
   });
+
+  test("falls back to another stable data-* attr", () => {
+    document.body.innerHTML = `<a data-target-selection-name="Home"></a>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map((c) => c.sel)).toContain(
+      '[data-target-selection-name="Home"]',
+    );
+  });
+
+  test("falls back to a portable href suffix", () => {
+    document.body.innerHTML = `<a href="https://x.example.com/lightning/page/home?foo=1"></a>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map((c) => c.sel)).toContain('a[href$="/home"]');
+  });
+
+  test("drops a dynamic href tail, emitting no candidate", () => {
+    document.body.innerHTML = `<a href="/lightning/r/Account/001A000001abcdefg"></a>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates).toEqual([]);
+  });
 });
 
 describe("__smScanLinks", () => {

--- a/go/authoring/scan.test.js
+++ b/go/authoring/scan.test.js
@@ -65,6 +65,38 @@ describe("__smScanCandidates", () => {
     const [candidate] = __smScanCandidates(10);
     expect(candidate.ancestorId).toBe("42");
   });
+
+  test("emits a custom-element tag candidate (no data-attr needed)", () => {
+    document.body.innerHTML = `<one-appnav></one-appnav><one-appnav></one-appnav>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates).toEqual([
+      expect.objectContaining({ sel: "one-appnav", count: 2 }),
+    ]);
+  });
+
+  test("emits a design-system class candidate for a control", () => {
+    document.body.innerHTML = `<button class="refreshButton"></button>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map((c) => c.sel)).toContain("button.refreshButton");
+  });
+
+  test("drops a hashed class, emitting no candidate", () => {
+    document.body.innerHTML = `<button class="lwc-1a2b3c4d"></button>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates).toEqual([]);
+  });
+
+  test("falls back to an aria-label hook for a landmark", () => {
+    document.body.innerHTML = `<div role="navigation" aria-label="Main"></div>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map((c) => c.sel)).toContain('div[aria-label="Main"]');
+  });
+
+  test("ignores pure layout wrappers (not candidate-worthy)", () => {
+    document.body.innerHTML = `<div class="slds-grid"><div class="slds-col"></div></div>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates).toEqual([]);
+  });
 });
 
 describe("__smScanLinks", () => {

--- a/go/cmd/sightmap/cmd_explain.go
+++ b/go/cmd/sightmap/cmd_explain.go
@@ -1,0 +1,290 @@
+// explain answers "what is this node, and how is it covered?" for one or a few
+// nodes picked out of the component tree — by CSS selector, by tree node id, or
+// by an accessible-name/role substring. For each it prints the node's raw facts
+// (tag/id/classes/attrs), ranked stable selector candidates, its coverage tier
+// and owning component, and its ancestor chain with each ancestor's best hook.
+//
+// It fills the node-first gap left by sel-probe (which is selector-first): when
+// you've spotted a node in a captured *.snap.tree.json but don't yet have a
+// selector, `explain --snap tree.json --grep Refresh` (or --id) dumps exactly the
+// facts you'd otherwise hand-walk the JSON for. Works live (default) or offline
+// against a captured tree via --snap.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/sightmap/sightmap/go/browser"
+	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+	"github.com/sightmap/sightmap/go/viewset"
+)
+
+func runExplain(args []string) error {
+	fs := flag.NewFlagSet("explain", flag.ContinueOnError)
+	lf := addLiveFlags(fs, "explain")
+	snapFlag := fs.String("snap", "", "Inspect a captured tree offline (path to a .snap or .snap.tree.json) instead of the live page")
+	idFlag := fs.String("id", "", "Select the node with this tree id")
+	grepFlag := fs.String("grep", "", "Select nodes whose role or accessible name contains this substring (case-insensitive)")
+	maxN := fs.Int("max", 10, "Max nodes to explain")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: explain [flags] [selector]\n\n")
+		fmt.Fprintf(os.Stderr, "Pick nodes by a CSS selector (positional), --id, or --grep, then dump each\n")
+		fmt.Fprintf(os.Stderr, "node's facts, selector candidates, coverage tier + owning component, and\n")
+		fmt.Fprintf(os.Stderr, "ancestor hooks. Live by default; --snap FILE inspects a captured tree.\n\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var selector string
+	if rest := fs.Args(); len(rest) == 1 {
+		selector = rest[0]
+	} else if len(rest) > 1 {
+		return fmt.Errorf("explain: expected at most one selector argument, got %d", len(rest))
+	}
+	if selector == "" && *idFlag == "" && *grepFlag == "" {
+		fs.Usage()
+		return fmt.Errorf("explain: choose nodes with a selector, --id, or --grep")
+	}
+
+	// ── Acquire the tree + matches (offline via --snap, else live) ────────────
+	var (
+		root    *sightmap.ComponentNode
+		matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch
+	)
+	corpus, cErr := lf.loadCorpus()
+	if cErr != nil {
+		fmt.Fprintf(os.Stderr, "explain: load corpus: %v (continuing without tier/owner)\n", cErr)
+	}
+
+	if *snapFlag != "" {
+		r, m, err := loadCapturedTree(*snapFlag, corpus)
+		if err != nil {
+			return err
+		}
+		root, matches = r, m
+	} else {
+		ctx := context.Background()
+		conn, cleanup, err := lf.connect(ctx)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		if err := lf.navigate(ctx, conn, navOpts{minWait: 0.5}); err != nil {
+			return err
+		}
+		pageURL, _ := browser.GetURL(ctx, conn)
+		page, err := conn.DefaultPage()
+		if err != nil {
+			return fmt.Errorf("explain: default page: %v", err)
+		}
+		root, err = browser.ExtractComponents(ctx, page)
+		if err != nil {
+			return fmt.Errorf("explain: extract components: %v", err)
+		}
+		if corpus != nil {
+			matches = match.NewMatcher(corpus).Match(root, pageURL)
+		}
+	}
+
+	parentMap := coverage.BuildParentMap(root)
+	selected := selectExplainNodes(root, selector, *idFlag, *grepFlag, *maxN)
+	if len(selected) == 0 {
+		fmt.Println("no matching nodes")
+		return nil
+	}
+
+	for i, n := range selected {
+		if i > 0 {
+			fmt.Println()
+		}
+		printExplainNode(n, matches, parentMap)
+	}
+	return nil
+}
+
+// loadCapturedTree reads a captured tree (accepting either the .snap or the
+// .snap.tree.json path) and matches it against the corpus using the capture's own
+// route header when available (globals-only otherwise).
+func loadCapturedTree(arg string, corpus *sightmap.Corpus) (*sightmap.ComponentNode, map[*sightmap.ComponentNode]*sightmap.ComponentMatch, error) {
+	treeFile := arg
+	if !strings.HasSuffix(treeFile, ".tree.json") {
+		treeFile = arg + ".tree.json"
+	}
+	data, err := os.ReadFile(treeFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("explain: read %s: %v", treeFile, err)
+	}
+	root := &sightmap.ComponentNode{}
+	if err := json.Unmarshal(data, root); err != nil {
+		return nil, nil, fmt.Errorf("explain: parse %s: %v", treeFile, err)
+	}
+	var matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch
+	if corpus != nil {
+		route := ""
+		if snapPath := strings.TrimSuffix(treeFile, ".tree.json"); snapPath != treeFile {
+			if _, statErr := os.Stat(snapPath); statErr == nil {
+				route = viewset.RouteOf(snapPath)
+			}
+		}
+		matches = match.NewMatcher(corpus).Match(root, route)
+	}
+	return root, matches, nil
+}
+
+// selectExplainNodes resolves the node selection (selector | --id | --grep) into
+// tree-ordered nodes, capped at max.
+func selectExplainNodes(root *sightmap.ComponentNode, selector, id, grep string, max int) []*sightmap.ComponentNode {
+	var matchSet map[*sightmap.ComponentNode]bool
+	if selector != "" {
+		defs := []sightmap.ComponentDef{{Name: "__explain__", Selectors: []string{selector}}}
+		m := match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs}).Match(root, "")
+		matchSet = make(map[*sightmap.ComponentNode]bool, len(m))
+		for n := range m {
+			matchSet[n] = true
+		}
+	}
+	grepLC := strings.ToLower(grep)
+
+	var out []*sightmap.ComponentNode
+	sightmap.Walk(root, func(n *sightmap.ComponentNode, _ int) bool {
+		if len(out) >= max {
+			return false
+		}
+		switch {
+		case id != "":
+			if n.Id == id {
+				out = append(out, n)
+			}
+		case selector != "":
+			if matchSet[n] {
+				out = append(out, n)
+			}
+		case grep != "":
+			if strings.Contains(strings.ToLower(n.Role), grepLC) || strings.Contains(strings.ToLower(n.Name), grepLC) {
+				out = append(out, n)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// printExplainNode dumps one node's facts, candidates, tier/owner, and ancestors.
+func printExplainNode(
+	n *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	parentMap map[*sightmap.ComponentNode]*sightmap.ComponentNode,
+) {
+	fmt.Printf("%s  #%s\n", elementDescOf(n.Element), n.Id)
+	if n.Role != "" || n.Name != "" {
+		fmt.Printf("    role/name: %s %q\n", nonEmpty(n.Role, "?"), n.Name)
+	}
+	flags := []string{}
+	if n.IsInteractive {
+		flags = append(flags, "interactive")
+	}
+	if !n.IsVisible {
+		flags = append(flags, "hidden")
+	}
+	if n.IsIgnored {
+		flags = append(flags, "ignored")
+	}
+	if len(flags) > 0 {
+		fmt.Printf("    flags: %s\n", strings.Join(flags, ", "))
+	}
+	if n.Element != nil && len(n.Element.Attrs) > 0 {
+		var parts []string
+		for k, v := range n.Element.Attrs {
+			if k == "id" || k == "class" {
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("%s=%q", k, v))
+		}
+		if len(parts) > 0 {
+			sort.Strings(parts)
+			fmt.Printf("    attrs: %s\n", strings.Join(parts, "  "))
+		}
+	}
+
+	// Coverage tier + owning component.
+	tier, owner := tierAndOwner(n, matches, parentMap)
+	if matches != nil {
+		line := "    coverage: " + tier
+		if owner != "" {
+			line += "  ← [" + owner + "]"
+		}
+		fmt.Println(line)
+	}
+
+	// Ranked selector candidates for THIS node.
+	if cands := coverage.SelectorCandidates(n.Element); len(cands) > 0 {
+		fmt.Printf("    candidates: %s\n", strings.Join(cands, "  ·  "))
+	}
+
+	// Ancestor chain with each ancestor's best hook + owning component.
+	var anc []string
+	depth := 0
+	for p := parentMap[n]; p != nil && depth < 6; p = parentMap[p] {
+		desc := elementDescOf(p.Element)
+		if cands := coverage.SelectorCandidates(p.Element); len(cands) > 0 {
+			desc += "  {" + cands[0] + "}"
+		}
+		if m := matches[p]; m != nil {
+			desc += "  ← [" + m.Name + "]"
+		}
+		anc = append(anc, desc)
+		depth++
+	}
+	if len(anc) > 0 {
+		fmt.Printf("    ancestors:\n")
+		for _, a := range anc {
+			fmt.Printf("      %s\n", a)
+		}
+	}
+}
+
+// tierAndOwner classifies a node as T1/T2/T3 and names its owning component (the
+// node's own match for T1, the nearest matched ancestor for T2).
+func tierAndOwner(
+	n *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	parentMap map[*sightmap.ComponentNode]*sightmap.ComponentNode,
+) (tier, owner string) {
+	if m := matches[n]; m != nil {
+		return "T1 (direct)", m.Name
+	}
+	for p := parentMap[n]; p != nil; p = parentMap[p] {
+		if m := matches[p]; m != nil {
+			return "T2 (scoped)", m.Name
+		}
+	}
+	return "T3 (orphan)", ""
+}
+
+// elementDescOf formats an element's identity as tag#id.class1.class2, or its
+// role when there is no underlying element.
+func elementDescOf(el *sightmap.Element) string {
+	if el == nil {
+		return "(no element)"
+	}
+	return elementDesc(el.Tag, el.Id, el.Classes)
+}
+
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/go/cmd/sightmap/cmd_explain_test.go
+++ b/go/cmd/sightmap/cmd_explain_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sightmap/sightmap/go/coverage"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func explainFixture() (root, nav, btn *sightmap.ComponentNode) {
+	btn = &sightmap.ComponentNode{
+		Id:            "b1",
+		Role:          "button",
+		Name:          "Refresh",
+		IsInteractive: true,
+		IsVisible:     true,
+		Element:       &sightmap.Element{Tag: "button", Classes: []string{"refreshButton"}},
+	}
+	nav = &sightmap.ComponentNode{
+		Id:       "n1",
+		Role:     "navigation",
+		Element:  &sightmap.Element{Tag: "one-appnav"},
+		Children: []*sightmap.ComponentNode{btn},
+	}
+	root = &sightmap.ComponentNode{
+		Id:       "root",
+		Element:  &sightmap.Element{Tag: "div"},
+		Children: []*sightmap.ComponentNode{nav},
+	}
+	return root, nav, btn
+}
+
+func TestSelectExplainNodes(t *testing.T) {
+	root, nav, btn := explainFixture()
+
+	if got := selectExplainNodes(root, "", "b1", "", 10); len(got) != 1 || got[0] != btn {
+		t.Errorf("--id b1: got %v, want [btn]", got)
+	}
+	if got := selectExplainNodes(root, "", "", "refresh", 10); len(got) != 1 || got[0] != btn {
+		t.Errorf("--grep refresh: got %v, want [btn] (case-insensitive on name)", got)
+	}
+	if got := selectExplainNodes(root, "one-appnav", "", "", 10); len(got) != 1 || got[0] != nav {
+		t.Errorf("selector one-appnav: got %v, want [nav]", got)
+	}
+	if got := selectExplainNodes(root, "", "", "nomatch", 10); len(got) != 0 {
+		t.Errorf("--grep nomatch: got %v, want []", got)
+	}
+}
+
+func TestSelectExplainNodes_RespectsMax(t *testing.T) {
+	// Two buttons under nav; --max 1 returns only the first in tree order.
+	root, nav, _ := explainFixture()
+	btn2 := &sightmap.ComponentNode{Id: "b2", Role: "button", Name: "Refresh again", IsInteractive: true, Element: &sightmap.Element{Tag: "button"}}
+	nav.Children = append(nav.Children, btn2)
+	if got := selectExplainNodes(root, "", "", "refresh", 1); len(got) != 1 {
+		t.Errorf("--max 1: got %d nodes, want 1", len(got))
+	}
+}
+
+func TestTierAndOwner(t *testing.T) {
+	root, nav, btn := explainFixture()
+	pm := coverage.BuildParentMap(root)
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
+		nav: {Name: "NavBar"},
+	}
+
+	if tier, owner := tierAndOwner(nav, matches, pm); tier != "T1 (direct)" || owner != "NavBar" {
+		t.Errorf("nav: got (%q,%q), want T1/NavBar", tier, owner)
+	}
+	if tier, owner := tierAndOwner(btn, matches, pm); tier != "T2 (scoped)" || owner != "NavBar" {
+		t.Errorf("btn: got (%q,%q), want T2/NavBar", tier, owner)
+	}
+	// With no matches at all, everything is an orphan.
+	if tier, _ := tierAndOwner(btn, map[*sightmap.ComponentNode]*sightmap.ComponentMatch{}, pm); tier != "T3 (orphan)" {
+		t.Errorf("btn no-matches: got %q, want T3", tier)
+	}
+}

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/sightmap/sightmap/go/sightmap"
 	"sort"
+	"strings"
 
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/coverage"
 	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func runGap(args []string) error {
@@ -250,9 +251,36 @@ func runGap(args []string) error {
 		fmt.Printf("  %d\u00d7 %s %s\n", len(g.nodes), key.role, nameDisp)
 		fmt.Printf("       inside: %s\n", g.ancestorDesc)
 
-		// Build arrow hint from the representative node.
-		if hint := coverage.ArrowHint(rep, parentMap); hint != "" {
-			fmt.Printf("       \u2192 %s\n", hint)
+		// Ranked selector candidates for the representative node. The strict
+		// data-attr hint (ArrowHint) leads when present; SelectorCandidates fills in
+		// the custom-element / design-system-class / id / attr hooks that make gap
+		// useful on hook-poor DOMs (where ArrowHint returns "").
+		strictHint := coverage.ArrowHint(rep, parentMap)
+		var hints []string
+		seenHint := map[string]bool{}
+		addHint := func(h string) {
+			if h == "" || seenHint[h] {
+				return
+			}
+			seenHint[h] = true
+			hints = append(hints, h)
+		}
+		addHint(strictHint)
+		for _, c := range coverage.SelectorCandidates(rep.Element) {
+			addHint(c)
+		}
+		if len(hints) > 3 {
+			hints = hints[:3]
+		}
+		if len(hints) > 0 {
+			fmt.Printf("       \u2192 %s\n", strings.Join(hints, "  \u00b7  "))
+		}
+		// When there was no strict data-attr hint (a hook-poor DOM), also surface a
+		// container hook so the leaf candidate can be scoped for uniqueness.
+		if strictHint == "" {
+			if _, anc := coverage.NearestHookAncestor(rep, parentMap); anc != "" {
+				fmt.Printf("       container: %s\n", anc)
+			}
 		}
 		fmt.Println()
 	}

--- a/go/cmd/sightmap/cmd_gap.go
+++ b/go/cmd/sightmap/cmd_gap.go
@@ -161,6 +161,13 @@ func runGap(args []string) error {
 			fmt.Printf("✓ No T2 gaps in [%s]\n", *scopeFlag)
 		} else {
 			fmt.Println("✓ no orphaned interactive nodes")
+			// Chrome-only guard: no hard orphans, but if every covered node is
+			// scoped only by GLOBAL (chrome) components the page isn't modeled by a
+			// view — "no orphaned" just reflects a broad global backstop. Mirror the
+			// snapshot/coverage advisory so gap doesn't show a false green (a11e.9).
+			if len(matches) > 0 && coverage.ViewScopedMatchCount(matches, corpus.GlobalComponentNames()) == 0 {
+				fmt.Println("⚠ but every covered node is scoped only by global (chrome) components — this page isn't modeled by a view. Model the view's own content before treating this as complete.")
+			}
 		}
 		return nil
 	}

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -44,6 +44,8 @@ func main() {
 		err = runBrowser(args)
 	case "inspect":
 		err = runInspect(args)
+	case "explain":
+		err = runExplain(args)
 	case "snapshot":
 		err = runSnapshot(args)
 	case "capture":
@@ -124,6 +126,7 @@ Commands:
   snapshot       [--url URL] [--coverage] [--out FILE] [--sightmap-dir DIR]  observe: annotated component tree + coverage
   capture        [--url URL] [--all] [--force] [--sightmap-dir DIR]  persist a capture into the matched view's set
   inspect        [--url URL] [--out FILE] [--sightmap-dir DIR]  raw DOM tree for selector authoring
+  explain        [--snap FILE] [--id ID | --grep STR | SELECTOR] [--sightmap-dir DIR]  one node's facts, candidates, tier + owner, ancestors
   coverage       [--sightmap-dir DIR] [FILE.snap ...]            offline T1/T2/T3 check
   multi-coverage [--sightmap-dir DIR] [FILE.snap ...]            cross-page coverage matrix
   capture-novelty [--sightmap-dir DIR] FILE.snap               does a capture add new components/slots vs its view set?

--- a/go/coverage/coverage.go
+++ b/go/coverage/coverage.go
@@ -13,8 +13,9 @@
 package coverage
 
 import (
-	"github.com/sightmap/sightmap/go/sightmap"
 	"math"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // Matches maps a component node to the sightmap rule it matched.
@@ -129,6 +130,21 @@ func nearestMatchedAncestor(node *sightmap.ComponentNode, parentMap ParentMap, m
 		curr = parentMap[curr]
 	}
 	return nil
+}
+
+// ViewScopedMatchCount returns the number of matched (T1) nodes whose component
+// is NOT a global (chrome) component. Zero while nodes are still covered means
+// the page is carried only by global backstops — a clean coverage pass that
+// reflects chrome, not a modeled view. Shared by the snapshot/coverage advisory
+// and `gap` so the two surfaces agree instead of one showing a false green.
+func ViewScopedMatchCount(matches Matches, globalNames map[string]bool) int {
+	n := 0
+	for _, m := range matches {
+		if m != nil && !globalNames[m.Name] {
+			n++
+		}
+	}
+	return n
 }
 
 // Pct returns a/b as a percentage rounded to the nearest integer (0 when b==0).

--- a/go/coverage/hooks.go
+++ b/go/coverage/hooks.go
@@ -1,0 +1,249 @@
+package coverage
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// Candidate generation for orphaned nodes. Where the anchor helpers (anchor.go)
+// recognize ONLY data-testid/data-component, these surface the full range of
+// stable hooks a framework-generated DOM actually offers — custom-element tags,
+// design-system classes, ids, name/href/aria attrs — so `gap` stops dead-ending
+// with "(no stable ancestor) → (no selector hint)" on hook-poor apps (Salesforce
+// Lightning, Angular, etc.). data-* hooks are still ranked highest; they are one
+// input to candidate generation, not an override that suppresses everything else.
+//
+// The philosophy is surface-and-rank, not auto-select: emit the plausible stable
+// candidates, ranked, and let the author verify with sel-probe (which the
+// authoring skill already mandates before any selector reaches YAML). Only
+// clearly machine-generated tokens are dropped.
+
+var (
+	// A run of 4+ digits: counters, timestamps, epoch-ish ids.
+	reDigitRun = regexp.MustCompile(`[0-9]{4,}`)
+	// A long hex run: hashes, uuids, content-addressed names.
+	reHexRun = regexp.MustCompile(`[0-9a-fA-F]{8,}`)
+	// data-component version suffix, e.g. ":v1.2.3" or ":v1.2.3-abc".
+	reComponentVersion = regexp.MustCompile(`:v\d+\.\d+\.\d+.*$`)
+	// A trailing numeric instance counter, e.g. "combobox-button-15", "tab_3".
+	reTrailingNum = regexp.MustCompile(`^(.+?)[-_]?\d+$`)
+	// Leading authored prefix before any digit — for [id^="prefix"] forms.
+	reLeadingPrefix = regexp.MustCompile(`^([A-Za-z][A-Za-z_-]{2,}?)[-_]?\d`)
+)
+
+// utilityClasses are presentational/layout tokens that make poor SOLE selectors.
+// They are ranked lower, never dropped — sometimes they are the only hook.
+var utilityClasses = map[string]bool{
+	"active": true, "open": true, "closed": true, "hidden": true, "show": true,
+	"hide": true, "selected": true, "disabled": true, "visible": true,
+	"container": true, "row": true, "col": true, "wrapper": true, "content": true,
+	"clearfix": true, "sr-only": true,
+}
+
+// looksHashed reports whether a token is likely machine-generated / per-instance
+// (Aura render ids like "1:1;a", hashed classnames, uuids, emotion/styled-
+// components suffixes) rather than a stable authored hook worth suggesting.
+func looksHashed(tok string) bool {
+	if tok == "" {
+		return true
+	}
+	if strings.ContainsAny(tok, ":;$") { // aura ids "1:1;a", scoped "$x"
+		return true
+	}
+	if reDigitRun.MatchString(tok) {
+		return true
+	}
+	if reHexRun.MatchString(tok) {
+		return true
+	}
+	// A hash-like segment (word-3k9f2h1): >=6 chars mixing letters with several
+	// digits. Catches emotion/styled/LWC-scoped suffixes that dodge the run
+	// checks, while sparing short utilities (col12, step2) and pure words.
+	for _, seg := range strings.FieldsFunc(tok, func(r rune) bool { return r == '-' || r == '_' }) {
+		if len(seg) >= 6 && hasLetter(seg) && countDigits(seg) >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLetter(s string) bool {
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			return true
+		}
+	}
+	return false
+}
+
+func countDigits(s string) int {
+	n := 0
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			n++
+		}
+	}
+	return n
+}
+
+func stripComponentVersion(v string) string {
+	return reComponentVersion.ReplaceAllString(v, "")
+}
+
+// idPrefix returns the stable leading prefix of an id that carries a trailing
+// counter/hash, for use in an [id^="prefix"] selector. "" if none usable.
+func idPrefix(id string) string {
+	if m := reLeadingPrefix.FindStringSubmatch(id); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// hrefSuffix extracts a portable, stable trailing path segment from an href, for
+// an a[href$="…"] selector. Returns "" for hrefs whose tail is dynamic (numeric
+// or hashed) or that carry no usable path. Prefers the suffix form because a
+// full href embeds site/workspace-specific prefixes (see dc26).
+func hrefSuffix(href string) string {
+	h := href
+	if i := strings.IndexAny(h, "?#"); i >= 0 {
+		h = h[:i]
+	}
+	h = strings.TrimRight(h, "/")
+	slash := strings.LastIndex(h, "/")
+	if slash < 0 {
+		return ""
+	}
+	seg := h[slash+1:]
+	if seg == "" || looksHashed(seg) {
+		return ""
+	}
+	return "/" + seg
+}
+
+// SelectorCandidates returns ranked stable selector candidates identifying el,
+// best first (up to 4). data-* hooks rank highest but never suppress the rest.
+// Clearly machine-generated tokens are dropped; callers verify with sel-probe.
+func SelectorCandidates(el *sightmap.Element) []string {
+	if el == nil {
+		return nil
+	}
+	type cand struct {
+		sel   string
+		score int
+	}
+	var cands []cand
+	seen := map[string]bool{}
+	add := func(sel string, score int) {
+		if sel == "" || seen[sel] {
+			return
+		}
+		seen[sel] = true
+		cands = append(cands, cand{sel, score})
+	}
+
+	tag := strings.ToLower(el.Tag)
+	a := el.Attrs
+
+	// Purpose-built test hooks (highest, but only one input).
+	if v := a["data-testid"]; v != "" && !looksHashed(v) {
+		add(fmt.Sprintf(`[data-testid="%s"]`, v), 100)
+	}
+	if v := a["data-component"]; v != "" {
+		add(fmt.Sprintf(`[data-component^="%s"]`, stripComponentVersion(v)), 95)
+	}
+	// Custom-element tag (web components) — stable and semantic.
+	if strings.Contains(tag, "-") {
+		add(tag, 80)
+	}
+	// Stable id.
+	if id := el.Id; id != "" {
+		switch {
+		case looksHashed(id):
+			if pre := idPrefix(id); pre != "" {
+				add(fmt.Sprintf(`[id^="%s"]`, pre), 45)
+			}
+		case reTrailingNum.MatchString(id):
+			// per-instance counter: prefer the prefix form
+			if pre := idPrefix(id); pre != "" {
+				add(fmt.Sprintf(`[id^="%s"]`, pre), 55)
+			} else {
+				add("#"+id, 60)
+			}
+		default:
+			add("#"+id, 70)
+		}
+	}
+	// Other stable data-* attributes (e.g. data-target-selection-name).
+	for k, v := range a {
+		if k == "data-testid" || k == "data-component" || !strings.HasPrefix(k, "data-") {
+			continue
+		}
+		if v == "" || looksHashed(v) {
+			continue
+		}
+		add(fmt.Sprintf(`[%s="%s"]`, k, v), 55)
+	}
+	// Form-control name.
+	if v := a["name"]; v != "" && !looksHashed(v) {
+		add(fmt.Sprintf(`%s[name="%s"]`, tag, v), 65)
+	}
+	// Stable classes, combined with the tag for specificity.
+	for _, cls := range el.Classes {
+		if cls == "" || looksHashed(cls) {
+			continue
+		}
+		score := 60
+		if utilityClasses[cls] {
+			score = 30
+		}
+		if strings.ContainsAny(cls, "-_") { // BEM/kebab reads authored
+			score += 5
+		}
+		if tag != "" {
+			add(tag+"."+cls, score)
+		} else {
+			add("."+cls, score)
+		}
+	}
+	// Link href suffix.
+	if v := a["href"]; v != "" {
+		if suf := hrefSuffix(v); suf != "" {
+			add(fmt.Sprintf(`a[href$="%s"]`, suf), 40)
+		}
+	}
+	// aria-label as a last resort (usually better as a property than a selector).
+	if v := a["aria-label"]; v != "" && !looksHashed(v) && len(v) <= 40 {
+		add(fmt.Sprintf(`%s[aria-label="%s"]`, tag, v), 20)
+	}
+
+	sort.SliceStable(cands, func(i, j int) bool { return cands[i].score > cands[j].score })
+	var out []string
+	for _, c := range cands {
+		out = append(out, c.sel)
+		if len(out) >= 4 {
+			break
+		}
+	}
+	return out
+}
+
+// NearestHookAncestor walks up to the nearest ancestor that has any stable
+// selector candidate, returning it and its best candidate. The broadened
+// analogue of NearestDataAttrAncestor (data-attr-only): it gives `gap` a
+// container hook to scope a leaf candidate even when no data-attr ancestor
+// exists. "" when nothing up the chain carries a stable hook.
+func NearestHookAncestor(node *sightmap.ComponentNode, parentMap ParentMap) (*sightmap.ComponentNode, string) {
+	for curr := parentMap[node]; curr != nil; curr = parentMap[curr] {
+		if curr.Element == nil {
+			continue
+		}
+		if cands := SelectorCandidates(curr.Element); len(cands) > 0 {
+			return curr, cands[0]
+		}
+	}
+	return nil, ""
+}

--- a/go/coverage/hooks.go
+++ b/go/coverage/hooks.go
@@ -29,8 +29,11 @@ var (
 	reHexRun = regexp.MustCompile(`[0-9a-fA-F]{8,}`)
 	// data-component version suffix, e.g. ":v1.2.3" or ":v1.2.3-abc".
 	reComponentVersion = regexp.MustCompile(`:v\d+\.\d+\.\d+.*$`)
-	// A trailing numeric instance counter, e.g. "combobox-button-15", "tab_3".
-	reTrailingNum = regexp.MustCompile(`^(.+?)[-_]?\d+$`)
+	// A trailing numeric instance counter: digits after a "-"/"_" separator
+	// ("combobox-button-15", "tab_3"), or 2+ trailing digits with no separator
+	// ("row42"). A single bare trailing digit ("step2", "tab1") is left alone —
+	// that's normal short-token spelling, not a counter.
+	reTrailingNum = regexp.MustCompile(`^(.+?)(?:[-_]\d+|\d{2,})$`)
 	// Leading authored prefix before any digit — for [id^="prefix"] forms.
 	reLeadingPrefix = regexp.MustCompile(`^([A-Za-z][A-Za-z_-]{2,}?)[-_]?\d`)
 )
@@ -177,11 +180,20 @@ func SelectorCandidates(el *sightmap.Element) []string {
 			add("#"+id, 70)
 		}
 	}
-	// Other stable data-* attributes (e.g. data-target-selection-name).
-	for k, v := range a {
+	// Other stable data-* attributes (e.g. data-target-selection-name). Attrs is
+	// a map, so keys are sorted first — otherwise candidates tied at the same
+	// score would land in a different order (and could drop out of the top-4
+	// cap differently) on every run.
+	dataKeys := make([]string, 0, len(a))
+	for k := range a {
 		if k == "data-testid" || k == "data-component" || !strings.HasPrefix(k, "data-") {
 			continue
 		}
+		dataKeys = append(dataKeys, k)
+	}
+	sort.Strings(dataKeys)
+	for _, k := range dataKeys {
+		v := a[k]
 		if v == "" || looksHashed(v) {
 			continue
 		}

--- a/go/coverage/hooks_test.go
+++ b/go/coverage/hooks_test.go
@@ -124,6 +124,32 @@ func TestSelectorCandidates_RankingDataAttrOverClass(t *testing.T) {
 	}
 }
 
+func TestViewScopedMatchCount(t *testing.T) {
+	globals := map[string]bool{"GlobalHeader": true, "AppShell": true}
+	n1 := &sightmap.ComponentNode{Id: "1"}
+	n2 := &sightmap.ComponentNode{Id: "2"}
+	n3 := &sightmap.ComponentNode{Id: "3"}
+
+	// All matches are global → 0 view-scoped (the chrome-only case).
+	chromeOnly := Matches{
+		n1: {Name: "GlobalHeader"},
+		n2: {Name: "AppShell"},
+	}
+	if got := ViewScopedMatchCount(chromeOnly, globals); got != 0 {
+		t.Errorf("chrome-only: got %d, want 0", got)
+	}
+
+	// One view-scoped match → count 1.
+	mixed := Matches{
+		n1: {Name: "GlobalHeader"},
+		n2: {Name: "ListSearchBox"},
+		n3: {Name: "AppShell"},
+	}
+	if got := ViewScopedMatchCount(mixed, globals); got != 1 {
+		t.Errorf("mixed: got %d, want 1", got)
+	}
+}
+
 func TestNearestHookAncestor(t *testing.T) {
 	leaf := &sightmap.ComponentNode{Id: "leaf", Role: "button", Element: &sightmap.Element{Tag: "button"}}
 	mid := &sightmap.ComponentNode{Id: "mid", Element: &sightmap.Element{Tag: "div"}, Children: []*sightmap.ComponentNode{leaf}}

--- a/go/coverage/hooks_test.go
+++ b/go/coverage/hooks_test.go
@@ -63,6 +63,12 @@ func TestSelectorCandidates(t *testing.T) {
 			want: []string{`[data-target-selection-name="Home"]`},
 		},
 		{
+			name:   "single trailing digit is not treated as a counter",
+			el:     &sightmap.Element{Tag: "div", Id: "step2"},
+			want:   []string{"#step2"},
+			absent: []string{`[id^="step"]`},
+		},
+		{
 			name: "form control name",
 			el:   &sightmap.Element{Tag: "input", Attrs: map[string]string{"name": "AccountName"}},
 			want: []string{`input[name="AccountName"]`},
@@ -121,6 +127,26 @@ func TestSelectorCandidates_RankingDataAttrOverClass(t *testing.T) {
 	}
 	if !contains(got, "article.forceBaseCard") {
 		t.Errorf("class candidate suppressed: %v", got)
+	}
+}
+
+func TestSelectorCandidates_OtherDataAttrOrderIsDeterministic(t *testing.T) {
+	// Two non-testid/component data-* attrs tie at the same score. Attrs is a
+	// map, so without sorting the keys first, their relative order (and thus
+	// which one survives the top-4 cap) would vary run to run.
+	el := &sightmap.Element{
+		Tag: "a",
+		Attrs: map[string]string{
+			"data-target-selection-name": "Home",
+			"data-row-key":               "row-Home",
+		},
+	}
+	first := SelectorCandidates(el)
+	for i := 0; i < 20; i++ {
+		got := SelectorCandidates(el)
+		if strings.Join(got, ",") != strings.Join(first, ",") {
+			t.Fatalf("run %d: got %v, want %v (order must be stable across calls)", i, got, first)
+		}
 	}
 }
 

--- a/go/coverage/hooks_test.go
+++ b/go/coverage/hooks_test.go
@@ -1,0 +1,150 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+func TestSelectorCandidates_Nil(t *testing.T) {
+	if got := SelectorCandidates(nil); got != nil {
+		t.Errorf("SelectorCandidates(nil) = %v, want nil", got)
+	}
+}
+
+func TestSelectorCandidates(t *testing.T) {
+	tests := []struct {
+		name    string
+		el      *sightmap.Element
+		wantTop string   // expected first (highest-ranked) candidate
+		want    []string // candidates that must all be present (order-insensitive)
+		absent  []string // candidates that must NOT appear
+	}{
+		{
+			name:    "data-testid wins",
+			el:      &sightmap.Element{Tag: "button", Attrs: map[string]string{"data-testid": "save-btn"}},
+			wantTop: `[data-testid="save-btn"]`,
+		},
+		{
+			name:    "data-component strips version suffix",
+			el:      &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-component": "forceChatterFeed:v1.2.3-abc"}},
+			wantTop: `[data-component^="forceChatterFeed"]`,
+		},
+		{
+			name:    "custom-element tag is a strong hook",
+			el:      &sightmap.Element{Tag: "one-appnav"},
+			wantTop: "one-appnav",
+		},
+		{
+			name:   "design-system class combines with tag; hashed class dropped",
+			el:     &sightmap.Element{Tag: "article", Classes: []string{"forceBaseCard", "lwc-3k9f2h1", "css-1a2b3c4d"}},
+			want:   []string{"article.forceBaseCard"},
+			absent: []string{"article.lwc-3k9f2h1", "article.css-1a2b3c4d"},
+		},
+		{
+			name: "stable id yields #id",
+			el:   &sightmap.Element{Tag: "input", Id: "account-name"},
+			want: []string{"#account-name"},
+		},
+		{
+			name:   "aura-style id is hashed and dropped",
+			el:     &sightmap.Element{Tag: "div", Id: "1:1;a"},
+			absent: []string{"#1:1;a"},
+		},
+		{
+			name: "trailing-counter id prefers [id^=] prefix form",
+			el:   &sightmap.Element{Tag: "button", Id: "combobox-button-15"},
+			want: []string{`[id^="combobox-button"]`},
+		},
+		{
+			name: "other stable data-* attr is surfaced",
+			el:   &sightmap.Element{Tag: "a", Attrs: map[string]string{"data-target-selection-name": "Home"}},
+			want: []string{`[data-target-selection-name="Home"]`},
+		},
+		{
+			name: "form control name",
+			el:   &sightmap.Element{Tag: "input", Attrs: map[string]string{"name": "AccountName"}},
+			want: []string{`input[name="AccountName"]`},
+		},
+		{
+			name: "link href suffix is portable form",
+			el:   &sightmap.Element{Tag: "a", Attrs: map[string]string{"href": "https://x.example.com/lightning/page/home?foo=1"}},
+			want: []string{`a[href$="/home"]`},
+		},
+		{
+			name:   "dynamic href tail is dropped",
+			el:     &sightmap.Element{Tag: "a", Attrs: map[string]string{"href": "/lightning/r/Account/001A000001abcdefg"}},
+			absent: []string{`a[href$="/001A000001abcdefg"]`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SelectorCandidates(tt.el)
+			if tt.wantTop != "" {
+				if len(got) == 0 || got[0] != tt.wantTop {
+					t.Errorf("top candidate = %v, want %q first", got, tt.wantTop)
+				}
+			}
+			for _, w := range tt.want {
+				if !contains(got, w) {
+					t.Errorf("candidates %v missing %q", got, w)
+				}
+			}
+			for _, a := range tt.absent {
+				if contains(got, a) {
+					t.Errorf("candidates %v should not contain %q", got, a)
+				}
+			}
+			if len(got) > 4 {
+				t.Errorf("returned %d candidates, want <= 4: %v", len(got), got)
+			}
+		})
+	}
+}
+
+func TestSelectorCandidates_RankingDataAttrOverClass(t *testing.T) {
+	// data-* must rank above a design-system class, but the class must still be
+	// present (data-testid is one input, not an override).
+	el := &sightmap.Element{
+		Tag:     "article",
+		Classes: []string{"forceBaseCard"},
+		Attrs:   map[string]string{"data-testid": "card"},
+	}
+	got := SelectorCandidates(el)
+	if len(got) < 2 {
+		t.Fatalf("want at least 2 candidates, got %v", got)
+	}
+	if got[0] != `[data-testid="card"]` {
+		t.Errorf("top = %q, want data-testid first", got[0])
+	}
+	if !contains(got, "article.forceBaseCard") {
+		t.Errorf("class candidate suppressed: %v", got)
+	}
+}
+
+func TestNearestHookAncestor(t *testing.T) {
+	leaf := &sightmap.ComponentNode{Id: "leaf", Role: "button", Element: &sightmap.Element{Tag: "button"}}
+	mid := &sightmap.ComponentNode{Id: "mid", Element: &sightmap.Element{Tag: "div"}, Children: []*sightmap.ComponentNode{leaf}}
+	nav := &sightmap.ComponentNode{Id: "nav", Element: &sightmap.Element{Tag: "one-appnav"}, Children: []*sightmap.ComponentNode{mid}}
+	root := &sightmap.ComponentNode{Id: "root", Element: &sightmap.Element{Tag: "div"}, Children: []*sightmap.ComponentNode{nav}}
+	pm := BuildParentMap(root)
+
+	anc, sel := NearestHookAncestor(leaf, pm)
+	if anc != nav {
+		t.Errorf("ancestor = %v, want the one-appnav node", anc)
+	}
+	if sel != "one-appnav" {
+		t.Errorf("ancestor selector = %q, want one-appnav", sel)
+	}
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s || strings.TrimSpace(x) == s {
+			return true
+		}
+	}
+	return false
+}

--- a/go/observe/format_test.go
+++ b/go/observe/format_test.go
@@ -80,6 +80,44 @@ func TestFormat_Conflicts(t *testing.T) {
 	}
 }
 
+// TestFormat_ChromeOnlyAdvisory: a clean pass (T3==0) whose only matches are
+// GLOBAL components must warn that the view isn't really modeled (a11e.9).
+func TestFormat_ChromeOnlyAdvisory(t *testing.T) {
+	n := &sightmap.ComponentNode{Id: "1", Role: "banner", IsVisible: true, IsInteractive: true}
+	r := &Result{
+		Root:          &sightmap.ComponentNode{Id: "root", Children: []*sightmap.ComponentNode{n}},
+		URL:           "https://app.example.com/x",
+		CorpusApplied: true,
+		View:          &sightmap.ViewDef{Name: "Stub", Route: "/x"},
+		Matches:       map[*sightmap.ComponentNode]*sightmap.ComponentMatch{n: {Name: "GlobalHeader"}},
+		GlobalNames:   map[string]bool{"GlobalHeader": true},
+		Coverage:      coverage.Result{Total: 3, T1: 1, T2: 2, T3: 0},
+	}
+	out := renderResult(r)
+	if !strings.Contains(out, "contributed 0 components") {
+		t.Errorf("expected chrome-only advisory, got:\n%s", out)
+	}
+}
+
+// TestFormat_NoChromeOnlyAdvisoryWhenViewModels: a view-scoped match suppresses
+// the advisory — a legitimate pass must stay quiet.
+func TestFormat_NoChromeOnlyAdvisoryWhenViewModels(t *testing.T) {
+	n := &sightmap.ComponentNode{Id: "1", Role: "button", IsVisible: true, IsInteractive: true}
+	r := &Result{
+		Root:          &sightmap.ComponentNode{Id: "root", Children: []*sightmap.ComponentNode{n}},
+		URL:           "https://app.example.com/x",
+		CorpusApplied: true,
+		View:          &sightmap.ViewDef{Name: "Stub", Route: "/x"},
+		Matches:       map[*sightmap.ComponentNode]*sightmap.ComponentMatch{n: {Name: "SaveButton"}},
+		GlobalNames:   map[string]bool{"GlobalHeader": true},
+		Coverage:      coverage.Result{Total: 1, T1: 1, T3: 0},
+	}
+	out := renderResult(r)
+	if strings.Contains(out, "contributed 0 components") || strings.Contains(out, "no view modeled") {
+		t.Errorf("advisory should NOT fire when a view-scoped component matched, got:\n%s", out)
+	}
+}
+
 // TestFormat_NoCorpus: no corpus at all — neither the no-view notice nor a
 // [Coverage] line should appear (the raw tree stands on its own).
 func TestFormat_NoCorpus(t *testing.T) {

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -88,6 +88,7 @@ func Format(w io.Writer, r *Result, opts FormatOpts) {
 		fmt.Fprintln(w)
 		cov := r.Coverage
 		writeCoverage(w, cov)
+		writeChromeOnlyAdvisory(w, r)
 
 		// ── Unlabeled clusters (--trace) ─────────────────────────────────────
 		// Coverage-only mode always shows the cluster traces — they are the point
@@ -250,6 +251,31 @@ func writeCoverage(w io.Writer, cov coverage.Result) {
 		cov.Total, cov.T1, coverage.Pct(cov.T1, cov.Total), cov.T2, coverage.Pct(cov.T2, cov.Total), cov.T3, cov.Mark())
 	if cov.Empty() {
 		fmt.Fprintf(w, "⚠ no interactive nodes — the page may be blank or still loading (no coverage signal)\n")
+	}
+}
+
+// writeChromeOnlyAdvisory warns when a clean coverage pass (no orphans) was
+// achieved purely by GLOBAL (chrome) components — the current view, or the
+// absence of one, contributed zero directly-matched components. "0 orphaned ✓"
+// then means the global backstop blankets the page, NOT that the view is
+// modeled, so a brand-new unmodeled page reads as done. Gated on a clean pass
+// with interactive content: real orphans (✗) and blank pages already tell their
+// own story. (a11e.9 — surfaced dogfooding SFDC, where a global div.viewport
+// backstop drove an unmodeled list page to "0 orphaned ✓".)
+func writeChromeOnlyAdvisory(w io.Writer, r *Result) {
+	cov := r.Coverage
+	if cov.Empty() || cov.T3 != 0 {
+		return
+	}
+	for _, m := range r.Matches {
+		if m != nil && !r.GlobalNames[m.Name] {
+			return // the view modeled at least one component — a legitimate pass
+		}
+	}
+	if r.View != nil {
+		fmt.Fprintf(w, "⚠ view [%s] contributed 0 components — this page is covered only by global (chrome) components. \"0 orphaned\" reflects the global backstop, not a modeled view.\n", r.View.Name)
+	} else {
+		fmt.Fprintf(w, "⚠ no view modeled this page — coverage came entirely from global (chrome) components. \"0 orphaned\" reflects the global backstop, not a modeled view.\n")
 	}
 }
 

--- a/go/observe/render.go
+++ b/go/observe/render.go
@@ -267,10 +267,8 @@ func writeChromeOnlyAdvisory(w io.Writer, r *Result) {
 	if cov.Empty() || cov.T3 != 0 {
 		return
 	}
-	for _, m := range r.Matches {
-		if m != nil && !r.GlobalNames[m.Name] {
-			return // the view modeled at least one component — a legitimate pass
-		}
+	if coverage.ViewScopedMatchCount(r.Matches, r.GlobalNames) > 0 {
+		return // the view modeled at least one component — a legitimate pass
 	}
 	if r.View != nil {
 		fmt.Fprintf(w, "⚠ view [%s] contributed 0 components — this page is covered only by global (chrome) components. \"0 orphaned\" reflects the global backstop, not a modeled view.\n", r.View.Name)

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -104,6 +104,7 @@ other dependency.
 | `sightmap discover` | Crawl page links → ✓ mapped / ○ surveyed / ? unseen. `--all` shows surveyed. |
 | `sightmap suggest --exclude-known` | Candidate selectors not yet in sightmap (`--exclude-known` always on). |
 | `sightmap gap` | Orphaned interactive nodes with selector hints. Add `--include-hidden` to also list hidden/off-screen nodes. |
+| `sightmap explain [SELECTOR] [--grep STR] [--id N] [--snap FILE]` | Node-first inspection: dump a node's facts (tag/id/classes/attrs), ranked selector candidates, coverage tier + owning component, and ancestor hooks. Use `--grep 'Refresh'` (by role/name) or a selector when you've spotted a node but don't have a selector yet — the shadow-transparent replacement for hand-reading `*.snap.tree.json`. `--snap FILE` inspects a captured tree offline. |
 
 ### Session management
 
@@ -247,7 +248,18 @@ brackets when not suppressed by Rule A (exact match with a property value).
 
 ## Property extraction principles
 
-Every child component that is a link or button **must** have at least one property.
+Two property rules are **mandatory**:
+
+1. Every child component that is a link or button **must** have at least one
+   property.
+2. Every component whose selector matches **more than one instance** — a
+   repeated container or control (cards, list rows, nav tabs, feed items) —
+   **must** carry a property that *varies per instance* (a title, label, key, or
+   state), even a pure container with no link/button of its own. Without one,
+   every instance collapses to an indistinguishable node and no component query
+   can resolve a single one. `sel-probe` already prints the match count: a count
+   > 1 with no per-instance property is the tell. Extract the discriminator from
+   wherever it lives — a header title, an `aria-label`, a stable `data-*`.
 
 ```yaml
 - name: FooterLink
@@ -255,6 +267,14 @@ Every child component that is a link or button **must** have at least one proper
   properties:
     - name: label
       extract: text
+
+# Repeated container: one selector, many instances → needs a per-instance
+# discriminator so `Card[title^="Today"]` can resolve exactly one.
+- name: Card
+  selector: 'article.card'
+  properties:
+    - name: title
+      extract: '.card__title'
 ```
 
 **Choosing an extract mode:**
@@ -521,8 +541,17 @@ Unlabeled clusters:
        → [data-testid="product-pod"] a
 ```
 
-The `→` selector hint is what to use for a new child component. Use
-`sightmap sel-probe` to verify match count before writing YAML.
+The `→` selector hint (and the `container:` hook on hook-poor DOMs) is what to
+use for a new child component. Use `sightmap sel-probe` to verify match count
+before writing YAML.
+
+When you've spotted a node but need its raw facts to craft a selector — common on
+shadow-DOM / hashed-id apps where `browser eval`'s `querySelector` returns `[]` —
+reach for `sightmap explain` instead of hand-reading the tree JSON: `explain
+--grep 'Refresh'` (by role/name), `explain 'div.card'` (by selector), or `explain
+--snap PAGE.snap --id N` (offline). It dumps the node's tag/id/classes/attrs,
+ranked selector candidates, its tier + owning component, and ancestor hooks —
+shadow-transparent, matching what the offline matcher sees.
 
 After YAML edits, re-snap and check coverage. Repeat until 0 orphaned ✓.
 

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -104,6 +104,7 @@ other dependency.
 | `sightmap discover` | Crawl page links → ✓ mapped / ○ surveyed / ? unseen. `--all` shows surveyed. |
 | `sightmap suggest --exclude-known` | Candidate selectors not yet in sightmap (`--exclude-known` always on). |
 | `sightmap gap` | Orphaned interactive nodes with selector hints. Add `--include-hidden` to also list hidden/off-screen nodes. |
+| `sightmap explain [SELECTOR] [--grep STR] [--id N] [--snap FILE]` | Node-first inspection: dump a node's facts (tag/id/classes/attrs), ranked selector candidates, coverage tier + owning component, and ancestor hooks. Use `--grep 'Refresh'` (by role/name) or a selector when you've spotted a node but don't have a selector yet — the shadow-transparent replacement for hand-reading `*.snap.tree.json`. `--snap FILE` inspects a captured tree offline. |
 
 ### Session management
 
@@ -540,8 +541,17 @@ Unlabeled clusters:
        → [data-testid="product-pod"] a
 ```
 
-The `→` selector hint is what to use for a new child component. Use
-`sightmap sel-probe` to verify match count before writing YAML.
+The `→` selector hint (and the `container:` hook on hook-poor DOMs) is what to
+use for a new child component. Use `sightmap sel-probe` to verify match count
+before writing YAML.
+
+When you've spotted a node but need its raw facts to craft a selector — common on
+shadow-DOM / hashed-id apps where `browser eval`'s `querySelector` returns `[]` —
+reach for `sightmap explain` instead of hand-reading the tree JSON: `explain
+--grep 'Refresh'` (by role/name), `explain 'div.card'` (by selector), or `explain
+--snap PAGE.snap --id N` (offline). It dumps the node's tag/id/classes/attrs,
+ranked selector candidates, its tier + owning component, and ancestor hooks —
+shadow-transparent, matching what the offline matcher sees.
 
 After YAML edits, re-snap and check coverage. Repeat until 0 orphaned ✓.
 

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -247,7 +247,18 @@ brackets when not suppressed by Rule A (exact match with a property value).
 
 ## Property extraction principles
 
-Every child component that is a link or button **must** have at least one property.
+Two property rules are **mandatory**:
+
+1. Every child component that is a link or button **must** have at least one
+   property.
+2. Every component whose selector matches **more than one instance** — a
+   repeated container or control (cards, list rows, nav tabs, feed items) —
+   **must** carry a property that *varies per instance* (a title, label, key, or
+   state), even a pure container with no link/button of its own. Without one,
+   every instance collapses to an indistinguishable node and no component query
+   can resolve a single one. `sel-probe` already prints the match count: a count
+   > 1 with no per-instance property is the tell. Extract the discriminator from
+   wherever it lives — a header title, an `aria-label`, a stable `data-*`.
 
 ```yaml
 - name: FooterLink
@@ -255,6 +266,14 @@ Every child component that is a link or button **must** have at least one proper
   properties:
     - name: label
       extract: text
+
+# Repeated container: one selector, many instances → needs a per-instance
+# discriminator so `Card[title^="Today"]` can resolve exactly one.
+- name: Card
+  selector: 'article.card'
+  properties:
+    - name: title
+      extract: '.card__title'
 ```
 
 **Choosing an extract mode:**


### PR DESCRIPTION
Toolset + skill changes that make from-scratch authoring work on **hook-poor, framework-generated DOMs** (Salesforce Lightning, Angular, LWC/Aura), validated by repeated cold-start authoring runs against a live Lightning app.

## Changes

**1. Generalized selector-candidate generation** (`coverage.SelectorCandidates`)
`gap`/`suggest` previously emitted candidates only from `data-testid`/`data-component`, so on a DOM without test attributes every orphan cluster read `(no stable ancestor) → (no selector hint)` and `suggest` returned "No candidate selectors found." They now rank custom-element tags, design-system classes, ids (`#id` / `[id^=]`), other stable `data-*`, and `name`/`href`/`aria` hooks — data-attributes stay top-ranked but are one input, not an override — dropping only clearly machine-generated tokens (aura ids, digit/hex runs, `word-<hash>` suffixes). `gap` also prints a `container:` hook on the hook-poor path.

**2. New `explain` command** (node-first inspection)
`sel-probe` is selector-first; when you've spotted a node in a captured tree but have no selector yet (common under shadow DOM, where `browser eval`'s `querySelector` returns `[]`), you had to hand-read `*.snap.tree.json`. `explain` picks nodes by selector, `--id`, or `--grep` (role/name), live or offline via `--snap`, and dumps each node's facts, ranked candidates, coverage tier + owning component, and ancestor hooks — shadow-transparent.

**3. Honest coverage**
A broad global backstop component makes every node T1/T2, so a brand-new **unmodeled** page reports "0 orphaned ✓". `snapshot --coverage` and `gap` now warn when a clean pass has zero view-scoped matches ("coverage came entirely from global components").

**4. Authoring skill**
Second mandatory property rule: any selector matching >1 instance must carry a per-instance discriminator (so repeated cards/rows/tabs stay addressable, e.g. `Card[title^="Today"]`). Plus `explain` docs in the tool table + discovery step.

## Testing

`go vet` + full `go test` + Jest (60) green; `gofmt` clean. New unit tests for `SelectorCandidates`, `ViewScopedMatchCount`, the chrome-only advisory, `scan.js` candidates, and `explain` node selection/tier. Behavior verified live on Salesforce Lightning. Changeset: `minor` (new command).
