### PR TITLE
match: drop unreachable self-check, table-drive component-property tests

### DIFF
--- a/go/match/component_props.go
+++ b/go/match/component_props.go
@@ -12,9 +12,9 @@ import (
 // DOM. It runs after all matches are collected, so PATH.prop / exists:PATH can
 // see sibling and descendant matches.
 //
-// A property is dropped silently when it does not resolve (empty text, an
+// A property is dropped silently when it does not resolve: empty text, an
 // attribute the node does not carry, or a PATH that matches no descendant
-// component), matching the spec's silent-omission rule.
+// component.
 func resolveComponentProperties(
 	result map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
 	defByNode map[*sightmap.ComponentNode]*sightmap.ComponentDef,
@@ -100,9 +100,6 @@ func resolvePath(
 			return nil
 		}
 		cur = next
-	}
-	if cur == node {
-		return nil // empty path resolves to self, which is not a descendant
 	}
 	return cur
 }

--- a/go/match/component_props_test.go
+++ b/go/match/component_props_test.go
@@ -50,7 +50,7 @@ func propVal(cm *sightmap.ComponentMatch, name string) (string, bool) {
 	return pv.Value, ok
 }
 
-func TestResolveComponentProperties_AllForms(t *testing.T) {
+func TestResolveComponentProperties(t *testing.T) {
 	price := &sightmap.ComponentNode{Id: "price", Name: "$42.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
 	badge := &sightmap.ComponentNode{Id: "badge", Name: "Sold Out", Element: &sightmap.Element{Tag: "span", Classes: []string{"sold-out"}}}
 	link := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a", Attrs: map[string]string{"href": "/p/1"}}}
@@ -61,79 +61,27 @@ func TestResolveComponentProperties_AllForms(t *testing.T) {
 		Children: []*sightmap.ComponentNode{price, badge, link},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
-
-	// Local text on the card itself.
-	if v, ok := propVal(res[card], "label"); !ok || v != "Product X" {
-		t.Errorf("label = %q, %v; want \"Product X\", true", v, ok)
-	}
-	// PATH.prop into the Price child's own text.
-	if v, ok := propVal(res[card], "price"); !ok || v != "$42.00" {
-		t.Errorf("price = %q, %v; want \"$42.00\", true", v, ok)
-	}
-	// exists:PATH — the SoldOutBadge is present.
-	if v, ok := propVal(res[card], "sold_out"); !ok || v != "true" {
-		t.Errorf("sold_out = %q, %v; want \"true\", true", v, ok)
-	}
-	// attr= on the Link child.
-	if v, ok := propVal(res[link], "href"); !ok || v != "/p/1" {
-		t.Errorf("href = %q, %v; want \"/p/1\", true", v, ok)
-	}
-	// The Price child carries its own resolved text.
-	if v, ok := propVal(res[price], "text"); !ok || v != "$42.00" {
-		t.Errorf("Price.text = %q, %v; want \"$42.00\", true", v, ok)
-	}
-}
-
-func TestResolveComponentProperties_SilentOmission(t *testing.T) {
-	// A card with no SoldOutBadge and no Price, and a link with no href.
-	link := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a"}}
-	card := &sightmap.ComponentNode{
+	noHrefLink := &sightmap.ComponentNode{Id: "link", Name: "Buy", Element: &sightmap.Element{Tag: "a"}}
+	emptyCard := &sightmap.ComponentNode{
 		Id:       "card",
 		Name:     "", // empty accessible name → label omitted
 		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
-		Children: []*sightmap.ComponentNode{link},
+		Children: []*sightmap.ComponentNode{noHrefLink},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
-
-	if _, ok := propVal(res[card], "label"); ok {
-		t.Error("label should be omitted when accessible name is empty")
-	}
-	if _, ok := propVal(res[card], "price"); ok {
-		t.Error("price should be omitted when there is no Price descendant")
-	}
-	if _, ok := propVal(res[card], "sold_out"); ok {
-		t.Error("sold_out should be omitted when SoldOutBadge is absent")
-	}
-	if _, ok := propVal(res[link], "href"); ok {
-		t.Error("href should be omitted when the attribute is not carried")
-	}
-}
-
-func TestResolveComponentProperties_MultiMatchFirstInDocumentOrder(t *testing.T) {
 	price1 := &sightmap.ComponentNode{Id: "p1", Name: "$10.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
 	price2 := &sightmap.ComponentNode{Id: "p2", Name: "$20.00", Element: &sightmap.Element{Tag: "span", Attrs: map[string]string{"data-testid": "price"}}}
-	card := &sightmap.ComponentNode{
+	multiCard := &sightmap.ComponentNode{
 		Id:       "card",
 		Name:     "Product X",
 		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
 		Children: []*sightmap.ComponentNode{price1, price2},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: productCardDefs()}).Match(card, "")
-
-	if v, ok := propVal(res[card], "price"); !ok || v != "$10.00" {
-		t.Errorf("price = %q, %v; want first-in-document-order \"$10.00\", true", v, ok)
-	}
-}
-
-func TestResolveComponentProperties_NestedPath(t *testing.T) {
 	amount := &sightmap.ComponentNode{Id: "amt", Name: "$5.00", Element: &sightmap.Element{Tag: "b", Attrs: map[string]string{"data-testid": "amount"}}}
 	pricebox := &sightmap.ComponentNode{Id: "pb", Element: &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "price"}}, Children: []*sightmap.ComponentNode{amount}}
 	row := &sightmap.ComponentNode{Id: "row", Element: &sightmap.Element{Tag: "li", Attrs: map[string]string{"data-testid": "row"}}, Children: []*sightmap.ComponentNode{pricebox}}
-
-	defs := []sightmap.ComponentDef{
+	nestedDefs := []sightmap.ComponentDef{
 		{
 			Name:       "Row",
 			Selectors:  []string{"[data-testid=row]"},
@@ -143,8 +91,68 @@ func TestResolveComponentProperties_NestedPath(t *testing.T) {
 		{Name: "Amount", Selectors: []string{"[data-testid=row] [data-testid=price] [data-testid=amount]"}, ParentChain: []string{"Row", "Price"}, Properties: []sightmap.ComponentPropertyDef{{Name: "text", Extract: "text"}}},
 	}
 
-	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs}).Match(row, "")
-	if v, ok := propVal(res[row], "amount"); !ok || v != "$5.00" {
-		t.Errorf("amount (Price.Amount.text) = %q, %v; want \"$5.00\", true", v, ok)
+	type check struct {
+		node *sightmap.ComponentNode
+		prop string
+		want string
+		ok   bool
+	}
+	tests := []struct {
+		name   string
+		defs   []sightmap.ComponentDef
+		root   *sightmap.ComponentNode
+		checks []check
+	}{
+		{
+			name: "all extract forms",
+			defs: productCardDefs(),
+			root: card,
+			checks: []check{
+				{card, "label", "Product X", true}, // local text
+				{card, "price", "$42.00", true},    // PATH.prop into Price child's text
+				{card, "sold_out", "true", true},   // exists:PATH — SoldOutBadge present
+				{link, "href", "/p/1", true},       // attr= on Link child
+				{price, "text", "$42.00", true},    // Price child carries its own resolved text
+			},
+		},
+		{
+			name: "silent omission",
+			defs: productCardDefs(),
+			root: emptyCard,
+			checks: []check{
+				{emptyCard, "label", "", false},    // empty accessible name
+				{emptyCard, "price", "", false},    // no Price descendant
+				{emptyCard, "sold_out", "", false}, // SoldOutBadge absent
+				{noHrefLink, "href", "", false},    // attribute not carried
+			},
+		},
+		{
+			name: "multi-match resolves first in document order",
+			defs: productCardDefs(),
+			root: multiCard,
+			checks: []check{
+				{multiCard, "price", "$10.00", true},
+			},
+		},
+		{
+			name: "nested PATH.prop",
+			defs: nestedDefs,
+			root: row,
+			checks: []check{
+				{row, "amount", "$5.00", true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: tt.defs}).Match(tt.root, "")
+			for _, c := range tt.checks {
+				v, ok := propVal(res[c.node], c.prop)
+				if ok != c.ok || v != c.want {
+					t.Errorf("%s = %q, %v; want %q, %v", c.prop, v, ok, c.want, c.ok)
+				}
+			}
+		})
 	}
 }

--- a/go/sightmap/validate_component_test.go
+++ b/go/sightmap/validate_component_test.go
@@ -18,46 +18,93 @@ func codesFor(errs []ValidationError) map[string]int {
 	return m
 }
 
-func TestCheckComponentProperties_ValidForms(t *testing.T) {
-	c := compCorpus(
-		ComponentPropertyDef{Name: "label", Extract: "text"},
-		ComponentPropertyDef{Name: "href", Extract: "attr=href"},
-		ComponentPropertyDef{Name: "price", Extract: "Price.text"},
-		ComponentPropertyDef{Name: "sold_out", Extract: "exists:SoldOutBadge"},
-		ComponentPropertyDef{Name: "amount", Extract: "Row.Price.amount"},
-	)
-	if errs := checkComponentProperties(c); len(errs) != 0 {
-		t.Fatalf("valid forms must not error, got %v", errs)
+func TestCheckComponentProperties(t *testing.T) {
+	tests := []struct {
+		name  string
+		props []ComponentPropertyDef
+		want  map[string]int // error code -> count; nil means no errors
+	}{
+		{
+			name: "valid forms",
+			props: []ComponentPropertyDef{
+				{Name: "label", Extract: "text"},
+				{Name: "href", Extract: "attr=href"},
+				{Name: "price", Extract: "Price.text"},
+				{Name: "sold_out", Extract: "exists:SoldOutBadge"},
+				{Name: "amount", Extract: "Row.Price.amount"},
+			},
+		},
+		{
+			name: "duplicate name",
+			props: []ComponentPropertyDef{
+				{Name: "price", Extract: "text"},
+				{Name: "price", Extract: "attr=data-price"},
+			},
+			want: map[string]int{"component-property-duplicate": 1},
+		},
+		{
+			name:  "removed DOM mode: inner_text",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "inner_text"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "removed DOM mode: text_only",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "text_only"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "removed DOM mode: inner_html",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "inner_html"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "bare CSS sub-selector",
+			props: []ComponentPropertyDef{{Name: "x", Extract: ".price"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "bare CSS selector",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "[data-testid=x]"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "mistyped attr (missing =)",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "attr"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "attr with no name",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "attr="}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "mistyped exists (missing :)",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "exists"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "exists with empty path",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "exists:"}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
+		{
+			name:  "path with empty prop",
+			props: []ComponentPropertyDef{{Name: "x", Extract: "Price."}},
+			want:  map[string]int{"component-property-extract-invalid": 1},
+		},
 	}
-}
 
-func TestCheckComponentProperties_DuplicateName(t *testing.T) {
-	c := compCorpus(
-		ComponentPropertyDef{Name: "price", Extract: "text"},
-		ComponentPropertyDef{Name: "price", Extract: "attr=data-price"},
-	)
-	if n := codesFor(checkComponentProperties(c))["component-property-duplicate"]; n != 1 {
-		t.Fatalf("expected 1 duplicate-name error, got %d (%v)", n, checkComponentProperties(c))
-	}
-}
-
-func TestCheckComponentProperties_RejectsRemovedAndMalformed(t *testing.T) {
-	bad := []string{
-		"inner_text",      // removed DOM mode
-		"text_only",       // removed DOM mode
-		"inner_html",      // removed DOM mode
-		".price",          // bare CSS sub-selector (empty leading segment)
-		"[data-testid=x]", // bare CSS selector
-		"attr",            // mistyped attr (missing =)
-		"attr=",           // attr with no name
-		"exists",          // mistyped exists (missing :)
-		"exists:",         // exists with empty path
-		"Price.",          // path with empty prop
-	}
-	for _, extract := range bad {
-		c := compCorpus(ComponentPropertyDef{Name: "x", Extract: extract})
-		if n := codesFor(checkComponentProperties(c))["component-property-extract-invalid"]; n != 1 {
-			t.Errorf("extract %q: expected 1 extract-invalid error, got %d", extract, n)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := codesFor(checkComponentProperties(compCorpus(tt.props...)))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got error codes %v, want %v", got, tt.want)
+			}
+			for code, wantCount := range tt.want {
+				if got[code] != wantCount {
+					t.Errorf("code %q: got %d, want %d", code, got[code], wantCount)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
`resolvePath` can never return the node it was handed — `firstDescendantNamed` only searches `root.Children` downward — so the trailing `cur == node` self-check was dead code carrying a comment that described a case which cannot occur.

The four `TestResolveComponentProperties_*` and three `TestCheckComponentProperties_*` functions collapse into one table-driven test each, matching the convention already used in `class_selectors_test.go` and `hooks_test.go`.

Based on #286.