### PR TITLE
docs(skills): document the browser daemon lifecycle (--detach, headless/sandbox)

### DIFF
--- a/.changeset/browser-daemon-skill-docs.md
+++ b/.changeset/browser-daemon-skill-docs.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Authoring + browser skills: document the browser daemon lifecycle. `browser start` is a long-running foreground daemon that holds the shell; scripts and agents should use `browser start --detach` (which returns once serving and survives the shell) rather than `nohup start &`. Also note headless auto-detection and the `--no-sandbox` hint on sandboxed hosts, and that `browser status` can report a `⚠ degraded` daemon.

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -111,7 +111,7 @@ other dependency.
 
 | Command | What it does |
 |---------|-------------|
-| `sightmap browser start` | Launch Chrome + the sightmap overlay server. Writes `.sightmap/.session`. |
+| `sightmap browser start` | Launch Chrome + the sightmap overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Writes `.sightmap/.session`. |
 | `sightmap browser status` | Check session health and current URL. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
@@ -567,6 +567,11 @@ transformed by the framework, and dynamic content only appears at runtime.
 cd sites/vividseats.com/    # or any site dir with a .sightmap/
 sightmap browser start   # launches Chrome + sightmap HTTP server (port 7891)
 ```
+
+`browser start` is a **foreground daemon that holds this shell** for the whole
+session. In a script or agent shell (each command run to completion), use
+`sightmap browser start --detach` instead — it backgrounds the daemon and
+returns once it's ready. See the `sightmap-browser` skill's *Session management*.
 
 Verify with `sightmap browser status` — should show `● running cdp=7892` and list your content tab(s).
 The sightmap HTTP server starts automatically and recompiles on YAML changes.

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -40,10 +40,26 @@ invocation). Use `npm` in instructions — the published package is identical un
 
 ## Session management
 
+`browser start` is a **long-running foreground daemon**: it owns Chrome and the
+console/network collector for the whole session, so it **holds the shell** until
+you stop it. Every other command here is a thin client that connects to that
+daemon and returns immediately.
+
+- **Interactive:** run `start` in its own terminal, drive from another.
+- **Scripts / agents** (shells that run each command to completion): use
+  **`sightmap browser start --detach`**. It backgrounds the daemon in its own
+  session, waits until it is serving, and returns — so it never hangs your shell,
+  and (unlike `nohup start &`) the daemon survives between one-shot commands.
+- A **client** command that hangs almost always means the daemon isn't up —
+  run `browser status`, don't wait it out.
+- On a headless Linux host `start` auto-detects the missing display and runs
+  headless; if Chrome hits a sandbox restriction the error tells you to add
+  `--chrome-flag=--no-sandbox`.
+
 | Command | What it does |
 |---------|-------------|
-| `sightmap browser start` | Launch Chrome + the sightmap overlay server. Writes `.sightmap/.session`. |
-| `sightmap browser status` | Check session health and current URL. |
+| `sightmap browser start` | Launch Chrome + the overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Writes `.sightmap/.session`. |
+| `sightmap browser status` | Check session health, tabs, and current URL. Reports `⚠ degraded` when Chrome's CDP is up but the daemon's HTTP server was reaped. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
 | `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -111,7 +111,7 @@ other dependency.
 
 | Command | What it does |
 |---------|-------------|
-| `sightmap browser start` | Launch Chrome + the sightmap overlay server. Writes `.sightmap/.session`. |
+| `sightmap browser start` | Launch Chrome + the sightmap overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Writes `.sightmap/.session`. |
 | `sightmap browser status` | Check session health and current URL. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
@@ -567,6 +567,11 @@ transformed by the framework, and dynamic content only appears at runtime.
 cd sites/vividseats.com/    # or any site dir with a .sightmap/
 sightmap browser start   # launches Chrome + sightmap HTTP server (port 7891)
 ```
+
+`browser start` is a **foreground daemon that holds this shell** for the whole
+session. In a script or agent shell (each command run to completion), use
+`sightmap browser start --detach` instead — it backgrounds the daemon and
+returns once it's ready. See the `sightmap-browser` skill's *Session management*.
 
 Verify with `sightmap browser status` — should show `● running cdp=7892` and list your content tab(s).
 The sightmap HTTP server starts automatically and recompiles on YAML changes.

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -40,10 +40,26 @@ invocation). Use `npm` in instructions — the published package is identical un
 
 ## Session management
 
+`browser start` is a **long-running foreground daemon**: it owns Chrome and the
+console/network collector for the whole session, so it **holds the shell** until
+you stop it. Every other command here is a thin client that connects to that
+daemon and returns immediately.
+
+- **Interactive:** run `start` in its own terminal, drive from another.
+- **Scripts / agents** (shells that run each command to completion): use
+  **`sightmap browser start --detach`**. It backgrounds the daemon in its own
+  session, waits until it is serving, and returns — so it never hangs your shell,
+  and (unlike `nohup start &`) the daemon survives between one-shot commands.
+- A **client** command that hangs almost always means the daemon isn't up —
+  run `browser status`, don't wait it out.
+- On a headless Linux host `start` auto-detects the missing display and runs
+  headless; if Chrome hits a sandbox restriction the error tells you to add
+  `--chrome-flag=--no-sandbox`.
+
 | Command | What it does |
 |---------|-------------|
-| `sightmap browser start` | Launch Chrome + the sightmap overlay server. Writes `.sightmap/.session`. |
-| `sightmap browser status` | Check session health and current URL. |
+| `sightmap browser start` | Launch Chrome + the overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Writes `.sightmap/.session`. |
+| `sightmap browser status` | Check session health, tabs, and current URL. Reports `⚠ degraded` when Chrome's CDP is up but the daemon's HTTP server was reaped. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
 | `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |


### PR DESCRIPTION
Part of #126 (the daemon-lifecycle docs). Stacked on #277 (base branch `feat/browser-headless-sandbox-2eac`).

Now that `--detach` and headless/sandbox auto-handling exist (the two PRs below this one), the skills can teach the clean end state instead of the fragile `nohup` workaround.

## Changes

**`skills/sightmap-browser/SKILL.md` — Session management**
- New lead paragraph: `browser start` is a long-running **foreground daemon** that holds the shell; every other command is a thin client that returns immediately. Interactive → own terminal; **scripts/agents → `browser start --detach`** (returns once serving, survives the shell, unlike `nohup start &`); a hanging *client* means the daemon is down (check `status`); headless auto-detects and sandbox failures point at `--chrome-flag=--no-sandbox`.
- `start`/`status` table rows updated (foreground-daemon note; `⚠ degraded`).

**`skills/sightmap-authoring/SKILL.md`**
- Phase 0 startup notes the foreground-daemon behavior and `--detach`, and the `start` table row matches.

`go/skills/` copies regenerated (no drift). Changeset included (`patch`).

Scope note: this closes the daemon-lifecycle documentation (the recurring "start hangs forever" trap). The other, unrelated CLI-consistency items originally collected in yak 6689 (initial-tab-in-headless, `--sightmap-dir` on the devtools commands, the `report` `url:` field) are tracked separately and not in this PR.
