### PR TITLE
browser install: fetch correct arch on linux-arm64 with channel fallback

### DIFF
--- a/.changeset/browser-install-linux-arm64.md
+++ b/.changeset/browser-install-linux-arm64.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`browser install` now fetches the correct architecture on **linux-arm64**. It previously mapped every Linux host to the `linux64` (x86-64) Chrome for Testing build regardless of CPU, so arm64 machines silently got an x64 Chrome under `~/.sightmap/browsers/chrome-<ver>/chrome-linux64/`. The platform is now resolved per-arch (`linux-arm64` on arm64, `linux64` on x64). Because Google does not currently ship an arm64 build to the **Stable** channel, resolution falls back through Beta → Dev → Canary for platforms Stable does not carry, printing a one-line warning when it uses a non-Stable channel. Every mainstream platform continues to install from Stable unchanged.

--- a/go/browser/install.go
+++ b/go/browser/install.go
@@ -31,16 +31,26 @@ type cftVersionsJSON struct {
 // cftPlatform returns the Chrome for Testing platform string for the current
 // OS/arch, or "" if the platform is unsupported.
 func cftPlatform() string {
-	switch runtime.GOOS {
+	return cftPlatformFor(runtime.GOOS, runtime.GOARCH)
+}
+
+// cftPlatformFor returns the Chrome for Testing platform string for goos/goarch
+// (Go's runtime.GOOS/GOARCH values), or "" if the platform is unsupported. It is
+// split out from cftPlatform so the arch mapping is unit-testable.
+func cftPlatformFor(goos, goarch string) string {
+	switch goos {
 	case "darwin":
-		if runtime.GOARCH == "arm64" {
+		if goarch == "arm64" {
 			return "mac-arm64"
 		}
 		return "mac-x64"
 	case "linux":
+		if goarch == "arm64" {
+			return "linux-arm64"
+		}
 		return "linux64"
 	case "windows":
-		if runtime.GOARCH == "386" {
+		if goarch == "386" {
 			return "win32"
 		}
 		return "win64"
@@ -60,6 +70,8 @@ func cftRelBin(platform string) string {
 		)
 	case "linux64":
 		return filepath.Join("chrome-linux64", "chrome")
+	case "linux-arm64":
+		return filepath.Join("chrome-linux-arm64", "chrome")
 	case "win64":
 		return filepath.Join("chrome-win64", "chrome.exe")
 	case "win32":
@@ -106,49 +118,85 @@ func InstalledCfTPath() (string, bool) {
 	return "", false
 }
 
-// ResolveLatestStableCfT queries the CfT JSON API and returns the current
-// Stable channel version and the download URL for the current platform.
-func ResolveLatestStableCfT(ctx context.Context) (version, downloadURL string, err error) {
-	platform := cftPlatform()
-	if platform == "" {
-		return "", "", fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
+// cftChannelOrder is the channel preference used when resolving a download.
+// Stable is always tried first; the less-stable channels are fallbacks for
+// platforms Google does not (yet) ship to Stable — notably linux-arm64, which
+// as of this writing appears only in Beta/Dev/Canary.
+var cftChannelOrder = []string{"Stable", "Beta", "Dev", "Canary"}
 
+// downloadForPlatform returns the chrome download URL (and its channel version)
+// for platform within channel, or ("", "") if that channel does not offer it.
+func (d *cftVersionsJSON) downloadForPlatform(channel, platform string) (version, url string) {
+	ch, ok := d.Channels[channel]
+	if !ok {
+		return "", ""
+	}
+	for _, dl := range ch.Downloads.Chrome {
+		if dl.Platform == platform {
+			return ch.Version, dl.URL
+		}
+	}
+	return "", ""
+}
+
+// resolve picks a download for platform, preferring Stable and falling back
+// through cftChannelOrder. It returns the channel it settled on so callers can
+// warn when a non-Stable build was used.
+func (d *cftVersionsJSON) resolve(platform string) (version, downloadURL, channel string, err error) {
+	for _, ch := range cftChannelOrder {
+		if v, u := d.downloadForPlatform(ch, platform); u != "" {
+			return v, u, ch, nil
+		}
+	}
+	return "", "", "", fmt.Errorf("no Chrome for Testing download for platform %q in any channel (%s)",
+		platform, strings.Join(cftChannelOrder, ", "))
+}
+
+// fetchCfTVersions retrieves and decodes the Chrome for Testing versions JSON.
+func fetchCfTVersions(ctx context.Context) (*cftVersionsJSON, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cftVersionsURL, nil)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("fetch CfT versions: %w", err)
+		return nil, fmt.Errorf("fetch CfT versions: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("fetch CfT versions: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("fetch CfT versions: HTTP %d", resp.StatusCode)
 	}
-
 	var data cftVersionsJSON
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return "", "", fmt.Errorf("parse CfT versions: %w", err)
+		return nil, fmt.Errorf("parse CfT versions: %w", err)
 	}
+	return &data, nil
+}
 
-	stable, ok := data.Channels["Stable"]
-	if !ok {
-		return "", "", fmt.Errorf("no Stable channel in CfT versions response")
+// ResolveCfT queries the CfT JSON API and returns the version, download URL and
+// channel for the current platform. It prefers the Stable channel and only
+// falls back to the less-stable channels (Beta, Dev, Canary) for platforms
+// Stable does not carry — currently just linux-arm64. For every mainstream
+// platform the returned channel is "Stable".
+func ResolveCfT(ctx context.Context) (version, downloadURL, channel string, err error) {
+	platform := cftPlatform()
+	if platform == "" {
+		return "", "", "", fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
-	for _, dl := range stable.Downloads.Chrome {
-		if dl.Platform == platform {
-			return stable.Version, dl.URL, nil
-		}
+	data, err := fetchCfTVersions(ctx)
+	if err != nil {
+		return "", "", "", err
 	}
-	return "", "", fmt.Errorf("no download URL for platform %q in CfT Stable channel", platform)
+	return data.resolve(platform)
 }
 
 // InstallCfT downloads and installs Chrome for Testing into the sightmap
 // cache directory (~/.sightmap/browsers/chrome-<version>/).
 //
-// It is idempotent: if the current Stable version is already installed the
-// binary path is returned immediately without a download.
+// It is idempotent: if the resolved version is already installed the binary
+// path is returned immediately without a download. It prefers the Stable
+// channel, falling back to Beta/Dev/Canary only for platforms Stable does not
+// carry (currently just linux-arm64), warning to w when it does.
 //
 // Progress messages are written to w (pass os.Stderr for interactive use,
 // io.Discard to suppress).
@@ -159,12 +207,15 @@ func InstallCfT(ctx context.Context, w io.Writer) (binaryPath string, err error)
 	}
 	relBin := cftRelBin(platform)
 
-	fmt.Fprintf(w, "Resolving latest Chrome for Testing (Stable)...\n")
-	version, downloadURL, err := ResolveLatestStableCfT(ctx)
+	fmt.Fprintf(w, "Resolving latest Chrome for Testing...\n")
+	version, downloadURL, channel, err := ResolveCfT(ctx)
 	if err != nil {
 		return "", err
 	}
-	fmt.Fprintf(w, "  version: %s  platform: %s\n", version, platform)
+	if channel != "Stable" {
+		fmt.Fprintf(w, "warning: no Stable Chrome for Testing build for %s; falling back to the %s channel.\n", platform, channel)
+	}
+	fmt.Fprintf(w, "  version: %s  platform: %s  channel: %s\n", version, platform, channel)
 
 	cacheDir, err := CfTCacheDir()
 	if err != nil {

--- a/go/browser/install_test.go
+++ b/go/browser/install_test.go
@@ -1,0 +1,108 @@
+package browser
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// TestCftPlatformFor guards the OS/arch → CfT platform mapping. The regression
+// this locks in: linux/arm64 previously resolved to "linux64" (the x64 build),
+// so `browser install` fetched an x86-64 Chrome onto arm64 machines.
+func TestCftPlatformFor(t *testing.T) {
+	cases := []struct {
+		goos, goarch, want string
+	}{
+		{"darwin", "arm64", "mac-arm64"},
+		{"darwin", "amd64", "mac-x64"},
+		{"linux", "amd64", "linux64"},
+		{"linux", "arm64", "linux-arm64"}, // the fix
+		{"windows", "amd64", "win64"},
+		{"windows", "386", "win32"},
+		{"plan9", "amd64", ""}, // unsupported
+	}
+	for _, c := range cases {
+		if got := cftPlatformFor(c.goos, c.goarch); got != c.want {
+			t.Errorf("cftPlatformFor(%q, %q) = %q, want %q", c.goos, c.goarch, got, c.want)
+		}
+	}
+}
+
+// TestCftRelBinLinuxArm64 checks the extracted-binary path for the arm64 build,
+// which lives in its own chrome-linux-arm64/ directory (not chrome-linux64/).
+func TestCftRelBinLinuxArm64(t *testing.T) {
+	got := cftRelBin("linux-arm64")
+	want := filepath.Join("chrome-linux-arm64", "chrome")
+	if got != want {
+		t.Errorf("cftRelBin(%q) = %q, want %q", "linux-arm64", got, want)
+	}
+	if cftRelBin("linux64") == got {
+		t.Error("linux-arm64 and linux64 must not share an install path")
+	}
+}
+
+// testVersionsJSON mirrors the real CfT endpoint shape: Stable omits
+// linux-arm64 (true as of this writing), while Beta and Dev carry it.
+const testVersionsJSON = `{
+  "channels": {
+    "Stable": {"version": "152.0", "downloads": {"chrome": [
+      {"platform": "linux64", "url": "https://cft/stable/linux64.zip"},
+      {"platform": "mac-arm64", "url": "https://cft/stable/mac-arm64.zip"}
+    ]}},
+    "Beta": {"version": "153.0", "downloads": {"chrome": [
+      {"platform": "linux-arm64", "url": "https://cft/beta/linux-arm64.zip"},
+      {"platform": "linux64", "url": "https://cft/beta/linux64.zip"}
+    ]}},
+    "Dev": {"version": "154.0", "downloads": {"chrome": [
+      {"platform": "linux-arm64", "url": "https://cft/dev/linux-arm64.zip"}
+    ]}}
+  }
+}`
+
+func parseTestVersions(t *testing.T) *cftVersionsJSON {
+	t.Helper()
+	var data cftVersionsJSON
+	if err := json.Unmarshal([]byte(testVersionsJSON), &data); err != nil {
+		t.Fatalf("unmarshal test versions: %v", err)
+	}
+	return &data
+}
+
+func TestResolvePrefersStable(t *testing.T) {
+	data := parseTestVersions(t)
+
+	// A platform Stable carries resolves to Stable even though later channels
+	// also offer it.
+	v, u, ch, err := data.resolve("linux64")
+	if err != nil {
+		t.Fatalf("resolve(linux64): %v", err)
+	}
+	if ch != "Stable" || v != "152.0" || u != "https://cft/stable/linux64.zip" {
+		t.Errorf("resolve(linux64) = (%q, %q, %q), want Stable/152.0", v, u, ch)
+	}
+}
+
+func TestResolveFallsBackOffStable(t *testing.T) {
+	data := parseTestVersions(t)
+
+	// linux-arm64 is absent from Stable, so resolution must fall through to the
+	// first channel that carries it (Beta, ahead of Dev in the preference order).
+	v, u, ch, err := data.resolve("linux-arm64")
+	if err != nil {
+		t.Fatalf("resolve(linux-arm64): %v", err)
+	}
+	if ch != "Beta" {
+		t.Errorf("resolve(linux-arm64) channel = %q, want Beta", ch)
+	}
+	if v != "153.0" || u != "https://cft/beta/linux-arm64.zip" {
+		t.Errorf("resolve(linux-arm64) = (%q, %q), want Beta's 153.0 / beta url", v, u)
+	}
+}
+
+func TestResolveUnknownPlatformErrors(t *testing.T) {
+	data := parseTestVersions(t)
+
+	if _, _, _, err := data.resolve("win64"); err == nil {
+		t.Error("resolve(win64) should error: no channel in the fixture carries it")
+	}
+}

--- a/go/cmd/sightmap/cmd_browser_install.go
+++ b/go/cmd/sightmap/cmd_browser_install.go
@@ -11,9 +11,10 @@ import (
 
 // runBrowserInstall implements `sightmap browser install`.
 //
-// Downloads and installs the latest stable Chrome for Testing into
-// ~/.sightmap/browsers/. Idempotent: if the current stable version is already
-// present it just prints the binary path and exits 0.
+// Downloads and installs the latest Chrome for Testing into ~/.sightmap/browsers/.
+// Prefers the Stable channel, falling back to Beta/Dev/Canary only for platforms
+// Stable does not carry (currently just linux-arm64). Idempotent: if the resolved
+// version is already present it just prints the binary path and exits 0.
 func runBrowserInstall(args []string) error {
 	// Parse args so `--help` (or any unknown flag) is handled before the
 	// download starts, rather than being ignored while the 184 MB install runs.


### PR DESCRIPTION
Reported on a linux-arm64 machine: `sightmap browser install` produced

```
~/.sightmap/browsers/chrome-152.0.7977.54/chrome-linux64
```

`chrome-linux64` is the x86-64 Chrome for Testing build, so arm64 hosts were silently getting an x64 Chrome.

## Root cause

`cftPlatform()` in `go/browser/install.go` mapped **every** Linux host to `linux64` regardless of `runtime.GOARCH` — the one platform branch that ignored arch (macOS and Windows already split by arch):

```go
case "linux":
    return "linux64"
```

## The wrinkle

Chrome for Testing does publish a `linux-arm64` platform, but only on the **Beta / Dev / Canary** channels — **not Stable** (verified against `last-known-good-versions-with-downloads.json`). The installer was hardwired to Stable, so simply mapping arm64 → `linux-arm64` would have made install fail outright on arm64.

## Change

- `cftPlatform` now resolves per-arch (`linux-arm64` on arm64, `linux64` on x64); extracted into `cftPlatformFor(goos, goarch)` so the mapping is unit-testable (mirrors the existing `findChrome(goos, …)` pattern).
- `cftRelBin` gains a `linux-arm64` case (`chrome-linux-arm64/chrome`).
- Download resolution now prefers Stable and falls back through **Beta → Dev → Canary** for platforms Stable does not carry (today just linux-arm64). `ResolveLatestStableCfT` is replaced by `ResolveCfT`, which returns the channel it settled on.
- `InstallCfT` prints a one-line warning when it uses a non-Stable channel.

Every mainstream platform still installs from Stable, unchanged. As a side effect, on an arm64 box that previously installed the x64 build, `InstalledCfTPath()` no longer matches the stale `chrome-linux64/` directory, so the next install correctly fetches the arm64 build instead of colliding.

## Tests

New `go/browser/install_test.go` (no network):
- `cftPlatformFor` mapping across OS/arch, incl. the `linux/arm64 → linux-arm64` regression.
- `cftRelBin` for the arm64 path.
- channel resolution: prefers Stable, falls back to Beta for linux-arm64, errors when no channel carries the platform.

`go build ./...` and `go test ./browser/` pass; `gofmt` clean.

## Follow-up

Google has shipped `linux-arm64` to Beta/Dev/Canary for a while; once it reaches **Stable**, arm64 will resolve to Stable automatically with no further change (the warning simply stops firing).