### PR TITLE
multi-coverage: don't let stale capture dirs manufacture phantom global candidates

### DIFF
--- a/.changeset/multi-coverage-stale-dirs.md
+++ b/.changeset/multi-coverage-stale-dirs.md
@@ -1,0 +1,7 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`sightmap multi-coverage` no longer manufactures phantom "global candidate" promotions from stale capture directories. It grouped columns purely by directory name under `snapshots/`, so a leftover or renamed dir (e.g. an old `snapshots/views/` kept alongside the current `snapshots/home/` for the same page) became a second column and made that page's own components look like they "appear in 2+ views" — advising the author to wrongly globalize view-scoped components.
+
+A capture dir is now treated as a real view only when it matches a view in the *current* corpus (by `SnapBasename`). Non-current dirs are still shown in the matrix (marked `*`) for context but are excluded from the cross-view global-candidate analysis, and a warning names them so the author can delete the stale dir or re-capture under the current name. The `sightmap-authoring` skill documents the new behavior.

--- a/go/cmd/sightmap/cmd_multi_coverage.go
+++ b/go/cmd/sightmap/cmd_multi_coverage.go
@@ -37,6 +37,16 @@ func runMultiCoverage(args []string) error {
 		globalNames[gc.Name] = true
 	}
 
+	// A capture dir is only a real VIEW if it matches a view in the CURRENT
+	// corpus (by SnapBasename, the name capture writes the dir under). A stale or
+	// renamed dir — snapshots/<old-name>/ left over after the view was renamed —
+	// otherwise becomes a phantom extra column and manufactures bogus "appears in
+	// 2+ views" promotion evidence for that page's own components.
+	currentBasenames := make(map[string]bool, len(corpus.Views))
+	for i := range corpus.Views {
+		currentBasenames[corpus.Views[i].SnapBasename()] = true
+	}
+
 	// Group captures into per-view sets, then fold each view's captures into one
 	// column whose cell value is the per-component MAX across the set.
 	sets := viewset.GroupByView(snapFiles)
@@ -49,7 +59,11 @@ func runMultiCoverage(args []string) error {
 	var cols []viewColumn
 	for _, v := range viewNames {
 		var caps []map[string]int
+		recorded := ""
 		for _, e := range sets[v] {
+			if recorded == "" {
+				recorded = viewset.ViewNameOf(e.Path)
+			}
 			_, matches, _, ok := matchCapture(e.Path, corpus)
 			if !ok {
 				continue
@@ -65,7 +79,10 @@ func runMultiCoverage(args []string) error {
 		if len(caps) == 0 {
 			continue
 		}
-		cols = append(cols, unionViewColumn(v, caps))
+		col := unionViewColumn(v, caps)
+		col.Current = currentBasenames[v]
+		col.Recorded = recorded
+		cols = append(cols, col)
 	}
 
 	if len(cols) == 0 {
@@ -74,6 +91,7 @@ func runMultiCoverage(args []string) error {
 
 	printMatrix(cols)
 	printGlobalCandidates(globalCandidatesAcrossViews(cols, globalNames))
+	printStaleColumns(cols)
 	return nil
 }
 
@@ -85,15 +103,27 @@ type viewColumn struct {
 	View   string
 	Snaps  int
 	Counts map[string]int
+	// Current is true when this capture dir maps to a view in the current corpus
+	// (by SnapBasename). Only current columns count toward global promotion; a
+	// non-current column is a stale/renamed dir shown for context but excluded.
+	Current bool
+	// Recorded is the "[View: NAME]" header the captures carry, surfaced only in
+	// the stale-column warning to help the author identify what the dir was.
+	Recorded string
 }
 
 // label renders the column header for a view: "view·N" when the view carries more
-// than one capture, else just the view name.
+// than one capture, else just the view name. A non-current (stale/renamed) dir
+// is suffixed with "*", tying it to the warning printed below the matrix.
 func (c viewColumn) label() string {
+	name := c.View
 	if c.Snaps > 1 {
-		return fmt.Sprintf("%s\u00b7%d", c.View, c.Snaps)
+		name = fmt.Sprintf("%s\u00b7%d", c.View, c.Snaps)
 	}
-	return c.View
+	if !c.Current {
+		name += "*"
+	}
+	return name
 }
 
 // unionViewColumn folds a view's per-capture component counts into one column,
@@ -182,12 +212,17 @@ type globalCandidate struct {
 }
 
 // globalCandidatesAcrossViews returns components that match (count > 0) in 2 or
-// more VIEWS and aren't already global. Counting views (not capture files) is the
-// A single view snapped many times no longer trips the threshold.
-// Result is sorted by name; each candidate's hits follow column order.
+// more CURRENT VIEWS and aren't already global. Counting views (not capture
+// files) means a single view snapped many times no longer trips the threshold;
+// restricting to CURRENT columns (Current == true) means a stale or renamed
+// capture dir can't manufacture phantom cross-view evidence for a page's own
+// components. Result is sorted by name; each candidate's hits follow column order.
 func globalCandidatesAcrossViews(cols []viewColumn, globalNames map[string]bool) []globalCandidate {
 	nameSet := map[string]bool{}
 	for _, c := range cols {
+		if !c.Current {
+			continue
+		}
 		for name := range c.Counts {
 			nameSet[name] = true
 		}
@@ -205,6 +240,9 @@ func globalCandidatesAcrossViews(cols []viewColumn, globalNames map[string]bool)
 		}
 		var hits []viewHit
 		for _, c := range cols {
+			if !c.Current {
+				continue
+			}
 			if count := c.Counts[name]; count > 0 {
 				hits = append(hits, viewHit{View: c.View, Count: count})
 			}
@@ -214,6 +252,39 @@ func globalCandidatesAcrossViews(cols []viewColumn, globalNames map[string]bool)
 		}
 	}
 	return candidates
+}
+
+// staleColumns returns the columns that don't map to a current corpus view, in
+// column order. These are the phantom-evidence sources #248 is about.
+func staleColumns(cols []viewColumn) []viewColumn {
+	var stale []viewColumn
+	for _, c := range cols {
+		if !c.Current {
+			stale = append(stale, c)
+		}
+	}
+	return stale
+}
+
+// printStaleColumns warns about capture dirs that match no current view. They
+// still appear in the matrix (marked "*") for context, but are excluded from the
+// global-candidate analysis so a stale or renamed dir can't mis-advise a
+// promotion. Prints nothing when every column maps to a current view.
+func printStaleColumns(cols []viewColumn) {
+	stale := staleColumns(cols)
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("⚠ %d capture dir(s) match no view in the current corpus (stale or renamed?) —\n", len(stale))
+	fmt.Println("  marked \"*\" above and EXCLUDED from the global-candidate analysis:")
+	for _, c := range stale {
+		recorded := ""
+		if c.Recorded != "" {
+			recorded = fmt.Sprintf(" (recorded [View: %s])", c.Recorded)
+		}
+		fmt.Printf("  %s%s   → delete the stale dir, or re-capture the view under its current name\n", c.View, recorded)
+	}
 }
 
 // printGlobalCandidates prints the promotion-candidate block (nothing if empty).

--- a/go/cmd/sightmap/cmd_multi_coverage_test.go
+++ b/go/cmd/sightmap/cmd_multi_coverage_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+)
+
+// col is a tiny viewColumn builder for the tests below.
+func col(view string, current bool, counts map[string]int) viewColumn {
+	return viewColumn{View: view, Snaps: 1, Counts: counts, Current: current}
+}
+
+// TestGlobalCandidates_IgnoresStaleColumns is the #248 regression: a stale or
+// renamed capture dir (Current=false) must not manufacture "appears in 2+ views"
+// evidence for a page's own components. Here "home" (current) and "views" (stale,
+// the same page under its old dir name) both render Card and Header; without the
+// current-column filter both would look like they appear in two views and get
+// wrongly promoted.
+func TestGlobalCandidates_IgnoresStaleColumns(t *testing.T) {
+	cols := []viewColumn{
+		col("home", true, map[string]int{"Card": 3, "Header": 1}),
+		col("views", false, map[string]int{"Card": 3, "Header": 1}), // stale dup of home
+	}
+
+	got := globalCandidatesAcrossViews(cols, map[string]bool{})
+	if len(got) != 0 {
+		t.Fatalf("stale column manufactured %d candidate(s), want 0: %+v", len(got), got)
+	}
+}
+
+// TestGlobalCandidates_CountsCurrentViews confirms the filter doesn't suppress a
+// genuine candidate: a component in two CURRENT views is still promoted, and one
+// already-global component is skipped.
+func TestGlobalCandidates_CountsCurrentViews(t *testing.T) {
+	cols := []viewColumn{
+		col("home", true, map[string]int{"Nav": 1, "Card": 2}),
+		col("search", true, map[string]int{"Nav": 1, "Result": 4}),
+		col("legacy", false, map[string]int{"Nav": 1}), // stale: must not inflate Nav's hits
+	}
+
+	got := globalCandidatesAcrossViews(cols, map[string]bool{"AlreadyGlobal": true})
+	if len(got) != 1 {
+		t.Fatalf("got %d candidates, want 1 (Nav): %+v", len(got), got)
+	}
+	if got[0].Name != "Nav" {
+		t.Errorf("candidate = %q, want Nav", got[0].Name)
+	}
+	// Nav appears in home + search only — the stale "legacy" column is excluded,
+	// so its two hits are exactly the two current views.
+	if len(got[0].Hits) != 2 {
+		t.Errorf("Nav hits = %+v, want exactly the 2 current views", got[0].Hits)
+	}
+	for _, h := range got[0].Hits {
+		if h.View == "legacy" {
+			t.Errorf("stale column 'legacy' leaked into Nav's hits: %+v", got[0].Hits)
+		}
+	}
+}
+
+// TestStaleColumns_Detection pins the helper the warning is built from.
+func TestStaleColumns_Detection(t *testing.T) {
+	cols := []viewColumn{
+		col("home", true, nil),
+		col("views", false, nil),
+		col("old-dir", false, nil),
+	}
+	stale := staleColumns(cols)
+	if len(stale) != 2 {
+		t.Fatalf("staleColumns = %d, want 2: %+v", len(stale), stale)
+	}
+	if stale[0].View != "views" || stale[1].View != "old-dir" {
+		t.Errorf("stale columns = %q,%q, want views,old-dir", stale[0].View, stale[1].View)
+	}
+}
+
+// TestViewColumnLabel_MarksStale: the matrix label suffixes non-current columns
+// with "*" (and still shows the ·N set-size marker).
+func TestViewColumnLabel_MarksStale(t *testing.T) {
+	if got := (viewColumn{View: "home", Snaps: 1, Current: true}).label(); got != "home" {
+		t.Errorf("current single-capture label = %q, want home", got)
+	}
+	if got := (viewColumn{View: "home", Snaps: 3, Current: true}).label(); got != "home·3" {
+		t.Errorf("current multi-capture label = %q, want home·3", got)
+	}
+	if got := (viewColumn{View: "views", Snaps: 1, Current: false}).label(); got != "views*" {
+		t.Errorf("stale label = %q, want views*", got)
+	}
+}

--- a/go/cmd/sightmap/snapshot_readers_test.go
+++ b/go/cmd/sightmap/snapshot_readers_test.go
@@ -67,6 +67,9 @@ func TestUnionViewColumn(t *testing.T) {
 	if !reflect.DeepEqual(col.Counts, want) {
 		t.Errorf("counts = %v, want %v", col.Counts, want)
 	}
+	// A current view's label carries no stale marker; runMultiCoverage sets
+	// Current after unioning (unionViewColumn is count-only).
+	col.Current = true
 	if got := col.label(); got != "home·3" {
 		t.Errorf("label = %q, want home·3", got)
 	}
@@ -74,6 +77,7 @@ func TestUnionViewColumn(t *testing.T) {
 
 func TestViewColumnLabelSingleCapture(t *testing.T) {
 	col := unionViewColumn("pdp", []map[string]int{{"AddToCartButton": 1}})
+	col.Current = true
 	if got := col.label(); got != "pdp" {
 		t.Errorf("single-capture label = %q, want pdp (no ·N suffix)", got)
 	}
@@ -84,15 +88,15 @@ func TestViewColumnLabelSingleCapture(t *testing.T) {
 // ProductPod (3 views) is a true candidate.
 func TestGlobalCandidatesAcrossViews(t *testing.T) {
 	cols := []viewColumn{
-		{View: "home", Snaps: 3, Counts: map[string]int{
+		{View: "home", Snaps: 3, Current: true, Counts: map[string]int{
 			"SiteHeader": 1, "GlobalNav": 7, "Footer": 1,
 			"DigitalEndcap": 4, "ProductPod": 12, "PromoBanner": 2,
 		}},
-		{View: "plp", Snaps: 2, Counts: map[string]int{
+		{View: "plp", Snaps: 2, Current: true, Counts: map[string]int{
 			"SiteHeader": 1, "GlobalNav": 7, "Footer": 1,
 			"ProductPod": 36, "FacetFilter": 8, "SortDropdown": 1,
 		}},
-		{View: "pdp", Snaps: 1, Counts: map[string]int{
+		{View: "pdp", Snaps: 1, Current: true, Counts: map[string]int{
 			"SiteHeader": 1, "GlobalNav": 7, "Footer": 1,
 			"AddToCartButton": 1, "ProductPod": 6,
 		}},

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -641,6 +641,13 @@ sightmap multi-coverage
 - 2 pages, identical selectors → usually promote
 - 2 pages, different selectors → keep view-scoped
 
+Only **current** views count toward this. A capture dir that matches no view in
+the current corpus (a stale or renamed `snapshots/<dir>/`) is marked `*` in the
+matrix and excluded from the candidate list, with a warning — so a leftover dir
+can't manufacture phantom "appears in 2+ views" evidence for a page's own
+components. When you see that warning, delete the stale dir (or re-capture the
+view under its current name) and re-run.
+
 ---
 
 ## Phase 3: Validation

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -641,6 +641,13 @@ sightmap multi-coverage
 - 2 pages, identical selectors → usually promote
 - 2 pages, different selectors → keep view-scoped
 
+Only **current** views count toward this. A capture dir that matches no view in
+the current corpus (a stale or renamed `snapshots/<dir>/`) is marked `*` in the
+matrix and excluded from the candidate list, with a warning — so a leftover dir
+can't manufacture phantom "appears in 2+ views" evidence for a page's own
+components. When you see that warning, delete the stale dir (or re-capture the
+view under its current name) and re-run.
+
 ---
 
 ## Phase 3: Validation


### PR DESCRIPTION
`multi-coverage` grouped its matrix columns purely by directory name under `snapshots/`. A stale or renamed capture dir — e.g. an old `snapshots/views/` left beside the current `snapshots/home/` for the *same* page — became a second column and manufactured phantom "appears in 2+ views" evidence, so `multi-coverage` advised promoting that page's own view-scoped components to globals (closes #248).

## Fix

A capture dir now counts as a real view only when it matches a view in the **current** corpus (by `SnapBasename` — the name `capture` writes the dir under). Legit captures always match, since `capture` created the dir from that same basename; only stale/renamed/hand-placed dirs fall out.

- **Global-candidate analysis** counts only current columns, so a stale dir can't inflate a component's view count.
- **Matrix** still shows every dir, marking non-current ones with `*` for context.
- **Warning** names the excluded dirs (with their recorded `[View: NAME]` header) and suggests deleting the stale dir or re-capturing under the current name.

Example (old `views/` dir kept beside current `home/`, same page):

```
Component  home  views*
───────────────────────
Banner        1       1
Card          2       2

⚠ 1 capture dir(s) match no view in the current corpus (stale or renamed?) —
  marked "*" above and EXCLUDED from the global-candidate analysis:
  views (recorded [View: OldHome])   → delete the stale dir, or re-capture the view under its current name
```

`Card`/`Banner` are no longer offered as global candidates; before, both were.

## Notes / scope
- The shared `viewset.GroupByView` primitive (used by prune/presence) is unchanged; this is scoped to `multi-coverage`'s promotion analysis.
- A `capture`-side guard against writing a view's snaps under a non-matching dir is a reasonable follow-up but intentionally out of scope here.

## Verification
- New unit tests: current-only candidate counting, stale-column detection, label marker; existing column tests updated for the new field.
- `gofmt -l` clean; `go build/vet/test ./...` green; `npx jest` green; skill regenerated via `go generate ./skills/...`.
- Verified end-to-end against an on-disk fixture (current `home` + stale `views` of the same page): stale column excluded + warned; genuine two-current-view components still promote.
