### PR TITLE
stats: global-row attribution; clearer capture-gate message

### DIFF
--- a/.changeset/stats-global-row-and-capture-message.md
+++ b/.changeset/stats-global-row-and-capture-message.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Two authoring-clarity fixes for the offline inventory and the capture gate.
+
+`sightmap stats` now attributes corpus-root **global** components and requests to their own `(global) · (all views)` row instead of showing `0` against every view. A corpus whose coverage lives entirely in globals (e.g. a single-view app mapped with global components) previously rendered a per-view table that read as empty, with the confusing footer "per-view rows sum to 0". The globals are shown once, on a leading row, and the footer explains them — globals apply to every view, so folding them into one view's row would misattribute coverage. The `--json` contract is unchanged.
+
+`sightmap capture`'s novelty-gate message no longer reads like it is refusing a first baseline. The first capture of a view always writes (an empty set can't be redundant); reaching the gate means a baseline already exists and the new capture adds nothing, so the message now says so plainly ("<view> already has N capture(s); this one adds no new component or interactive slot — not saved"). The `sightmap-authoring` skill is updated to match and to reinforce the first-capture-always-writes guarantee.

--- a/go/cmd/sightmap/cmd_capture.go
+++ b/go/cmd/sightmap/cmd_capture.go
@@ -101,8 +101,12 @@ func runCapture(args []string) error {
 	if !*forceFlag {
 		cand := viewset.SlotsFromMatch(res.Matches, cov.Orphans, cov.ParentMap)
 		if gres, write := viewset.Gate(corpus, *lf.sightmapDir, viewBasename, cand, false); !write {
-			fmt.Fprintf(os.Stderr, "capture: nothing new vs %d capture(s) in %s — not saved (use --force to keep)\n",
-				gres.ComparedTo, viewBasename)
+			// The gate always writes the first capture of a view (len(others)==0),
+			// so reaching here means a baseline already exists and this one is
+			// redundant — say that plainly rather than "nothing new vs N", which
+			// reads like the first baseline is being refused.
+			fmt.Fprintf(os.Stderr, "capture: %s already has %d capture(s); this one adds no new component or interactive slot — not saved (use --force to keep it anyway)\n",
+				viewBasename, gres.ComparedTo)
 			return nil
 		}
 	}
@@ -218,7 +222,7 @@ func runCaptureAll(
 			continue
 		}
 		if r.skipped {
-			fmt.Fprintf(os.Stderr, "%-20s  = nothing new vs %d capture(s) — not saved\n", r.name, r.skippedVs)
+			fmt.Fprintf(os.Stderr, "%-20s  = redundant vs %d existing capture(s) — not saved\n", r.name, r.skippedVs)
 			continue
 		}
 		if r.empty {

--- a/go/cmd/sightmap/cmd_stats.go
+++ b/go/cmd/sightmap/cmd_stats.go
@@ -99,7 +99,10 @@ func runStatsOut(args []string, out io.Writer) error {
 			"Define views under a top-level \"views:\" list:\n%s", *sightmapDir, viewSchemaExample())
 	}
 
-	printStats(out, s)
+	// Globals apply to every view, so the table reports them as their own row
+	// rather than attributing them to one view. These counts are derived here
+	// from the corpus (not carried on Stats) to keep the --json contract stable.
+	printStats(out, s, len(corpus.GlobalComponents), len(corpus.Requests))
 	return nil
 }
 
@@ -157,14 +160,23 @@ func writeJSONLine(out io.Writer, v any) error {
 // printStats renders the human summary: a totals block, then a per-view table
 // in the shared offline-table style (banner, ─ separators, width-capped
 // name/route columns, trailing summary line).
-func printStats(out io.Writer, s sightmap.Stats) {
+func printStats(out io.Writer, s sightmap.Stats, globalComponents, globalRequests int) {
 	printTableBanner(out, "stats")
 
-	names := make([]string, len(s.PerView))
-	routes := make([]string, len(s.PerView))
-	for i, r := range s.PerView {
-		names[i] = r.Name
-		routes[i] = r.Route
+	// A leading synthetic row surfaces corpus-root globals, which apply to every
+	// view. Its labels join the width calculation so the columns fit it too.
+	const globalName, globalRoute = "(global)", "(all views)"
+	hasGlobals := globalComponents > 0 || globalRequests > 0
+
+	names := make([]string, 0, len(s.PerView)+1)
+	routes := make([]string, 0, len(s.PerView)+1)
+	if hasGlobals {
+		names = append(names, globalName)
+		routes = append(routes, globalRoute)
+	}
+	for _, r := range s.PerView {
+		names = append(names, r.Name)
+		routes = append(routes, r.Route)
 	}
 	nameW, routeW := viewColWidths(names, routes)
 	sep := strings.Repeat("─", nameW+routeW+25)
@@ -189,9 +201,13 @@ func printStats(out io.Writer, s sightmap.Stats) {
 		nameW, "View", routeW, "Route", "Components", "Requests")
 	fmt.Fprintln(out, sep)
 
-	sumComponents := 0
+	if hasGlobals {
+		fmt.Fprintf(out, " %-*s  %-*s  %10d  %8d\n",
+			nameW, truncate(globalName, nameW),
+			routeW, truncate(globalRoute, routeW),
+			globalComponents, globalRequests)
+	}
 	for _, r := range s.PerView {
-		sumComponents += r.Components
 		fmt.Fprintf(out, " %-*s  %-*s  %10d  %8d\n",
 			nameW, truncate(r.Name, nameW),
 			routeW, truncate(r.Route, routeW),
@@ -200,6 +216,13 @@ func printStats(out io.Writer, s sightmap.Stats) {
 
 	// ── Summary line ──────────────────────────────────────────────────────────
 	fmt.Fprintln(out, sep)
-	fmt.Fprintf(out, " %d views  ·  %d distinct components (per-view rows sum to %d)\n",
-		s.Views, s.Components, sumComponents)
+	viewWord := "views"
+	if s.Views == 1 {
+		viewWord = "view"
+	}
+	fmt.Fprintf(out, " %d %s  ·  %d distinct components", s.Views, viewWord, s.Components)
+	if globalComponents > 0 {
+		fmt.Fprintf(out, "  (%d declared globally, shared by every view)", globalComponents)
+	}
+	fmt.Fprintln(out)
 }

--- a/go/cmd/sightmap/cmd_stats_test.go
+++ b/go/cmd/sightmap/cmd_stats_test.go
@@ -82,8 +82,9 @@ views:
 
 // TestStats_TableRendersPerViewRows drives the table end to end over a real
 // on-disk corpus: the totals dedupe the $ref-reused global (6 distinct names,
-// not 8), each per-view row still counts its own expanded copy, and the summary
-// line prints both numbers so the reader can see where they diverge.
+// not 8), the corpus-root globals get their own leading row rather than showing
+// as 0 against a view, each per-view row still counts its own expanded copy, and
+// the summary line explains the globals so the rows reconcile with the total.
 func TestStats_TableRendersPerViewRows(t *testing.T) {
 	dir := writeStatsCorpus(t, sharedGlobalCorpus)
 
@@ -93,6 +94,7 @@ func TestStats_TableRendersPerViewRows(t *testing.T) {
 	}
 	got := out.String()
 
+	// Totals block: fixed-width, unaffected by the per-view column widths.
 	for _, want := range []string{
 		"Views       2",
 		// Navigation, Footer, CartSummary, PaymentForm, submit, ActivityFeed —
@@ -101,17 +103,39 @@ func TestStats_TableRendersPerViewRows(t *testing.T) {
 		"Requests    2", // 1 global + 1 view-scoped
 		"Properties  1",
 		"Memory      2", // Navigation's entry once + PaymentForm's
-		"Checkout   /checkout            4         1",
-		"Dashboard  /dashboard           2         0",
-		"2 views  ·  6 distinct components (per-view rows sum to 6)",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q:\n%s", want, got)
 		}
 	}
+
+	// Rows and footer: assert on whitespace-collapsed lines so the exact column
+	// padding (which shifts with the widest label) isn't baked into the test.
+	for _, want := range []string{
+		"(global) (all views) 2 1", // 2 global components + 1 global request
+		"Checkout /checkout 4 1",
+		"Dashboard /dashboard 2 0",
+		"2 views · 6 distinct components (2 declared globally, shared by every view)",
+	} {
+		if !containsCollapsed(got, want) {
+			t.Errorf("output missing row/line %q (whitespace-collapsed):\n%s", want, got)
+		}
+	}
 	if strings.Contains(got, "Components  8") {
 		t.Errorf("totals counted every expanded copy instead of distinct names:\n%s", got)
 	}
+}
+
+// containsCollapsed reports whether any line of got, with runs of whitespace
+// collapsed to a single space and trimmed, equals want. It keeps the table
+// assertions robust to column-width shifts while still pinning field order.
+func containsCollapsed(got, want string) bool {
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Join(strings.Fields(line), " ") == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestStatsJSON_DedupedTotals is the --json half of the same corpus: the

--- a/go/sightmap/stats.go
+++ b/go/sightmap/stats.go
@@ -55,10 +55,12 @@ type Totals struct {
 	Memory     int `json:"memory"`     // file-, view-, component-, and request-level entries
 }
 
-// ViewStats is one per-view row: the components and requests reachable in that
-// view after $ref expansion. A global component reused by several views appears
-// in each view's row but only once in Stats.Components, and global (view-less)
-// components and requests appear in the totals only — so the per-view columns
+// ViewStats is one per-view row: the components and requests DECLARED under that
+// view after $ref expansion. It does not include corpus-root globals, which
+// apply to every view (see Corpus.ComponentsForRoute) and are reported once —
+// the CLI renders them as a separate "(global)" row rather than folding them
+// into any single view, where they would misattribute coverage. A view's
+// effective coverage is thus its own row plus the globals; per-view columns
 // need not sum to the totals.
 type ViewStats struct {
 	Name       string `json:"name"`

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -690,12 +690,14 @@ to stdout (or `--out FILE`) — it never touches the corpus and never gates.
 (different loads, a drawer open, a tab switched).
 
 A capture that adds **no new component type or orphan slot** vs the view set is
-skipped by the **novelty gate** — `capture` prints "nothing new … not saved" and
-the overlay's Snap-view button shows "= nothing new (not saved)". The first
-capture of a view always writes; `capture --force` overrides. So just re-`capture`
-a dynamic view a few times — only loads that render something structurally new
-are kept; pure value churn (different products/prices) is ignored. `coverage`
-unions the whole view set.
+skipped by the **novelty gate** — `capture` reports that the view *already has* N
+capture(s) and this one is redundant ("not saved"), and the overlay's Snap-view
+button likewise marks it skipped. Read that as "already covered", **not** as a
+refusal of a first baseline: **the first capture of a view always writes** (an
+empty set can't be redundant), and `capture --force` keeps a redundant one
+anyway. So just re-`capture` a dynamic view a few times — only loads that render
+something structurally new are kept; pure value churn (different products/prices)
+is ignored. `coverage` unions the whole view set.
 
 **`coverage` / `multi-coverage`** require `.snap.tree.json` companion files.
 `capture` writes them automatically; `snapshot` writes one when `--tree-out` is

--- a/go/viewset/sets_test.go
+++ b/go/viewset/sets_test.go
@@ -1,8 +1,12 @@
 package viewset
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func TestSnapshotStamp(t *testing.T) {
@@ -233,5 +237,68 @@ func TestFormatStampDisplay(t *testing.T) {
 	}
 	if got, want := FormatStamp("not-a-stamp"), "not-a-stamp"; got != want {
 		t.Errorf("unparseable stamp = %q, want passthrough %q", got, want)
+	}
+}
+
+// TestGate pins the write decision, especially the first-baseline guarantee that
+// motivated issue #251: an empty view set always writes the very first capture
+// (even one whose fingerprint is empty), and it must not be reported as if a
+// prior capture existed. A set that already holds a capture then gates a
+// redundant candidate, reporting ComparedTo == 1 so the message can say so.
+func TestGate(t *testing.T) {
+	corpus := &sightmap.Corpus{}
+
+	// ── First baseline: empty snapshots dir → always writes ──────────────────
+	empty := t.TempDir()
+	emptyDir := filepath.Join(empty, ".sightmap")
+	cand := Slots{Matched: map[string]bool{"Header": true}, Orphans: map[string]int{}}
+	res, write := Gate(corpus, emptyDir, "home", cand, false)
+	if !write {
+		t.Errorf("first capture into an empty set was refused: %+v", res)
+	}
+	if res.ComparedTo != 0 {
+		t.Errorf("ComparedTo = %d for the first capture, want 0 (nothing to compare against)", res.ComparedTo)
+	}
+
+	// Even a fingerprint-empty first capture must write — len(others)==0 wins
+	// over IsNovel(); the blank-page guard lives in the capture command, not here.
+	if _, write := Gate(corpus, emptyDir, "home", Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}, false); !write {
+		t.Error("an empty first capture was refused; the first baseline must always write")
+	}
+
+	// ── Redundant second: one capture already on disk → gated ────────────────
+	second := t.TempDir()
+	secondDir := filepath.Join(second, ".sightmap")
+	writeFakeCapture(t, secondDir, "home", "20260101T000000Z")
+	res2, write2 := Gate(corpus, secondDir, "home", Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}, false)
+	if write2 {
+		t.Errorf("redundant capture vs an existing set was written: %+v", res2)
+	}
+	if res2.ComparedTo != 1 {
+		t.Errorf("ComparedTo = %d, want 1 (one existing capture)", res2.ComparedTo)
+	}
+
+	// --force bypasses the gate even when nothing is novel.
+	if _, write := Gate(corpus, secondDir, "home", Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}, true); !write {
+		t.Error("--force did not bypass the novelty gate")
+	}
+}
+
+// writeFakeCapture writes a minimal on-disk capture (a .snap plus its
+// .tree.json sibling) into a view set, enough for Find + SlotsForCapture to
+// treat it as one existing capture. The empty tree re-matches to an empty
+// fingerprint, which is all Gate's count needs.
+func writeFakeCapture(t *testing.T, sightmapDir, viewBasename, stamp string) {
+	t.Helper()
+	dir := filepath.Join(sightmapDir, "snapshots", viewBasename)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	snap := filepath.Join(dir, stamp+".snap")
+	if err := os.WriteFile(snap, []byte("(fake capture)\n"), 0o644); err != nil {
+		t.Fatalf("write snap: %v", err)
+	}
+	if err := os.WriteFile(snap+".tree.json", []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write tree: %v", err)
 	}
 }

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -690,12 +690,14 @@ to stdout (or `--out FILE`) — it never touches the corpus and never gates.
 (different loads, a drawer open, a tab switched).
 
 A capture that adds **no new component type or orphan slot** vs the view set is
-skipped by the **novelty gate** — `capture` prints "nothing new … not saved" and
-the overlay's Snap-view button shows "= nothing new (not saved)". The first
-capture of a view always writes; `capture --force` overrides. So just re-`capture`
-a dynamic view a few times — only loads that render something structurally new
-are kept; pure value churn (different products/prices) is ignored. `coverage`
-unions the whole view set.
+skipped by the **novelty gate** — `capture` reports that the view *already has* N
+capture(s) and this one is redundant ("not saved"), and the overlay's Snap-view
+button likewise marks it skipped. Read that as "already covered", **not** as a
+refusal of a first baseline: **the first capture of a view always writes** (an
+empty set can't be redundant), and `capture --force` keeps a redundant one
+anyway. So just re-`capture` a dynamic view a few times — only loads that render
+something structurally new are kept; pure value churn (different products/prices)
+is ignored. `coverage` unions the whole view set.
 
 **`coverage` / `multi-coverage`** require `.snap.tree.json` companion files.
 `capture` writes them automatically; `snapshot` writes one when `--tree-out` is


### PR DESCRIPTION
Two small authoring-clarity fixes to the offline inventory and the capture gate. Both surfaced when driving the from-scratch authoring loop against a real single-view app whose coverage lives entirely in global components.

## `stats`: attribute globals to their own row (closes #250)

A corpus that maps its coverage with corpus-root **global** components rendered a per-view table that read as empty — every view showed `0` components — with the confusing footer "per-view rows sum to 0". Globals apply to *every* view (`Corpus.ComponentsForRoute`), so folding them into one view's row would misattribute coverage.

Now they get a single leading row and a footer that explains them:

```
 View          Route          Components  Requests
 ──────────────────────────────────────────────────
 (global)      (all views)             3         1
 LightningApp  /lightning/**           0         0
 ──────────────────────────────────────────────────
 1 view  ·  3 distinct components  (3 declared globally, shared by every view)
```

The counts are derived in the CLI from the corpus rather than added to `Stats`, so the `stats --json` contract (and the atlas catalog's `Totals` shape) is unchanged — verified by the existing published-field-set test.

## `capture`: clarify the novelty-gate message (closes #251)

The gate always writes the first capture of a view (`len(others) == 0` short-circuits before the novelty check), so an empty snapshots dir is never refused. But the message — "nothing new vs N capture(s) … not saved" — read like a *first baseline* was being rejected, when in fact a baseline already existed and the new capture was redundant. Reworded to say so plainly:

> capture: `<view>` already has 1 capture(s); this one adds no new component or interactive slot — not saved (use --force to keep it anyway)

Adds a `viewset.Gate` test pinning the first-write guarantee (empty set always writes, even a fingerprint-empty capture; a redundant second is gated with `ComparedTo == 1`), and updates the `sightmap-authoring` skill to match and to reinforce that the first capture always writes.

## Verification
- `gofmt -l` clean; `go build/vet/test ./...` green; `npx jest` green.
- Skill change regenerated into `go/skills/` via `go generate ./skills/...`.
