### PR TITLE
docs(skills): fix authoring-skill Further-reading pointers

### DIFF
--- a/.changeset/authoring-skill-further-reading.md
+++ b/.changeset/authoring-skill-further-reading.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Authoring skill: fix the "Further reading" pointers. They referenced `go/README.md` (not shipped with the installed skill) and `docs/reference.md` (which does not exist). The skill is self-contained — coverage model, outer loop, tool surface, lint rules, quality checklist, and the component model are all in it — and now points to the published docs for the normative spec instead of dead repo-relative paths.

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -15,11 +15,12 @@ Two outputs drive everything:
 - **Coverage**: every interactive node has a component ancestor (T1 direct or T2 scoped)
 - **Annotation**: component names + extracted properties appear inline in the tree
 
-> **Further reading.** The Go implementation's `README.md` (`go/README.md`) has a
-> runnable quickstart, and `docs/reference.md` is the full authoring reference (coverage
-> model, component model, the outer loop, tool reference, lint rules, quality
-> checklist). To *use* a finished corpus — driving the browser and interacting
-> with the page — see the `sightmap-browser` skill.
+> **Further reading.** This skill is the authoring reference: the coverage model,
+> the component model (**Component hierarchy** and **Cross-view references**
+> below), the outer loop, the tool surface, lint rules, and the quality checklist
+> are all here. For the normative spec and deeper background, see the docs at
+> <https://docs.sightmap.org>. To *use* a finished corpus — driving the browser
+> and interacting with the page — see the `sightmap-browser` skill.
 
 ## Installation
 

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -15,11 +15,12 @@ Two outputs drive everything:
 - **Coverage**: every interactive node has a component ancestor (T1 direct or T2 scoped)
 - **Annotation**: component names + extracted properties appear inline in the tree
 
-> **Further reading.** The Go implementation's `README.md` (`go/README.md`) has a
-> runnable quickstart, and `docs/reference.md` is the full authoring reference (coverage
-> model, component model, the outer loop, tool reference, lint rules, quality
-> checklist). To *use* a finished corpus — driving the browser and interacting
-> with the page — see the `sightmap-browser` skill.
+> **Further reading.** This skill is the authoring reference: the coverage model,
+> the component model (**Component hierarchy** and **Cross-view references**
+> below), the outer loop, the tool surface, lint rules, and the quality checklist
+> are all here. For the normative spec and deeper background, see the docs at
+> <https://docs.sightmap.org>. To *use* a finished corpus — driving the browser
+> and interacting with the page — see the `sightmap-browser` skill.
 
 ## Installation
 


### PR DESCRIPTION
Closes #267.

Stacked on #268 (base branch `skill/component-model-266`).

The authoring skill's "Further reading" block deferred to two paths that are unreachable for anyone using the installed/published skill:

- `go/README.md` — the installed skill ships only `SKILL.md`, so it doesn't travel with it (and it's Install + Quickstart, already covered by the skill's own Installation section and loop).
- `docs/reference.md` — does not exist (it's referenced from `go/README.md` too, but was never created; the reference content lives under `docs/reference/*` and `docs/authoring/*`).

## Change

Rewrote the block to stop deferring to dead/redundant repo-relative paths. The skill already contains the coverage model, outer loop, tool surface, lint rules, quality checklist, and — after #268 — the component model, so it now states that plainly and points to the published docs (docs.sightmap.org) for the normative spec.

Nothing needed folding in: `go/README.md`'s only agent-relevant content (install + quickstart) was already in the skill, and there was no `docs/reference.md` to fold from.

Per the review note: I checked both skills for redundancy while here — the component-model additions from #268 defer query syntax to the browser skill and don't duplicate existing sections, and this change is net-negative in size. No further trimming was warranted.

`go/skills/` copy regenerated; changeset included (`patch`).
