### PR TITLE
stats: count the messages entity in the inventory

### DIFF
--- a/.changeset/stats-count-messages.md
+++ b/.changeset/stats-count-messages.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`sightmap stats` now reports a **Messages** count. The offline inventory listed views, components, requests, properties, and memory but silently omitted the SEP-0006 `messages:` entity, so a corpus's console/exception matchers were invisible in the totals (and in `--json`). Adds `messages` to the totals table and the `--json` contract.

--- a/go/cmd/sightmap/cmd_stats.go
+++ b/go/cmd/sightmap/cmd_stats.go
@@ -174,6 +174,7 @@ func printStats(out io.Writer, s sightmap.Stats) {
 	fmt.Fprintf(out, " %-10s  %d\n", "Views", s.Views)
 	fmt.Fprintf(out, " %-10s  %d\n", "Components", s.Components)
 	fmt.Fprintf(out, " %-10s  %d\n", "Requests", s.Requests)
+	fmt.Fprintf(out, " %-10s  %d\n", "Messages", s.Messages)
 	fmt.Fprintf(out, " %-10s  %d\n", "Properties", s.Properties)
 	fmt.Fprintf(out, " %-10s  %d\n", "Memory", s.Memory)
 	fmt.Fprintln(out, sep)

--- a/go/cmd/sightmap/cmd_stats_test.go
+++ b/go/cmd/sightmap/cmd_stats_test.go
@@ -204,7 +204,7 @@ views:
 		t.Fatalf("unmarshal %q: %v", out.String(), err)
 	}
 	assertFieldSet(t, "top level", raw,
-		[]string{"components", "memory", "per_view", "properties", "requests", "views"})
+		[]string{"components", "memory", "messages", "per_view", "properties", "requests", "views"})
 
 	var rows []map[string]json.RawMessage
 	if err := json.Unmarshal(raw["per_view"], &rows); err != nil {

--- a/go/sightmap/stats.go
+++ b/go/sightmap/stats.go
@@ -50,6 +50,7 @@ type Totals struct {
 	Views      int `json:"views"`      // number of views
 	Components int `json:"components"` // distinct component names corpus-wide
 	Requests   int `json:"requests"`   // global + view-scoped request definitions
+	Messages   int `json:"messages"`   // file-root console/exception message definitions
 	Properties int `json:"properties"` // properties over distinct component definitions
 	Memory     int `json:"memory"`     // file-, view-, component-, and request-level entries
 }
@@ -70,7 +71,7 @@ type ViewStats struct {
 // no components, no requests, and no memory entries. A corpus that holds only
 // memory is legal (Validate accepts it) and is NOT empty.
 func (s Stats) IsEmpty() bool {
-	return s.Views == 0 && s.Components == 0 && s.Requests == 0 && s.Memory == 0
+	return s.Views == 0 && s.Components == 0 && s.Requests == 0 && s.Messages == 0 && s.Memory == 0
 }
 
 // Stats folds the corpus into its count summary. See Stats for exactly what
@@ -85,8 +86,9 @@ func (s Stats) IsEmpty() bool {
 func (c *Corpus) Stats() Stats {
 	s := Stats{
 		Totals: Totals{
-			Views:  len(c.Views),
-			Memory: len(c.Memory),
+			Views:    len(c.Views),
+			Messages: len(c.Messages),
+			Memory:   len(c.Memory),
 		},
 		PerView: make([]ViewStats, 0, len(c.Views)),
 	}

--- a/go/sightmap/stats_test.go
+++ b/go/sightmap/stats_test.go
@@ -26,6 +26,9 @@ func TestStats_DedupesSharedGlobals(t *testing.T) {
 		Requests: []RequestDef{
 			{Name: "GetCurrentUser", Route: "/api/me", Method: "GET"},
 		},
+		Messages: []MessageDef{
+			{Name: "CartVersionMismatch", Level: "ERROR", Message: "cart version mismatch"},
+		},
 		Views: []ViewDef{
 			{
 				Name:   "Checkout",
@@ -66,6 +69,9 @@ func TestStats_DedupesSharedGlobals(t *testing.T) {
 	}
 	if s.Requests != 2 {
 		t.Errorf("Requests = %d, want 2 (1 global + 1 view-scoped)", s.Requests)
+	}
+	if s.Messages != 1 {
+		t.Errorf("Messages = %d, want 1", s.Messages)
 	}
 	if s.Properties != 1 {
 		t.Errorf("Properties = %d, want 1", s.Properties)


### PR DESCRIPTION
`sightmap stats` reported Views / Components / Requests / Properties / Memory but **omitted Messages** — so a corpus's SEP-0006 `messages:` (console/exception matchers) were invisible in the inventory, both in the table and in `--json`. Confirmed repeatedly while authoring a corpus with `messages:` entries: `validate` clean, but `stats` showed no messages line.

Adds a `Messages` total to the table and the `messages` key to the `--json` contract (additive; `sightmap.Totals` is the shared type the atlas also uses). Small, mirrors the existing Requests counter.

`go test ./...` + `go vet` green; the published-`--json`-field-set contract test updated to include `messages`.
