### PR TITLE
docs(skills): document memory: shape, route matching, and class-selector nuance

### DIFF
--- a/.changeset/authoring-skill-minor-gaps.md
+++ b/.changeset/authoring-skill-minor-gaps.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Authoring skill: fill three small content gaps. Document the `memory:` shape (a list of plain strings, attachable at the file root or on a view/component), add a route-matching note (`*` matches one path segment, `**` matches zero or more, and the URL is matched decoded so `%2F` counts as a separator), and reconcile the class-selector guidance (stable hand-authored class names are fine — the volatility risk is generated/hashed classes).

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -330,6 +330,25 @@ views:
   fine. Use `$ref` to attest which globals a view can show (a rail that's usually
   there, a modal reachable from the page).
 
+## Memory (`memory:`)
+
+`memory:` carries short free-text notes that surface in your `[Guide]` context
+whenever the definition is active — quirks, invariants, "you have to click this
+twice" lore that isn't recoverable from the DOM. It is a **list of plain
+strings** (not objects — a list of `{name, text}` maps fails to parse), and it
+attaches at the file root (global notes), on a view, or on a component:
+
+```yaml
+version: 1
+memory:
+  - Auth rail is present on every page except /login.
+components:
+  - name: RangeSlider
+    selector: '.range'
+    memory:
+      - "Range: 1st click = start, 2nd = end, 3rd resets"
+```
+
 ---
 
 ## Property extraction principles
@@ -567,8 +586,10 @@ sightmap suggest --exclude-known   # candidates not in sightmap
 sightmap discover                  # URL patterns — find unseen routes
 ```
 
-Prefer selectors with `data-testid`, `data-component^=`, `#id`. Avoid
-class selectors (volatile) and auto-generated IDs.
+Prefer selectors with `data-testid`, `data-component^=`, `#id`. Stable,
+hand-authored class names are fine too — the volatility risk is *generated or
+hashed* classes (CSS-modules, hashed production builds) and auto-generated IDs;
+avoid those, not classes as a category.
 
 Create a view file `.sightmap/views/PAGE.yaml`. **View fields go under a
 top-level `views:` list** — `route:`/`url:`/`name:` are *not* file-root fields
@@ -587,6 +608,13 @@ views:
 ```
 
 Run `sightmap validate` before snapping.
+
+**Route matching (globs).** `*` matches exactly one path segment; `**` as its
+own segment matches zero or more (`/a/**` matches `/a`, `/a/b`, `/a/b/c`; `/a/*`
+matches only `/a/b`). Matching is against the URL's **decoded** path, so a `%2F`
+in the URL counts as a separator: `/app/x%2Fy%2Fz` is five segments, not three,
+and a `/app/*/*` route won't match it (use `/app/**`). When several views match,
+the most specific wins; ties go to the first-declared view.
 
 **Keep routes specific.** A `route:` glob should identify *this* view, not every
 page. A catch-all like `/lightning/**` or `/**` that matches every URL is a smell:

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -330,6 +330,25 @@ views:
   fine. Use `$ref` to attest which globals a view can show (a rail that's usually
   there, a modal reachable from the page).
 
+## Memory (`memory:`)
+
+`memory:` carries short free-text notes that surface in your `[Guide]` context
+whenever the definition is active — quirks, invariants, "you have to click this
+twice" lore that isn't recoverable from the DOM. It is a **list of plain
+strings** (not objects — a list of `{name, text}` maps fails to parse), and it
+attaches at the file root (global notes), on a view, or on a component:
+
+```yaml
+version: 1
+memory:
+  - Auth rail is present on every page except /login.
+components:
+  - name: RangeSlider
+    selector: '.range'
+    memory:
+      - "Range: 1st click = start, 2nd = end, 3rd resets"
+```
+
 ---
 
 ## Property extraction principles
@@ -567,8 +586,10 @@ sightmap suggest --exclude-known   # candidates not in sightmap
 sightmap discover                  # URL patterns — find unseen routes
 ```
 
-Prefer selectors with `data-testid`, `data-component^=`, `#id`. Avoid
-class selectors (volatile) and auto-generated IDs.
+Prefer selectors with `data-testid`, `data-component^=`, `#id`. Stable,
+hand-authored class names are fine too — the volatility risk is *generated or
+hashed* classes (CSS-modules, hashed production builds) and auto-generated IDs;
+avoid those, not classes as a category.
 
 Create a view file `.sightmap/views/PAGE.yaml`. **View fields go under a
 top-level `views:` list** — `route:`/`url:`/`name:` are *not* file-root fields
@@ -587,6 +608,13 @@ views:
 ```
 
 Run `sightmap validate` before snapping.
+
+**Route matching (globs).** `*` matches exactly one path segment; `**` as its
+own segment matches zero or more (`/a/**` matches `/a`, `/a/b`, `/a/b/c`; `/a/*`
+matches only `/a/b`). Matching is against the URL's **decoded** path, so a `%2F`
+in the URL counts as a separator: `/app/x%2Fy%2Fz` is five segments, not three,
+and a `/app/*/*` route won't match it (use `/app/**`). When several views match,
+the most specific wins; ties go to the first-declared view.
 
 **Keep routes specific.** A `route:` glob should identify *this* view, not every
 page. A catch-all like `/lightning/**` or `/**` that matches every URL is a smell:


### PR DESCRIPTION
Fills three small, verified content gaps in the authoring skill.

Stacked on #269 (base branch `skill/further-reading-267`).

## Changes (`skills/sightmap-authoring/SKILL.md`)

- **`memory:` shape.** The skill referenced `memory:` in several places but never showed its shape. Added a short section: it's a **list of plain strings** (a list of `{name, text}` objects fails to parse), attachable at the file root or on a view/component. Matches `spec/v1/schema.md`.
- **Route matching.** Added a compact note: `*` matches exactly one path segment; `**` (as its own segment) matches zero or more; matching is against the URL's **decoded** path, so `%2F` counts as a separator (`/app/x%2Fy%2Fz` is five segments — a `/app/*/*` route won't match it). Verified against `MatchRoute`/`routeToRegex` and `ViewForURL` (which matches on `url.Parse(...).Path`, i.e. decoded) in `go/sightmap/corpus.go`.
- **Class-selector guidance.** Reconciled an internal contradiction: Step 1a said "avoid class selectors (volatile)" while the Hard Rules section says stable `.classname` selectors are fine. Reworded to: stable hand-authored class names are fine; the volatility risk is *generated/hashed* classes.

No upstream issue for this batch (the two headline issues, #266/#267, are the earlier PRs in the stack). `go/skills/` copy regenerated; changeset included (`patch`).
