### PR TITLE
Make sightmap.org more agent-readable

### DIFF
--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -5,6 +5,7 @@ memory:
   - All homepage sections live in src/components/ and compose into src/pages/Home.tsx
   - Posts are markdown in content/blog/; scripts/build-blog.ts generates the manifest and per-post HTML modules
   - Pages are statically prerendered by scripts/prerender.tsx; the client hydrates rather than mounting fresh
+  - The negotiate edge function (netlify/edge-functions/negotiate.ts) serves markdown twins for Accept: text/markdown and JSON errors for /api/* and for 404s that asked for JSON; it always sets Vary: Accept
   - "The offline matcher has no pseudo-class support: a selector like `.foo:first-child` probes 1 live and 0 offline, so keep selectors to attributes, classes and descendant combinators"
 
 views:
@@ -280,13 +281,28 @@ views:
         source: src/pages/AtlasEntry.tsx
         description: Returns to the gallery from an entry
 
+  - name: Developers
+    route: /developers
+    description: Sightmap developer resources — OpenAPI, Atlas HTTP API, docs, CLI, and skills
+    source: src/pages/Developers.tsx
+    memory:
+      - Title and h1 both contain "Sightmap developer resources" so name-based search can find this page
+      - The public API is read-only and unauthenticated; that is stated in the header copy
+      - Machine twins live at /developers.md, /openapi.json, and /api/openapi.yaml
+    components:
+      - name: DeveloperResource
+        selector: '.developers__item'
+        source: src/pages/Developers.tsx
+        description: One developer resource — title, what it is, and its URL
+
   - name: NotFound
     route: '*'
     description: Catch-all 404 page for any unmatched route
     source: src/pages/NotFound.tsx
     memory:
-      - "netlify.toml rewrites every path to /index.html with a 200 status, so this always renders as a soft 404 (HTTP 200 with 404 content), never a true 404 response"
-      - The prerender never emits a page for this route; it only ever renders client-side, after the catch-all route match
+      - "netlify.toml's catch-all serves dist/404.html with HTTP 404; the negotiate edge function may replace that body with markdown or JSON based on Accept"
+      - Recovery links (llms.txt, sitemap, /developers, docs) are on the HTML page so an agent that got HTML can still continue
+      - The prerender writes one unstamped dist/404.html; main.tsx mounts fresh for the actual URL
 
 components:
   - name: Navigation
@@ -304,7 +320,7 @@ components:
   - name: Footer
     selector: '[data-component="Footer"]'
     source: src/components/Footer.tsx
-    description: Site-wide attribution and the full secondary link set, plus the only entry point to the privacy preferences dialog
+    description: Site-wide attribution and the full secondary link set (including Developers), plus the only entry point to the privacy preferences dialog
     memory:
       - The banner auto-shows once and never again once a choice is stored, so the "Privacy preferences" button here is the only route back to the consent dialog
     children:

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,8 @@
   <meta name="description" content="An open YAML spec and CLI that maps views, components, and API requests to source files, with memory for runtime behavior.">
   <link rel="canonical" href="https://sightmap.org/">
   <link rel="alternate" type="application/rss+xml" title="Sightmap Blog" href="https://sightmap.org/rss.xml">
+  <link rel="alternate" type="text/markdown" href="https://sightmap.org/index.md">
+  <link rel="alternate" type="application/json" title="Sightmap OpenAPI" href="https://sightmap.org/openapi.json">
   <meta property="og:title" content="Sightmap — runtime context for agents using your web app">
   <meta property="og:description" content="An open YAML spec and CLI that maps views, components, and API requests to source files, with memory for runtime behavior.">
   <meta property="og:type" content="website">

--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -2,6 +2,21 @@
   command = "pnpm build"
   publish = "dist"
 
+# Pretty API URLs. Static files at these paths win over a non-forced rewrite,
+# so /api/atlas.json and /api/atlas/<slug>.json (written by
+# scripts/generate-agent-files.ts) are the source of truth. Unknown slugs
+# fall through to the 404 catch-all; the negotiate edge function turns that
+# HTML 404 into a JSON error for /api/*.
+[[redirects]]
+  from = "/api/atlas"
+  to = "/api/atlas.json"
+  status = 200
+
+[[redirects]]
+  from = "/api/atlas/:slug"
+  to = "/api/atlas/:slug.json"
+  status = 200
+
 # Unknown URLs. Every real route has a prerendered dist/<route>/index.html, and
 # Netlify serves an existing static file before applying a non-forced redirect,
 # so this rule only ever answers paths that do not exist. It used to return 200
@@ -31,10 +46,48 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
+[[headers]]
+  for = "/*.md"
+  [headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
+    Vary = "Accept, Accept-Encoding"
+
+[[headers]]
+  for = "/blog/*.md"
+  [headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
+    Vary = "Accept, Accept-Encoding"
+
+[[headers]]
+  for = "/atlas/*.md"
+  [headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
+    Vary = "Accept, Accept-Encoding"
+
+[[headers]]
+  for = "/openapi.json"
+  [headers.values]
+    Content-Type = "application/json; charset=utf-8"
+    Access-Control-Allow-Origin = "*"
+
+[[headers]]
+  for = "/api/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Vary = "Accept, Accept-Encoding"
+
 # Inject the visitor's consent region into app HTML (replaces <!--CC_REGION-->).
 # The function guards on content-type, so non-HTML responses pass through;
 # assets are excluded outright to avoid pointless invocations.
 [[edge_functions]]
   function = "geo-region"
+  path = "/*"
+  excludedPath = ["/assets/*"]
+
+# Accept negotiation (markdown / JSON errors / Vary: Accept). Declared after
+# geo-region so geo-region is outermost: it calls next(), this function
+# rewrites, and geo-region only injects into remaining HTML.
+[[edge_functions]]
+  function = "negotiate"
   path = "/*"
   excludedPath = ["/assets/*"]

--- a/web/netlify/edge-functions/negotiate.ts
+++ b/web/netlify/edge-functions/negotiate.ts
@@ -1,0 +1,18 @@
+// netlify/edge-functions/negotiate.ts
+//
+// Accept-negotiates HTML pages as text/markdown, returns structured JSON
+// errors for /api/* and for 404s that asked for JSON, and always sets
+// Vary: Accept so a CDN cannot serve the HTML variant to an agent (or
+// the markdown variant to a browser).
+import type { Context } from '@netlify/edge-functions'
+import { handleNegotiate } from '../lib/handler.ts'
+
+export default async function handler(
+  request: Request,
+  context: Context
+): Promise<Response | undefined> {
+  return handleNegotiate(request, {
+    next: () => context.next(),
+    fetch: (input) => fetch(input),
+  })
+}

--- a/web/netlify/lib/accept.test.ts
+++ b/web/netlify/lib/accept.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isPassthroughPath,
+  markdownTwinPath,
+  mergeVary,
+  negotiate,
+  normalizePathname,
+  parseAccept,
+} from './accept'
+
+describe('parseAccept', () => {
+  it('defaults q to 1 and lowercases types', () => {
+    expect(parseAccept('Text/Markdown, text/html;q=0.8')).toEqual([
+      { type: 'text', subtype: 'markdown', q: 1, specificity: 3 },
+      { type: 'text', subtype: 'html', q: 0.8, specificity: 3 },
+    ])
+  })
+
+  it('treats a missing or empty header as no entries', () => {
+    expect(parseAccept(null)).toEqual([])
+    expect(parseAccept(undefined)).toEqual([])
+    expect(parseAccept('')).toEqual([])
+    expect(parseAccept('   ')).toEqual([])
+  })
+})
+
+describe('negotiate', () => {
+  const mdHtml = ['text/markdown', 'text/html'] as const
+
+  it('serves markdown when Accept prefers it', () => {
+    expect(negotiate('text/markdown', mdHtml, 'text/html')).toBe('text/markdown')
+    expect(negotiate('text/markdown, text/html;q=0.8', mdHtml, 'text/html')).toBe(
+      'text/markdown'
+    )
+  })
+
+  it('serves html when Accept prefers it', () => {
+    expect(negotiate('text/html', mdHtml, 'text/html')).toBe('text/html')
+  })
+
+  it('honors q=0 refusal of markdown', () => {
+    expect(negotiate('text/markdown;q=0, text/html', mdHtml, 'text/html')).toBe('text/html')
+  })
+
+  it('returns null (406) when every offered type is refused', () => {
+    expect(negotiate('text/markdown;q=0', ['text/markdown'], 'text/markdown')).toBeNull()
+    expect(negotiate('application/pdf', mdHtml, 'text/html')).toBeNull()
+  })
+
+  it('serves the default when Accept is missing or */*', () => {
+    expect(negotiate(null, mdHtml, 'text/html')).toBe('text/html')
+    expect(negotiate('*/*', mdHtml, 'text/html')).toBe('text/html')
+    expect(negotiate('text/*, */*;q=0.1', mdHtml, 'text/html')).toBe('text/html')
+  })
+
+  it('prefers a more specific type at the same q', () => {
+    expect(
+      negotiate('text/markdown, text/*;q=1, */*;q=1', mdHtml, 'text/html')
+    ).toBe('text/markdown')
+  })
+})
+
+describe('mergeVary', () => {
+  it('adds Accept next to an existing Accept-Encoding token', () => {
+    expect(mergeVary('accept-encoding', ['Accept'])).toBe('Accept-Encoding, Accept')
+  })
+
+  it('does not duplicate Accept', () => {
+    expect(mergeVary('Accept, Accept-Encoding', ['Accept', 'Accept-Encoding'])).toBe(
+      'Accept, Accept-Encoding'
+    )
+  })
+})
+
+describe('path helpers', () => {
+  it('treats hashed assets and extension-bearing files as passthrough', () => {
+    expect(isPassthroughPath('/assets/index-abc.js')).toBe(true)
+    expect(isPassthroughPath('/openapi.json')).toBe(true)
+    expect(isPassthroughPath('/atlas/airbnb.md')).toBe(true)
+    expect(isPassthroughPath('/llms.txt')).toBe(true)
+    expect(isPassthroughPath('/blog')).toBe(false)
+    expect(isPassthroughPath('/')).toBe(false)
+  })
+
+  it('maps HTML routes onto their markdown twins', () => {
+    expect(markdownTwinPath('/')).toBe('/index.md')
+    expect(markdownTwinPath('/blog')).toBe('/blog.md')
+    expect(markdownTwinPath('/blog/')).toBe('/blog.md')
+    expect(markdownTwinPath('/blog/sightmap')).toBe('/blog/sightmap.md')
+    expect(markdownTwinPath('/developers')).toBe('/developers.md')
+  })
+
+  it('strips a trailing slash except on the homepage', () => {
+    expect(normalizePathname('/')).toBe('/')
+    expect(normalizePathname('/developers/')).toBe('/developers')
+  })
+})

--- a/web/netlify/lib/accept.ts
+++ b/web/netlify/lib/accept.ts
@@ -1,0 +1,181 @@
+// RFC 9110 Accept parsing for content negotiation.
+//
+// Ranking: higher q wins; ties break by specificity (type/subtype >
+// type/* > */*). q=0 is an explicit refusal. A missing Accept header is
+// "no constraint" and the caller should serve its default — it is not
+// the same as an empty list.
+//
+// Follows the algorithm at acceptmarkdown.com/guides/accept-parsing.
+
+export interface AcceptEntry {
+  type: string
+  subtype: string
+  q: number
+  specificity: number
+}
+
+const SPECIFICITY_EXACT = 3
+const SPECIFICITY_SUBTYPE_WILD = 2
+const SPECIFICITY_TYPE_WILD = 1
+
+function parseQ(raw: string | undefined): number {
+  if (raw === undefined || raw === '') return 1
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n < 0) return 0
+  if (n > 1) return 1
+  return n
+}
+
+function specificity(type: string, subtype: string): number {
+  if (type === '*' && subtype === '*') return SPECIFICITY_TYPE_WILD
+  if (subtype === '*') return SPECIFICITY_SUBTYPE_WILD
+  return SPECIFICITY_EXACT
+}
+
+/** Split an Accept header into typed entries. Invalid pieces are dropped. */
+export function parseAccept(header: string | null | undefined): AcceptEntry[] {
+  if (header === null || header === undefined) return []
+  const trimmed = header.trim()
+  if (trimmed === '') return []
+
+  const entries: AcceptEntry[] = []
+  for (const part of trimmed.split(',')) {
+    const params = part.split(';').map((s) => s.trim()).filter(Boolean)
+    const media = params.shift()
+    if (!media) continue
+    const slash = media.indexOf('/')
+    if (slash <= 0 || slash === media.length - 1) continue
+    const type = media.slice(0, slash).toLowerCase()
+    const subtype = media.slice(slash + 1).toLowerCase()
+    if (!type || !subtype) continue
+
+    let q = 1
+    for (const param of params) {
+      const eq = param.indexOf('=')
+      if (eq === -1) continue
+      const name = param.slice(0, eq).trim().toLowerCase()
+      if (name !== 'q') continue
+      q = parseQ(param.slice(eq + 1).trim())
+    }
+
+    entries.push({ type, subtype, q, specificity: specificity(type, subtype) })
+  }
+  return entries
+}
+
+function matches(offered: string, entry: AcceptEntry): boolean {
+  const slash = offered.indexOf('/')
+  if (slash <= 0) return false
+  const type = offered.slice(0, slash).toLowerCase()
+  const subtype = offered.slice(slash + 1).toLowerCase()
+  if (entry.type === '*' && entry.subtype === '*') return true
+  if (entry.type === type && entry.subtype === '*') return true
+  return entry.type === type && entry.subtype === subtype
+}
+
+/**
+ * Pick the offered type the client prefers, or null when nothing matches
+ * (the caller should return 406). `defaultType` is used when Accept is
+ * missing or every matching entry is a wildcard (star/star or type/star) — i.e.
+ * the client said "anything is fine".
+ *
+ * `defaultType` must be in `offered`.
+ */
+export function negotiate(
+  header: string | null | undefined,
+  offered: readonly string[],
+  defaultType: string
+): string | null {
+  if (!offered.includes(defaultType)) {
+    throw new Error(`negotiate: defaultType "${defaultType}" is not in offered`)
+  }
+  // Missing header = no constraint. Empty header is treated the same:
+  // some clients send `Accept:` with nothing after it.
+  if (header === null || header === undefined || header.trim() === '') {
+    return defaultType
+  }
+
+  const entries = parseAccept(header)
+  if (entries.length === 0) return defaultType
+
+  let bestType: string | null = null
+  let bestQ = 0
+  let bestSpec = -1
+
+  for (const type of offered) {
+    let matchQ = 0
+    let matchSpec = -1
+    for (const entry of entries) {
+      if (!matches(type, entry)) continue
+      if (entry.q === 0) {
+        // Explicit refusal of this class. A more specific positive match
+        // (already recorded) still wins; a q=0 exact match knocks this
+        // offered type out if it is the best match we have.
+        if (entry.specificity > matchSpec) {
+          matchQ = 0
+          matchSpec = entry.specificity
+        }
+        continue
+      }
+      if (entry.specificity > matchSpec || (entry.specificity === matchSpec && entry.q > matchQ)) {
+        matchQ = entry.q
+        matchSpec = entry.specificity
+      }
+    }
+    if (matchQ > bestQ || (matchQ === bestQ && matchQ > 0 && matchSpec > bestSpec)) {
+      bestQ = matchQ
+      bestSpec = matchSpec
+      bestType = type
+    }
+  }
+
+  if (bestQ === 0 || bestType === null) return null
+
+  // Wildcards only (`*/*` or `text/*`) mean "anything is fine" — serve
+  // the default rather than the first offered type that happened to match.
+  if (bestSpec < SPECIFICITY_EXACT) return defaultType
+  return bestType
+}
+
+/** Merge Vary tokens, canonicalizing Accept / Accept-Encoding. */
+export function mergeVary(existing: string | null | undefined, extras: readonly string[]): string {
+  const seen = new Map<string, string>()
+  const add = (raw: string) => {
+    const token = raw.trim()
+    if (!token) return
+    const key = token.toLowerCase()
+    if (key === 'accept') seen.set(key, 'Accept')
+    else if (key === 'accept-encoding') seen.set(key, 'Accept-Encoding')
+    else if (!seen.has(key)) seen.set(key, token)
+  }
+  if (existing) {
+    for (const part of existing.split(',')) add(part)
+  }
+  for (const extra of extras) add(extra)
+  return [...seen.values()].join(', ')
+}
+
+/** Paths that are already a concrete representation — do not negotiate. */
+export function isPassthroughPath(pathname: string): boolean {
+  if (pathname.startsWith('/assets/')) return true
+  // A trailing file extension means the client named a representation
+  // (openapi.json, airbnb.md, llms.txt). Negotiating those would loop
+  // when this function fetches a twin through the same origin.
+  const last = pathname.split('/').pop() ?? ''
+  return last.includes('.')
+}
+
+/**
+ * Where the markdown twin of an HTML page lives in dist/. `/` → `/index.md`;
+ * every other route drops a trailing slash and appends `.md`.
+ */
+export function markdownTwinPath(pathname: string): string {
+  const cleaned = pathname.replace(/\/+$/, '') || '/'
+  if (cleaned === '/') return '/index.md'
+  return `${cleaned}.md`
+}
+
+export function normalizePathname(pathname: string): string {
+  if (pathname === '/') return '/'
+  return pathname.replace(/\/+$/, '') || '/'
+}

--- a/web/netlify/lib/errors.test.ts
+++ b/web/netlify/lib/errors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { methodNotAllowedError, notAcceptableBody, notFoundError } from './errors'
+
+describe('notFoundError', () => {
+  it('returns a JSON body with code, message, hint, and status', () => {
+    const body = notFoundError('/nope')
+    expect(body.error.code).toBe('not_found')
+    expect(body.error.status).toBe(404)
+    expect(body.error.message).toContain('/nope')
+    expect(body.error.hint).toContain('https://sightmap.org/llms.txt')
+    expect(body.error.hint).toContain('https://sightmap.org/openapi.json')
+    expect(body.error.hint).toContain('https://docs.sightmap.org')
+  })
+})
+
+describe('methodNotAllowedError', () => {
+  it('tells the client the API is read-only', () => {
+    const body = methodNotAllowedError('POST', '/api/atlas')
+    expect(body.error.code).toBe('method_not_allowed')
+    expect(body.error.status).toBe(405)
+    expect(body.error.hint).toContain('GET')
+  })
+})
+
+describe('notAcceptableBody', () => {
+  it('lists the representations the server can produce', () => {
+    const text = notAcceptableBody(['text/html', 'text/markdown'], 'application/pdf')
+    expect(text).toContain('- text/html')
+    expect(text).toContain('- text/markdown')
+    expect(text).toContain('application/pdf')
+  })
+})

--- a/web/netlify/lib/errors.ts
+++ b/web/netlify/lib/errors.ts
@@ -1,0 +1,46 @@
+// Structured JSON errors for the public HTTP API and for 404s negotiated
+// as application/json. Agents cannot recover from an HTML error page.
+
+export interface ApiErrorBody {
+  error: {
+    code: string
+    message: string
+    hint: string
+    status: number
+  }
+}
+
+export const NOT_FOUND_HINT =
+  'See https://sightmap.org/llms.txt for the published Sightmap site map, https://sightmap.org/openapi.json for the HTTP API, https://sightmap.org/developers for Sightmap developer resources, or https://docs.sightmap.org for documentation.'
+
+export function apiError(
+  code: string,
+  message: string,
+  hint: string,
+  status: number
+): ApiErrorBody {
+  return { error: { code, message, hint, status } }
+}
+
+export function notFoundError(path: string): ApiErrorBody {
+  return apiError(
+    'not_found',
+    `No Sightmap resource at ${path}.`,
+    NOT_FOUND_HINT,
+    404
+  )
+}
+
+export function methodNotAllowedError(method: string, path: string): ApiErrorBody {
+  return apiError(
+    'method_not_allowed',
+    `${method} is not allowed on ${path}.`,
+    'This API is read-only. Use GET or HEAD. See https://sightmap.org/openapi.json.',
+    405
+  )
+}
+
+export function notAcceptableBody(available: readonly string[], requested: string): string {
+  const listed = available.map((t) => `- ${t}`).join('\n')
+  return `This Sightmap resource is available as:\n${listed}\n\nYou requested: ${requested || '(none)'}\n`
+}

--- a/web/netlify/lib/handler.test.ts
+++ b/web/netlify/lib/handler.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import { handleNegotiate, JSON_TYPE, MARKDOWN_TYPE } from './handler'
+
+function request(path: string, headers: Record<string, string> = {}, method = 'GET') {
+  return new Request(`https://sightmap.org${path}`, { method, headers })
+}
+
+function deps(opts: {
+  origin?: Response
+  files?: Record<string, Response>
+}): { next: () => Promise<Response>; fetch: (input: URL) => Promise<Response> } {
+  return {
+    next: async () =>
+      opts.origin ??
+      new Response('<html>ok</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8', vary: 'accept-encoding' },
+      }),
+    fetch: async (input) => {
+      const path = new URL(input).pathname
+      const found = opts.files?.[path]
+      if (found) return found.clone()
+      return new Response('missing', { status: 404 })
+    },
+  }
+}
+
+describe('handleNegotiate', () => {
+  it('passes through extension-bearing paths so twin fetches do not loop', async () => {
+    const res = await handleNegotiate(request('/openapi.json'), deps({}))
+    expect(res).toBeUndefined()
+  })
+
+  it('returns JSON 404 for an unknown /api path', async () => {
+    const res = await handleNegotiate(request('/api/nope'), deps({}))
+    expect(res).toBeDefined()
+    expect(res!.status).toBe(404)
+    expect(res!.headers.get('content-type')).toBe(JSON_TYPE)
+    const body = (await res!.json()) as { error: { code: string; hint: string } }
+    expect(body.error.code).toBe('not_found')
+    expect(body.error.hint).toContain('llms.txt')
+    expect(res!.headers.get('vary')?.toLowerCase()).toContain('accept')
+  })
+
+  it('rejects non-GET methods on the API with JSON 405', async () => {
+    const res = await handleNegotiate(request('/api/atlas', {}, 'POST'), deps({}))
+    expect(res!.status).toBe(405)
+    const body = (await res!.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('method_not_allowed')
+  })
+
+  it('proxies GET /api/atlas to the generated catalog', async () => {
+    const res = await handleNegotiate(
+      request('/api/atlas'),
+      deps({
+        files: {
+          '/api/atlas.json': new Response(JSON.stringify({ schema_version: 1, entries: [] }), {
+            status: 200,
+          }),
+        },
+      })
+    )
+    expect(res!.status).toBe(200)
+    expect(res!.headers.get('content-type')).toBe(JSON_TYPE)
+    expect(await res!.json()).toEqual({ schema_version: 1, entries: [] })
+  })
+
+  it('returns JSON 404 for a missing atlas slug', async () => {
+    const res = await handleNegotiate(request('/api/atlas/missing'), deps({ files: {} }))
+    expect(res!.status).toBe(404)
+    const body = (await res!.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('not_found')
+  })
+
+  it('serves the markdown 404 body for Accept: text/markdown on a missing page', async () => {
+    const res = await handleNegotiate(
+      request('/no-such-page', { Accept: 'text/markdown' }),
+      deps({
+        origin: new Response('<html>404</html>', { status: 404, headers: { 'content-type': 'text/html' } }),
+        files: {
+          '/404.md': new Response('# Not found\n\nSee https://sightmap.org/llms.txt\n', {
+            status: 200,
+          }),
+        },
+      })
+    )
+    expect(res!.status).toBe(404)
+    expect(res!.headers.get('content-type')).toBe(MARKDOWN_TYPE)
+    expect(res!.headers.get('vary')?.toLowerCase()).toContain('accept')
+    expect(await res!.text()).toContain('llms.txt')
+  })
+
+  it('serves a JSON 404 when Accept prefers application/json on a missing page', async () => {
+    const res = await handleNegotiate(
+      request('/no-such-page', { Accept: 'application/json' }),
+      deps({
+        origin: new Response('<html>404</html>', { status: 404 }),
+      })
+    )
+    expect(res!.status).toBe(404)
+    expect(res!.headers.get('content-type')).toBe(JSON_TYPE)
+    const body = (await res!.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('not_found')
+  })
+
+  it('serves the markdown twin of an existing page and sets Vary: Accept', async () => {
+    const res = await handleNegotiate(
+      request('/blog', { Accept: 'text/markdown' }),
+      deps({
+        files: {
+          '/blog.md': new Response('# Blog — Sightmap\n', { status: 200 }),
+        },
+      })
+    )
+    expect(res!.status).toBe(200)
+    expect(res!.headers.get('content-type')).toBe(MARKDOWN_TYPE)
+    expect(res!.headers.get('vary')).toMatch(/Accept/)
+    expect(await res!.text()).toContain('# Blog — Sightmap')
+  })
+
+  it('adds Accept to Vary on the HTML representation', async () => {
+    const res = await handleNegotiate(
+      request('/blog', { Accept: 'text/html' }),
+      deps({
+        origin: new Response('<html>blog</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html', vary: 'accept-encoding' },
+        }),
+      })
+    )
+    expect(res!.status).toBe(200)
+    expect(await res!.text()).toBe('<html>blog</html>')
+    const vary = res!.headers.get('vary') ?? ''
+    expect(vary.toLowerCase()).toContain('accept')
+    expect(vary.toLowerCase()).toContain('accept-encoding')
+  })
+
+  it('returns 406 when Accept cannot be satisfied', async () => {
+    const res = await handleNegotiate(
+      request('/blog', { Accept: 'application/pdf' }),
+      deps({})
+    )
+    expect(res!.status).toBe(406)
+    expect(res!.headers.get('vary')?.toLowerCase()).toContain('accept')
+    expect(await res!.text()).toContain('text/markdown')
+  })
+})

--- a/web/netlify/lib/handler.ts
+++ b/web/netlify/lib/handler.ts
@@ -1,0 +1,155 @@
+// Content negotiation + JSON API errors for sightmap.org.
+//
+// The edge function is a thin wrapper around handleNegotiate so the
+// Accept / 404 / API behavior can be tested in Node without Deno.
+
+import {
+  isPassthroughPath,
+  markdownTwinPath,
+  mergeVary,
+  negotiate,
+  normalizePathname,
+} from './accept.ts'
+import {
+  methodNotAllowedError,
+  notAcceptableBody,
+  notFoundError,
+  type ApiErrorBody,
+} from './errors.ts'
+
+export const MARKDOWN_TYPE = 'text/markdown; charset=utf-8'
+export const JSON_TYPE = 'application/json; charset=utf-8'
+export const PLAIN_TYPE = 'text/plain; charset=utf-8'
+
+const PAGE_TYPES = ['text/html', 'text/markdown'] as const
+const ERROR_TYPES = ['text/html', 'text/markdown', 'application/json'] as const
+const VARY_ACCEPT = ['Accept', 'Accept-Encoding'] as const
+
+export interface NegotiateDeps {
+  next: () => Promise<Response>
+  fetch: (input: URL) => Promise<Response>
+}
+
+function withVary(res: Response): Response {
+  const headers = new Headers(res.headers)
+  headers.set('Vary', mergeVary(headers.get('Vary'), VARY_ACCEPT))
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers })
+}
+
+function jsonResponse(body: unknown, status: number, extra?: HeadersInit): Response {
+  const headers = new Headers(extra)
+  headers.set('Content-Type', JSON_TYPE)
+  headers.set('Vary', mergeVary(headers.get('Vary'), VARY_ACCEPT))
+  headers.set('Cache-Control', status >= 400 ? 'no-store' : 'public, max-age=300')
+  return new Response(JSON.stringify(body), { status, headers })
+}
+
+function markdownResponse(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': MARKDOWN_TYPE,
+      Vary: mergeVary(null, VARY_ACCEPT),
+      'Cache-Control': status >= 400 ? 'no-store' : 'public, max-age=300',
+    },
+  })
+}
+
+function notAcceptable(available: readonly string[], requested: string): Response {
+  return new Response(notAcceptableBody(available, requested), {
+    status: 406,
+    headers: {
+      'Content-Type': PLAIN_TYPE,
+      Vary: mergeVary(null, VARY_ACCEPT),
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+function errorJson(body: ApiErrorBody): Response {
+  return jsonResponse(body, body.error.status)
+}
+
+async function fetchSameOrigin(deps: NegotiateDeps, request: Request, path: string): Promise<Response> {
+  return deps.fetch(new URL(path, request.url))
+}
+
+async function handleApi(request: Request, path: string, deps: NegotiateDeps): Promise<Response> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return errorJson(methodNotAllowedError(request.method, path))
+  }
+
+  if (path === '/api/atlas') {
+    const upstream = await fetchSameOrigin(deps, request, '/api/atlas.json')
+    if (!upstream.ok) return errorJson(notFoundError(path))
+    const body = await upstream.text()
+    return jsonResponse(JSON.parse(body), 200)
+  }
+
+  const entry = path.match(/^\/api\/atlas\/([^/]+)$/)
+  if (entry) {
+    const slug = entry[1]
+    const upstream = await fetchSameOrigin(deps, request, `/api/atlas/${slug}.json`)
+    if (!upstream.ok) {
+      return errorJson(
+        notFoundError(path)
+      )
+    }
+    const body = await upstream.text()
+    return jsonResponse(JSON.parse(body), 200)
+  }
+
+  return errorJson(notFoundError(path))
+}
+
+async function markdownFor(request: Request, path: string, status: number, deps: NegotiateDeps): Promise<Response> {
+  const twin = status === 404 ? '/404.md' : markdownTwinPath(path)
+  const upstream = await fetchSameOrigin(deps, request, twin)
+  if (upstream.ok) {
+    return markdownResponse(await upstream.text(), status)
+  }
+  if (status !== 404) {
+    const fallback = await fetchSameOrigin(deps, request, '/404.md')
+    if (fallback.ok) return markdownResponse(await fallback.text(), 404)
+  }
+  return markdownResponse(
+    '# Not found\n\nThis path is not on sightmap.org.\n\nSee https://sightmap.org/llms.txt\n',
+    404
+  )
+}
+
+export async function handleNegotiate(
+  request: Request,
+  deps: NegotiateDeps
+): Promise<Response | undefined> {
+  const url = new URL(request.url)
+  const path = normalizePathname(url.pathname)
+
+  if (isPassthroughPath(path)) return undefined
+
+  if (path === '/api' || path.startsWith('/api/')) {
+    return handleApi(request, path, deps)
+  }
+
+  const accept = request.headers.get('Accept')
+  const origin = await deps.next()
+
+  if (origin.status === 404) {
+    const chosen = negotiate(accept, ERROR_TYPES, 'text/html')
+    if (chosen === null) return notAcceptable(ERROR_TYPES, accept ?? '')
+    if (chosen === 'text/markdown') return markdownFor(request, path, 404, deps)
+    if (chosen === 'application/json') return errorJson(notFoundError(path))
+    return withVary(origin)
+  }
+
+  const chosen = negotiate(accept, PAGE_TYPES, 'text/html')
+  if (chosen === null) {
+    // Client refused HTML and Markdown. application/json is only a 404
+    // representation, so an existing page cannot satisfy it.
+    const asError = negotiate(accept, ERROR_TYPES, 'text/html')
+    if (asError === 'application/json') return notAcceptable(PAGE_TYPES, accept ?? '')
+    return notAcceptable(PAGE_TYPES, accept ?? '')
+  }
+  if (chosen === 'text/markdown') return markdownFor(request, path, origin.status, deps)
+  return withVary(origin)
+}

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx scripts/build-blog.ts && tsx scripts/build-atlas.ts && vite",
     "build:blog": "tsx scripts/build-blog.ts",
     "build:atlas": "tsx scripts/build-atlas.ts",
-    "build": "tsx scripts/build-blog.ts && tsx scripts/build-atlas.ts && tsc -b && vite build && tsx scripts/prerender.tsx && tsx scripts/check-route-coverage.ts && tsx scripts/generate-feeds.ts && tsx scripts/upload-sourcemaps.ts",
+    "build": "tsx scripts/build-blog.ts && tsx scripts/build-atlas.ts && tsc -b && vite build && tsx scripts/prerender.tsx && tsx scripts/check-route-coverage.ts && tsx scripts/generate-feeds.ts && tsx scripts/generate-agent-files.ts && tsx scripts/upload-sourcemaps.ts",
     "sourcemaps:upload": "tsx scripts/upload-sourcemaps.ts",
     "preview": "vite preview",
     "test": "vitest run",

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -2,3 +2,9 @@ User-agent: *
 Allow: /
 
 Sitemap: https://sightmap.org/sitemap.xml
+
+# Sightmap machine-readable index and HTTP API
+# https://sightmap.org/llms.txt
+# https://sightmap.org/openapi.json
+# https://sightmap.org/developers
+

--- a/web/scripts/check-route-coverage.test.ts
+++ b/web/scripts/check-route-coverage.test.ts
@@ -8,6 +8,7 @@ const APP = `
         <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/atlas" element={<AtlasIndex />} />
         <Route path="/atlas/:slug" element={<AtlasEntry />} />
+        <Route path="/developers" element={<Developers />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
 `
@@ -20,6 +21,7 @@ describe('extractRoutePaths', () => {
       '/blog/:slug',
       '/atlas',
       '/atlas/:slug',
+      '/developers',
       '*',
     ])
   })
@@ -41,13 +43,14 @@ describe('checkCoverage', () => {
       '/blog/sightmap',
       '/atlas',
       '/atlas/airbnb',
+      '/developers',
     ])
     expect(out.uncovered).toEqual([])
     expect(out.emptyDynamic).toEqual([])
   })
 
   it('flags a static route with no prerendered page', () => {
-    const out = checkCoverage(declared, ['/', '/blog', '/blog/sightmap', '/atlas/airbnb'])
+    const out = checkCoverage(declared, ['/', '/blog', '/blog/sightmap', '/atlas/airbnb', '/developers'])
     expect(out.uncovered).toEqual(['/atlas'])
   })
 
@@ -59,7 +62,7 @@ describe('checkCoverage', () => {
   it('reports a dynamic route with no instances without failing the build', () => {
     // A production build excludes drafts, so a blog with nothing published
     // legitimately has zero /blog/<slug> pages — and those URLs *should* 404.
-    const out = checkCoverage(declared, ['/', '/blog', '/atlas', '/atlas/airbnb'])
+    const out = checkCoverage(declared, ['/', '/blog', '/atlas', '/atlas/airbnb', '/developers'])
     expect(out.uncovered).toEqual([])
     expect(out.emptyDynamic).toEqual(['/blog/:slug'])
   })

--- a/web/scripts/generate-agent-files.ts
+++ b/web/scripts/generate-agent-files.ts
@@ -1,0 +1,111 @@
+// Emits the site's agent-facing machine files into dist/:
+//
+//   - openapi.json / api/openapi.yaml — OpenAPI 3.1 of the public HTTP API
+//   - api/atlas.json and api/atlas/<slug>.json — JSON catalog + per-entry docs
+//   - per-page markdown twins (index.md, blog.md, developers.md, 404.md, …)
+//
+// Runs after prerender so dist/ already exists. Vite copies public/ first;
+// these files are generated, not authored, and must not linger after a
+// takedown the way a committed public/ file would.
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { loadPosts } from './lib/posts'
+import { loadAtlas } from './lib/atlas'
+import { primaryDomain } from '../src/lib/atlas'
+import type { FeedAtlasEntry, FeedPost } from './generate-feeds'
+import {
+  buildAtlasApiIndex,
+  buildAtlasIndexMarkdown,
+  buildBlogIndexMarkdown,
+  buildBlogPostMarkdown,
+  buildDevelopersMarkdown,
+  buildHomeMarkdown,
+  buildNotFoundMarkdown,
+  buildOpenApiSpec,
+  toAtlasApiEntry,
+  toYaml,
+} from './lib/agent'
+
+const DIST = path.resolve('dist')
+const CONTENT_DIR = path.resolve('content/blog')
+const ATLAS_DIR = path.resolve('src/data/atlas')
+
+function write(rel: string, body: string) {
+  const full = path.join(DIST, rel)
+  fs.mkdirSync(path.dirname(full), { recursive: true })
+  fs.writeFileSync(full, body.endsWith('\n') ? body : `${body}\n`)
+}
+
+async function main() {
+  if (!fs.existsSync(DIST)) {
+    console.error('dist/ not found — run `vite build` first.')
+    process.exit(1)
+  }
+
+  const loaded = await loadPosts(CONTENT_DIR)
+  const posts: FeedPost[] = loaded.map((p) => ({
+    slug: p.frontmatter.slug,
+    title: p.frontmatter.title,
+    excerpt: p.frontmatter.excerpt,
+    date: p.frontmatter.date,
+    author: p.frontmatter.author,
+  }))
+
+  const raw = await loadAtlas(ATLAS_DIR)
+  const atlas: Array<FeedAtlasEntry & { site_url: string; categories: string[] }> =
+    raw.entries.map((e) => ({
+      slug: e.slug,
+      name: e.name,
+      description: e.description,
+      updated: e.updated,
+      domains: e.domains.length > 0 ? e.domains : [primaryDomain(e)],
+      last_verified: e.last_verified,
+      stats: e.stats,
+      site_url: e.site_url,
+      categories: e.categories,
+    }))
+
+  const spec = buildOpenApiSpec()
+  write('openapi.json', JSON.stringify(spec, null, 2))
+  write('api/openapi.yaml', `${toYaml(spec)}\n`)
+  write('api/openapi.json', JSON.stringify(spec, null, 2))
+
+  const catalog = buildAtlasApiIndex(atlas)
+  write('api/atlas.json', JSON.stringify(catalog, null, 2))
+  for (const entry of atlas) {
+    write(`api/atlas/${entry.slug}.json`, JSON.stringify(toAtlasApiEntry(entry), null, 2))
+  }
+
+  write('404.md', buildNotFoundMarkdown())
+  write('index.md', buildHomeMarkdown())
+  write('blog.md', buildBlogIndexMarkdown(posts))
+  write('atlas.md', buildAtlasIndexMarkdown(atlas))
+  write('developers.md', buildDevelopersMarkdown())
+
+  for (const post of loaded) {
+    write(
+      `blog/${post.frontmatter.slug}.md`,
+      buildBlogPostMarkdown({
+        slug: post.frontmatter.slug,
+        title: post.frontmatter.title,
+        excerpt: post.frontmatter.excerpt,
+        date: post.frontmatter.date,
+        author: post.frontmatter.author,
+        body: post.body,
+      })
+    )
+  }
+
+  console.log(
+    `  wrote dist/openapi.json, dist/api/* and markdown twins (${posts.length} post(s), ${atlas.length} atlas entry(s))`
+  )
+}
+
+const entry = process.argv[1]
+if (entry && import.meta.url === pathToFileURL(entry).href) {
+  main().catch((err) => {
+    console.error('Agent-file generation failed:\n', err instanceof Error ? err.message : err)
+    process.exit(1)
+  })
+}

--- a/web/scripts/generate-feeds.test.ts
+++ b/web/scripts/generate-feeds.test.ts
@@ -102,7 +102,8 @@ describe('buildSitemap', () => {
     expect(xml).toContain('<loc>https://sightmap.org/atlas</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/atlas/sightmap-org</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/atlas/example-shop</loc>')
-    expect(xml.match(/<url>/g)).toHaveLength(7)
+    expect(xml).toContain('<loc>https://sightmap.org/developers</loc>')
+    expect(xml.match(/<url>/g)).toHaveLength(8)
   })
 
   it('uses the post date as lastmod for post URLs', () => {
@@ -122,7 +123,8 @@ describe('buildSitemap', () => {
     expect(xml).toContain('<loc>https://sightmap.org/</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/blog</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/atlas</loc>')
-    expect(xml.match(/<url>/g)).toHaveLength(3)
+    expect(xml).toContain('<loc>https://sightmap.org/developers</loc>')
+    expect(xml.match(/<url>/g)).toHaveLength(4)
     expect(xml).not.toContain('undefined')
     expect(xml).toContain('<lastmod>2026-07-28</lastmod>')
   })
@@ -133,6 +135,10 @@ describe('buildLlmsTxt', () => {
     const txt = buildLlmsTxt(POSTS, ATLAS)
     expect(txt.startsWith('# Sightmap\n')).toBe(true)
     expect(txt).toContain('> An open YAML spec and CLI')
+    expect(txt).toContain('## Sightmap developer resources')
+    expect(txt).toContain('https://sightmap.org/openapi.json')
+    expect(txt).toContain('https://sightmap.org/developers')
+    expect(txt).toContain('https://sightmap.org/api/atlas')
   })
 
   it('teaches the lookup an agent holding a hostname actually needs', () => {

--- a/web/scripts/generate-feeds.ts
+++ b/web/scripts/generate-feeds.ts
@@ -91,6 +91,7 @@ export function buildSitemap(posts: FeedPost[], atlas: FeedAtlasEntry[], now: Da
   const today = now.toISOString().slice(0, 10)
   const urls = [
     { loc: `${SITE_URL}/`, lastmod: today, priority: '1.0' },
+    { loc: `${SITE_URL}/developers`, lastmod: today, priority: '0.8' },
     { loc: `${SITE_URL}/blog`, lastmod: posts[0]?.date ?? today, priority: '0.8' },
     ...posts.map((p) => ({
       loc: `${SITE_URL}/blog/${p.slug}`,
@@ -194,6 +195,13 @@ export function buildLlmsTxt(posts: FeedPost[], atlas: FeedAtlasEntry[]): string
     '',
     `- [Documentation](https://docs.sightmap.org): Guides, CLI reference, and the schema reference.`,
     `- [Specification](https://github.com/sightmap/sightmap/tree/main/spec): The normative spec, JSON Schema, and conformance fixtures.`,
+    '',
+    '## Sightmap developer resources',
+    '',
+    `- [Sightmap developer resources](${SITE_URL}/developers): OpenAPI, Atlas HTTP API, docs, CLI, and agent skills.`,
+    `- [OpenAPI specification](${SITE_URL}/openapi.json): Machine-readable description of the public Sightmap HTTP API.`,
+    `- [Atlas HTTP API](${SITE_URL}/api/atlas): JSON catalog of published sightmaps. No authentication.`,
+    `- [CLI on npm](https://www.npmjs.com/package/@sightmap/sightmap): \`npm install -g @sightmap/sightmap\`.`,
     '',
     '## Atlas',
     '',

--- a/web/scripts/lib/agent.test.ts
+++ b/web/scripts/lib/agent.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAtlasApiIndex,
+  buildDevelopersMarkdown,
+  buildHomeMarkdown,
+  buildNotFoundMarkdown,
+  buildOpenApiSpec,
+  buildSiteJsonLd,
+  toYaml,
+} from './agent'
+import { DEVELOPERS_TITLE, SITE_NAME } from './site'
+
+const ATLAS = [
+  {
+    slug: 'airbnb',
+    name: 'Airbnb',
+    description: 'Stay search.',
+    updated: '2026-08-08',
+    domains: ['airbnb.com'],
+    last_verified: '2026-08-08',
+    stats: { views: 5, components: 53, requests: 16 },
+    site_url: 'https://www.airbnb.com/',
+    categories: ['travel'],
+  },
+]
+
+describe('buildNotFoundMarkdown', () => {
+  it('points agents at the sitemap, llms.txt, docs, and developer resources', () => {
+    const md = buildNotFoundMarkdown()
+    expect(md.startsWith('# Not found\n')).toBe(true)
+    expect(md).toContain('https://sightmap.org/llms.txt')
+    expect(md).toContain('https://sightmap.org/sitemap.xml')
+    expect(md).toContain('https://sightmap.org/developers')
+    expect(md).toContain('https://sightmap.org/openapi.json')
+    expect(md).toContain('https://docs.sightmap.org')
+  })
+})
+
+describe('buildHomeMarkdown', () => {
+  it('names Sightmap and links developer resources', () => {
+    const md = buildHomeMarkdown()
+    expect(md.startsWith(`# ${SITE_NAME}\n`)).toBe(true)
+    expect(md).toContain('/developers')
+    expect(md).toContain('/openapi.json')
+  })
+})
+
+describe('buildDevelopersMarkdown', () => {
+  it('uses the Sightmap developer-resources title and lists the API', () => {
+    const md = buildDevelopersMarkdown()
+    expect(md).toContain(`# ${DEVELOPERS_TITLE}`)
+    expect(md).toContain('/openapi.json')
+    expect(md).toContain('/api/atlas')
+    expect(md).toContain('no authentication')
+  })
+})
+
+describe('buildAtlasApiIndex', () => {
+  it('adds machine-twin URLs on every entry', () => {
+    const catalog = buildAtlasApiIndex(ATLAS)
+    expect(catalog.schema_version).toBe(1)
+    expect(catalog.entries[0]).toMatchObject({
+      slug: 'airbnb',
+      html: 'https://sightmap.org/atlas/airbnb',
+      markdown: 'https://sightmap.org/atlas/airbnb.md',
+      archive: 'https://sightmap.org/atlas/airbnb.tar.gz',
+    })
+  })
+})
+
+describe('buildOpenApiSpec', () => {
+  it('is OpenAPI 3.1 and documents the public Sightmap API plus JSON errors', () => {
+    const spec = buildOpenApiSpec()
+    expect(spec.openapi).toBe('3.1.0')
+    expect((spec.info as { title: string }).title).toContain('Sightmap')
+    const paths = spec.paths as Record<string, unknown>
+    expect(paths['/openapi.json']).toBeDefined()
+    expect(paths['/api/atlas']).toBeDefined()
+    expect(paths['/api/atlas/{slug}']).toBeDefined()
+    const schemas = (spec.components as { schemas: Record<string, { required?: string[] }> })
+      .schemas
+    expect(schemas.Error.required).toEqual(['error'])
+    const error = (
+      schemas.Error as {
+        properties: { error: { required: string[] } }
+      }
+    ).properties.error
+    expect(error.required).toEqual(['code', 'message', 'hint', 'status'])
+  })
+})
+
+describe('buildSiteJsonLd', () => {
+  it('advertises the Sightmap name, alternates, and sameAs profiles', () => {
+    const json = buildSiteJsonLd() as {
+      '@graph': Array<{ name?: string; alternateName?: string[]; sameAs?: string[] }>
+    }
+    const names = json['@graph'].map((n) => n.name)
+    expect(names).toContain('Sightmap')
+    const org = json['@graph'].find((n) => n.sameAs)
+    expect(org?.alternateName).toContain('Sightmap spec')
+    expect(org?.sameAs).toContain('https://github.com/sightmap/sightmap')
+    expect(org?.sameAs).toContain('https://docs.sightmap.org')
+  })
+})
+
+describe('toYaml', () => {
+  it('round-trips the OpenAPI document into parseable YAML-shaped text', () => {
+    const yaml = toYaml({ openapi: '3.1.0', info: { title: 'Sightmap HTTP API' }, tags: [] })
+    expect(yaml).toContain('openapi: 3.1.0')
+    expect(yaml).toContain('title: Sightmap HTTP API')
+    expect(yaml).toContain('tags: []')
+  })
+
+  it('quotes strings that would break YAML', () => {
+    expect(toYaml({ path: '/api/atlas/{slug}' })).toContain('"/api/atlas/{slug}"')
+  })
+
+  it('emits block-style array objects without extra indent on the first key', () => {
+    const yaml = toYaml({ servers: [{ url: 'https://sightmap.org', description: 'prod' }] })
+    expect(yaml).toContain('- url: "https://sightmap.org"')
+    expect(yaml).toContain('  description: prod')
+  })
+})

--- a/web/scripts/lib/agent.ts
+++ b/web/scripts/lib/agent.ts
@@ -1,0 +1,477 @@
+// Machine-readable files aimed at agents: OpenAPI, per-page markdown
+// twins, JSON API documents, and the 404 recovery note. generate-agent-files.ts
+// writes them into dist/; the negotiate edge function serves the twins
+// when Accept prefers text/markdown.
+import {
+  DEVELOPERS_DESCRIPTION,
+  DEVELOPERS_TITLE,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+} from './site'
+import type { FeedAtlasEntry, FeedPost } from '../generate-feeds'
+
+export const DEVELOPERS_PATH = '/developers'
+
+export interface AtlasApiEntry {
+  slug: string
+  name: string
+  site_url: string
+  domains: string[]
+  description: string
+  categories: string[]
+  updated: string
+  last_verified: string
+  stats: FeedAtlasEntry['stats']
+  html: string
+  markdown: string
+  archive: string
+}
+
+export function buildNotFoundMarkdown(): string {
+  return `# Not found
+
+This path is not on ${SITE_NAME}.
+
+## Where to look next
+
+- [Sightmap llms.txt](${SITE_URL}/llms.txt) — published site index for agents
+- [Sitemap](${SITE_URL}/sitemap.xml)
+- [Sightmap developer resources](${SITE_URL}${DEVELOPERS_PATH})
+- [OpenAPI specification](${SITE_URL}/openapi.json)
+- [Atlas HTTP API](${SITE_URL}/api/atlas)
+- [Documentation](https://docs.sightmap.org)
+- [GitHub](https://github.com/sightmap/sightmap)
+`
+}
+
+export function buildHomeMarkdown(): string {
+  return `# ${SITE_NAME}
+
+> ${SITE_DESCRIPTION}
+
+This is the ${SITE_NAME} homepage at ${SITE_URL}. ${SITE_NAME} is an open YAML spec and CLI that maps views, components, and API requests to source files, with memory for runtime behavior.
+
+## Start here
+
+- [Sightmap developer resources](${SITE_URL}${DEVELOPERS_PATH})
+- [OpenAPI specification](${SITE_URL}/openapi.json)
+- [llms.txt](${SITE_URL}/llms.txt)
+- [Documentation](https://docs.sightmap.org)
+- [Atlas](${SITE_URL}/atlas)
+- [Blog](${SITE_URL}/blog)
+- [GitHub](https://github.com/sightmap/sightmap)
+- [CLI on npm](https://www.npmjs.com/package/@sightmap/sightmap)
+
+## Get started
+
+    npm install -g @sightmap/sightmap
+    sightmap skills install
+`
+}
+
+export function buildBlogIndexMarkdown(posts: FeedPost[]): string {
+  const items =
+    posts.length === 0
+      ? '- No posts published yet.'
+      : posts
+          .map((p) => `- [${p.title}](${SITE_URL}/blog/${p.slug}): ${p.excerpt}`)
+          .join('\n')
+  return `# Blog — ${SITE_NAME}
+
+Research and release notes from the people building the sightmap spec.
+
+${items}
+`
+}
+
+export function buildBlogPostMarkdown(post: FeedPost & { body: string }): string {
+  return `# ${post.title}
+
+${post.excerpt}
+
+${post.body.trim()}
+`
+}
+
+export function buildAtlasIndexMarkdown(atlas: FeedAtlasEntry[]): string {
+  const items =
+    atlas.length === 0
+      ? '- No entries published yet.'
+      : atlas
+          .map(
+            (e) =>
+              `- [${e.name}](${SITE_URL}/atlas/${e.slug}.md) (${e.domains.join(', ')}): ${e.description}`
+          )
+          .join('\n')
+  return `# Atlas — ${SITE_NAME}
+
+Community-contributed maps of views, components, and requests.
+
+Machine index: ${SITE_URL}/atlas/index.json
+HTTP API: ${SITE_URL}/api/atlas
+
+${items}
+`
+}
+
+export function buildDevelopersMarkdown(): string {
+  return `# ${DEVELOPERS_TITLE}
+
+${DEVELOPERS_DESCRIPTION}
+
+${SITE_NAME} is an open specification and CLI. The public HTTP API on this site is read-only and requires no authentication.
+
+## HTTP API
+
+- [OpenAPI specification (JSON)](${SITE_URL}/openapi.json)
+- [OpenAPI specification (YAML)](${SITE_URL}/api/openapi.yaml)
+- [Atlas catalog](${SITE_URL}/api/atlas) — \`GET /api/atlas\`
+- [One Atlas entry](${SITE_URL}/api/atlas/{slug}) — \`GET /api/atlas/{slug}\`
+
+Errors are JSON objects with \`error.code\`, \`error.message\`, and \`error.hint\`.
+
+## Documentation
+
+- [Sightmap documentation](https://docs.sightmap.org)
+- [Quickstart](https://docs.sightmap.org/start/quickstart)
+- [Schema reference](https://docs.sightmap.org/reference/schema)
+- [Specification (normative)](https://github.com/sightmap/sightmap/tree/main/spec)
+
+## CLI and skills
+
+- [CLI on npm](https://www.npmjs.com/package/@sightmap/sightmap) — \`npm install -g @sightmap/sightmap\`
+- [GitHub repository](https://github.com/sightmap/sightmap)
+- Agent skills: \`sightmap skills install\` installs \`sightmap-authoring\` and \`sightmap-browser\`
+
+## Site index
+
+- [llms.txt](${SITE_URL}/llms.txt)
+- [Sitemap](${SITE_URL}/sitemap.xml)
+- [RSS](${SITE_URL}/rss.xml)
+`
+}
+
+export function toAtlasApiEntry(
+  entry: FeedAtlasEntry & { site_url?: string; categories?: string[] }
+): AtlasApiEntry {
+  return {
+    slug: entry.slug,
+    name: entry.name,
+    site_url: entry.site_url ?? `${SITE_URL}/atlas/${entry.slug}`,
+    domains: entry.domains,
+    description: entry.description,
+    categories: entry.categories ?? [],
+    updated: entry.updated,
+    last_verified: entry.last_verified,
+    stats: entry.stats,
+    html: `${SITE_URL}/atlas/${entry.slug}`,
+    markdown: `${SITE_URL}/atlas/${entry.slug}.md`,
+    archive: `${SITE_URL}/atlas/${entry.slug}.tar.gz`,
+  }
+}
+
+export function buildAtlasApiIndex(
+  entries: Array<FeedAtlasEntry & { site_url?: string; categories?: string[] }>
+): { schema_version: number; entries: AtlasApiEntry[] } {
+  return {
+    schema_version: 1,
+    entries: entries.map(toAtlasApiEntry),
+  }
+}
+
+export function buildSiteJsonLd(): object {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': `${SITE_URL}/#organization`,
+        name: SITE_NAME,
+        alternateName: ['Sightmap spec', 'Sightmap.org'],
+        url: SITE_URL,
+        description: SITE_DESCRIPTION,
+        sameAs: [
+          'https://github.com/sightmap/sightmap',
+          'https://www.npmjs.com/package/@sightmap/sightmap',
+          'https://docs.sightmap.org',
+        ],
+      },
+      {
+        '@type': 'WebSite',
+        '@id': `${SITE_URL}/#website`,
+        name: SITE_NAME,
+        alternateName: ['Sightmap spec', 'Sightmap.org'],
+        url: SITE_URL,
+        description: SITE_DESCRIPTION,
+        publisher: { '@id': `${SITE_URL}/#organization` },
+      },
+      {
+        '@type': 'SoftwareApplication',
+        '@id': `${SITE_URL}/#software`,
+        name: SITE_NAME,
+        alternateName: 'Sightmap spec',
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'Linux, macOS, Windows',
+        url: SITE_URL,
+        downloadUrl: 'https://www.npmjs.com/package/@sightmap/sightmap',
+        description: SITE_DESCRIPTION,
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        publisher: { '@id': `${SITE_URL}/#organization` },
+      },
+    ],
+  }
+}
+
+export function buildOpenApiSpec(): Record<string, unknown> {
+  const errorSchema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['error'],
+    properties: {
+      error: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['code', 'message', 'hint', 'status'],
+        properties: {
+          code: { type: 'string', examples: ['not_found'] },
+          message: { type: 'string' },
+          hint: {
+            type: 'string',
+            description: 'Where an agent should look next to recover.',
+          },
+          status: { type: 'integer' },
+        },
+      },
+    },
+  }
+
+  const atlasEntrySchema = {
+    type: 'object',
+    required: ['slug', 'name', 'domains', 'html', 'markdown', 'archive'],
+    properties: {
+      slug: { type: 'string' },
+      name: { type: 'string' },
+      site_url: { type: 'string', format: 'uri' },
+      domains: { type: 'array', items: { type: 'string' } },
+      description: { type: 'string' },
+      categories: { type: 'array', items: { type: 'string' } },
+      updated: { type: 'string' },
+      last_verified: { type: 'string' },
+      stats: {
+        type: 'object',
+        properties: {
+          views: { type: 'integer' },
+          components: { type: 'integer' },
+          requests: { type: 'integer' },
+        },
+      },
+      html: { type: 'string', format: 'uri' },
+      markdown: { type: 'string', format: 'uri' },
+      archive: { type: 'string', format: 'uri' },
+    },
+  }
+
+  const errorResponse = {
+    description: 'Structured JSON error',
+    content: {
+      'application/json': {
+        schema: { $ref: '#/components/schemas/Error' },
+      },
+    },
+  }
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: `${SITE_NAME} HTTP API`,
+      summary: `Public read-only HTTP API for the ${SITE_NAME} site and Atlas catalog`,
+      description: `Machine-readable surface of ${SITE_URL}. No authentication. Errors are JSON objects with error.code, error.message, and error.hint.`,
+      version: '1.0.0',
+      license: {
+        name: 'MIT',
+        identifier: 'MIT',
+        url: 'https://github.com/sightmap/sightmap/blob/main/LICENSE',
+      },
+      contact: {
+        name: SITE_NAME,
+        url: 'https://github.com/sightmap/sightmap',
+      },
+    },
+    servers: [{ url: SITE_URL, description: `${SITE_NAME} production` }],
+    tags: [
+      { name: 'Atlas', description: 'Community-contributed sightmaps of live sites' },
+      { name: 'Discovery', description: 'Site index and specification documents' },
+    ],
+    paths: {
+      '/openapi.json': {
+        get: {
+          tags: ['Discovery'],
+          summary: 'OpenAPI specification',
+          operationId: 'getOpenApi',
+          responses: {
+            '200': {
+              description: 'OpenAPI 3.1 document',
+              content: {
+                'application/json': { schema: { type: 'object' } },
+              },
+            },
+          },
+        },
+      },
+      '/api/openapi.yaml': {
+        get: {
+          tags: ['Discovery'],
+          summary: 'OpenAPI specification (YAML)',
+          operationId: 'getOpenApiYaml',
+          responses: {
+            '200': {
+              description: 'OpenAPI 3.1 document in YAML',
+              content: { 'application/yaml': { schema: { type: 'string' } } },
+            },
+          },
+        },
+      },
+      '/api/atlas': {
+        get: {
+          tags: ['Atlas'],
+          summary: 'List published Atlas entries',
+          operationId: 'listAtlas',
+          responses: {
+            '200': {
+              description: 'Atlas catalog',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/AtlasCatalog' },
+                },
+              },
+            },
+            '404': { $ref: '#/components/responses/NotFound' },
+          },
+        },
+      },
+      '/api/atlas/{slug}': {
+        get: {
+          tags: ['Atlas'],
+          summary: 'Get one Atlas entry',
+          operationId: 'getAtlasEntry',
+          parameters: [
+            {
+              name: 'slug',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+              description: 'Atlas entry slug, e.g. airbnb',
+            },
+          ],
+          responses: {
+            '200': {
+              description: 'One Atlas entry plus machine-twin URLs',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/AtlasEntry' },
+                },
+              },
+            },
+            '404': { $ref: '#/components/responses/NotFound' },
+          },
+        },
+      },
+      '/llms.txt': {
+        get: {
+          tags: ['Discovery'],
+          summary: 'Agent site index (llmstxt.org)',
+          operationId: 'getLlmsTxt',
+          responses: {
+            '200': {
+              description: 'Plain-text site index',
+              content: { 'text/plain': { schema: { type: 'string' } } },
+            },
+          },
+        },
+      },
+      '/atlas/index.json': {
+        get: {
+          tags: ['Atlas'],
+          summary: 'Vendored Atlas index (full gallery record)',
+          operationId: 'getAtlasIndex',
+          responses: {
+            '200': {
+              description: 'Full Atlas index.json',
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Error: errorSchema,
+        AtlasEntry: atlasEntrySchema,
+        AtlasCatalog: {
+          type: 'object',
+          required: ['schema_version', 'entries'],
+          properties: {
+            schema_version: { type: 'integer' },
+            entries: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/AtlasEntry' },
+            },
+          },
+        },
+      },
+      responses: {
+        NotFound: errorResponse,
+      },
+    },
+  }
+}
+
+/** Minimal YAML 1.2 dump for the OpenAPI document (JSON-serializable values). */
+export function toYaml(value: unknown, indent = 0): string {
+  const pad = '  '.repeat(indent)
+  if (value === null) return 'null'
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value)
+  if (typeof value === 'string') {
+    if (value === '' || /[:#{}[\],&*?|<>=!%@`'"\n]/.test(value) || value !== value.trim()) {
+      return JSON.stringify(value)
+    }
+    return value
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    return value
+      .map((item) => {
+        if (item !== null && typeof item === 'object' && !Array.isArray(item)) {
+          const keys = Object.keys(item as Record<string, unknown>)
+          if (keys.length === 0) return `${pad}- {}`
+          const innerLines = toYaml(item, indent + 1).split('\n')
+          const first = (innerLines[0] ?? '').replace(/^\s+/, '')
+          const rest = innerLines.slice(1).join('\n')
+          return rest ? `${pad}- ${first}\n${rest}` : `${pad}- ${first}`
+        }
+        if (Array.isArray(item)) {
+          const inner = toYaml(item, indent + 1)
+          return `${pad}-\n${inner}`
+        }
+        return `${pad}- ${toYaml(item, 0)}`
+      })
+      .join('\n')
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) return '{}'
+    return entries
+      .map(([k, v]) => {
+        const key = /^[A-Za-z_][A-Za-z0-9_/-]*$/.test(k) ? k : JSON.stringify(k)
+        if (v !== null && typeof v === 'object') {
+          const inner = toYaml(v, indent + 1)
+          if (inner === '{}' || inner === '[]') return `${pad}${key}: ${inner}`
+          return `${pad}${key}:\n${inner}`
+        }
+        return `${pad}${key}: ${toYaml(v, 0)}`
+      })
+      .join('\n')
+  }
+  return JSON.stringify(value)
+}

--- a/web/scripts/lib/site.test.ts
+++ b/web/scripts/lib/site.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { SITE_URL, SITE_NAME, HOME_TITLE, BLOG_INDEX_TITLE, postTitle, esc, escXml } from './site'
+import {
+  SITE_URL,
+  SITE_NAME,
+  HOME_TITLE,
+  BLOG_INDEX_TITLE,
+  DEVELOPERS_TITLE,
+  postTitle,
+  esc,
+  escXml,
+} from './site'
 
 describe('site constants', () => {
   it('has no trailing slash on SITE_URL', () => {
@@ -23,6 +32,10 @@ describe('title builders', () => {
 
   it('builds a post title by appending SITE_NAME', () => {
     expect(postTitle('Announcing widgets')).toBe(`Announcing widgets — ${SITE_NAME}`)
+  })
+
+  it('names the developers page so a Sightmap search can find it', () => {
+    expect(DEVELOPERS_TITLE).toBe('Sightmap developer resources')
   })
 })
 

--- a/web/scripts/lib/site.ts
+++ b/web/scripts/lib/site.ts
@@ -46,6 +46,9 @@ export const ATLAS_INDEX_TITLE = `Atlas — ${SITE_NAME}`
 // advertising two different titles depending on who asked.
 export const NOT_FOUND_TITLE = `Page not found — ${SITE_NAME}`
 export const NOT_FOUND_DESCRIPTION = "This page doesn't exist."
+export const DEVELOPERS_TITLE = `${SITE_NAME} developer resources`
+export const DEVELOPERS_DESCRIPTION =
+  'OpenAPI, the Atlas HTTP API, documentation, CLI, and agent skills for the Sightmap spec.'
 export const postTitle = (title: string): string => `${title} — ${SITE_NAME}`
 // An atlas entry's own title carries the mapped site's name, so the suffix
 // says which gallery it came from rather than repeating the site name twice.

--- a/web/scripts/prerender.tsx
+++ b/web/scripts/prerender.tsx
@@ -25,10 +25,13 @@ import {
   ATLAS_INDEX_TITLE,
   NOT_FOUND_TITLE,
   NOT_FOUND_DESCRIPTION,
+  DEVELOPERS_TITLE,
+  DEVELOPERS_DESCRIPTION,
   postTitle,
   atlasTitle,
   esc,
 } from './lib/site'
+import { buildSiteJsonLd } from './lib/agent'
 
 const DIST = path.resolve('dist')
 const CONTENT_DIR = path.resolve('content/blog')
@@ -252,37 +255,51 @@ async function main() {
   }
   const shell = fs.readFileSync(shellPath, 'utf-8')
 
+  const siteJsonLd = `<script type="application/ld+json">${JSON.stringify(buildSiteJsonLd()).replace(/</g, '\\u003c')}</script>`
+  const mdAlternate = (href: string): string =>
+    `<link rel="alternate" type="text/markdown" href="${href}">`
+
   // Homepage. Overwrites the shell in place.
   fs.writeFileSync(
     shellPath,
-    renderRoute(shell, '/', {
-      url: `${SITE_URL}/`,
-      ogUrl: `${DEPLOY_URL}/`,
-      title: HOME_TITLE,
-      description: SITE_DESCRIPTION,
-      image: `${SITE_URL}/og-image.png`,
-      ogImage: `${DEPLOY_URL}/og-image.png`,
-      imageAlt: DEFAULT_IMAGE_ALT,
-      imageDimensionsKnown: true,
-      type: 'website',
-    })
+    renderRoute(
+      shell,
+      '/',
+      {
+        url: `${SITE_URL}/`,
+        ogUrl: `${DEPLOY_URL}/`,
+        title: HOME_TITLE,
+        description: SITE_DESCRIPTION,
+        image: `${SITE_URL}/og-image.png`,
+        ogImage: `${DEPLOY_URL}/og-image.png`,
+        imageAlt: DEFAULT_IMAGE_ALT,
+        imageDimensionsKnown: true,
+        type: 'website',
+      },
+      [mdAlternate(`${SITE_URL}/index.md`), siteJsonLd].join('\n    ')
+    )
   )
   console.log('  prerendered /')
 
   // Blog index.
   write(
     'blog',
-    renderRoute(shell, '/blog', {
-      url: `${SITE_URL}/blog`,
-      ogUrl: `${DEPLOY_URL}/blog`,
-      title: BLOG_INDEX_TITLE,
-      description: BLOG_DESCRIPTION,
-      image: `${SITE_URL}/og-image.png`,
-      ogImage: `${DEPLOY_URL}/og-image.png`,
-      imageAlt: DEFAULT_IMAGE_ALT,
-      imageDimensionsKnown: true,
-      type: 'website',
-    })
+    renderRoute(
+      shell,
+      '/blog',
+      {
+        url: `${SITE_URL}/blog`,
+        ogUrl: `${DEPLOY_URL}/blog`,
+        title: BLOG_INDEX_TITLE,
+        description: BLOG_DESCRIPTION,
+        image: `${SITE_URL}/og-image.png`,
+        ogImage: `${DEPLOY_URL}/og-image.png`,
+        imageAlt: DEFAULT_IMAGE_ALT,
+        imageDimensionsKnown: true,
+        type: 'website',
+      },
+      mdAlternate(`${SITE_URL}/blog.md`)
+    )
   )
 
   // Netlify sets CONTEXT to 'production', 'deploy-preview', or
@@ -332,6 +349,7 @@ async function main() {
       `<meta property="article:published_time" content="${fm.date}">`,
       `<meta property="article:author" content="${esc(fm.author)}">`,
       `<meta property="article:section" content="${esc(fm.topic)}">`,
+      mdAlternate(`${SITE_URL}/blog/${fm.slug}.md`),
       `<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>`,
     ].join('\n    ')
 
@@ -389,17 +407,22 @@ async function main() {
 
   write(
     'atlas',
-    renderRoute(shell, '/atlas', {
-      url: `${SITE_URL}/atlas`,
-      ogUrl: `${DEPLOY_URL}/atlas`,
-      title: ATLAS_INDEX_TITLE,
-      description: ATLAS_DESCRIPTION,
-      image: `${SITE_URL}/og-image.png`,
-      ogImage: `${DEPLOY_URL}/og-image.png`,
-      imageAlt: DEFAULT_IMAGE_ALT,
-      imageDimensionsKnown: true,
-      type: 'website',
-    })
+    renderRoute(
+      shell,
+      '/atlas',
+      {
+        url: `${SITE_URL}/atlas`,
+        ogUrl: `${DEPLOY_URL}/atlas`,
+        title: ATLAS_INDEX_TITLE,
+        description: ATLAS_DESCRIPTION,
+        image: `${SITE_URL}/og-image.png`,
+        ogImage: `${DEPLOY_URL}/og-image.png`,
+        imageAlt: DEFAULT_IMAGE_ALT,
+        imageDimensionsKnown: true,
+        type: 'website',
+      },
+      mdAlternate(`${SITE_URL}/atlas.md`)
+    )
   )
 
   for (const entry of atlas.entries) {
@@ -503,15 +526,35 @@ async function main() {
         type: 'website',
         noindex: true,
       },
-      '',
+      mdAlternate(`${SITE_URL}/404.md`),
       '',
       false
     )
   )
   console.log('  prerendered /404.html')
 
+  write(
+    'developers',
+    renderRoute(
+      shell,
+      '/developers',
+      {
+        url: `${SITE_URL}/developers`,
+        ogUrl: `${DEPLOY_URL}/developers`,
+        title: DEVELOPERS_TITLE,
+        description: DEVELOPERS_DESCRIPTION,
+        image: `${SITE_URL}/og-image.png`,
+        ogImage: `${DEPLOY_URL}/og-image.png`,
+        imageAlt: DEFAULT_IMAGE_ALT,
+        imageDimensionsKnown: true,
+        type: 'website',
+      },
+      [mdAlternate(`${SITE_URL}/developers.md`), siteJsonLd].join('\n    ')
+    )
+  )
+
   console.log(
-    `\n  prerender complete: ${posts.length + atlas.entries.length + 4} page(s)`
+    `\n  prerender complete: ${posts.length + atlas.entries.length + 5} page(s)`
   )
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import BlogIndex from '@/pages/BlogIndex'
 import BlogPost from '@/pages/BlogPost'
 import AtlasIndex from '@/pages/AtlasIndex'
 import AtlasEntry from '@/pages/AtlasEntry'
+import Developers from '@/pages/Developers'
 import NotFound from '@/pages/NotFound'
 import { ConsentProvider } from '@/components/consent/ConsentContext'
 import ConsentUI from '@/components/consent/ConsentUI'
@@ -21,6 +22,7 @@ export default function App() {
             one declared only in this file ships as a client-only page. */}
         <Route path="/atlas" element={<AtlasIndex />} />
         <Route path="/atlas/:slug" element={<AtlasEntry />} />
+        <Route path="/developers" element={<Developers />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <ConsentUI />

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -12,6 +12,7 @@ export default function Footer() {
           <div className="footer-links">
             <a href="/atlas">Atlas</a>
             <a href="/blog">Blog</a>
+            <a href="/developers">Developers</a>
             <a href="https://docs.sightmap.org">Docs</a>
             <a href="https://docs.sightmap.org/start/quickstart">Quickstart</a>
             <a href="https://docs.sightmap.org/reference/schema">Schema reference</a>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1990,6 +1990,86 @@ footer {
   gap: 1rem;
 }
 
+.not-found__recover {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 1.25rem;
+  margin-top: 2rem;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.not-found__recover a {
+  color: var(--text-dim);
+  text-decoration: none;
+}
+
+.not-found__recover a:hover {
+  color: var(--accent);
+}
+
+/* ---- DEVELOPERS ---- */
+.developers {
+  padding-top: 9rem;
+  padding-bottom: 5rem;
+}
+
+.developers__header {
+  margin-bottom: 3rem;
+}
+
+.developers__auth {
+  margin-top: 1rem;
+  max-width: 40rem;
+  font-size: 0.95rem;
+  color: var(--text-dim);
+}
+
+.developers__auth code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+}
+
+.developers__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.developers__item {
+  display: block;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-raised);
+  text-decoration: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.developers__item:hover {
+  border-color: var(--border-bright);
+  box-shadow: 0 2px 16px rgba(201, 69, 109, 0.08);
+}
+
+.developers__item-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 0.4rem;
+}
+
+.developers__item-detail {
+  color: var(--text);
+  margin-bottom: 0.6rem;
+}
+
+.developers__item-href {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+}
+
 /* ---- CONSENT ---- */
 .consent-banner {
   position: fixed;

--- a/web/src/pages/Developers.tsx
+++ b/web/src/pages/Developers.tsx
@@ -1,0 +1,88 @@
+import Navigation from '@/components/Navigation'
+import Footer from '@/components/Footer'
+import Seo from '@/components/Seo'
+import { DEVELOPERS_DESCRIPTION, DEVELOPERS_TITLE } from '../../scripts/lib/site'
+
+const RESOURCES: { href: string; label: string; detail: string; external?: boolean }[] = [
+  {
+    href: '/openapi.json',
+    label: 'OpenAPI specification',
+    detail: 'Machine-readable description of the Sightmap HTTP API at /openapi.json.',
+  },
+  {
+    href: '/api/openapi.yaml',
+    label: 'OpenAPI (YAML)',
+    detail: 'The same specification at /api/openapi.yaml.',
+  },
+  {
+    href: '/api/atlas',
+    label: 'Atlas HTTP API',
+    detail: 'GET /api/atlas lists published sightmaps. GET /api/atlas/{slug} returns one entry.',
+  },
+  {
+    href: 'https://docs.sightmap.org',
+    label: 'Sightmap documentation',
+    detail: 'Guides, CLI reference, and the schema reference.',
+    external: true,
+  },
+  {
+    href: 'https://docs.sightmap.org/start/quickstart',
+    label: 'Quickstart',
+    detail: 'Install the Sightmap CLI and author a first corpus.',
+    external: true,
+  },
+  {
+    href: 'https://github.com/sightmap/sightmap',
+    label: 'GitHub repository',
+    detail: 'Spec, reference implementation, and agent skills.',
+    external: true,
+  },
+  {
+    href: 'https://www.npmjs.com/package/@sightmap/sightmap',
+    label: 'CLI on npm',
+    detail: 'npm install -g @sightmap/sightmap — then sightmap skills install.',
+    external: true,
+  },
+  {
+    href: '/llms.txt',
+    label: 'llms.txt',
+    detail: 'Published site index for agents, including every Atlas entry.',
+  },
+]
+
+export default function Developers() {
+  return (
+    <>
+      <Seo title={DEVELOPERS_TITLE} description={DEVELOPERS_DESCRIPTION} />
+      <Navigation />
+      <main className="developers" data-component="Developers">
+        <div className="container">
+          <div className="developers__header">
+            <div className="section-label">Developers</div>
+            <h1>Sightmap developer resources</h1>
+            <p className="section-desc">{DEVELOPERS_DESCRIPTION}</p>
+            <p className="developers__auth">
+              The public HTTP API is read-only and requires no authentication. Errors
+              return JSON with <code>error.code</code>, <code>error.message</code>, and <code>error.hint</code>.
+            </p>
+          </div>
+          <div className="developers__list">
+            {RESOURCES.map((r) => (
+              <a
+                key={r.href}
+                href={r.href}
+                className="developers__item"
+                {...(r.external ? { target: '_blank', rel: 'noreferrer' } : {})}
+              >
+                <div className="developers__item-title">{r.label}</div>
+                <p className="developers__item-detail">{r.detail}</p>
+                <code className="developers__item-href">{r.href}</code>
+              </a>
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -20,6 +20,12 @@ export default function NotFound() {
             <Link to="/" className="btn-primary">Back to home</Link>
             <Link to="/blog" className="btn-secondary">Read the blog</Link>
           </div>
+          <nav className="not-found__recover" aria-label="Where to look next">
+            <a href="/llms.txt">llms.txt</a>
+            <a href="/sitemap.xml">Sitemap</a>
+            <Link to="/developers">Sightmap developer resources</Link>
+            <a href="https://docs.sightmap.org">Docs</a>
+          </nav>
         </div>
       </main>
       <Footer />

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['scripts/**/*.test.ts', 'src/**/*.test.ts', 'src/**/*.test.tsx'],
+    include: ['scripts/**/*.test.ts', 'src/**/*.test.ts', 'src/**/*.test.tsx', 'netlify/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this changes

Makes https://sightmap.org easier for agents to use: real 404s with a markdown recovery body, a published OpenAPI document, structured JSON API errors, `Accept: text/markdown` negotiation with `Vary: Accept`, and a `/developers` page named so “Sightmap” searches can find the project’s own docs.

## Why

An Is Agentic audit scored the site 67/100. Nonexistent paths already returned HTTP 404 (partial credit) but had no markdown recovery body; there was no OpenAPI document or JSON API; HTML pages ignored `Accept: text/markdown`; and developer resources were not listed under the product name.

## Area

- [ ] Spec (`spec/`)
- [ ] Go implementation / CLI (`go/`)
- [ ] Docs site (`docs/`)
- [x] Marketing site (`web/`)
- [ ] Maintainer / infrastructure

## Type of change

- [ ] Bug fix
- [ ] Docs / wording / typo
- [x] Feature
- [ ] Spec clarification (no semantic change)
- [ ] Spec change (requires an accepted SEP — link below)
- [ ] Example or conformance fixture added/updated

## Linked issues or SEPs

Improves agent readiness of sightmap.org (Is Agentic / Ora audit).

## What landed

1. **Agent-friendly 404s** — HTML 404 keeps the existing page and adds recovery links. `Accept: text/markdown` returns `dist/404.md` (sitemap, llms.txt, docs, OpenAPI). `Accept: application/json` returns a structured JSON error.
2. **OpenAPI** — `GET /openapi.json` and `GET /api/openapi.yaml` (OpenAPI 3.1) describe the public read-only HTTP API.
3. **JSON errors** — `/api/*` always returns `{ error: { code, message, hint, status } }`. Unknown slugs and methods are 404 / 405.
4. **Markdown negotiation** — the `negotiate` edge function serves per-page `.md` twins when `Accept` prefers `text/markdown`, honors q-values, returns 406 when nothing matches, and always sets `Vary: Accept, Accept-Encoding`.
5. **Developer discoverability** — `/developers` is titled **Sightmap developer resources**, listed in `llms.txt`, the sitemap, footer, and robots.txt.
6. **Brand discoverability** — Organization / WebSite / SoftwareApplication JSON-LD with `name: Sightmap`, `alternateName` (`Sightmap spec`, `Sightmap.org`), and `sameAs` links to GitHub, npm, and docs.

## Checklist

- [x] I read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] Every commit on this branch is signed off (`git commit -s`) per [DCO](../CONTRIBUTING.md#developer-certificate-of-origin)
- [x] I kept this PR focused on a single concern
- [x] Relevant checks pass locally (`pnpm test` and `pnpm build` in `web/`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02c05-9c2a-7d03-ab47-de03086bba73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02c05-9c2a-7d03-ab47-de03086bba73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

