### PR TITLE
spec: SEP-0010 tree-closed component properties + remove transforms

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -128,43 +128,32 @@ See [SEP-0002](https://github.com/sightmap/sightmap/blob/main/spec/seps/0002-com
 - A list of strings is tried in order; the first selector that matches wins.
 - Selectors in `children` are evaluated **within** their parent's matched subtree, not globally. This scoping is how Sightmap avoids naming collisions between, say, two different card components that both contain a `button.primary`.
 - Selectors are not required to be unique at their level. If a selector matches multiple elements, all matches are named.
-- **Shadow DOM.** Selectors are matched against the captured component tree, which is a *flattened* representation: each shadow root's content is inlined as ordinary children of its host. Selectors therefore match **across shadow boundaries** — shadow-DOM content is addressed exactly like light-DOM content, and there is no piercing syntax (standard CSS has none: `>>>`/`/deep/` were removed, and `::part()`/`::slotted()` reach only explicitly-exposed nodes). `children` scoping and combinators operate over the flattened tree, where a shadow host → shadow child is an ordinary parent→child edge. This is a deliberate divergence from a live `document.querySelector`, which does **not** cross shadow roots: a tool re-implementing matching or property extraction against the live DOM MUST traverse shadow roots (walk each element's `shadowRoot`) to agree with the corpus. The same rule governs the `exists:`/sub-selector extract modes below — they resolve within the matched element's flattened subtree, including its shadow DOM.
+- **Shadow DOM.** Selectors are matched against the captured component tree, which is a *flattened* representation: each shadow root's content is inlined as ordinary children of its host. Selectors therefore match **across shadow boundaries** — shadow-DOM content is addressed exactly like light-DOM content, and there is no piercing syntax (standard CSS has none: `>>>`/`/deep/` were removed, and `::part()`/`::slotted()` reach only explicitly-exposed nodes). `children` scoping and combinators operate over the flattened tree, where a shadow host → shadow child is an ordinary parent→child edge. This is a deliberate divergence from a live `document.querySelector`, which does **not** cross shadow roots: a tool re-implementing matching against the live DOM MUST traverse shadow roots (walk each element's `shadowRoot`) to agree with the corpus.
 
 
 ### Component properties
 
-A component may declare `properties: Property[]` — named values extracted from its matched DOM element and surfaced alongside the component name in enriched snapshots, e.g. `[DateFilterButton label="This Weekend"]`. Extraction operates on the exact element the selector matched (not an ancestor, not the AX node). Properties are read from the **live DOM at snapshot time**; SDKs operating on saved component-tree data MUST omit the values rather than approximate them (the declarations are not an error offline). When a component's selector matches multiple elements, extraction runs independently on each. See [SEP-0003](https://github.com/sightmap/sightmap/blob/main/spec/seps/0003-component-properties.md).
+A component may declare `properties: Property[]` — named values surfaced alongside the component name in enriched snapshots, e.g. `[DateFilterButton label="This Weekend"]`. Values are **resolved over the component tree**, from the matched component's own node and the extracted properties of components nested beneath it — never from arbitrary DOM. This makes resolution work offline, against a serialized tree, on any UI platform. See [SEP-0010](https://github.com/sightmap/sightmap/blob/main/spec/seps/0010-tree-closed-component-properties.md), which supersedes the extraction model of [SEP-0003](https://github.com/sightmap/sightmap/blob/main/spec/seps/0003-component-properties.md).
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `name` | string | yes | Key used in the annotation (`name="value"`). Must match `^[a-z][a-z0-9_]*$`. The name `value` is reserved: it may be declared to override the AX built-in, and SDKs MUST prefer a declared `value` over the AX tree's own value. |
+| `name` | string | yes | Key used in the annotation (`name="value"`). Must match `^[a-z][a-z0-9_]*$`, and must be unique within a component. The name `value` is reserved: it may be declared to override the AX built-in, and SDKs MUST prefer a declared `value` over the AX tree's own value. |
 | `extract` | string | yes | Extraction directive (see below). |
-| `transform` | string | no | Optional post-processing applied to the extracted string (see below). |
 
-**Extract modes.** The `extract` value is interpreted in this order (named modes match by exact, case-sensitive equality before the `attr=`/`exists:` prefixes):
+**Extract grammar.** The `extract` value is exactly one of the following forms; any other value is invalid and MUST be rejected by validation.
 
-| Value | Source |
+| Form | Resolves to |
 |---|---|
-| `text` | `element.textContent.trim()`, internal whitespace collapsed to single spaces |
-| `inner_text` | `element.innerText.trim()` — layout-aware; use when `text` runs adjacent inline elements together |
-| `text_only` | `textContent` after removing `img`, `svg`, and `[alt]` descendants — use when icon alt-text bleeds into the label |
-| `inner_html` | `element.innerHTML` |
-| `attr=NAME` | `element.getAttribute(NAME)` |
-| `exists:SEL` | `"true"` if `SEL` matches an element within the matched element's subtree — **including its shadow DOM** (see [Selector semantics](#selector-semantics)) — else **omitted** (boolean state flag) |
-| *any other string* | Treated as a CSS sub-selector resolved within the matched element's subtree, **including its shadow DOM**: the first match's `innerText` (falling back to `textContent`), trimmed; omitted when nothing matches |
+| `text` | the node's accessible text (implementation-defined accessible name) |
+| `attr=NAME` | the value of attribute `NAME` carried on the node's observed attribute set; omitted if the node does not carry it |
+| `PATH.prop` | the value extracted for property `prop` of the descendant component addressed by `PATH` |
+| `exists:PATH` | `"true"` if `PATH` resolves to at least one matched component; omitted otherwise (boolean state flag) |
 
-**Transforms.** When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1).
+`PATH` is a dotted sequence of component names naming a descendant, each segment resolved first-match (in document order) within the previous segment's matched subtree (`Price`, `Row.Price`). In a `PATH.prop` value reference the final segment is a property name; in `exists:PATH` the whole path names components. References descend only — a property may address a component nested beneath the one declaring it, never a parent, sibling, or cousin — so resolution is a bottom-up pass over a DAG. To surface a value from a sub-element, promote that sub-element to a declared child component and reference it.
 
-| Value | Effect |
-|---|---|
-| `first_word` | First whitespace-delimited token |
-| `last_word` | Last whitespace-delimited token |
-| `first_number` | First substring matching `\d[\d,.]*` |
-| `first_dollar` | First substring matching `\$[\d,.]+` |
-| `number` | Strip all non-digit, non-decimal characters |
-| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
+The observed attribute set read by `attr=NAME` is implementation-defined: which attributes a node carries depends on the consumer (a web SDK may carry a fixed allowlist plus `aria-*`/`data-*`; other platforms carry synthetic attributes). An attribute the consumer did not carry is indistinguishable from one that was absent.
 
-**Value omission is silent** — a property that extracts to an empty string (or whose `exists:`/sub-selector finds nothing) is simply dropped from the annotation; consumers MUST NOT treat omission as an error.
+**Value omission is silent** — a property whose `text` is empty, whose attribute is not carried, or whose `PATH` matches nothing is simply dropped from the annotation; consumers MUST NOT treat omission as an error.
 
 ## Dependencies
 
@@ -280,7 +269,7 @@ A named API endpoint.
 | `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
 | `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
 | `pattern` | string | see below | An [RE2](#regular-expressions) regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes). `pattern` is an [RE2 regular expression](#regular-expressions); the reference CLI rejects an invalid one (`request-property-pattern-invalid`).
 
@@ -291,6 +280,19 @@ Extraction requires **live traffic**. A tool operating on static corpus definiti
 `status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. They sit outside `source` entirely — a consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
 
 `properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md).
+
+#### Transforms
+
+When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1). Used by request and message `properties:`.
+
+| Value | Effect |
+|---|---|
+| `first_word` | First whitespace-delimited token |
+| `last_word` | Last whitespace-delimited token |
+| `first_number` | First substring matching `\d[\d,.]*` |
+| `first_dollar` | First substring matching `\$[\d,.]+` |
+| `number` | Strip all non-digit, non-decimal characters |
+| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
 
 ### Payload
 
@@ -376,7 +378,7 @@ messages:
 | `source` | string | yes | Which root to read from. The only value in v1 is `stack` (the exception's call stack). |
 | `field` | string | yes | The frame and attribute to select, `<frame>.<attribute>`: `<frame>` is `top` (an alias for `0`) or a non-negative frame index (`0`, `1`, …), throwing frame first; `<attribute>` is one of `function`, `file`, `line`, or `column`. Required — a `stack` source has no meaningful bare-regex scan, the same reasoning that requires `field` for a request's headers source. |
 | `pattern` | string | no | An [RE2](#regular-expressions) regex applied to whatever `field` resolved. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 Extraction requires **live traffic** and **value omission is silent**, exactly as for [request properties](#request-properties): a property that doesn't resolve (a plain console record with no stack, a frame index out of range, an unknown attribute, no pattern match) is simply absent, never an error. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
 
@@ -566,7 +568,7 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
 - MUST omit an unresolved property value silently, without a diagnostic
 - MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
-- SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
+- SHOULD apply `transform` as [Transforms](#transforms) specifies: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
 - MUST resolve a `MessageProperty` only from a live record's stack, omitting the value silently when the record has no stack or the addressed frame/attribute doesn't resolve

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -269,7 +269,6 @@ A named API endpoint.
 | `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
 | `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
 | `pattern` | string | see below | An [RE2](#regular-expressions) regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes). `pattern` is an [RE2 regular expression](#regular-expressions); the reference CLI rejects an invalid one (`request-property-pattern-invalid`).
 
@@ -280,19 +279,6 @@ Extraction requires **live traffic**. A tool operating on static corpus definiti
 `status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. They sit outside `source` entirely — a consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
 
 `properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](https://github.com/sightmap/sightmap/blob/main/spec/seps/0005-request-properties.md).
-
-#### Transforms
-
-When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1). Used by request and message `properties:`.
-
-| Value | Effect |
-|---|---|
-| `first_word` | First whitespace-delimited token |
-| `last_word` | Last whitespace-delimited token |
-| `first_number` | First substring matching `\d[\d,.]*` |
-| `first_dollar` | First substring matching `\$[\d,.]+` |
-| `number` | Strip all non-digit, non-decimal characters |
-| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
 
 ### Payload
 
@@ -350,7 +336,7 @@ A record matches when every declared constraint holds. Declaring neither `level`
 
 ### Message properties
 
-`properties:` declares named values to pull out of an uncaught exception's **stack trace**, so a corpus can classify an exception by where it came from and extract the failing location — the message-side analogue of a request's [`properties:`](#request-properties). It reuses that mechanism's `source` / `field` / `pattern` / `transform` shape.
+`properties:` declares named values to pull out of an uncaught exception's **stack trace**, so a corpus can classify an exception by where it came from and extract the failing location — the message-side analogue of a request's [`properties:`](#request-properties). It reuses that mechanism's `source` / `field` / `pattern` shape.
 
 ```yaml
 messages:
@@ -378,7 +364,6 @@ messages:
 | `source` | string | yes | Which root to read from. The only value in v1 is `stack` (the exception's call stack). |
 | `field` | string | yes | The frame and attribute to select, `<frame>.<attribute>`: `<frame>` is `top` (an alias for `0`) or a non-negative frame index (`0`, `1`, …), throwing frame first; `<attribute>` is one of `function`, `file`, `line`, or `column`. Required — a `stack` source has no meaningful bare-regex scan, the same reasoning that requires `field` for a request's headers source. |
 | `pattern` | string | no | An [RE2](#regular-expressions) regex applied to whatever `field` resolved. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 Extraction requires **live traffic** and **value omission is silent**, exactly as for [request properties](#request-properties): a property that doesn't resolve (a plain console record with no stack, a frame index out of range, an unknown attribute, no pattern match) is simply absent, never an error. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
 
@@ -568,12 +553,11 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
 - MUST omit an unresolved property value silently, without a diagnostic
 - MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
-- SHOULD apply `transform` as [Transforms](#transforms) specifies: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
 - MUST resolve a `MessageProperty` only from a live record's stack, omitting the value silently when the record has no stack or the addressed frame/attribute doesn't resolve
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern` and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/spec/conformance/014-component-properties.fixture/sightmap/app.yaml
+++ b/spec/conformance/014-component-properties.fixture/sightmap/app.yaml
@@ -7,9 +7,16 @@ views:
         selector: '[data-testid="product-pod"]'
         properties:
           - name: price
-            extract: '[data-testid="price"]'
-            transform: first_dollar
+            extract: Price.text
           - name: sold_out
-            extract: 'exists:[aria-label="Sold Out"]'
+            extract: exists:SoldOutBadge
           - name: label
             extract: text
+        children:
+          - name: Price
+            selector: '[data-testid="price"]'
+            properties:
+              - name: text
+                extract: text
+          - name: SoldOutBadge
+            selector: '[aria-label="Sold Out"]'

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -50,7 +50,7 @@ For arrays in `expected`, the actual array must be at least as long, and the pre
 | 011 | `component-ref-unresolved` | `$ref` to an unknown component → `ref-unresolved` error |
 | 012 | `component-ref-circular` | Self-referential `$ref` chain → `ref-circular` error |
 | 013 | `route-trailing-slash` | Trailing slashes on the URL path are normalized away before matching |
-| 014 | `component-properties` | `properties:` (`name`/`extract`/`transform`) validates ([SEP-0003](../seps/0003-component-properties.md)) |
+| 014 | `component-properties` | `properties:` (`name`/`extract`, tree-closed grammar `text`/`attr=`/`PATH.prop`/`exists:PATH`) validates ([SEP-0010](../seps/0010-tree-closed-component-properties.md)) |
 | 015 | `view-url` | `url:` on a view (and a file-level default) validates |
 | 016 | `stability-tooling-fields` | `stability:` (view + component) validates; reserved tooling fields `access:`/`snapshots:` are permitted |
 | 017 | `tags` | `tags:` validates on components (at multiple nesting levels), requests, and views ([SEP-0004](../seps/0004-component-tags.md)) |

--- a/spec/seps/0003-component-properties.md
+++ b/spec/seps/0003-component-properties.md
@@ -10,6 +10,13 @@ related-issues: [52]
 related-discussions: []
 ---
 
+> **Superseded in part by [SEP-0010](0010-tree-closed-component-properties.md).**
+> The `extract` grammar and live-DOM extraction model described below are
+> replaced by SEP-0010, which resolves property values over the component tree
+> (offline, cross-platform) and removes `transform`. The property *declaration
+> shape* introduced here — `properties[]` with `name`/`extract`, the reserved
+> `value` name, and silent omission — carries forward unchanged.
+
 ## Summary
 
 Add an optional `properties: Property[]` field to `Component` entries. Each

--- a/spec/seps/0005-request-properties.md
+++ b/spec/seps/0005-request-properties.md
@@ -10,6 +10,11 @@ related-issues: [157]
 related-discussions: []
 ---
 
+> **Amended by [SEP-0010](0010-tree-closed-component-properties.md):** the
+> `transform` field is removed from request `properties[]`. Fold any
+> post-processing into `pattern` (RE2 + capture groups). The `source` / `field` /
+> `pattern` extraction described below is otherwise unchanged.
+
 ## Summary
 
 Add an optional `properties: RequestProperty[]` field to `Request` entries. Each property declares a named value extracted from a live request's own request/response body or headers: `source` names the root (a request/response body or header block), `field` names the value within it, and an optional `pattern` regex refines whatever `field` resolved. It is the request-side analogue of SEP-0003's DOM `properties[]`: SEP-0003 answers "what state is this element in," this answers "what does this endpoint's traffic actually say."

--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -10,6 +10,11 @@ related-issues: [158]
 related-discussions: []
 ---
 
+> **Amended by [SEP-0010](0010-tree-closed-component-properties.md):** the
+> `transform` field is removed from message `properties[]`. Fold any
+> post-processing into `pattern` (RE2 + capture groups). The `source` / `field` /
+> `pattern` extraction described below is otherwise unchanged.
+
 ## Summary
 
 Introduce a new top-level `messages` concept, peer to `views`/`components`/`requests`: a named, declarative pattern matching console output and runtime exceptions by `level` and a `message` regex. It gives console/exception activity the same thing `requests:` already gives network activity — a named, referenceable entity.

--- a/spec/seps/0010-tree-closed-component-properties.md
+++ b/spec/seps/0010-tree-closed-component-properties.md
@@ -17,10 +17,14 @@ Redefine component `properties[]` extraction so it resolves against the abstract
 component tree instead of the live DOM. Every `extract` directive references only
 (a) the matched node's own carried data — its accessible text and its
 attributes — or (b) the extracted property of a component nested beneath it. The
-DOM-shaped modes (`inner_text`, `text_only`, `inner_html`, bare-CSS
-sub-selectors) and `transform` are removed. This makes property values resolvable
-offline, from a serialized tree, on any UI platform — closing the gap where the
-only path that produced values was a live-DOM pass over CDP.
+DOM-shaped component modes (`inner_text`, `text_only`, `inner_html`, bare-CSS
+sub-selectors) are removed. Separately, `transform` is removed from **every**
+property type — component, request, and message: the fixed transform vocabulary
+was ill-conceived and inconsistent (an unspecced `match:` mode even leaked into
+tooling), and request/message extraction already has `pattern` (RE2 + capture
+groups) for the cases that matter. The tree-closed component change makes property
+values resolvable offline, from a serialized tree, on any UI platform — closing
+the gap where the only path that produced values was a live-DOM pass over CDP.
 
 ## Motivation
 
@@ -118,6 +122,8 @@ property name; in `exists:PATH` the whole path names components.
 ### JSON Schema diff
 
 - `$defs.componentProperty`: remove the `transform` property entirely.
+- `$defs.requestProperty` and `$defs.messageProperty`: remove the `transform`
+  property entirely; their `source`/`field`/`pattern` extraction is unchanged.
 - `$defs.componentProperty.extract`: unchanged as a type (`string`, `minLength:
   1`); its *accepted grammar* narrows to the four forms above. The named DOM
   modes `inner_text`, `text_only`, `inner_html` and the bare-CSS-sub-selector
@@ -159,8 +165,9 @@ A conforming SDK:
   serialized component tree, without requiring a live DOM.
 - MUST resolve references over the complete tree and MUST descend only.
 - MUST omit a property that does not resolve, silently.
-- MUST reject `transform` and the removed DOM extract modes as invalid corpus
-  input (validation error), rather than silently accepting them.
+- MUST reject `transform` (on any property type) and the removed DOM component
+  extract modes as invalid corpus input (validation error), rather than silently
+  accepting them.
 - MAY define what `text` and the carried attribute set contain for its platform.
 
 ## Alternatives considered
@@ -187,7 +194,11 @@ on the matched node.
 - **Corpora** using a bare-CSS sub-selector, `exists:SEL`, `inner_text`,
   `text_only`, or `inner_html` must promote the referenced sub-element to a
   declared child component and reference it via `PATH.prop` / `exists:PATH`.
-  Corpora using `transform` must drop it.
+  Corpora using `transform` on **any** property type (component, request, or
+  message) must drop it; for request/message, fold the extraction into `pattern`
+  where possible (`first_number` → `(\d[\d,.]*)`, `first_dollar` → `(\$[\d,.]+)`,
+  etc.). The two mutation transforms `number` and `slug` have no `pattern`
+  equivalent, but are near-useless on request bodies and stack frames.
 - **SDKs** replace the live-DOM extraction pass with tree resolution; the live
   path becomes "build tree → match → resolve over the tree," so one
   implementation serves both live and offline.
@@ -199,7 +210,9 @@ on the matched node.
 
 This SEP supersedes the extraction model of SEP-0003; SEP-0003's property
 *declaration shape* (`name`/`extract`, the reserved `value` name, silent
-omission) carries forward.
+omission) carries forward. It also removes the `transform` field from request
+(SEP-0005) and message (SEP-0006) properties; the `source`/`field`/`pattern`
+extraction those SEPs define is otherwise unchanged.
 
 ## Open questions
 
@@ -215,6 +228,7 @@ omission) carries forward.
 
 - SEP-0003 (component `properties[]`) — the declaration shape this supersedes the
   extraction model of.
-- SEP-0005 / SEP-0006 and issue #170 — the request/message offline-evaluation
-  precedent this parallels.
+- SEP-0005 / SEP-0006 — the request/message property SEPs; this SEP removes their
+  `transform` field (issue #170 is the offline-evaluation precedent this
+  parallels).
 - Issue #282 — the missing offline component-property evaluation half.

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -120,43 +120,32 @@ See [SEP-0002](../seps/0002-component-ref.md) for the full proposal and rational
 - A list of strings is tried in order; the first selector that matches wins.
 - Selectors in `children` are evaluated **within** their parent's matched subtree, not globally. This scoping is how Sightmap avoids naming collisions between, say, two different card components that both contain a `button.primary`.
 - Selectors are not required to be unique at their level. If a selector matches multiple elements, all matches are named.
-- **Shadow DOM.** Selectors are matched against the captured component tree, which is a *flattened* representation: each shadow root's content is inlined as ordinary children of its host. Selectors therefore match **across shadow boundaries** — shadow-DOM content is addressed exactly like light-DOM content, and there is no piercing syntax (standard CSS has none: `>>>`/`/deep/` were removed, and `::part()`/`::slotted()` reach only explicitly-exposed nodes). `children` scoping and combinators operate over the flattened tree, where a shadow host → shadow child is an ordinary parent→child edge. This is a deliberate divergence from a live `document.querySelector`, which does **not** cross shadow roots: a tool re-implementing matching or property extraction against the live DOM MUST traverse shadow roots (walk each element's `shadowRoot`) to agree with the corpus. The same rule governs the `exists:`/sub-selector extract modes below — they resolve within the matched element's flattened subtree, including its shadow DOM.
+- **Shadow DOM.** Selectors are matched against the captured component tree, which is a *flattened* representation: each shadow root's content is inlined as ordinary children of its host. Selectors therefore match **across shadow boundaries** — shadow-DOM content is addressed exactly like light-DOM content, and there is no piercing syntax (standard CSS has none: `>>>`/`/deep/` were removed, and `::part()`/`::slotted()` reach only explicitly-exposed nodes). `children` scoping and combinators operate over the flattened tree, where a shadow host → shadow child is an ordinary parent→child edge. This is a deliberate divergence from a live `document.querySelector`, which does **not** cross shadow roots: a tool re-implementing matching against the live DOM MUST traverse shadow roots (walk each element's `shadowRoot`) to agree with the corpus.
 
 
 ### Component properties
 
-A component may declare `properties: Property[]` — named values extracted from its matched DOM element and surfaced alongside the component name in enriched snapshots, e.g. `[DateFilterButton label="This Weekend"]`. Extraction operates on the exact element the selector matched (not an ancestor, not the AX node). Properties are read from the **live DOM at snapshot time**; SDKs operating on saved component-tree data MUST omit the values rather than approximate them (the declarations are not an error offline). When a component's selector matches multiple elements, extraction runs independently on each. See [SEP-0003](../seps/0003-component-properties.md).
+A component may declare `properties: Property[]` — named values surfaced alongside the component name in enriched snapshots, e.g. `[DateFilterButton label="This Weekend"]`. Values are **resolved over the component tree**, from the matched component's own node and the extracted properties of components nested beneath it — never from arbitrary DOM. This makes resolution work offline, against a serialized tree, on any UI platform. See [SEP-0010](../seps/0010-tree-closed-component-properties.md), which supersedes the extraction model of [SEP-0003](../seps/0003-component-properties.md).
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `name` | string | yes | Key used in the annotation (`name="value"`). Must match `^[a-z][a-z0-9_]*$`. The name `value` is reserved: it may be declared to override the AX built-in, and SDKs MUST prefer a declared `value` over the AX tree's own value. |
+| `name` | string | yes | Key used in the annotation (`name="value"`). Must match `^[a-z][a-z0-9_]*$`, and must be unique within a component. The name `value` is reserved: it may be declared to override the AX built-in, and SDKs MUST prefer a declared `value` over the AX tree's own value. |
 | `extract` | string | yes | Extraction directive (see below). |
-| `transform` | string | no | Optional post-processing applied to the extracted string (see below). |
 
-**Extract modes.** The `extract` value is interpreted in this order (named modes match by exact, case-sensitive equality before the `attr=`/`exists:` prefixes):
+**Extract grammar.** The `extract` value is exactly one of the following forms; any other value is invalid and MUST be rejected by validation.
 
-| Value | Source |
+| Form | Resolves to |
 |---|---|
-| `text` | `element.textContent.trim()`, internal whitespace collapsed to single spaces |
-| `inner_text` | `element.innerText.trim()` — layout-aware; use when `text` runs adjacent inline elements together |
-| `text_only` | `textContent` after removing `img`, `svg`, and `[alt]` descendants — use when icon alt-text bleeds into the label |
-| `inner_html` | `element.innerHTML` |
-| `attr=NAME` | `element.getAttribute(NAME)` |
-| `exists:SEL` | `"true"` if `SEL` matches an element within the matched element's subtree — **including its shadow DOM** (see [Selector semantics](#selector-semantics)) — else **omitted** (boolean state flag) |
-| *any other string* | Treated as a CSS sub-selector resolved within the matched element's subtree, **including its shadow DOM**: the first match's `innerText` (falling back to `textContent`), trimmed; omitted when nothing matches |
+| `text` | the node's accessible text (implementation-defined accessible name) |
+| `attr=NAME` | the value of attribute `NAME` carried on the node's observed attribute set; omitted if the node does not carry it |
+| `PATH.prop` | the value extracted for property `prop` of the descendant component addressed by `PATH` |
+| `exists:PATH` | `"true"` if `PATH` resolves to at least one matched component; omitted otherwise (boolean state flag) |
 
-**Transforms.** When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1).
+`PATH` is a dotted sequence of component names naming a descendant, each segment resolved first-match (in document order) within the previous segment's matched subtree (`Price`, `Row.Price`). In a `PATH.prop` value reference the final segment is a property name; in `exists:PATH` the whole path names components. References descend only — a property may address a component nested beneath the one declaring it, never a parent, sibling, or cousin — so resolution is a bottom-up pass over a DAG. To surface a value from a sub-element, promote that sub-element to a declared child component and reference it.
 
-| Value | Effect |
-|---|---|
-| `first_word` | First whitespace-delimited token |
-| `last_word` | Last whitespace-delimited token |
-| `first_number` | First substring matching `\d[\d,.]*` |
-| `first_dollar` | First substring matching `\$[\d,.]+` |
-| `number` | Strip all non-digit, non-decimal characters |
-| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
+The observed attribute set read by `attr=NAME` is implementation-defined: which attributes a node carries depends on the consumer (a web SDK may carry a fixed allowlist plus `aria-*`/`data-*`; other platforms carry synthetic attributes). An attribute the consumer did not carry is indistinguishable from one that was absent.
 
-**Value omission is silent** — a property that extracts to an empty string (or whose `exists:`/sub-selector finds nothing) is simply dropped from the annotation; consumers MUST NOT treat omission as an error.
+**Value omission is silent** — a property whose `text` is empty, whose attribute is not carried, or whose `PATH` matches nothing is simply dropped from the annotation; consumers MUST NOT treat omission as an error.
 
 ## Dependencies
 
@@ -272,7 +261,7 @@ A named API endpoint.
 | `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
 | `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
 | `pattern` | string | see below | An [RE2](#regular-expressions) regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes). `pattern` is an [RE2 regular expression](#regular-expressions); the reference CLI rejects an invalid one (`request-property-pattern-invalid`).
 
@@ -283,6 +272,19 @@ Extraction requires **live traffic**. A tool operating on static corpus definiti
 `status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. They sit outside `source` entirely — a consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
 
 `properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](../seps/0005-request-properties.md).
+
+#### Transforms
+
+When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1). Used by request and message `properties:`.
+
+| Value | Effect |
+|---|---|
+| `first_word` | First whitespace-delimited token |
+| `last_word` | Last whitespace-delimited token |
+| `first_number` | First substring matching `\d[\d,.]*` |
+| `first_dollar` | First substring matching `\$[\d,.]+` |
+| `number` | Strip all non-digit, non-decimal characters |
+| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
 
 ### Payload
 
@@ -368,7 +370,7 @@ messages:
 | `source` | string | yes | Which root to read from. The only value in v1 is `stack` (the exception's call stack). |
 | `field` | string | yes | The frame and attribute to select, `<frame>.<attribute>`: `<frame>` is `top` (an alias for `0`) or a non-negative frame index (`0`, `1`, …), throwing frame first; `<attribute>` is one of `function`, `file`, `line`, or `column`. Required — a `stack` source has no meaningful bare-regex scan, the same reasoning that requires `field` for a request's headers source. |
 | `pattern` | string | no | An [RE2](#regular-expressions) regex applied to whatever `field` resolved. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Same vocabulary as [Component properties](#component-properties)' transform. |
+| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 Extraction requires **live traffic** and **value omission is silent**, exactly as for [request properties](#request-properties): a property that doesn't resolve (a plain console record with no stack, a frame index out of range, an unknown attribute, no pattern match) is simply absent, never an error. See [SEP-0006](../seps/0006-message-entity.md).
 
@@ -558,7 +560,7 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
 - MUST omit an unresolved property value silently, without a diagnostic
 - MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
-- SHOULD apply `transform` as [Component properties](#component-properties) does: skipped on an empty or absent raw value, single transform only, not composable
+- SHOULD apply `transform` as [Transforms](#transforms) specifies: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
 - MUST resolve a `MessageProperty` only from a live record's stack, omitting the value silently when the record has no stack or the addressed frame/attribute doesn't resolve

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -261,7 +261,6 @@ A named API endpoint.
 | `source` | string | yes | Which root to read from: `req.body`, `rsp.body`, `req.headers`, or `rsp.headers`. |
 | `field` | string | see below | The value to select within `source`. For a `.body` source, an object-key dot-path (a numeric segment indexes an array when the value there is one — `items.0.name`). For a `.headers` source, a header name matched case-insensitively; **required** whenever `source` is a headers source. |
 | `pattern` | string | see below | An [RE2](#regular-expressions) regex applied to whatever `field` resolved, or to the raw source text when `field` is absent. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 At least one of `field`/`pattern` is required — the two compose: `field` selects a value, `pattern` optionally extracts a substring from it. `source` is always required, and when it names a headers source `field` is required too (a bare regex across a raw header block is the addressing foot-gun this shape removes). `pattern` is an [RE2 regular expression](#regular-expressions); the reference CLI rejects an invalid one (`request-property-pattern-invalid`).
 
@@ -272,19 +271,6 @@ Extraction requires **live traffic**. A tool operating on static corpus definiti
 `status`, `method`, and `duration` are **reserved identity names**, addressing the request's own already-structured HTTP identity. They sit outside `source` entirely — a consumer may reference them wherever a property name is expected with no `properties:` declaration at all. Declaring a property under one of those names is legal and shadows the identity: the name then resolves to the extracted value, and the HTTP identity becomes unreachable. The reference CLI warns (`request-property-shadows-reserved`). Prefer a distinct name such as `outcome` unless shadowing is what you want.
 
 `properties:` and `request:`/`response:` (Payload) answer different questions: `Payload.fields[]` documents expected shape for a reader and is not enforced; `properties:` names a value to extract from live traffic. The two lists are independent. See [SEP-0005](../seps/0005-request-properties.md).
-
-#### Transforms
-
-When `transform` is set it is applied to the trimmed extracted string; if the value is empty or absent, the transform is skipped and the property omitted. Exactly one transform may be given (not composable in v1). Used by request and message `properties:`.
-
-| Value | Effect |
-|---|---|
-| `first_word` | First whitespace-delimited token |
-| `last_word` | Last whitespace-delimited token |
-| `first_number` | First substring matching `\d[\d,.]*` |
-| `first_dollar` | First substring matching `\$[\d,.]+` |
-| `number` | Strip all non-digit, non-decimal characters |
-| `slug` | Lowercase; spaces and underscores → hyphens; strip non-`[a-z0-9-]` |
 
 ### Payload
 
@@ -342,7 +328,7 @@ A record matches when every declared constraint holds. Declaring neither `level`
 
 ### Message properties
 
-`properties:` declares named values to pull out of an uncaught exception's **stack trace**, so a corpus can classify an exception by where it came from and extract the failing location — the message-side analogue of a request's [`properties:`](#request-properties). It reuses that mechanism's `source` / `field` / `pattern` / `transform` shape.
+`properties:` declares named values to pull out of an uncaught exception's **stack trace**, so a corpus can classify an exception by where it came from and extract the failing location — the message-side analogue of a request's [`properties:`](#request-properties). It reuses that mechanism's `source` / `field` / `pattern` shape.
 
 ```yaml
 messages:
@@ -370,7 +356,6 @@ messages:
 | `source` | string | yes | Which root to read from. The only value in v1 is `stack` (the exception's call stack). |
 | `field` | string | yes | The frame and attribute to select, `<frame>.<attribute>`: `<frame>` is `top` (an alias for `0`) or a non-negative frame index (`0`, `1`, …), throwing frame first; `<attribute>` is one of `function`, `file`, `line`, or `column`. Required — a `stack` source has no meaningful bare-regex scan, the same reasoning that requires `field` for a request's headers source. |
 | `pattern` | string | no | An [RE2](#regular-expressions) regex applied to whatever `field` resolved. Capture group 1 is the extracted value when the pattern has one, otherwise the entire match. |
-| `transform` | string | no | Optional post-processing applied to the extracted string; see [Transforms](#transforms). |
 
 Extraction requires **live traffic** and **value omission is silent**, exactly as for [request properties](#request-properties): a property that doesn't resolve (a plain console record with no stack, a frame index out of range, an unknown attribute, no pattern match) is simply absent, never an error. See [SEP-0006](../seps/0006-message-entity.md).
 
@@ -560,12 +545,11 @@ An SDK that also **evaluates live activity** (observed network requests, console
 - MUST resolve `properties:` only from live traffic, and MUST NOT error when a `properties:`-declaring request is used in a static context — omit the value instead
 - MUST omit an unresolved property value silently, without a diagnostic
 - MUST apply `pattern` to the value `field` resolved (not the whole source) when both are present, taking capture group 1 as the value when the pattern has one, else the entire match
-- SHOULD apply `transform` as [Transforms](#transforms) specifies: skipped on an empty or absent raw value, single transform only, not composable
 - MUST match a `messages:` entry by case-insensitive equality on `level` and by regex on `message`, treating either as match-any when omitted
 - MUST surface an ambiguity when a record matches more than one `messages:` entry, rather than silently resolving to a first match
 - MUST resolve a `MessageProperty` only from a live record's stack, omitting the value silently when the record has no stack or the addressed frame/attribute doesn't resolve
 
-**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern`, applies no `transform`, and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
+**Not yet implemented in the reference SDK.** The Go SDK under `go/` parses and validates every field above, but does not evaluate live activity: it resolves no `source`/`field`/`pattern` and matches no `messages:` entry against a console record. The evaluation requirements in this section are normative for consumers that do evaluate, and are not yet exercised by the reference implementation or by the conformance fixtures.
 
 ## Open questions
 

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -178,24 +178,19 @@
     },
     "componentProperty": {
       "type": "object",
-      "description": "A named DOM-value extraction from a matched element. See SEP-0003.",
+      "description": "A named value extracted from a matched component's node, resolved over the component tree. See SEP-0010.",
       "required": ["name", "extract"],
       "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9_]*$",
-          "description": "Key used in the snapshot annotation (name=\"value\"). The name 'value' is reserved: it may be declared to override the AX built-in, but SDKs treat 'value' as the AX-value fallback even without a declaration."
+          "description": "Key used in the snapshot annotation (name=\"value\"). Must be unique within a component. The name 'value' is reserved: it may be declared to override the AX built-in, but SDKs treat 'value' as the AX-value fallback even without a declaration."
         },
         "extract": {
           "type": "string",
           "minLength": 1,
-          "description": "Extraction directive: text | inner_text | text_only | inner_html | attr=NAME | exists:SEL | a CSS sub-selector. See SEP-0003 Extract modes."
-        },
-        "transform": {
-          "type": "string",
-          "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
-          "description": "Optional post-processing applied to the extracted string."
+          "description": "Extraction directive, one of: text | attr=NAME | PATH.prop | exists:PATH. The grammar is validated by the SDK. See SEP-0010 Extract grammar."
         }
       }
     },
@@ -267,7 +262,7 @@
         "transform": {
           "type": "string",
           "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
-          "description": "Optional post-processing applied to the extracted string. Same vocabulary as componentProperty.transform (SEP-0003)."
+          "description": "Optional post-processing applied to the extracted string: first_word | last_word | first_number | first_dollar | number | slug. See schema.md Transforms."
         }
       }
     },
@@ -333,7 +328,7 @@
         "transform": {
           "type": "string",
           "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
-          "description": "Optional post-processing applied to the extracted string. Same vocabulary as componentProperty.transform (SEP-0003)."
+          "description": "Optional post-processing applied to the extracted string: first_word | last_word | first_number | first_dollar | number | slug. See schema.md Transforms."
         }
       }
     },

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -258,11 +258,6 @@
           "type": "string",
           "minLength": 1,
           "description": "RE2 regex (no backreferences or lookaround) applied to what field resolved, or to the raw source text when field is absent. Capture group 1 is the value if present, else the full match."
-        },
-        "transform": {
-          "type": "string",
-          "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
-          "description": "Optional post-processing applied to the extracted string: first_word | last_word | first_number | first_dollar | number | slug. See schema.md Transforms."
         }
       }
     },
@@ -324,11 +319,6 @@
           "type": "string",
           "minLength": 1,
           "description": "RE2 regex (no backreferences or lookaround) applied to what field resolved. Capture group 1 is the value if present, else the full match."
-        },
-        "transform": {
-          "type": "string",
-          "enum": ["first_word", "last_word", "first_number", "first_dollar", "number", "slug"],
-          "description": "Optional post-processing applied to the extracted string: first_word | last_word | first_number | first_dollar | number | slug. See schema.md Transforms."
         }
       }
     },


### PR DESCRIPTION
Spec + docs implementation of **SEP-0010 (tree-closed component property extraction)**, now Accepted (#283), whose scope was expanded to also **remove `transform` from every property type**. Spec/docs only — no library behavior change yet (that follows in the implementation herd), so no changeset.

## Tree-closed component properties

- **`spec/v1/schema.md`** — rewrite *Component properties* to the four-mode grammar: `text`, `attr=NAME`, `PATH.prop`, `exists:PATH`. Remove the DOM-shaped modes and the live-DOM "MUST omit offline" clause; state resolution over the complete component tree (descend-only, first-match, silent omission); `attr=`'s observed attribute set is implementation-defined.
- **`spec/v1/sightmap.schema.json`** — narrow `componentProperty.extract`; drop `componentProperty.transform`.
- **`spec/conformance/014-component-properties.fixture`** — rewritten to the new grammar (sub-elements promoted to child components).
- **`spec/seps/0003`** — noted as superseded-in-part (extraction model; declaration shape carries forward).

## Remove `transform` from all property types

Per SEP-0010's expanded scope, the fixed transform vocabulary is removed everywhere, not just from components:

- Drop `transform` from `requestProperty` and `messageProperty` in `sightmap.schema.json`.
- Remove the `transform` rows and the `Transforms` subsection from `schema.md`, plus the message-eval `transform` reference. Request/message extraction keeps `source`/`field`/`pattern`; post-processing folds into `pattern` (RE2 + capture groups).
- `spec/seps/0005` and `spec/seps/0006` get amended-by-SEP-0010 notes.
- `spec/seps/0010` scope broadened (Summary, schema diff, conformance, migration, references).

## Verified

- `go test ./sightmap/ ./match/ -count=1` (incl. spec-conformance + schema tests) passes.
- Docs regenerated (`docs/reference/schema.md`); no `transform` / old-mode references remain in spec or docs.

## Follows separately (herd)

Library (offline extractor + `checkComponentProperties` grammar validation), retiring the live JS extractor **and all `transform` plumbing** (`ApplyTransform`, the req/msg extractor fields + calls, `unknownfields.go` key sets, `stats`), and the authoring-skill rewrite.
