### PR TITLE
coverage: deterministic candidate ranking + scan.js parity fixes

### DIFF
--- a/go/authoring/scan.js
+++ b/go/authoring/scan.js
@@ -54,10 +54,25 @@ function __smCandidateWorthy(el) {
   return ["a", "button", "input", "select", "textarea"].includes(tag);
 }
 
+// __smHrefSuffix mirrors coverage.hrefSuffix (Go): the portable, stable
+// trailing path segment of an href, "" when the tail is dynamic/hashed.
+function __smHrefSuffix(href) {
+  let h = href;
+  const cut = h.search(/[?#]/);
+  if (cut >= 0) h = h.slice(0, cut);
+  h = h.replace(/\/+$/, "");
+  const slash = h.lastIndexOf("/");
+  if (slash < 0) return "";
+  const seg = h.slice(slash + 1);
+  if (!seg || __smLooksHashed(seg)) return "";
+  return "/" + seg;
+}
+
 // __smBestHook returns the single strongest stable selector for el, or "".
-// Priority mirrors coverage.SelectorCandidates (Go): data-* hooks lead but are
-// one input, not an override — a custom-element tag, stable id, form name, or
-// design-system class is surfaced when no data-attr exists.
+// A best-effort single pick, not the full ranked list coverage.SelectorCandidates
+// (Go) returns — but the same hooks, roughly by the same priority: data-* leads
+// but is one input, falling through to custom-element tag, stable id, form name,
+// other stable data-*, design-system class, href, then aria-label.
 function __smBestHook(el) {
   const tag = el.tagName.toLowerCase();
   const dt = el.getAttribute("data-testid");
@@ -70,6 +85,17 @@ function __smBestHook(el) {
   if (id && !__smLooksHashed(id) && !/\d+$/.test(id)) return "#" + id;
   const name = el.getAttribute("name");
   if (name && !__smLooksHashed(name)) return tag + '[name="' + name + '"]';
+  for (const attr of el.attributes) {
+    if (
+      attr.name.startsWith("data-") &&
+      attr.name !== "data-testid" &&
+      attr.name !== "data-component" &&
+      attr.value &&
+      !__smLooksHashed(attr.value)
+    ) {
+      return "[" + attr.name + '="' + attr.value + '"]';
+    }
+  }
   let utility = "";
   for (const cls of el.classList) {
     if (!cls || __smLooksHashed(cls)) continue;
@@ -80,6 +106,11 @@ function __smBestHook(el) {
     return tag + "." + cls; // first specific class wins
   }
   if (utility) return utility;
+  const href = el.getAttribute("href");
+  if (href) {
+    const suf = __smHrefSuffix(href);
+    if (suf) return 'a[href$="' + suf + '"]';
+  }
   const al = el.getAttribute("aria-label");
   if (al && !__smLooksHashed(al) && al.length <= 40)
     return tag + '[aria-label="' + al + '"]';

--- a/go/authoring/scan.test.js
+++ b/go/authoring/scan.test.js
@@ -97,6 +97,26 @@ describe("__smScanCandidates", () => {
     const candidates = __smScanCandidates(10);
     expect(candidates).toEqual([]);
   });
+
+  test("falls back to another stable data-* attr", () => {
+    document.body.innerHTML = `<a data-target-selection-name="Home"></a>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map((c) => c.sel)).toContain(
+      '[data-target-selection-name="Home"]',
+    );
+  });
+
+  test("falls back to a portable href suffix", () => {
+    document.body.innerHTML = `<a href="https://x.example.com/lightning/page/home?foo=1"></a>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates.map((c) => c.sel)).toContain('a[href$="/home"]');
+  });
+
+  test("drops a dynamic href tail, emitting no candidate", () => {
+    document.body.innerHTML = `<a href="/lightning/r/Account/001A000001abcdefg"></a>`;
+    const candidates = __smScanCandidates(10);
+    expect(candidates).toEqual([]);
+  });
 });
 
 describe("__smScanLinks", () => {

--- a/go/coverage/hooks.go
+++ b/go/coverage/hooks.go
@@ -29,8 +29,11 @@ var (
 	reHexRun = regexp.MustCompile(`[0-9a-fA-F]{8,}`)
 	// data-component version suffix, e.g. ":v1.2.3" or ":v1.2.3-abc".
 	reComponentVersion = regexp.MustCompile(`:v\d+\.\d+\.\d+.*$`)
-	// A trailing numeric instance counter, e.g. "combobox-button-15", "tab_3".
-	reTrailingNum = regexp.MustCompile(`^(.+?)[-_]?\d+$`)
+	// A trailing numeric instance counter: digits after a "-"/"_" separator
+	// ("combobox-button-15", "tab_3"), or 2+ trailing digits with no separator
+	// ("row42"). A single bare trailing digit ("step2", "tab1") is left alone —
+	// that's normal short-token spelling, not a counter.
+	reTrailingNum = regexp.MustCompile(`^(.+?)(?:[-_]\d+|\d{2,})$`)
 	// Leading authored prefix before any digit — for [id^="prefix"] forms.
 	reLeadingPrefix = regexp.MustCompile(`^([A-Za-z][A-Za-z_-]{2,}?)[-_]?\d`)
 )
@@ -177,11 +180,20 @@ func SelectorCandidates(el *sightmap.Element) []string {
 			add("#"+id, 70)
 		}
 	}
-	// Other stable data-* attributes (e.g. data-target-selection-name).
-	for k, v := range a {
+	// Other stable data-* attributes (e.g. data-target-selection-name). Attrs is
+	// a map, so keys are sorted first — otherwise candidates tied at the same
+	// score would land in a different order (and could drop out of the top-4
+	// cap differently) on every run.
+	dataKeys := make([]string, 0, len(a))
+	for k := range a {
 		if k == "data-testid" || k == "data-component" || !strings.HasPrefix(k, "data-") {
 			continue
 		}
+		dataKeys = append(dataKeys, k)
+	}
+	sort.Strings(dataKeys)
+	for _, k := range dataKeys {
+		v := a[k]
 		if v == "" || looksHashed(v) {
 			continue
 		}

--- a/go/coverage/hooks_test.go
+++ b/go/coverage/hooks_test.go
@@ -63,6 +63,12 @@ func TestSelectorCandidates(t *testing.T) {
 			want: []string{`[data-target-selection-name="Home"]`},
 		},
 		{
+			name:   "single trailing digit is not treated as a counter",
+			el:     &sightmap.Element{Tag: "div", Id: "step2"},
+			want:   []string{"#step2"},
+			absent: []string{`[id^="step"]`},
+		},
+		{
 			name: "form control name",
 			el:   &sightmap.Element{Tag: "input", Attrs: map[string]string{"name": "AccountName"}},
 			want: []string{`input[name="AccountName"]`},
@@ -121,6 +127,26 @@ func TestSelectorCandidates_RankingDataAttrOverClass(t *testing.T) {
 	}
 	if !contains(got, "article.forceBaseCard") {
 		t.Errorf("class candidate suppressed: %v", got)
+	}
+}
+
+func TestSelectorCandidates_OtherDataAttrOrderIsDeterministic(t *testing.T) {
+	// Two non-testid/component data-* attrs tie at the same score. Attrs is a
+	// map, so without sorting the keys first, their relative order (and thus
+	// which one survives the top-4 cap) would vary run to run.
+	el := &sightmap.Element{
+		Tag: "a",
+		Attrs: map[string]string{
+			"data-target-selection-name": "Home",
+			"data-row-key":               "row-Home",
+		},
+	}
+	first := SelectorCandidates(el)
+	for i := 0; i < 20; i++ {
+		got := SelectorCandidates(el)
+		if strings.Join(got, ",") != strings.Join(first, ",") {
+			t.Fatalf("run %d: got %v, want %v (order must be stable across calls)", i, got, first)
+		}
 	}
 }
 


### PR DESCRIPTION
Two fixes found while reviewing #245: `coverage.SelectorCandidates`'s "other data-*" ranking depended on unsorted Go map iteration order, so tied candidates could reorder (and drop out of the top-4 cap differently) between identical runs; and its `reTrailingNum` regex demoted any id ending in a single digit (`step2`, `tab1`) to a coarser `[id^=]` prefix form, even though `looksHashed`'s own comment says those exact shapes should be spared. Also closes a parity gap in `scan.js`'s `__smBestHook`, which claimed to mirror `SelectorCandidates`' priority but had no fallback for other stable `data-*` attributes or href suffixes.
