### PR TITLE
stats: fix ComponentsForURL doc reference; simplify Gate test; pin issue #250 scenario

### DIFF
--- a/go/cmd/sightmap/cmd_stats_test.go
+++ b/go/cmd/sightmap/cmd_stats_test.go
@@ -138,6 +138,45 @@ func containsCollapsed(got, want string) bool {
 	return false
 }
 
+// TestStats_ViewWithNoOwnComponentsShowsGlobalRow reproduces issue #250 itself:
+// a view that declares no components or requests of its own, with all of its
+// coverage living in corpus-root globals. Before the global row existed, this
+// rendered as an all-zero per-view table; now the view's row is legitimately 0
+// and the global row carries the real counts.
+func TestStats_ViewWithNoOwnComponentsShowsGlobalRow(t *testing.T) {
+	dir := writeStatsCorpus(t, map[string]string{
+		"components.yaml": `version: 1
+components:
+  - name: Header
+    selector: '#header'
+requests:
+  - name: Ping
+    route: /api/ping
+`,
+		"views/lightning.yaml": `version: 1
+views:
+  - name: LightningApp
+    route: /lightning/**
+`,
+	})
+
+	var out bytes.Buffer
+	if err := runStatsOut([]string{"--sightmap-dir", dir}, &out); err != nil {
+		t.Fatalf("runStatsOut: %v", err)
+	}
+	got := out.String()
+
+	for _, want := range []string{
+		"(global) (all views) 1 1",
+		"LightningApp /lightning/** 0 0",
+		"1 view · 1 distinct components (1 declared globally, shared by every view)",
+	} {
+		if !containsCollapsed(got, want) {
+			t.Errorf("output missing row/line %q (whitespace-collapsed):\n%s", want, got)
+		}
+	}
+}
+
 // TestStatsJSON_DedupedTotals is the --json half of the same corpus: the
 // machine-readable numbers must agree with the table, and the payload must be
 // nothing but JSON — no banner for a consumer to strip.

--- a/go/sightmap/stats.go
+++ b/go/sightmap/stats.go
@@ -57,7 +57,7 @@ type Totals struct {
 
 // ViewStats is one per-view row: the components and requests DECLARED under that
 // view after $ref expansion. It does not include corpus-root globals, which
-// apply to every view (see Corpus.ComponentsForRoute) and are reported once —
+// apply to every view (see Corpus.ComponentsForURL) and are reported once —
 // the CLI renders them as a separate "(global)" row rather than folding them
 // into any single view, where they would misattribute coverage. A view's
 // effective coverage is thus its own row plus the globals; per-view columns

--- a/go/viewset/sets_test.go
+++ b/go/viewset/sets_test.go
@@ -248,10 +248,14 @@ func TestFormatStampDisplay(t *testing.T) {
 func TestGate(t *testing.T) {
 	corpus := &sightmap.Corpus{}
 
+	// Gate only ever ranges over cand's maps, never writes to them, so the zero
+	// value stands in for "nothing matched, no orphans" as well as an explicit
+	// empty map would.
+	empty := Slots{}
+
 	// ── First baseline: empty snapshots dir → always writes ──────────────────
-	empty := t.TempDir()
-	emptyDir := filepath.Join(empty, ".sightmap")
-	cand := Slots{Matched: map[string]bool{"Header": true}, Orphans: map[string]int{}}
+	emptyDir := filepath.Join(t.TempDir(), ".sightmap")
+	cand := Slots{Matched: map[string]bool{"Header": true}}
 	res, write := Gate(corpus, emptyDir, "home", cand, false)
 	if !write {
 		t.Errorf("first capture into an empty set was refused: %+v", res)
@@ -262,15 +266,14 @@ func TestGate(t *testing.T) {
 
 	// Even a fingerprint-empty first capture must write — len(others)==0 wins
 	// over IsNovel(); the blank-page guard lives in the capture command, not here.
-	if _, write := Gate(corpus, emptyDir, "home", Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}, false); !write {
+	if _, write := Gate(corpus, emptyDir, "home", empty, false); !write {
 		t.Error("an empty first capture was refused; the first baseline must always write")
 	}
 
 	// ── Redundant second: one capture already on disk → gated ────────────────
-	second := t.TempDir()
-	secondDir := filepath.Join(second, ".sightmap")
+	secondDir := filepath.Join(t.TempDir(), ".sightmap")
 	writeFakeCapture(t, secondDir, "home", "20260101T000000Z")
-	res2, write2 := Gate(corpus, secondDir, "home", Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}, false)
+	res2, write2 := Gate(corpus, secondDir, "home", empty, false)
 	if write2 {
 		t.Errorf("redundant capture vs an existing set was written: %+v", res2)
 	}
@@ -279,7 +282,7 @@ func TestGate(t *testing.T) {
 	}
 
 	// --force bypasses the gate even when nothing is novel.
-	if _, write := Gate(corpus, secondDir, "home", Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}, true); !write {
+	if _, write := Gate(corpus, secondDir, "home", empty, true); !write {
 		t.Error("--force did not bypass the novelty gate")
 	}
 }


### PR DESCRIPTION
Follow-up fixes from reviewing #255.

- `go/sightmap/stats.go`: the new `ViewStats` doc comment pointed to `Corpus.ComponentsForRoute`, which doesn't exist — the real method is `Corpus.ComponentsForURL`. Fixed the reference.
- `go/viewset/sets_test.go`: `TestGate` repeated the same `Slots{Matched: map[string]bool{}, Orphans: map[string]int{}}` literal three times. `Gate`/`ComputeNovelty` only read those maps, so a zero-value `Slots{}` behaves identically — replaced the three literals with one reused value.
- `go/cmd/sightmap/cmd_stats_test.go`: added `TestStats_ViewWithNoOwnComponentsShowsGlobalRow`, covering the actual issue #250 scenario (a view with no components of its own, all coverage from corpus-root globals) — the existing test only used views that already had non-zero components of their own.