### PR TITLE
multi-coverage: only compute Recorded for stale columns, split current/stale filtering out of candidate math

### DIFF
--- a/go/cmd/sightmap/cmd_multi_coverage.go
+++ b/go/cmd/sightmap/cmd_multi_coverage.go
@@ -81,7 +81,9 @@ func runMultiCoverage(args []string) error {
 		}
 		col := unionViewColumn(v, caps)
 		col.Current = currentBasenames[v]
-		col.Recorded = recorded
+		if !col.Current {
+			col.Recorded = recorded
+		}
 		cols = append(cols, col)
 	}
 
@@ -90,8 +92,8 @@ func runMultiCoverage(args []string) error {
 	}
 
 	printMatrix(cols)
-	printGlobalCandidates(globalCandidatesAcrossViews(cols, globalNames))
-	printStaleColumns(cols)
+	printGlobalCandidates(globalCandidatesAcrossViews(currentColumns(cols), globalNames))
+	printStaleColumns(staleColumns(cols))
 	return nil
 }
 
@@ -211,18 +213,39 @@ type globalCandidate struct {
 	Hits []viewHit
 }
 
+// currentColumns returns the columns that map to a view in the current corpus,
+// in column order.
+func currentColumns(cols []viewColumn) []viewColumn {
+	var current []viewColumn
+	for _, c := range cols {
+		if c.Current {
+			current = append(current, c)
+		}
+	}
+	return current
+}
+
+// staleColumns returns the columns that don't map to a current corpus view, in
+// column order. These are the phantom-evidence sources #248 is about.
+func staleColumns(cols []viewColumn) []viewColumn {
+	var stale []viewColumn
+	for _, c := range cols {
+		if !c.Current {
+			stale = append(stale, c)
+		}
+	}
+	return stale
+}
+
 // globalCandidatesAcrossViews returns components that match (count > 0) in 2 or
-// more CURRENT VIEWS and aren't already global. Counting views (not capture
-// files) means a single view snapped many times no longer trips the threshold;
-// restricting to CURRENT columns (Current == true) means a stale or renamed
-// capture dir can't manufacture phantom cross-view evidence for a page's own
+// more of the given views and aren't already global. Counting views (not
+// capture files) means a single view snapped many times no longer trips the
+// threshold. Callers pass currentColumns(cols) so a stale or renamed capture
+// dir can't manufacture phantom cross-view evidence for a page's own
 // components. Result is sorted by name; each candidate's hits follow column order.
 func globalCandidatesAcrossViews(cols []viewColumn, globalNames map[string]bool) []globalCandidate {
 	nameSet := map[string]bool{}
 	for _, c := range cols {
-		if !c.Current {
-			continue
-		}
 		for name := range c.Counts {
 			nameSet[name] = true
 		}
@@ -240,9 +263,6 @@ func globalCandidatesAcrossViews(cols []viewColumn, globalNames map[string]bool)
 		}
 		var hits []viewHit
 		for _, c := range cols {
-			if !c.Current {
-				continue
-			}
 			if count := c.Counts[name]; count > 0 {
 				hits = append(hits, viewHit{View: c.View, Count: count})
 			}
@@ -254,24 +274,11 @@ func globalCandidatesAcrossViews(cols []viewColumn, globalNames map[string]bool)
 	return candidates
 }
 
-// staleColumns returns the columns that don't map to a current corpus view, in
-// column order. These are the phantom-evidence sources #248 is about.
-func staleColumns(cols []viewColumn) []viewColumn {
-	var stale []viewColumn
-	for _, c := range cols {
-		if !c.Current {
-			stale = append(stale, c)
-		}
-	}
-	return stale
-}
-
 // printStaleColumns warns about capture dirs that match no current view. They
 // still appear in the matrix (marked "*") for context, but are excluded from the
 // global-candidate analysis so a stale or renamed dir can't mis-advise a
-// promotion. Prints nothing when every column maps to a current view.
-func printStaleColumns(cols []viewColumn) {
-	stale := staleColumns(cols)
+// promotion. Prints nothing when stale is empty. Callers pass staleColumns(cols).
+func printStaleColumns(stale []viewColumn) {
 	if len(stale) == 0 {
 		return
 	}

--- a/go/cmd/sightmap/cmd_multi_coverage_test.go
+++ b/go/cmd/sightmap/cmd_multi_coverage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -9,79 +10,83 @@ func col(view string, current bool, counts map[string]int) viewColumn {
 	return viewColumn{View: view, Snaps: 1, Counts: counts, Current: current}
 }
 
-// TestGlobalCandidates_IgnoresStaleColumns is the #248 regression: a stale or
+// TestGlobalCandidatesAcrossViews_CurrentOnly is the #248 regression: a stale or
 // renamed capture dir (Current=false) must not manufacture "appears in 2+ views"
-// evidence for a page's own components. Here "home" (current) and "views" (stale,
-// the same page under its old dir name) both render Card and Header; without the
-// current-column filter both would look like they appear in two views and get
-// wrongly promoted.
-func TestGlobalCandidates_IgnoresStaleColumns(t *testing.T) {
-	cols := []viewColumn{
-		col("home", true, map[string]int{"Card": 3, "Header": 1}),
-		col("views", false, map[string]int{"Card": 3, "Header": 1}), // stale dup of home
+// evidence, and callers are expected to pre-filter with currentColumns before
+// calling globalCandidatesAcrossViews.
+func TestGlobalCandidatesAcrossViews_CurrentOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		cols    []viewColumn
+		globals map[string]bool
+		want    []globalCandidate
+	}{
+		{
+			name: "stale duplicate of a current view yields no candidates",
+			cols: []viewColumn{
+				col("home", true, map[string]int{"Card": 3, "Header": 1}),
+				col("views", false, map[string]int{"Card": 3, "Header": 1}), // stale dup of home
+			},
+			globals: map[string]bool{},
+			want:    nil,
+		},
+		{
+			name: "component in two current views is still promoted; stale view excluded from hits",
+			cols: []viewColumn{
+				col("home", true, map[string]int{"Nav": 1, "Card": 2}),
+				col("search", true, map[string]int{"Nav": 1, "Result": 4}),
+				col("legacy", false, map[string]int{"Nav": 1}), // stale: must not inflate Nav's hits
+			},
+			globals: map[string]bool{"AlreadyGlobal": true},
+			want: []globalCandidate{
+				{Name: "Nav", Hits: []viewHit{{View: "home", Count: 1}, {View: "search", Count: 1}}},
+			},
+		},
 	}
-
-	got := globalCandidatesAcrossViews(cols, map[string]bool{})
-	if len(got) != 0 {
-		t.Fatalf("stale column manufactured %d candidate(s), want 0: %+v", len(got), got)
-	}
-}
-
-// TestGlobalCandidates_CountsCurrentViews confirms the filter doesn't suppress a
-// genuine candidate: a component in two CURRENT views is still promoted, and one
-// already-global component is skipped.
-func TestGlobalCandidates_CountsCurrentViews(t *testing.T) {
-	cols := []viewColumn{
-		col("home", true, map[string]int{"Nav": 1, "Card": 2}),
-		col("search", true, map[string]int{"Nav": 1, "Result": 4}),
-		col("legacy", false, map[string]int{"Nav": 1}), // stale: must not inflate Nav's hits
-	}
-
-	got := globalCandidatesAcrossViews(cols, map[string]bool{"AlreadyGlobal": true})
-	if len(got) != 1 {
-		t.Fatalf("got %d candidates, want 1 (Nav): %+v", len(got), got)
-	}
-	if got[0].Name != "Nav" {
-		t.Errorf("candidate = %q, want Nav", got[0].Name)
-	}
-	// Nav appears in home + search only — the stale "legacy" column is excluded,
-	// so its two hits are exactly the two current views.
-	if len(got[0].Hits) != 2 {
-		t.Errorf("Nav hits = %+v, want exactly the 2 current views", got[0].Hits)
-	}
-	for _, h := range got[0].Hits {
-		if h.View == "legacy" {
-			t.Errorf("stale column 'legacy' leaked into Nav's hits: %+v", got[0].Hits)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := globalCandidatesAcrossViews(currentColumns(tt.cols), tt.globals)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-// TestStaleColumns_Detection pins the helper the warning is built from.
-func TestStaleColumns_Detection(t *testing.T) {
+func TestCurrentAndStaleColumns_Partition(t *testing.T) {
 	cols := []viewColumn{
 		col("home", true, nil),
 		col("views", false, nil),
 		col("old-dir", false, nil),
 	}
-	stale := staleColumns(cols)
-	if len(stale) != 2 {
-		t.Fatalf("staleColumns = %d, want 2: %+v", len(stale), stale)
+
+	current := currentColumns(cols)
+	if len(current) != 1 || current[0].View != "home" {
+		t.Errorf("currentColumns = %+v, want just [home]", current)
 	}
-	if stale[0].View != "views" || stale[1].View != "old-dir" {
-		t.Errorf("stale columns = %q,%q, want views,old-dir", stale[0].View, stale[1].View)
+
+	stale := staleColumns(cols)
+	if len(stale) != 2 || stale[0].View != "views" || stale[1].View != "old-dir" {
+		t.Errorf("staleColumns = %+v, want [views, old-dir]", stale)
 	}
 }
 
-// TestViewColumnLabel_MarksStale: the matrix label suffixes non-current columns
-// with "*" (and still shows the ·N set-size marker).
-func TestViewColumnLabel_MarksStale(t *testing.T) {
-	if got := (viewColumn{View: "home", Snaps: 1, Current: true}).label(); got != "home" {
-		t.Errorf("current single-capture label = %q, want home", got)
+func TestViewColumnLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		col  viewColumn
+		want string
+	}{
+		{"current single-capture", viewColumn{View: "home", Snaps: 1, Current: true}, "home"},
+		{"current multi-capture", viewColumn{View: "home", Snaps: 3, Current: true}, "home·3"},
+		{"stale single-capture", viewColumn{View: "views", Snaps: 1, Current: false}, "views*"},
+		{"stale multi-capture", viewColumn{View: "views", Snaps: 2, Current: false}, "views·2*"},
 	}
-	if got := (viewColumn{View: "home", Snaps: 3, Current: true}).label(); got != "home·3" {
-		t.Errorf("current multi-capture label = %q, want home·3", got)
-	}
-	if got := (viewColumn{View: "views", Snaps: 1, Current: false}).label(); got != "views*" {
-		t.Errorf("stale label = %q, want views*", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.col.label(); got != tt.want {
+				t.Errorf("label() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`Recorded` was written on every column, even though only `printStaleColumns` reads it and only for non-current ones. It's now set only when `!col.Current`, so the write site matches the only read site.

`globalCandidatesAcrossViews` and `staleColumns` each reimplemented the same `!c.Current` filter: twice in one, once in the other. A new `currentColumns` helper partitions once, at the call site in `runMultiCoverage`; `globalCandidatesAcrossViews` now just computes candidates over whatever columns it's handed, with no knowledge of what "current" means.

Tests for these three functions are table-driven now, covering the current/stale partition and label suffix behavior in one function each instead of one test function per scenario.