### PR TITLE
feat(browser): browser start --detach + server-aware status

### DIFF
--- a/.changeset/browser-start-detach.md
+++ b/.changeset/browser-start-detach.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+`sightmap browser start --detach` runs the daemon in the background (in its own session) and returns once it is serving, so scripts and agents no longer hang on the foreground daemon. Unlike `nohup start &`, the detached daemon survives the launching shell (it `setsid`s into its own session). `browser start` also now prints that it is a foreground daemon holding the shell, and `browser status` probes the sightmap HTTP server in addition to Chrome's CDP — reporting `⚠ degraded` when CDP is up but the server has been reaped, instead of a misleading `running`.

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -70,7 +70,7 @@ Setup:
   install                                                           download Chrome for Testing
 
 Session:
-  start [--port N] [--extensions PATH] [--url URL] [--profile DIR]  launch Chrome + sightmap server
+  start [--detach] [--port N] [--extensions PATH] [--url URL] [--profile DIR]  launch Chrome + sightmap server (blocks the shell; --detach backgrounds it)
   stop
   status
   navigate <url>
@@ -134,6 +134,28 @@ func isPortAlive(port int) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	return cdpVersionAlive(ctx, fmt.Sprintf("127.0.0.1:%d", port))
+}
+
+// serverAlive reports whether the sightmap HTTP server (console/network + live
+// corpus reload) answers on port. It is distinct from cdpVersionAlive, which
+// probes Chrome's DevTools endpoint: the two are separate processes on separate
+// ports, and a reaped daemon can leave Chrome's CDP up while the server is gone.
+func serverAlive(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://127.0.0.1:%d/sightmap/version", port), nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }
 
 func pollCDPReady(addr string) error {
@@ -303,8 +325,23 @@ func runStatus(args []string) error {
 	}
 
 	addr := fmt.Sprintf("localhost:%d", info.Port)
-	fmt.Printf("● running  cdp=%d  pid=%d\n", info.Port, info.PID)
-	fmt.Printf("  profile: %s\n", info.Profile)
+	if info.ServerPort > 0 && !serverAlive(info.ServerPort) {
+		// CDP is up but the sightmap HTTP server is gone — typically a reaped
+		// daemon (Chrome is launched detached and outlives its launcher). A
+		// CDP-only probe would call this "running", but console/network and live
+		// corpus reload are dead, so report the true, degraded state.
+		fmt.Printf("⚠ degraded  cdp=%d up, but the sightmap server (:%d) is not responding  pid=%d\n",
+			info.Port, info.ServerPort, info.PID)
+		fmt.Printf("  console/network + live corpus reload are unavailable (the daemon was likely reaped).\n")
+		fmt.Printf("  recover: 'browser stop' then 'browser start' — use --detach in scripts so the daemon survives.\n")
+		fmt.Printf("  profile: %s\n", info.Profile)
+	} else if info.ServerPort > 0 {
+		fmt.Printf("● running  cdp=%d  server=%d  pid=%d\n", info.Port, info.ServerPort, info.PID)
+		fmt.Printf("  profile: %s\n", info.Profile)
+	} else {
+		fmt.Printf("● running  cdp=%d  pid=%d\n", info.Port, info.PID)
+		fmt.Printf("  profile: %s\n", info.Profile)
+	}
 
 	// Enumerate CONTENT tabs (the extension side panel is excluded) so an agent
 	// can see exactly which tab IDs to pass via --tab. Page-affecting commands

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -36,6 +36,8 @@ func runBrowserStart(args []string) error {
 	chromeBinaryFlag := fset.String("chrome-binary", "", "Path to a specific Chrome binary (overrides auto-detection)")
 	var chromeFlags stringSliceFlag
 	fset.Var(&chromeFlags, "chrome-flag", "Extra flag to pass to Chrome (repeatable), e.g. --chrome-flag=--no-sandbox")
+	detachFlag := fset.Bool("detach", false, "Run the daemon in the background (its own session) and return once it is ready. Use this in scripts/agents: plain 'start' blocks the shell for the whole session.")
+	logFileFlag := fset.String("log-file", "", "With --detach, where to write the daemon log (default: ~/.sightmap/logs/<site>-daemon.log)")
 	if err := fset.Parse(args); err != nil {
 		return err
 	}
@@ -58,6 +60,13 @@ func runBrowserStart(args []string) error {
 	// launch/profile/extension machinery entirely.
 	if *attachFlag != "" {
 		return runAttachedSession(*attachFlag, *sightmapDir, *portFlag, *urlFlag)
+	}
+
+	// Detached mode: re-exec ourselves as a background daemon and return once it
+	// is serving, so the launching shell is never held. Must come before any of
+	// the launch work below — the re-exec'd child does all of that.
+	if *detachFlag {
+		return startDetached(args, *sightmapDir, *logFileFlag)
 	}
 
 	// Resolve profile early so the existing-Chrome check can match it.
@@ -243,7 +252,8 @@ func runBrowserStart(args []string) error {
 		resolvedServerPort, resolvedCDPPort, pid, initialTabID)
 	fmt.Fprintf(os.Stderr, "  Addr: --addr localhost:%d\n", resolvedCDPPort)
 	fmt.Fprintf(os.Stderr, "  Tab:  --tab %s  (pass this on commands once other agents open tabs here)\n", initialTabID)
-	fmt.Fprintf(os.Stderr, "  Press Ctrl-C to stop.\n")
+	fmt.Fprintf(os.Stderr, "  This is a foreground daemon — it holds THIS shell until you Ctrl-C.\n")
+	fmt.Fprintf(os.Stderr, "  Run other 'sightmap browser' commands from a DIFFERENT shell, or launch with --detach in scripts/agents.\n")
 
 	// ── Block until signal or Chrome exits ───────────────────────────────────
 	sigCh := make(chan os.Signal, 1)
@@ -359,6 +369,154 @@ func startDevtoolsServer(sightmapDir, siteName string, serverPort int) (*http.Se
 		return nil, nil, fmt.Errorf("sightmap server could not bind port %d: %w", serverPort, srvErr)
 	}
 	return srv, collectorPtr, nil
+}
+
+// ── detach ──────────────────────────────────────────────────────────────────
+
+// startDetached re-execs `browser start` (minus --detach) as a background daemon
+// in its own session, redirects its output to a log file, waits until it is
+// actually serving (session file + CDP + HTTP server), then returns. This is the
+// scriptable/agent entry point: unlike bare `start` it does NOT hold the shell,
+// and unlike `nohup start &` the daemon is not reaped when the launching shell
+// tears down (it setsid's into its own session).
+func startDetached(args []string, sightmapDir, logFile string) error {
+	// Idempotent: if a live daemon already owns this corpus, don't spawn another.
+	if info, err := browser.ReadSessionInfo(sightmapDir); err == nil && info.Port > 0 && isPortAlive(info.Port) {
+		fmt.Fprintf(os.Stderr, "● already running  cdp=%d  server=%d  (see 'sightmap browser status')\n", info.Port, info.ServerPort)
+		return nil
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("start --detach: locate self: %w", err)
+	}
+
+	logPath := logFile
+	if logPath == "" {
+		logPath = defaultDaemonLog(sightmapDir)
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("start --detach: create log dir: %w", err)
+	}
+	logf, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("start --detach: open log %s: %w", logPath, err)
+	}
+	defer logf.Close()
+
+	childArgs := append([]string{"browser", "start"}, stripStartFlags(args, "detach", "log-file")...)
+	cmd := exec.Command(self, childArgs...)
+	cmd.Stdout = logf
+	cmd.Stderr = logf
+	cmd.Stdin = nil
+	configureDetachedDaemon(cmd) // sysproc_*.go: setsid (unix) / detached (windows)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start --detach: launch daemon: %w", err)
+	}
+	daemonPID := 0
+	if cmd.Process != nil {
+		daemonPID = cmd.Process.Pid
+	}
+	// Watch for early exit (Chrome missing / sandbox / no display) so we fail fast
+	// with the log instead of waiting out the whole readiness timeout. We never
+	// block on this Wait; once the parent returns and exits, the setsid'd child is
+	// reparented to init and keeps running.
+	childDone := make(chan error, 1)
+	go func() { childDone <- cmd.Wait() }()
+
+	info, ready, exitErr := waitDetachedReady(sightmapDir, childDone, 25*time.Second)
+	if exitErr != nil {
+		return fmt.Errorf("start --detach: daemon exited before it was ready (%v)\n"+
+			"  log: %s\n%s", exitErr, logPath, tailFile(logPath, 4000))
+	}
+	if !ready {
+		return fmt.Errorf("start --detach: daemon did not become ready in time\n"+
+			"  log: %s\n%s", logPath, tailFile(logPath, 4000))
+	}
+
+	fmt.Fprintf(os.Stderr, "● detached  cdp=%d  server=%d  daemon-pid=%d\n", info.Port, info.ServerPort, daemonPID)
+	fmt.Fprintf(os.Stderr, "  log:  %s\n", logPath)
+	fmt.Fprintf(os.Stderr, "  The daemon runs in the background and survives this shell.\n")
+	fmt.Fprintf(os.Stderr, "  Drive it with other 'sightmap browser' commands; stop it with 'sightmap browser stop'.\n")
+	return nil
+}
+
+// defaultDaemonLog picks a per-corpus daemon log under ~/.sightmap/logs, keyed by
+// the site directory so concurrent corpora don't clash.
+func defaultDaemonLog(sightmapDir string) string {
+	home, _ := os.UserHomeDir()
+	key := "default"
+	if abs, err := filepath.Abs(sightmapDir); err == nil {
+		if base := filepath.Base(filepath.Dir(abs)); base != "" && base != "." && base != string(os.PathSeparator) {
+			key = base
+		}
+	}
+	return filepath.Join(home, ".sightmap", "logs", key+"-daemon.log")
+}
+
+// waitDetachedReady polls until the daemon for sightmapDir is serving — session
+// file written, CDP answering, and (when its port is known) the HTTP server up —
+// or it returns early if the child process exits first (childDone) or the
+// timeout elapses.
+func waitDetachedReady(sightmapDir string, childDone <-chan error, timeout time.Duration) (browser.SessionInfo, bool, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-childDone:
+			if err == nil {
+				err = fmt.Errorf("process exited")
+			}
+			return browser.SessionInfo{}, false, err
+		default:
+		}
+		info, err := browser.ReadSessionInfo(sightmapDir)
+		if err == nil && info.Port > 0 && isPortAlive(info.Port) &&
+			(info.ServerPort == 0 || serverAlive(info.ServerPort)) {
+			return info, true, nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return browser.SessionInfo{}, false, nil
+}
+
+// stripStartFlags removes the named flags (and their `=value` / separate-value
+// forms) from a start arg list, so the detach parent can re-exec the child
+// without them.
+func stripStartFlags(args []string, names ...string) []string {
+	drop := map[string]bool{}
+	takesValue := map[string]bool{"--log-file": true, "-log-file": true}
+	for _, n := range names {
+		drop["--"+n] = true
+		drop["-"+n] = true
+	}
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if drop[a] {
+			if takesValue[a] {
+				i++ // skip the separate value token
+			}
+			continue
+		}
+		if eq := strings.IndexByte(a, '='); eq > 0 && drop[a[:eq]] {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// tailFile returns up to the last maxBytes of the file at path, for surfacing a
+// failed daemon's log without dumping the whole thing.
+func tailFile(path string, maxBytes int64) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	if int64(len(data)) > maxBytes {
+		data = data[int64(len(data))-maxBytes:]
+	}
+	return string(data)
 }
 
 // runAttachedSession runs the daemon against a caller-launched Chrome reached at

--- a/go/cmd/sightmap/cmd_browser_start_test.go
+++ b/go/cmd/sightmap/cmd_browser_start_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestStripStartFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		strip []string
+		want  []string
+	}{
+		{"bool flag alone", []string{"--detach"}, []string{"detach", "log-file"}, nil},
+		{"bool =true form", []string{"--detach=true"}, []string{"detach", "log-file"}, nil},
+		{"single dash", []string{"-detach"}, []string{"detach", "log-file"}, nil},
+		{
+			"keeps other flags",
+			[]string{"--headless", "--detach", "--port", "9"},
+			[]string{"detach", "log-file"},
+			[]string{"--headless", "--port", "9"},
+		},
+		{
+			"value flag with separate value token",
+			[]string{"--log-file", "/tmp/x", "--url", "http://y"},
+			[]string{"detach", "log-file"},
+			[]string{"--url", "http://y"},
+		},
+		{
+			"value flag =form",
+			[]string{"--log-file=/tmp/x", "--headless"},
+			[]string{"detach", "log-file"},
+			[]string{"--headless"},
+		},
+		{
+			"both stripped",
+			[]string{"--detach", "--log-file", "/tmp/x", "--headless"},
+			[]string{"detach", "log-file"},
+			[]string{"--headless"},
+		},
+		{
+			"does not eat the token after a bool flag",
+			[]string{"--detach", "--port", "7890"},
+			[]string{"detach", "log-file"},
+			[]string{"--port", "7890"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripStartFlags(tc.args, tc.strip...)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("stripStartFlags(%v, %v) = %v, want %v", tc.args, tc.strip, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/cmd/sightmap/sysproc_unix.go
+++ b/go/cmd/sightmap/sysproc_unix.go
@@ -14,6 +14,14 @@ func setSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
+// configureDetachedDaemon prepares cmd to run as a background daemon in its own
+// session (setsid). Detaching from the launching shell's session is what makes
+// `browser start --detach` survive one-shot agent shells — unlike `nohup … &`,
+// which is still reaped when the launching shell tears down.
+func configureDetachedDaemon(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
 // terminateGroup sends SIGTERM to an entire process group (negative pid), so
 // Chrome's helper/renderer children are reaped too — not just the leader.
 func terminateGroup(pgid int) error {

--- a/go/cmd/sightmap/sysproc_windows.go
+++ b/go/cmd/sightmap/sysproc_windows.go
@@ -2,10 +2,21 @@
 
 package main
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+)
 
 func setSysProcAttr(cmd *exec.Cmd) {
 	// Windows: no equivalent of Setpgid needed; Chrome detaches naturally.
+}
+
+// configureDetachedDaemon prepares cmd to run as a background daemon dissociated
+// from the launching console/process group, so `browser start --detach` survives
+// the shell that launched it. DETACHED_PROCESS (0x8) | CREATE_NEW_PROCESS_GROUP
+// (0x200).
+func configureDetachedDaemon(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x00000008 | 0x00000200}
 }
 
 // Process-group / profile reaping is a no-op on Windows; stop falls back to the


### PR DESCRIPTION
Part of #126 (the `--detach` + honest-status items).

`browser start` is a foreground daemon that owns Chrome + the console/network collector for the session, so it holds the shell — and an agent whose shell runs each command to completion hangs on it forever. `nohup start &` doesn't fix it either: the daemon is reaped when the launching shell tears down.

## Changes

- **`browser start --detach`** re-execs `start` (minus `--detach`) as a background daemon in its **own session** (`setsid`), redirects its output to a log, waits until it is actually serving (session file + CDP + HTTP server), then returns. Because it `setsid`s, it survives the launching shell — the durability `nohup` can't provide. Idempotent if a live daemon already owns the corpus; fails fast with the log tail if the daemon exits early. `--log-file` overrides the default `~/.sightmap/logs/<site>-daemon.log`.
- **Foreground `start`** now says plainly that it is a foreground daemon holding the shell, and points at `--detach` for scripts/agents.
- **`browser status`** now probes the sightmap HTTP server (`:7891`) in addition to Chrome's CDP. When CDP is up but the server has been reaped (Chrome is launched detached and outlives its launcher), it reports `⚠ degraded` with recovery steps instead of a misleading `● running`. `status` now also shows the `server=` port.
- Platform helper `configureDetachedDaemon` (`setsid` on Unix; `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows).
- Unit test for the arg-stripping helper.

## Verification

Built + vetted + gofmt clean; `GOOS=windows` cross-build passes; `go test ./...` green. Verified end-to-end against headless system Chrome:
- `--detach` returns immediately (shell not held) and the daemon is reachable from a **separate** shell (durability);
- `status` reports `● running server=7891`;
- graceful `SIGTERM` → clean shutdown, no orphan;
- ungraceful `kill -9` of the daemon → `status` correctly reports `⚠ degraded` (CDP up, `:7891` down);
- `stop` reaps the orphaned Chrome, back to `○ no session`.

Follow-ups in the same effort (separate PRs): headless (`no $DISPLAY`) + sandbox (userns clamp) auto-handling, and the skill/docs updates.
