### PR TITLE
feat(browser): auto-headless on no-display + sandbox hint on launch failure

### DIFF
--- a/.changeset/browser-start-headless-sandbox.md
+++ b/.changeset/browser-start-headless-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`browser start` now comes up out of the box on headless and sandboxed Linux hosts. With no display (`$DISPLAY`/`$WAYLAND_DISPLAY` unset) it defaults to headless instead of dying with "Missing X server or $DISPLAY", and when Chrome's launch fails because the host restricts its sandbox (unprivileged user namespaces clamped by AppArmor or a container) the error points straight at the fix (`--chrome-flag=--no-sandbox`) rather than leaving you to decode Chrome's stderr.

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -149,6 +151,13 @@ func runBrowserStart(args []string) error {
 		"--no-default-browser-check",
 		"--disable-blink-features=AutomationControlled",
 	}
+	// Headless auto-detection: on Linux with no display, a non-headless Chrome
+	// dies with "Missing X server or $DISPLAY". Default to headless so a headless
+	// host just works for agents; an explicit --headless or a real display skips it.
+	if !*headlessFlag && shouldAutoHeadless() {
+		*headlessFlag = true
+		fmt.Fprintln(os.Stderr, "start: no display detected ($DISPLAY/$WAYLAND_DISPLAY unset) — running headless (pass --headless to silence).")
+	}
 	if *headlessFlag {
 		chromeArgs = append(chromeArgs, "--headless=new")
 	}
@@ -189,9 +198,11 @@ func runBrowserStart(args []string) error {
 	if pollErr := pollCDPReady(cdpAddr); pollErr != nil {
 		cmd.Process.Kill()
 		_ = cmd.Wait() // let the stderr copy goroutine finish before reading the buffer
+		report := chromeStderr.tailReport()
 		return fmt.Errorf("start: chrome did not become ready: %w\n"+
-			"  binary: %s\n  args:   %s\n%s",
-			pollErr, chromePath, strings.Join(chromeArgs, " "), chromeStderr.tailReport())
+			"  binary: %s\n  args:   %s\n%s%s",
+			pollErr, chromePath, strings.Join(chromeArgs, " "), report,
+			sandboxHint(report, slices.Contains(chromeArgs, "--no-sandbox")))
 	}
 
 	// Start the console/network collector against the now-ready session and
@@ -517,6 +528,32 @@ func tailFile(path string, maxBytes int64) string {
 		data = data[int64(len(data))-maxBytes:]
 	}
 	return string(data)
+}
+
+// shouldAutoHeadless reports whether to default to headless: only on Linux with
+// no X or Wayland display, where a non-headless Chrome would die with "Missing X
+// server or $DISPLAY". macOS/Windows always have a usable display.
+func shouldAutoHeadless() bool {
+	return runtime.GOOS == "linux" && os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == ""
+}
+
+// sandboxHint returns an actionable note when Chrome's launch failure looks like
+// its zygote sandbox being blocked (unprivileged user namespaces clamped by
+// AppArmor or a container policy). We deliberately do NOT auto-add --no-sandbox
+// (it's a security downgrade) but point straight at the fix. Empty when the
+// failure isn't sandbox-related or --no-sandbox is already set.
+func sandboxHint(chromeStderr string, hasNoSandbox bool) string {
+	if hasNoSandbox {
+		return ""
+	}
+	for _, sig := range []string{"No usable sandbox", "Running as root without --no-sandbox", "namespace sandbox"} {
+		if strings.Contains(chromeStderr, sig) {
+			return "\n  hint: this host blocks Chrome's sandbox (unprivileged user namespaces are restricted —\n" +
+				"        common under AppArmor on recent Ubuntu and inside containers).\n" +
+				"        rerun with --chrome-flag=--no-sandbox"
+		}
+	}
+	return ""
 }
 
 // runAttachedSession runs the daemon against a caller-launched Chrome reached at

--- a/go/cmd/sightmap/cmd_browser_start_test.go
+++ b/go/cmd/sightmap/cmd_browser_start_test.go
@@ -1,9 +1,47 @@
 package main
 
 import (
+	"runtime"
 	"slices"
+	"strings"
 	"testing"
 )
+
+func TestSandboxHint(t *testing.T) {
+	// A sandbox-signature stderr yields a --no-sandbox hint...
+	if h := sandboxHint("Failed to move to new namespace: No usable sandbox!", false); !strings.Contains(h, "--no-sandbox") {
+		t.Errorf("expected a --no-sandbox hint, got %q", h)
+	}
+	// ...unless --no-sandbox is already set (then the failure is something else).
+	if h := sandboxHint("No usable sandbox!", true); h != "" {
+		t.Errorf("expected no hint when --no-sandbox already present, got %q", h)
+	}
+	// Unrelated failures get no sandbox hint.
+	if h := sandboxHint("Missing X server or $DISPLAY", false); h != "" {
+		t.Errorf("expected no hint for a non-sandbox failure, got %q", h)
+	}
+}
+
+func TestShouldAutoHeadless(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// Off Linux there is always a usable display; never auto-headless.
+		t.Setenv("DISPLAY", "")
+		t.Setenv("WAYLAND_DISPLAY", "")
+		if shouldAutoHeadless() {
+			t.Errorf("shouldAutoHeadless must be false off Linux")
+		}
+		return
+	}
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "")
+	if !shouldAutoHeadless() {
+		t.Errorf("expected auto-headless on Linux with no display")
+	}
+	t.Setenv("DISPLAY", ":0")
+	if shouldAutoHeadless() {
+		t.Errorf("expected no auto-headless when DISPLAY is set")
+	}
+}
 
 func TestStripStartFlags(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
Part of #126 (the headless + sandbox items). Stacked on #276 (base branch `feat/browser-detach-d5ee`).

A fresh `browser start` on a headless Linux host (and on sandbox-restricted distros/containers) fails at Chrome launch until you know the two magic flags. This makes it come up on its own.

## Changes (`go/cmd/sightmap/cmd_browser_start.go`)

- **Headless auto-detection.** On Linux with neither `$DISPLAY` nor `$WAYLAND_DISPLAY` set, `start` now defaults to headless (with a one-line note) instead of dying with "Missing X server or $DISPLAY". An explicit `--headless`, or a real display, skips it; macOS/Windows are unaffected.
- **Sandbox hint.** When Chrome fails to become ready and its stderr shows the zygote-sandbox signature (`No usable sandbox`, etc.) — unprivileged user namespaces clamped by AppArmor on recent Ubuntu or by a container — the launch error now explicitly suggests `--chrome-flag=--no-sandbox`. We deliberately do **not** silently add `--no-sandbox` (it's a security downgrade); we point at it. No hint is shown if `--no-sandbox` is already set or the failure is unrelated.

Sandbox and display are orthogonal, and neither is architecture-specific.

Unit tests added for `sandboxHint` and `shouldAutoHeadless`. `go build ./...`, `GOOS=windows` cross-build, `go vet`, `gofmt`, and `go test ./...` all pass. (The Linux-only runtime paths are covered by unit tests; they can't be exercised live on the macOS dev box.)
