### PR TITLE
refactor(cli): dedupe query property extraction, add coverage

### DIFF
--- a/go/cmd/sightmap/cmd_browser_bounds.go
+++ b/go/cmd/sightmap/cmd_browser_bounds.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/compquery"
 	"github.com/sightmap/sightmap/go/match"
-	"github.com/sightmap/sightmap/go/observe"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -177,6 +176,59 @@ func boundsByComponent(
 		return nil, fmt.Errorf("bounds: no sightmap components matched the current page (%s)", pageURL)
 	}
 
+	parsed, props, err := prepareBoundsQuery(ctx, conn, matcher, matches, pageURL, queries, all, substring)
+	if err != nil {
+		return nil, err
+	}
+	return selectBoundsResults(root, matches, queries, all, substring, parsed, props, vw, vh), nil
+}
+
+// prepareBoundsQuery parses the positional queries and, for the default
+// (query-grammar) mode, extracts live properties for the components they
+// reference so [prop] predicates resolve (mirrors resolveComponentQuery;
+// keeps the extraction small). --all and --substring don't use the query
+// grammar, so both return values are nil for those modes.
+func prepareBoundsQuery(
+	ctx context.Context,
+	conn *browser.CDPConn,
+	matcher *match.Matcher,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	pageURL string,
+	queries []string,
+	all, substring bool,
+) ([]*compquery.Query, map[string]map[string]string, error) {
+	if all || substring {
+		return nil, nil, nil
+	}
+
+	parsed := make([]*compquery.Query, len(queries))
+	for i, qs := range queries {
+		q, perr := compquery.ParseQuery(qs)
+		if perr != nil {
+			return nil, nil, fmt.Errorf("bounds: %w", perr)
+		}
+		parsed[i] = q
+	}
+	props := extractQueryProperties(ctx, conn, matcher, matches, pageURL, parsed...)
+	return parsed, props, nil
+}
+
+// selectBoundsResults runs bounds's three selection modes over an
+// already-matched component tree: --all emits every matched component,
+// --substring does a case-insensitive substring match on component name, and
+// the default mode resolves each query through the compquery grammar (names +
+// [prop] predicates + descendant chains) using parsed/props from
+// prepareBoundsQuery. Pure — no browser or filesystem I/O — so it exercises
+// the exact selection logic directly, without a live page.
+func selectBoundsResults(
+	root *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	queries []string,
+	all, substring bool,
+	parsed []*compquery.Query,
+	props map[string]map[string]string,
+	vw, vh int,
+) []boundsResult {
 	var results []boundsResult
 	seen := map[string]bool{}
 	add := func(n *sightmap.ComponentNode, m *sightmap.ComponentMatch) {
@@ -224,34 +276,6 @@ func boundsByComponent(
 		// chains — via the same compquery engine as click/fill/hover/wait-for.
 		// FindCandidates returns EVERY match, so bounds keeps its multi-instance
 		// semantics instead of resolving to a single node.
-		parsed := make([]*compquery.Query, len(queries))
-		queryNames := map[string]bool{}
-		for i, qs := range queries {
-			q, perr := compquery.ParseQuery(qs)
-			if perr != nil {
-				return nil, fmt.Errorf("bounds: %w", perr)
-			}
-			parsed[i] = q
-			for _, part := range q.Parts {
-				queryNames[part.Name] = true
-			}
-		}
-		// Extract properties for the queried component names so [prop] predicates
-		// resolve (mirrors resolveComponentQuery; keeps the extraction small).
-		relevant := make(map[*sightmap.ComponentNode]*sightmap.ComponentMatch)
-		for n, m := range matches {
-			if queryNames[m.Name] {
-				relevant[n] = m
-			}
-		}
-		components := matcher.Components(pageURL)
-		compByName := make(map[string]sightmap.ComponentDef, len(components))
-		for _, c := range components {
-			compByName[c.Name] = c
-		}
-		observe.ExtractProperties(ctx, conn, relevant, compByName)
-		props := propsByNodeID(matches)
-
 		matched := make([]bool, len(queries))
 		for i, q := range parsed {
 			for _, n := range compquery.FindCandidates(root, matches, props, q) {
@@ -263,7 +287,7 @@ func boundsByComponent(
 	}
 
 	sortResults(results)
-	return results, nil
+	return results
 }
 
 // warnUnmatchedQueries prints a stderr note for each query that matched no

--- a/go/cmd/sightmap/cmd_browser_bounds_test.go
+++ b/go/cmd/sightmap/cmd_browser_bounds_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/compquery"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// TestSelectBoundsResults exercises selectBoundsResults, the pure selection
+// core of `bounds` --all/--substring/query-grammar modes, against a fixture
+// tree with a descendant relationship (Row > Star) and two Card instances
+// disambiguated by a [title] property. The descendant-chain and predicate
+// cases are the exact scenarios issue #273 reported as "matched no
+// component" before bounds routed through compquery.
+func TestSelectBoundsResults(t *testing.T) {
+	box := &sightmap.Bounds{X: 0, Y: 0, Width: 10, Height: 10}
+
+	star := &sightmap.ComponentNode{Id: "star", Bounds: box}
+	row := &sightmap.ComponentNode{Id: "row", Bounds: box, Children: []*sightmap.ComponentNode{star}}
+	cardWidgets := &sightmap.ComponentNode{Id: "card-widgets", Bounds: box}
+	cardOther := &sightmap.ComponentNode{Id: "card-other", Bounds: box}
+	cardOffscreen := &sightmap.ComponentNode{Id: "card-offscreen"} // no Bounds: never selectable
+	root := &sightmap.ComponentNode{
+		Id:       "root",
+		Children: []*sightmap.ComponentNode{row, cardWidgets, cardOther, cardOffscreen},
+	}
+
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
+		row:           {Name: "Row"},
+		star:          {Name: "Star"},
+		cardWidgets:   {Name: "Card"},
+		cardOther:     {Name: "Card"},
+		cardOffscreen: {Name: "Card"},
+	}
+	props := map[string]map[string]string{
+		cardWidgets.Id: {"title": "Widgets"},
+		cardOther.Id:   {"title": "Gadgets"},
+	}
+
+	cases := []struct {
+		name      string
+		all       bool
+		substring bool
+		queries   []string
+		wantIDs   []string
+	}{
+		{
+			name:    "--all returns every matched component that has bounds",
+			all:     true,
+			wantIDs: []string{"row", "star", "card-widgets", "card-other"},
+		},
+		{
+			name:      "--substring matches a case-insensitive name fragment",
+			substring: true,
+			queries:   []string{"row"},
+			wantIDs:   []string{"row"},
+		},
+		{
+			name:    "query grammar: a [prop] predicate narrows to one Card instance",
+			queries: []string{`Card[title="Widgets"]`},
+			wantIDs: []string{"card-widgets"},
+		},
+		{
+			name:    "query grammar: a descendant chain resolves through compquery (issue #273)",
+			queries: []string{"Row Star"},
+			wantIDs: []string{"star"},
+		},
+		{
+			name:    "query grammar: a name with no match returns nothing",
+			queries: []string{"NoSuchComponent"},
+			wantIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var parsed []*compquery.Query
+			var queryProps map[string]map[string]string
+			if !tc.all && !tc.substring {
+				queryProps = props
+				for _, qs := range tc.queries {
+					q, err := compquery.ParseQuery(qs)
+					if err != nil {
+						t.Fatalf("parse %q: %v", qs, err)
+					}
+					parsed = append(parsed, q)
+				}
+			}
+
+			results := selectBoundsResults(root, matches, tc.queries, tc.all, tc.substring, parsed, queryProps, 100, 100)
+
+			var gotIDs []string
+			for _, r := range results {
+				gotIDs = append(gotIDs, r.Id)
+			}
+			sort.Strings(gotIDs)
+			wantIDs := append([]string(nil), tc.wantIDs...)
+			sort.Strings(wantIDs)
+
+			if len(gotIDs) != len(wantIDs) {
+				t.Fatalf("got IDs %v, want %v", gotIDs, wantIDs)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != wantIDs[i] {
+					t.Errorf("got IDs %v, want %v", gotIDs, wantIDs)
+					break
+				}
+			}
+		})
+	}
+}

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -67,20 +67,36 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
-	m := match.NewMatcher(corpus)
-	matches := m.Match(root, pageURL)
+	matcher := match.NewMatcher(corpus)
+	matches := matcher.Match(root, pageURL)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
 			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
 	}
-	components := m.Components(pageURL)
 
-	// Extract properties only for nodes whose component name appears in the
-	// query — keeps the live extraction small and avoids the per-snapshot node
-	// cap dropping a candidate.
-	queryNames := make(map[string]bool, len(q.Parts))
-	for _, part := range q.Parts {
-		queryNames[part.Name] = true
+	props := extractQueryProperties(ctx, conn, matcher, matches, pageURL, q)
+	return compquery.Resolve(root, matches, props, q)
+}
+
+// extractQueryProperties extracts live properties for every node whose matched
+// component name is referenced by one of the given queries — keeps the live
+// extraction small and avoids the per-snapshot node cap dropping a candidate —
+// then projects them into the node-id → (name → value) map the component-query
+// engine consumes. Shared by resolveComponentQuery (single query) and
+// prepareBoundsQuery (one or more queries).
+func extractQueryProperties(
+	ctx context.Context,
+	conn *browser.CDPConn,
+	matcher *match.Matcher,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	pageURL string,
+	queries ...*compquery.Query,
+) map[string]map[string]string {
+	queryNames := make(map[string]bool)
+	for _, q := range queries {
+		for _, part := range q.Parts {
+			queryNames[part.Name] = true
+		}
 	}
 	relevant := make(map[*sightmap.ComponentNode]*sightmap.ComponentMatch)
 	for n, m := range matches {
@@ -88,18 +104,13 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 			relevant[n] = m
 		}
 	}
+	components := matcher.Components(pageURL)
 	compByName := make(map[string]sightmap.ComponentDef, len(components))
 	for _, c := range components {
 		compByName[c.Name] = c
 	}
 	observe.ExtractProperties(ctx, conn, relevant, compByName)
 
-	return compquery.Resolve(root, matches, propsByNodeID(matches), q)
-}
-
-// propsByNodeID projects the extracted property values folded into each match
-// back into the node-id → (name → value) map the component-query engine consumes.
-func propsByNodeID(matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch) map[string]map[string]string {
 	out := make(map[string]map[string]string)
 	for node, m := range matches {
 		if m == nil || len(m.Properties) == 0 {

--- a/go/cmd/sightmap/cmd_browser_query_test.go
+++ b/go/cmd/sightmap/cmd_browser_query_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/compquery"
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// TestExtractQueryProperties pins down the logic shared by resolveComponentQuery
+// and boundsByComponent: which nodes get probed for [prop] predicates (only
+// those whose matched name is referenced by one of the given queries) and how
+// the result projects into the node-id keyed map compquery.Resolve/FindCandidates
+// consume.
+//
+// conn is nil throughout: none of the fixture's ComponentDefs declare
+// Properties/Selectors, so observe.ExtractProperties finds no specs to probe and
+// returns before ever touching conn — that's what makes this unit-testable
+// without a live browser.
+func TestExtractQueryProperties(t *testing.T) {
+	corpus := &sightmap.Corpus{
+		GlobalComponents: []sightmap.ComponentDef{
+			{Name: "Card"},
+			{Name: "Row"},
+			{Name: "Star"},
+			{Name: "Other"},
+		},
+	}
+	matcher := match.NewMatcher(corpus)
+
+	card := &sightmap.ComponentNode{Id: "n1"}
+	row := &sightmap.ComponentNode{Id: "n2"}
+	star := &sightmap.ComponentNode{Id: "n3"}
+	other := &sightmap.ComponentNode{Id: "n4"}
+
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{
+		// Queried, and already carries a property value (as if a prior
+		// extraction pass had populated it).
+		card: {Name: "Card", Properties: []sightmap.PropertyValue{{Name: "title", Value: "Widgets"}}},
+		// Queried, but has no property values yet.
+		row: {Name: "Row"},
+		// Queried, with a property value.
+		star: {Name: "Star", Properties: []sightmap.PropertyValue{{Name: "filled", Value: "true"}}},
+		// NOT referenced by any query, but already carries a property value.
+		other: {Name: "Other", Properties: []sightmap.PropertyValue{{Name: "leftover", Value: "stale"}}},
+	}
+
+	cardQuery, err := compquery.ParseQuery(`Card[title="Widgets"]`)
+	if err != nil {
+		t.Fatalf("parse Card query: %v", err)
+	}
+	rowQuery, err := compquery.ParseQuery("Row")
+	if err != nil {
+		t.Fatalf("parse Row query: %v", err)
+	}
+
+	props := extractQueryProperties(context.Background(), nil, matcher, matches, "https://example.com/", cardQuery, rowQuery)
+
+	cases := []struct {
+		name       string
+		nodeID     string
+		wantProp   string
+		wantVal    string
+		wantAbsent bool
+	}{
+		{name: "queried node with a property surfaces it", nodeID: card.Id, wantProp: "title", wantVal: "Widgets"},
+		{name: "queried node with no properties yet is absent", nodeID: row.Id, wantAbsent: true},
+		{name: "unqueried node with a pre-existing property still surfaces (final map isn't filtered by query names)", nodeID: other.Id, wantProp: "leftover", wantVal: "stale"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pm, ok := props[tc.nodeID]
+			if tc.wantAbsent {
+				if ok {
+					t.Errorf("node %s: got %v, want absent from props", tc.nodeID, pm)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("node %s: missing from props (got %v)", tc.nodeID, props)
+			}
+			if got := pm[tc.wantProp]; got != tc.wantVal {
+				t.Errorf("node %s prop %q: got %q, want %q", tc.nodeID, tc.wantProp, got, tc.wantVal)
+			}
+		})
+	}
+
+	// Star wasn't in the queries passed to extractQueryProperties above, so its
+	// pre-existing property should surface exactly like Other's (queryNames only
+	// gates live-DOM probing, not what ends up in the returned map) — confirmed
+	// by re-running with Star included in the query set instead.
+	starQuery, err := compquery.ParseQuery("Star")
+	if err != nil {
+		t.Fatalf("parse Star query: %v", err)
+	}
+	props = extractQueryProperties(context.Background(), nil, matcher, matches, "https://example.com/", starQuery)
+	if got, want := props[star.Id]["filled"], "true"; got != want {
+		t.Errorf("star filled (queried case): got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
resolveComponentQuery and bounds's query-grammar path duplicated the same property-extraction block (queryNames -> relevant -> compByName -> ExtractProperties -> node-id projection); this shares it as extractQueryProperties. Also splits bounds's --all/--substring/query-grammar selection into a pure selectBoundsResults, decoupled from the live browser calls, so it's testable without a CDP connection.

Adds tests for both: TestSelectBoundsResults exercises the Row Star descendant-chain case from #273 directly, plus a [prop] predicate and the --all/--substring modes; TestExtractQueryProperties covers the shared extraction logic.