### PR TITLE
docs: guard changelog entries against MDX-unsafe raw tags

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -36,6 +36,8 @@ That's the whole workflow. No build step, no dependencies — Mintlify serves th
 
 The body below the frontmatter is the prose shown inside the entry. Keep **Markdown headings (`##`) out of the body** — Mintlify splits the RSS feed per heading, so a heading turns one release into several feed entries.
 
+Keep the body **MDX-safe**: it renders as MDX, so a bare `<view>` (or `{x}`) placeholder in prose is parsed as a JSX element/expression and fails `mint validate` with `Expected a closing tag for <view>`. Wrap placeholders in backticks — `` `<view>` `` — as every entry already does. `build-changelog.mjs` enforces this for `<…>` tags and fails the build, naming the offending entry. This matters most because entry prose is copied **verbatim** from a changeset, so an unsafe placeholder in a changeset rides straight through to the page.
+
 ## How entries get written
 
 **Automatically, as part of the release.** `npm run version-packages` — the command `changesets/action` runs to open the "Version Packages" PR — chains `scripts/changelog-entry.mjs` after `changeset version`. So the moment changesets writes a new block to `go/npm/CHANGELOG.md`, the matching entry file and the regenerated `changelog.mdx` are written too, and all of it lands in that same PR alongside the version bump.
@@ -69,6 +71,7 @@ The `docs` workflow enforces both halves, and they catch different failures:
 | Check | Catches |
 |-------|---------|
 | `node docs/scripts/build-changelog.mjs --check` | `changelog.mdx` is stale relative to the entry files — someone edited an entry and forgot to rebuild. |
+| `node docs/scripts/build-changelog.mjs` (build or `--check`) | An entry body has a raw `<tag>` placeholder outside backticks — MDX would fail `mint validate` downstream. |
 | `node scripts/changelog-entry.mjs --check` | A released version in `go/npm/CHANGELOG.md` has no entry at all — the docs site is a version behind npm. |
 
 The first passes happily when a release has no entry (there's nothing to be stale against), which is how 0.17.0 shipped without one. The second is why `go/npm/CHANGELOG.md` is in the workflow's path filter: the "Version Packages" PR touches no `docs/` files, so without it the job wouldn't run on the one PR that matters.

--- a/docs/scripts/build-changelog.mjs
+++ b/docs/scripts/build-changelog.mjs
@@ -65,6 +65,24 @@ function renderUpdate({ meta, body }) {
   return `<Update ${attrs.join(' ')}>\n\n${body}\n\n</Update>`;
 }
 
+// Reject MDX-unsafe raw tags in an entry body. changelog.mdx is MDX, so a bare
+// `<view>` in prose is parsed as an unclosed JSX/HTML element and fails
+// `mint validate` ("Expected a closing tag for `<view>`"). Placeholders belong in
+// backticks — `<view>` — which every entry already does; this guard keeps it that
+// way. Code spans and fenced blocks are stripped first, so backticked tags pass.
+// Lowercase-only by design: real Mintlify components are capitalized, and the
+// recurring hazard is a lowercase placeholder copied verbatim from a changeset.
+function lintBody(file, body) {
+  const prose = body
+    .replace(/```[\s\S]*?```/g, '') // fenced code blocks
+    .replace(/`[^`]*`/g, '');        // inline code
+  const tags = [...new Set(prose.match(/<\/?[a-z][\w-]*\/?>?/g) || [])];
+  if (!tags.length) return null;
+  return `${file}: raw tag(s) in prose — ${tags.join(', ')} — MDX reads these as JSX `
+    + `elements and \`mint validate\` will fail. Wrap angle-bracket placeholders in `
+    + `backticks, e.g. \`<view>\`.`;
+}
+
 function build() {
   let files;
   try {
@@ -78,6 +96,13 @@ function build() {
       a.meta.date === b.meta.date
         ? b.file.localeCompare(a.file)
         : b.meta.date.localeCompare(a.meta.date));
+
+  const problems = entries.map((e) => lintBody(e.file, e.body)).filter(Boolean);
+  if (problems.length) {
+    console.error('changelog: MDX-unsafe entry content:\n'
+      + problems.map((p) => '  - ' + p).join('\n'));
+    process.exit(1);
+  }
 
   const header = `---
 title: "Changelog"


### PR DESCRIPTION
`changelog.mdx` is, unsurprisingly, MDX, and entry prose is copied verbatim from changesets, so a bare `<view>`-style placeholder rides through and fails mint validate ("Expected a closing tag for <view>"), as it did on the 0.26.2 release PR. `build-changelog.mjs` now rejects a lowercase raw `<tag>` in an entry body (code spans excluded, so backticked placeholders pass), failing the build and CI --check with the offending entry named. Documents the rule in `changelog/README.md`.

Zero changes to existing entries -- they already backtick their placeholders.