### PR TITLE
match: resolve component properties offline over the tree (SEP-0010, #282)

### DIFF
--- a/.changeset/sep-0010-component-properties.md
+++ b/.changeset/sep-0010-component-properties.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Component properties now resolve offline over the component tree (SEP-0010). `Matcher.Match` populates each `ComponentMatch.Properties` from the matched tree with no live DOM, so a downstream consumer holding a serialized component tree gets property values directly. The `extract` grammar is the four tree-closed forms — `text`, `attr=NAME`, `PATH.prop`, `exists:PATH` — and `transform` is removed from component properties. `sightmap validate` now checks component `properties[]`: duplicate names within a component and unrecognized/removed extract modes are errors.

--- a/go/match/chain.go
+++ b/go/match/chain.go
@@ -61,17 +61,12 @@ func (m *Matcher) MatchChain(chain []sightmap.Element, pageURL string) []ChainMa
 		}
 	}
 
-	byName := make(map[string]*sightmap.ComponentDef, len(entry.components))
-	for i := range entry.components {
-		byName[entry.components[i].Name] = &entry.components[i]
-	}
-
 	var out []ChainMatch
 	FindAllMatches(nodes[0], entry.queries, func(node *sightmap.ComponentNode, q *MatchQuery) {
 		cm := ChainMatch{Depth: depthOf[node], Name: q.Name}
-		if def := byName[q.Name]; def != nil {
-			cm.Tags = def.Tags
-			cm.Memory = def.Memory
+		if q.Def != nil {
+			cm.Tags = q.Def.Tags
+			cm.Memory = q.Def.Memory
 		}
 		out = append(out, cm)
 	})

--- a/go/match/component_props.go
+++ b/go/match/component_props.go
@@ -12,9 +12,9 @@ import (
 // DOM. It runs after all matches are collected, so PATH.prop / exists:PATH can
 // see sibling and descendant matches.
 //
-// A property is dropped silently when it does not resolve (empty text, an
+// A property is dropped silently when it does not resolve: empty text, an
 // attribute the node does not carry, or a PATH that matches no descendant
-// component), matching the spec's silent-omission rule.
+// component.
 func resolveComponentProperties(
 	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	defByNode map[*sightmap.ComponentNode]*sightmap.ComponentDef,
@@ -100,9 +100,6 @@ func resolvePath(
 			return nil
 		}
 		cur = next
-	}
-	if cur == node {
-		return nil // empty path resolves to self, which is not a descendant
 	}
 	return cur
 }

--- a/go/match/component_props.go
+++ b/go/match/component_props.go
@@ -1,0 +1,139 @@
+package match
+
+import (
+	"strings"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// resolveComponentProperties fills each match's Properties by resolving its
+// component definition's extract directives over the matched component tree,
+// per SEP-0010. Resolution is tree-closed and offline: it never touches a live
+// DOM. It runs after all matches are collected, so PATH.prop / exists:PATH can
+// see sibling and descendant matches.
+//
+// A property is dropped silently when it does not resolve (empty text, an
+// attribute the node does not carry, or a PATH that matches no descendant
+// component), matching the spec's silent-omission rule.
+func resolveComponentProperties(
+	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	defByNode map[*sightmap.ComponentNode]*sightmap.ComponentDef,
+) {
+	for node, cm := range result {
+		def := defByNode[node]
+		if def == nil || len(def.Properties) == 0 {
+			continue
+		}
+		var props []sightmap.PropertyValue
+		for _, p := range def.Properties {
+			if v, ok := resolveExtract(node, p.Extract, result, defByNode); ok {
+				props = append(props, sightmap.PropertyValue{Name: p.Name, Value: v})
+			}
+		}
+		cm.Properties = props
+	}
+}
+
+// resolveExtract resolves one extract directive against node. References descend
+// only, so recursion strictly enters smaller subtrees and always terminates.
+func resolveExtract(
+	node *sightmap.ComponentNode,
+	extract string,
+	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	defByNode map[*sightmap.ComponentNode]*sightmap.ComponentDef,
+) (string, bool) {
+	switch {
+	case extract == "text":
+		return node.Name, node.Name != ""
+
+	case strings.HasPrefix(extract, "attr="):
+		name := extract[len("attr="):]
+		if name == "" || node.Element == nil {
+			return "", false
+		}
+		v, ok := node.Element.Attrs[name]
+		return v, ok && v != ""
+
+	case strings.HasPrefix(extract, "exists:"):
+		if resolvePath(node, extract[len("exists:"):], result) != nil {
+			return "true", true
+		}
+		return "", false
+
+	default: // PATH.prop
+		dot := strings.LastIndex(extract, ".")
+		if dot <= 0 || dot == len(extract)-1 {
+			return "", false
+		}
+		target := resolvePath(node, extract[:dot], result)
+		if target == nil {
+			return "", false
+		}
+		tdef := defByNode[target]
+		if tdef == nil {
+			return "", false
+		}
+		prop := extract[dot+1:]
+		for _, tp := range tdef.Properties {
+			if tp.Name == prop {
+				return resolveExtract(target, tp.Extract, result, defByNode)
+			}
+		}
+		return "", false
+	}
+}
+
+// resolvePath walks a dotted component-name path into node's subtree, returning
+// the deepest matched node (first in document order at each segment) or nil.
+func resolvePath(
+	node *sightmap.ComponentNode,
+	path string,
+	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+) *sightmap.ComponentNode {
+	cur := node
+	for _, seg := range strings.Split(path, ".") {
+		if seg == "" {
+			return nil
+		}
+		next := firstDescendantNamed(cur, seg, result)
+		if next == nil {
+			return nil
+		}
+		cur = next
+	}
+	if cur == node {
+		return nil // empty path resolves to self, which is not a descendant
+	}
+	return cur
+}
+
+// firstDescendantNamed returns the first node in root's subtree (pre-order,
+// excluding root) whose winning component match name equals name.
+func firstDescendantNamed(
+	root *sightmap.ComponentNode,
+	name string,
+	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+) *sightmap.ComponentNode {
+	for _, child := range root.Children {
+		if found := searchNamed(child, name, result); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func searchNamed(
+	node *sightmap.ComponentNode,
+	name string,
+	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+) *sightmap.ComponentNode {
+	if cm := result[node]; cm != nil && cm.Name == name {
+		return node
+	}
+	for _, child := range node.Children {
+		if found := searchNamed(child, name, result); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/go/match/component_props_test.go
+++ b/go/match/component_props_test.go
@@ -1,0 +1,150 @@
+package match_test
+
+import (
+	"testing"
+
+	"github.com/sightmap/sightmap/go/match"
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// productCardDefs is the flattened corpus for a ProductCard with a Price child,
+// a SoldOutBadge child, and a Link child — exercising every SEP-0010 extract
+// form: text (local), attr= (local), PATH.prop (descendant value), and
+// exists:PATH (descendant presence).
+func productCardDefs() []sightmap.ComponentDef {
+	return []sightmap.ComponentDef{
+		{
+			Name:      "ProductCard",
+			Selectors: []string{"[data-testid=pod]"},
+			Properties: []sightmap.ComponentPropertyDef{
+				{Name: "label", Extract: "text"},
+				{Name: "price", Extract: "Price.text"},
+				{Name: "sold_out", Extract: "exists:SoldOutBadge"},
+			},
+		},
+		{
+			Name:        "Price",
+			Selectors:   []string{"[data-testid=pod] [data-testid=price]"},
+			ParentChain: []string{"ProductCard"},
+			Properties:  []sightmap.ComponentPropertyDef{{Name: "text", Extract: "text"}},
+		},
+		{
+			Name:        "SoldOutBadge",
+			Selectors:   []string{"[data-testid=pod] .sold-out"},
+			ParentChain: []string{"ProductCard"},
+		},
+		{
+			Name:        "Link",
+			Selectors:   []string{"[data-testid=pod] a"},
+			ParentChain: []string{"ProductCard"},
+			Properties:  []sightmap.ComponentPropertyDef{{Name: "href", Extract: "attr=href"}},
+		},
+	}
+}
+
+func propVal(cm *sightmap.ComponentMatch, name string) (string, bool) {
+	if cm == nil {
+		return "", false
+	}
+	pv, ok := cm.Property(name)
+	return pv.Value, ok
+}
+
+func TestResolveComponentProperties_AllForms(t *testing.T) {
+	price := &sightmap.ComponentNode{Id: "price", Name: "$42.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
+	badge := &sightmap.ComponentNode{Id: "badge", Name: "Sold Out", Element: &sightmap.Element{Tag: "span", Classes: []string{"sold-out"}}}
+	link := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a", Attrs: map[string]string{"href": "/p/1"}}}
+	card := &sightmap.ComponentNode{
+		Id:       "card",
+		Name:     "Product X",
+		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
+		Children: []*sightmap.ComponentNode{price, badge, link},
+	}
+
+	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
+
+	// Local text on the card itself.
+	if v, ok := propVal(res[card], "label"); !ok || v != "Product X" {
+		t.Errorf("label = %q, %v; want \"Product X\", true", v, ok)
+	}
+	// PATH.prop into the Price child's own text.
+	if v, ok := propVal(res[card], "price"); !ok || v != "$42.00" {
+		t.Errorf("price = %q, %v; want \"$42.00\", true", v, ok)
+	}
+	// exists:PATH — the SoldOutBadge is present.
+	if v, ok := propVal(res[card], "sold_out"); !ok || v != "true" {
+		t.Errorf("sold_out = %q, %v; want \"true\", true", v, ok)
+	}
+	// attr= on the Link child.
+	if v, ok := propVal(res[link], "href"); !ok || v != "/p/1" {
+		t.Errorf("href = %q, %v; want \"/p/1\", true", v, ok)
+	}
+	// The Price child carries its own resolved text.
+	if v, ok := propVal(res[price], "text"); !ok || v != "$42.00" {
+		t.Errorf("Price.text = %q, %v; want \"$42.00\", true", v, ok)
+	}
+}
+
+func TestResolveComponentProperties_SilentOmission(t *testing.T) {
+	// A card with no SoldOutBadge and no Price, and a link with no href.
+	link := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a"}}
+	card := &sightmap.ComponentNode{
+		Id:       "card",
+		Name:     "", // empty accessible name → label omitted
+		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
+		Children: []*sightmap.ComponentNode{link},
+	}
+
+	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
+
+	if _, ok := propVal(res[card], "label"); ok {
+		t.Error("label should be omitted when accessible name is empty")
+	}
+	if _, ok := propVal(res[card], "price"); ok {
+		t.Error("price should be omitted when there is no Price descendant")
+	}
+	if _, ok := propVal(res[card], "sold_out"); ok {
+		t.Error("sold_out should be omitted when SoldOutBadge is absent")
+	}
+	if _, ok := propVal(res[link], "href"); ok {
+		t.Error("href should be omitted when the attribute is not carried")
+	}
+}
+
+func TestResolveComponentProperties_MultiMatchFirstInDocumentOrder(t *testing.T) {
+	price1 := &sightmap.ComponentNode{Id: "p1", Name: "$10.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
+	price2 := &sightmap.ComponentNode{Id: "p2", Name: "$20.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
+	card := &sightmap.ComponentNode{
+		Id:       "card",
+		Name:     "Product X",
+		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
+		Children: []*sightmap.ComponentNode{price1, price2},
+	}
+
+	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
+
+	if v, ok := propVal(res[card], "price"); !ok || v != "$10.00" {
+		t.Errorf("price = %q, %v; want first-in-document-order \"$10.00\", true", v, ok)
+	}
+}
+
+func TestResolveComponentProperties_NestedPath(t *testing.T) {
+	amount := &sightmap.ComponentNode{Id: "amt", Name: "$5.00", Element: &sightmap.Element{Tag: "b", Attrs: map[string]string{"data-testid": "amount"}}}
+	pricebox := &sightmap.ComponentNode{Id: "pb", Element: &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "price"}}, Children: []*sightmap.ComponentNode{amount}}
+	row := &sightmap.ComponentNode{Id: "row", Element: &sightmap.Element{Tag: "li", Attrs: map[string]string{"data-testid": "row"}}, Children: []*sightmap.ComponentNode{pricebox}}
+
+	defs := []sightmap.ComponentDef{
+		{
+			Name:       "Row",
+			Selectors:  []string{"[data-testid=row]"},
+			Properties: []sightmap.ComponentPropertyDef{{Name: "amount", Extract: "Price.Amount.text"}},
+		},
+		{Name: "Price", Selectors: []string{"[data-testid=row] [data-testid=price]"}, ParentChain: []string{"Row"}},
+		{Name: "Amount", Selectors: []string{"[data-testid=row] [data-testid=price] [data-testid=amount]"}, ParentChain: []string{"Row", "Price"}, Properties: []sightmap.ComponentPropertyDef{{Name: "text", Extract: "text"}}},
+	}
+
+	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs}).Match(row, "")
+	if v, ok := propVal(res[row], "amount"); !ok || v != "$5.00" {
+		t.Errorf("amount (Price.Amount.text) = %q, %v; want \"$5.00\", true", v, ok)
+	}
+}

--- a/go/match/component_props_test.go
+++ b/go/match/component_props_test.go
@@ -50,7 +50,7 @@ func propVal(cm *sightmap.ComponentMatch, name string) (string, bool) {
 	return pv.Value, ok
 }
 
-func TestResolveComponentProperties_AllForms(t *testing.T) {
+func TestResolveComponentProperties(t *testing.T) {
 	price := &sightmap.ComponentNode{Id: "price", Name: "$42.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
 	badge := &sightmap.ComponentNode{Id: "badge", Name: "Sold Out", Element: &sightmap.Element{Tag: "span", Classes: []string{"sold-out"}}}
 	link := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a", Attrs: map[string]string{"href": "/p/1"}}}
@@ -61,79 +61,27 @@ func TestResolveComponentProperties_AllForms(t *testing.T) {
 		Children: []*sightmap.ComponentNode{price, badge, link},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
-
-	// Local text on the card itself.
-	if v, ok := propVal(res[card], "label"); !ok || v != "Product X" {
-		t.Errorf("label = %q, %v; want \"Product X\", true", v, ok)
-	}
-	// PATH.prop into the Price child's own text.
-	if v, ok := propVal(res[card], "price"); !ok || v != "$42.00" {
-		t.Errorf("price = %q, %v; want \"$42.00\", true", v, ok)
-	}
-	// exists:PATH — the SoldOutBadge is present.
-	if v, ok := propVal(res[card], "sold_out"); !ok || v != "true" {
-		t.Errorf("sold_out = %q, %v; want \"true\", true", v, ok)
-	}
-	// attr= on the Link child.
-	if v, ok := propVal(res[link], "href"); !ok || v != "/p/1" {
-		t.Errorf("href = %q, %v; want \"/p/1\", true", v, ok)
-	}
-	// The Price child carries its own resolved text.
-	if v, ok := propVal(res[price], "text"); !ok || v != "$42.00" {
-		t.Errorf("Price.text = %q, %v; want \"$42.00\", true", v, ok)
-	}
-}
-
-func TestResolveComponentProperties_SilentOmission(t *testing.T) {
-	// A card with no SoldOutBadge and no Price, and a link with no href.
-	link := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a"}}
-	card := &sightmap.ComponentNode{
+	noHrefLink := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a"}}
+	emptyCard := &sightmap.ComponentNode{
 		Id:       "card",
 		Name:     "", // empty accessible name → label omitted
 		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
-		Children: []*sightmap.ComponentNode{link},
+		Children: []*sightmap.ComponentNode{noHrefLink},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
-
-	if _, ok := propVal(res[card], "label"); ok {
-		t.Error("label should be omitted when accessible name is empty")
-	}
-	if _, ok := propVal(res[card], "price"); ok {
-		t.Error("price should be omitted when there is no Price descendant")
-	}
-	if _, ok := propVal(res[card], "sold_out"); ok {
-		t.Error("sold_out should be omitted when SoldOutBadge is absent")
-	}
-	if _, ok := propVal(res[link], "href"); ok {
-		t.Error("href should be omitted when the attribute is not carried")
-	}
-}
-
-func TestResolveComponentProperties_MultiMatchFirstInDocumentOrder(t *testing.T) {
 	price1 := &sightmap.ComponentNode{Id: "p1", Name: "$10.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
 	price2 := &sightmap.ComponentNode{Id: "p2", Name: "$20.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
-	card := &sightmap.ComponentNode{
+	multiCard := &sightmap.ComponentNode{
 		Id:       "card",
 		Name:     "Product X",
 		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
 		Children: []*sightmap.ComponentNode{price1, price2},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
-
-	if v, ok := propVal(res[card], "price"); !ok || v != "$10.00" {
-		t.Errorf("price = %q, %v; want first-in-document-order \"$10.00\", true", v, ok)
-	}
-}
-
-func TestResolveComponentProperties_NestedPath(t *testing.T) {
 	amount := &sightmap.ComponentNode{Id: "amt", Name: "$5.00", Element: &sightmap.Element{Tag: "b", Attrs: map[string]string{"data-testid": "amount"}}}
 	pricebox := &sightmap.ComponentNode{Id: "pb", Element: &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "price"}}, Children: []*sightmap.ComponentNode{amount}}
 	row := &sightmap.ComponentNode{Id: "row", Element: &sightmap.Element{Tag: "li", Attrs: map[string]string{"data-testid": "row"}}, Children: []*sightmap.ComponentNode{pricebox}}
-
-	defs := []sightmap.ComponentDef{
+	nestedDefs := []sightmap.ComponentDef{
 		{
 			Name:       "Row",
 			Selectors:  []string{"[data-testid=row]"},
@@ -143,8 +91,68 @@ func TestResolveComponentProperties_NestedPath(t *testing.T) {
 		{Name: "Amount", Selectors: []string{"[data-testid=row] [data-testid=price] [data-testid=amount]"}, ParentChain: []string{"Row", "Price"}, Properties: []sightmap.ComponentPropertyDef{{Name: "text", Extract: "text"}}},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs}).Match(row, "")
-	if v, ok := propVal(res[row], "amount"); !ok || v != "$5.00" {
-		t.Errorf("amount (Price.Amount.text) = %q, %v; want \"$5.00\", true", v, ok)
+	type check struct {
+		node *sightmap.ComponentNode
+		prop string
+		want string
+		ok   bool
+	}
+	tests := []struct {
+		name   string
+		defs   []sightmap.ComponentDef
+		root   *sightmap.ComponentNode
+		checks []check
+	}{
+		{
+			name: "all extract forms",
+			defs: productCardDefs(),
+			root: card,
+			checks: []check{
+				{card, "label", "Product X", true}, // local text
+				{card, "price", "$42.00", true},    // PATH.prop into Price child's text
+				{card, "sold_out", "true", true},   // exists:PATH — SoldOutBadge present
+				{link, "href", "/p/1", true},       // attr= on Link child
+				{price, "text", "$42.00", true},    // Price child carries its own resolved text
+			},
+		},
+		{
+			name: "silent omission",
+			defs: productCardDefs(),
+			root: emptyCard,
+			checks: []check{
+				{emptyCard, "label", "", false},    // empty accessible name
+				{emptyCard, "price", "", false},    // no Price descendant
+				{emptyCard, "sold_out", "", false}, // SoldOutBadge absent
+				{noHrefLink, "href", "", false},    // attribute not carried
+			},
+		},
+		{
+			name: "multi-match resolves first in document order",
+			defs: productCardDefs(),
+			root: multiCard,
+			checks: []check{
+				{multiCard, "price", "$10.00", true},
+			},
+		},
+		{
+			name: "nested PATH.prop",
+			defs: nestedDefs,
+			root: row,
+			checks: []check{
+				{row, "amount", "$5.00", true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: tt.defs}).Match(tt.root, "")
+			for _, c := range tt.checks {
+				v, ok := propVal(res[c.node], c.prop)
+				if ok != c.ok || v != c.want {
+					t.Errorf("%s = %q, %v; want %q, %v", c.prop, v, ok, c.want, c.ok)
+				}
+			}
+		})
 	}
 }

--- a/go/match/corpus_matcher.go
+++ b/go/match/corpus_matcher.go
@@ -58,24 +58,25 @@ func (m *Matcher) Match(root *sightmap.ComponentNode, pageURL string) map[*sight
 		return nil
 	}
 
-	// Map component name → definition for memory resolution at match time.
-	byName := make(map[string]*sightmap.ComponentDef, len(entry.components))
-	for i := range entry.components {
-		byName[entry.components[i].Name] = &entry.components[i]
-	}
-
 	result := make(map[*sightmap.ComponentNode]*sightmap.ComponentMatch)
+	defByNode := make(map[*sightmap.ComponentNode]*sightmap.ComponentDef)
 	FindAllMatches(root, entry.queries, func(node *sightmap.ComponentNode, q *MatchQuery) {
 		if _, already := result[node]; already {
 			return // first-match-wins
 		}
 		cm := &sightmap.ComponentMatch{Name: q.Name}
-		if def := byName[q.Name]; def != nil {
-			cm.Memory = def.Memory
-			cm.Tags = def.Tags
+		if q.Def != nil {
+			cm.Memory = q.Def.Memory
+			cm.Tags = q.Def.Tags
+			defByNode[node] = q.Def
 		}
 		result[node] = cm
 	})
+
+	// Resolve declared component properties over the matched tree (SEP-0010):
+	// text/attr read the node itself; PATH.prop and exists:PATH resolve a
+	// descendant matched component. No live DOM is required.
+	resolveComponentProperties(result, defByNode)
 	return result
 }
 

--- a/go/match/matcher.go
+++ b/go/match/matcher.go
@@ -12,6 +12,10 @@ type MatchQuery struct {
 	Name        string
 	Parts       []*sightmap.SelectorPart
 	Combinators []string
+	// Def is the component definition this query was compiled from — the precise
+	// def for this match (component names are unique only per parent, so a name
+	// lookup would collide). Consumers read Memory/Tags/Properties from it.
+	Def *sightmap.ComponentDef
 }
 
 // FindAllMatches traverses root depth-first, invoking onMatch for every node

--- a/go/match/sightmap.go
+++ b/go/match/sightmap.go
@@ -14,7 +14,8 @@ func ParseQueries(defs []sightmap.ComponentDef) ([]MatchQuery, []error) {
 	var queries []MatchQuery
 	var errs []error
 
-	for _, def := range defs {
+	for i := range defs {
+		def := &defs[i]
 		for _, selStr := range def.Selectors {
 			ps, err := sightmap.ParseSightmapSelector(selStr)
 			if err != nil {
@@ -25,6 +26,7 @@ func ParseQueries(defs []sightmap.ComponentDef) ([]MatchQuery, []error) {
 				Name:        def.Name,
 				Parts:       ps.Parts,
 				Combinators: ps.Combinators,
+				Def:         def,
 			})
 		}
 	}

--- a/go/observe/properties.go
+++ b/go/observe/properties.go
@@ -31,9 +31,8 @@ func ExtractProperties(
 	compByName map[string]sightmap.ComponentDef,
 ) {
 	type specProp struct {
-		Name      string `json:"name"`
-		Extract   string `json:"extract"`
-		Transform string `json:"transform"`
+		Name    string `json:"name"`
+		Extract string `json:"extract"`
 	}
 	type spec struct {
 		ID       string     `json:"id"`
@@ -57,7 +56,7 @@ func ExtractProperties(
 			Props:    make([]specProp, len(comp.Properties)),
 		}
 		for i, p := range comp.Properties {
-			sp.Props[i] = specProp{Name: p.Name, Extract: p.Extract, Transform: p.Transform}
+			sp.Props[i] = specProp{Name: p.Name, Extract: p.Extract}
 		}
 		specs = append(specs, sp)
 	}

--- a/go/sightmap/component.go
+++ b/go/sightmap/component.go
@@ -14,16 +14,16 @@ type ComponentDef struct {
 	Stability   string                 `json:"stability,omitempty"`   // "" (default), "uncertain", or "unstable"
 }
 
-// ComponentPropertyDef describes a value to extract from a matched DOM element.
+// ComponentPropertyDef describes a value extracted from a matched component,
+// resolved over the component tree (SEP-0010).
 type ComponentPropertyDef struct {
-	Name      string `json:"name"`
-	Extract   string `json:"extract"`   // see extract modes: text, inner_text, text_only, attr=NAME, exists:SEL, CSS selector
-	Transform string `json:"transform"` // optional post-processing
+	Name    string `json:"name"`
+	Extract string `json:"extract"` // SEP-0010: text | attr=NAME | PATH.prop | exists:PATH
 }
 
 // ComponentMatch records which component definition matched a node, and carries
-// any live-extracted property values for it (Properties, in the definition's
-// order; nil unless properties were extracted).
+// its resolved property values (Properties, in the definition's order; nil
+// unless the component declares properties that resolved).
 type ComponentMatch struct {
 	Name       string
 	Memory     []string

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -89,9 +89,8 @@ type rawAccess struct {
 }
 
 type rawProperty struct {
-	Name      string `yaml:"name"`
-	Extract   string `yaml:"extract"`
-	Transform string `yaml:"transform"`
+	Name    string `yaml:"name"`
+	Extract string `yaml:"extract"`
 }
 
 type rawRequest struct {
@@ -314,7 +313,7 @@ func rawPropsToMatch(rps []rawProperty) []ComponentPropertyDef {
 	}
 	ps := make([]ComponentPropertyDef, len(rps))
 	for i, rp := range rps {
-		ps[i] = ComponentPropertyDef{Name: rp.Name, Extract: rp.Extract, Transform: rp.Transform}
+		ps[i] = ComponentPropertyDef{Name: rp.Name, Extract: rp.Extract}
 	}
 	return ps
 }

--- a/go/sightmap/stats.go
+++ b/go/sightmap/stats.go
@@ -161,7 +161,7 @@ func componentIdentity(c ComponentDef) string {
 	writeField(c.Tags...)
 	writeField(c.Memory...)
 	for _, p := range c.Properties {
-		writeField(p.Name, p.Extract, p.Transform)
+		writeField(p.Name, p.Extract)
 	}
 	return b.String()
 }

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -29,7 +29,7 @@ var (
 	requestFields   = set("name", "route", "method", "description", "source", "request", "response", "headers", "memory", "tags", "properties")
 	payloadFields   = set("fields")
 	fieldFields     = set("name", "type", "description")
-	propertyFields  = set("name", "extract", "transform")
+	propertyFields  = set("name", "extract")
 	accessFields    = set("status", "reason")
 	snapshotFields  = set("name", "notes", "url")
 

--- a/go/sightmap/unknownfields_test.go
+++ b/go/sightmap/unknownfields_test.go
@@ -107,7 +107,6 @@ views:
         properties:
           - name: price
             extract: text
-            transform: first_dollar
         children:
           - name: Inner
             selector: .inner

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -119,6 +119,9 @@ func Validate(c *Corpus) []ValidationError {
 	errs = append(errs, checkViewNameCollisions(c.Views)...)
 	errs = append(errs, checkRouteCollisions(c.Views)...)
 
+	// Component property shape (SEP-0010); see validate_component.go.
+	errs = append(errs, checkComponentProperties(c)...)
+
 	// Request property shape (SEP-0005); see validate_request.go.
 	errs = append(errs, checkRequestProperties(c)...)
 

--- a/go/sightmap/validate_component.go
+++ b/go/sightmap/validate_component.go
@@ -1,0 +1,91 @@
+package sightmap
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	// propertyNameRe is the schema pattern for a property name.
+	propertyNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	// pathSegmentRe is a component-name segment inside a PATH reference. It is
+	// intentionally identifier-ish so an old CSS sub-selector (brackets, spaces,
+	// '#', ':', '=', …) is rejected rather than mistaken for a path.
+	pathSegmentRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+)
+
+// checkComponentProperties validates every component's properties[] (SEP-0010):
+// names must be unique within a component, and each extract directive must be one
+// of the four forms text | attr=NAME | PATH.prop | exists:PATH. Anything else —
+// the removed DOM modes (inner_text, text_only, inner_html), a bare CSS
+// sub-selector, or a mistyped attr/exists prefix — is an error.
+func checkComponentProperties(c *Corpus) []ValidationError {
+	var errs []ValidationError
+	for _, comp := range c.AllComponents() {
+		seen := make(map[string]bool, len(comp.Properties))
+		for _, p := range comp.Properties {
+			if p.Name != "" {
+				if seen[p.Name] {
+					errs = append(errs, ValidationError{
+						Component: comp.Name,
+						Code:      "component-property-duplicate",
+						Severity:  SeverityError,
+						Message:   fmt.Sprintf("component %q declares property %q more than once", comp.Name, p.Name),
+					})
+				}
+				seen[p.Name] = true
+			}
+			if msg := checkExtractMode(p.Extract); msg != "" {
+				errs = append(errs, ValidationError{
+					Component: comp.Name,
+					Code:      "component-property-extract-invalid",
+					Severity:  SeverityError,
+					Message:   fmt.Sprintf("component %q property %q: %s", comp.Name, p.Name, msg),
+				})
+			}
+		}
+	}
+	return errs
+}
+
+// checkExtractMode returns "" when extract is a valid SEP-0010 directive, else a
+// human-readable reason it is rejected.
+func checkExtractMode(extract string) string {
+	switch {
+	case extract == "text":
+		return ""
+	case strings.HasPrefix(extract, "attr="):
+		if extract == "attr=" {
+			return "attr= requires an attribute name"
+		}
+		return ""
+	case strings.HasPrefix(extract, "exists:"):
+		return checkComponentPath(strings.TrimPrefix(extract, "exists:"))
+	default: // PATH.prop
+		dot := strings.LastIndex(extract, ".")
+		if dot <= 0 || dot == len(extract)-1 {
+			return fmt.Sprintf("unrecognized extract mode %q (expected text, attr=NAME, PATH.prop, or exists:PATH)", extract)
+		}
+		if msg := checkComponentPath(extract[:dot]); msg != "" {
+			return msg
+		}
+		if prop := extract[dot+1:]; !propertyNameRe.MatchString(prop) {
+			return fmt.Sprintf("invalid referenced property name %q in %q", prop, extract)
+		}
+		return ""
+	}
+}
+
+// checkComponentPath validates a dotted path of component names.
+func checkComponentPath(path string) string {
+	if path == "" {
+		return "empty component path"
+	}
+	for _, seg := range strings.Split(path, ".") {
+		if !pathSegmentRe.MatchString(seg) {
+			return fmt.Sprintf("invalid component name %q in path %q", seg, path)
+		}
+	}
+	return ""
+}

--- a/go/sightmap/validate_component_test.go
+++ b/go/sightmap/validate_component_test.go
@@ -1,0 +1,63 @@
+package sightmap
+
+import "testing"
+
+func compCorpus(props ...ComponentPropertyDef) *Corpus {
+	return &Corpus{
+		GlobalComponents: []ComponentDef{
+			{Name: "Card", Selectors: []string{".card"}, Properties: props},
+		},
+	}
+}
+
+func codesFor(errs []ValidationError) map[string]int {
+	m := map[string]int{}
+	for _, e := range errs {
+		m[e.Code]++
+	}
+	return m
+}
+
+func TestCheckComponentProperties_ValidForms(t *testing.T) {
+	c := compCorpus(
+		ComponentPropertyDef{Name: "label", Extract: "text"},
+		ComponentPropertyDef{Name: "href", Extract: "attr=href"},
+		ComponentPropertyDef{Name: "price", Extract: "Price.text"},
+		ComponentPropertyDef{Name: "sold_out", Extract: "exists:SoldOutBadge"},
+		ComponentPropertyDef{Name: "amount", Extract: "Row.Price.amount"},
+	)
+	if errs := checkComponentProperties(c); len(errs) != 0 {
+		t.Fatalf("valid forms must not error, got %v", errs)
+	}
+}
+
+func TestCheckComponentProperties_DuplicateName(t *testing.T) {
+	c := compCorpus(
+		ComponentPropertyDef{Name: "price", Extract: "text"},
+		ComponentPropertyDef{Name: "price", Extract: "attr=data-price"},
+	)
+	if n := codesFor(checkComponentProperties(c))["component-property-duplicate"]; n != 1 {
+		t.Fatalf("expected 1 duplicate-name error, got %d (%v)", n, checkComponentProperties(c))
+	}
+}
+
+func TestCheckComponentProperties_RejectsRemovedAndMalformed(t *testing.T) {
+	bad := []string{
+		"inner_text",      // removed DOM mode
+		"text_only",       // removed DOM mode
+		"inner_html",      // removed DOM mode
+		".price",          // bare CSS sub-selector (empty leading segment)
+		"[data-testid=x]", // bare CSS selector
+		"attr",            // mistyped attr (missing =)
+		"attr=",           // attr with no name
+		"exists",          // mistyped exists (missing :)
+		"exists:",         // exists with empty path
+		"Price.",          // path with empty prop
+	}
+	for _, extract := range bad {
+		c := compCorpus(ComponentPropertyDef{Name: "x", Extract: extract})
+		if n := codesFor(checkComponentProperties(c))["component-property-extract-invalid"]; n != 1 {
+			t.Errorf("extract %q: expected 1 extract-invalid error, got %d", extract, n)
+		}
+	}
+}

--- a/go/sightmap/validate_component_test.go
+++ b/go/sightmap/validate_component_test.go
@@ -18,46 +18,93 @@ func codesFor(errs []ValidationError) map[string]int {
 	return m
 }
 
-func TestCheckComponentProperties_ValidForms(t *testing.T) {
-	c := compCorpus(
-		ComponentPropertyDef{Name: "label", Extract: "text"},
-		ComponentPropertyDef{Name: "href", Extract: "attr=href"},
-		ComponentPropertyDef{Name: "price", Extract: "Price.text"},
-		ComponentPropertyDef{Name: "sold_out", Extract: "exists:SoldOutBadge"},
-		ComponentPropertyDef{Name: "amount", Extract: "Row.Price.amount"},
-	)
-	if errs := checkComponentProperties(c); len(errs) != 0 {
-		t.Fatalf("valid forms must not error, got %v", errs)
+func TestCheckComponentProperties(t *testing.T) {
+	tests := []struct {
+		name  string
+		props []ComponentPropertyDef
+		want  map[string]int // error code -> count; nil means no errors
+	}{
+		{
+			name: "valid forms",
+			props: []ComponentPropertyDef{
+				{Name: "label", Extract: "text"},
+				{Name: "href", Extract: "attr=href"},
+				{Name: "price", Extract: "Price.text"},
+				{Name: "sold_out", Extract: "exists:SoldOutBadge"},
+				{Name: "amount", Extract: "Row.Price.amount"},
+			},
+		},
+		{
+			name: "duplicate name",
+			props: []ComponentPropertyDef{
+				{Name: "price", Extract: "text"},
+				{Name: "price", Extract: "attr=data-price"},
+			},
+			want: map[string]int{"component-property-duplicate": 1},
+		},
+		{
+			name:  "removed DOM mode: inner_text",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "inner_text"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "removed DOM mode: text_only",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "text_only"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "removed DOM mode: inner_html",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "inner_html"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "bare CSS sub-selector",
+			props: []ComponentPropertyDef{{Name: "x", Extract: ".price"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "bare CSS selector",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "[data-testid=x]"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "mistyped attr (missing =)",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "attr"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "attr with no name",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "attr="}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "mistyped exists (missing :)",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "exists"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "exists with empty path",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "exists:"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "path with empty prop",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "Price."}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
 	}
-}
 
-func TestCheckComponentProperties_DuplicateName(t *testing.T) {
-	c := compCorpus(
-		ComponentPropertyDef{Name: "price", Extract: "text"},
-		ComponentPropertyDef{Name: "price", Extract: "attr=data-price"},
-	)
-	if n := codesFor(checkComponentProperties(c))["component-property-duplicate"]; n != 1 {
-		t.Fatalf("expected 1 duplicate-name error, got %d (%v)", n, checkComponentProperties(c))
-	}
-}
-
-func TestCheckComponentProperties_RejectsRemovedAndMalformed(t *testing.T) {
-	bad := []string{
-		"inner_text",      // removed DOM mode
-		"text_only",       // removed DOM mode
-		"inner_html",      // removed DOM mode
-		".price",          // bare CSS sub-selector (empty leading segment)
-		"[data-testid=x]", // bare CSS selector
-		"attr",            // mistyped attr (missing =)
-		"attr=",           // attr with no name
-		"exists",          // mistyped exists (missing :)
-		"exists:",         // exists with empty path
-		"Price.",          // path with empty prop
-	}
-	for _, extract := range bad {
-		c := compCorpus(ComponentPropertyDef{Name: "x", Extract: extract})
-		if n := codesFor(checkComponentProperties(c))["component-property-extract-invalid"]; n != 1 {
-			t.Errorf("extract %q: expected 1 extract-invalid error, got %d", extract, n)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := codesFor(checkComponentProperties(compCorpus(tt.props...)))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got error codes %v, want %v", got, tt.want)
+			}
+			for code, wantCount := range tt.want {
+				if got[code] != wantCount {
+					t.Errorf("code %q: got %d, want %d", code, got[code], wantCount)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Library implementation of **SEP-0010** — the offline component-property evaluation half, which resolves issue #282: a consumer holding a matched, serialized component tree (no browser) now gets property values directly. This is the piece FS/lidar pulls back to finish the component-properties arc.

## What changed

- **Offline extractor (`go/match/component_props.go`).** `Matcher.Match` now populates each `ComponentMatch.Properties` by resolving the component's `extract` directives over the matched tree:
  - `text` → the node's accessible name
  - `attr=NAME` → the node's carried attribute
  - `PATH.prop` → the resolved property of a descendant matched component (first-in-document-order per segment)
  - `exists:PATH` → `"true"` if the descendant component matched, else omitted
  Resolution is descend-only (a DAG, so recursion always terminates) and requires **no live DOM**. Unresolved values are dropped silently.
- **Precise def per match.** `MatchQuery` now carries `Def *ComponentDef`, so names/tags/properties come from the exact matched definition. Component names are unique only per parent, so the old `byName[q.Name]` lookups collided — those are removed from both `Match` and `NamesForChain`.
- **`transform` removed from component properties** — dropped from `ComponentPropertyDef`, the raw loader type, `unknownfields`, and `stats`.
- **Validation (`checkComponentProperties`)** — duplicate property names within a component, and unrecognized/removed extract modes (`inner_text`/`text_only`/`inner_html`, bare CSS, mistyped `attr`/`exists`), are now errors.

## Verified

- New tests: `component_props_test.go` (all four forms, silent omission, multi-match first-in-document-order, nested `Price.Amount.text`) and `validate_component_test.go` (valid forms, duplicate names, and each removed/malformed mode).
- `go test ./...`, `gofmt -l`, `go vet` all clean.

## Interim note

The live-DOM extractor (`observe.ExtractProperties` / `properties.js`) still runs on the `snapshot`/browser path and would overwrite these offline values; it does not understand the new `PATH.prop`/`exists:PATH` grammar. Retiring it (and removing the remaining `transform` plumbing from request/message properties) is the next PR in the herd. The offline `Match` path — the one #282 is about — is correct and complete here.

Changeset: `minor` (pre-1.0; new offline resolution + breaking removal of component `transform`).
