### PR TITLE
skill: rewrite authoring property guidance for SEP-0010

### DIFF
--- a/.changeset/sep-0010-skill.md
+++ b/.changeset/sep-0010-skill.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Update the `sightmap-authoring` skill for SEP-0010: component `properties[]` now document the four tree-closed extract forms (`text`, `attr=NAME`, `PATH.prop`, `exists:PATH`) and the promote-a-sub-element-to-a-child-component pattern. Removed the DOM-shaped modes (`inner_text`/`text_only`/`inner_html`/raw CSS sub-selectors) and all `transform` guidance (including the request-properties `transform` reference).

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -152,18 +152,14 @@ Sibling combinators (`+`, `~`) are NOT supported, including inside `:has()`.
 `:has()` scopes a component to a container by what it *contains* — invaluable
 when a row has no unique attribute of its own. Combinators inside work: `:has(x)`
 = descendant, `:has(> x)` = direct child. Example — target only the add-on row
-that holds a checkbox (not the sibling radio row), so its `text` frames the whole
-offer and feeds a `match:` split:
+that holds a checkbox (not the sibling radio row), so its `text` captures the
+whole offer:
 ```yaml
 - name: AssemblyOption
   selector: '[data-testid="form-group"]:has(input[type="checkbox"])'
   properties:
-    - name: assemblyType        # In-Store | In-Home
+    - name: label               # the whole offer, e.g. "In-Home Assembly $179.00"
       extract: text
-      transform: 'match:(In-Store|In-Home)'
-    - name: price               # FREE | $179.00
-      extract: text
-      transform: 'match:(FREE|\$[\d,.]+)'
 ```
 Always `sel-probe`/`sel-check` first — `:has()` now agrees across the live and
 offline matchers.
@@ -382,48 +378,43 @@ Two property rules are **mandatory**:
   selector: 'article.card'
   properties:
     - name: title
-      extract: '.card__title'
+      extract: attr=aria-label
 ```
 
-**Choosing an extract mode:**
+**Extract modes** — exactly one of four forms:
 
-| Mode | Use when |
-|------|----------|
-| `text` | Default for most cases |
-| `inner_text` | Adjacent inline elements concatenate without spaces (date+time+venue) |
-| `text_only` | Image alt text bleeds into the label (icon+text buttons) |
-| `attr=NAME` | Need a specific attribute (aria-label, href, data-value) |
-| `exists:SEL` | Boolean state flag — emits "true" or omits entirely |
-| CSS selector | `el.querySelector(SEL)?.textContent` for a specific child element |
+| Mode | Resolves to |
+|------|-------------|
+| `text` | the matched node's accessible text (the default) |
+| `attr=NAME` | the value of attribute `NAME` on the matched node |
+| `Child.prop` | the extracted `prop` of a descendant *component* `Child` |
+| `exists:Child` | `"true"` if descendant component `Child` matched, else omitted (a boolean flag) |
 
-**Transforms** (post-extract): `first_word`, `last_word`, `first_number`,
-`first_dollar`, `number`, `slug`, `match:REGEX`.
-
-`match:REGEX` captures an arbitrary substring or enum from the extracted value.
-If the pattern has a capture group, the value is **group 1**; otherwise the full
-match. On no match (or an invalid pattern) the value passes through unchanged.
-Use it to split one concatenated label into several structured, queryable props
-(which is also what the component-query DSL matches on):
+Extraction is **tree-closed**: `text` and `attr=` read the matched node itself;
+`Child.prop` and `exists:Child` reference a component nested beneath it. A path
+may descend through several declared children (`Row.Price.amount`), taking the
+first match at each step. There is no raw-CSS sub-selector and no text-splitting
+transform — to surface a value from a sub-element, **promote it to a child
+component** and reference it. This is also how you disambiguate a repeated
+identical leaf (rule 2): give the container a discriminator and nest the leaf.
 
 ```yaml
-# "Add In-Store Assembly / FREE"  vs  "Add In-Home Assembly / +$179.00"
-- name: AssemblyCheckbox
-  selector: '[data-testid="assembly-option"]'
+- name: ProductCard
+  selector: 'article.card'
   properties:
-    - name: assemblyType            # → "In-Store" | "In-Home"
-      extract: text
-      transform: 'match:(In-Store|In-Home)'
-    - name: price                   # → "FREE" | "$179.00"
-      extract: text
-      transform: 'match:(FREE|\$[\d,.]+)'
+    - name: title
+      extract: Title.text          # a child component, not a raw CSS sub-selector
+    - name: on_sale
+      extract: exists:SaleBadge    # boolean flag: "true" or omitted
+  children:
+    - name: Title
+      selector: '.card__title'
+      properties:
+        - name: text
+          extract: text
+    - name: SaleBadge
+      selector: '.badge--sale'
 ```
-
-Write patterns in the Go-RE2 ∩ JS-RegExp common subset (alternation, character
-classes, anchors, quantifiers, groups). Avoid inline flags like `(?i)` and
-backreferences — JS rejects them, so the live overlay would silently drop the
-prop while the offline path keeps it. For case-insensitivity use an explicit
-class (`[Ss]tore`) or alternation. Quote the whole `transform:` value in YAML so
-`$`, `|`, and `\` survive.
 
 **Text deduplication (automatic):** If a property value exactly equals the
 accessible name, the accessible name is suppressed from the annotation. Use
@@ -465,7 +456,7 @@ The HTTP status often lies: an endpoint returns `200 OK` while the real outcome
 lives inside the body. A request `properties:` entry pulls a named value out of
 the live request/response so a consumer can reason about it (the SEP-0005 "200 OK
 but the body says declined" case). Each property is resolved
-**source → field → pattern → transform**:
+**source → field → pattern**:
 
 - **`source:`** — which half to read: `rsp.body`, `req.body`, `rsp.headers`, or
   `req.headers`.
@@ -475,7 +466,6 @@ but the body says declined" case). Each property is resolved
 - **`pattern:`** *(optional)* — an RE2 regex refining what `field` resolved (or
   scanning the raw source when `field` is omitted). Capture group 1 is the value
   when present, else the whole match.
-- **`transform:`** *(optional)* — same vocabulary as component properties.
 
 ```yaml
 requests:
@@ -690,14 +680,24 @@ Check `textbox`, `combobox` nodes — if scoped inside a component but unlabeled
 add a named child for them.
 
 **2. Structured data in cards**
-If a property value is a long concatenated string containing date+time+venue
-mixed together, split it:
+If a card mixes several values (date, venue, price) into one blob, promote each
+sub-element to a child component and reference it, rather than reaching in with a
+raw selector:
 ```yaml
-properties:
-  - name: date
-    extract: inner_text
-  - name: venue
-    extract: '[data-testid="venue-name"]'
+- name: EventCard
+  selector: 'article.event'
+  properties:
+    - name: date
+      extract: DateLabel.text
+    - name: venue
+      extract: Venue.text
+  children:
+    - name: DateLabel
+      selector: 'time'
+      properties: [{ name: text, extract: text }]
+    - name: Venue
+      selector: '[data-testid="venue-name"]'
+      properties: [{ name: text, extract: text }]
 ```
 
 **3. T2 triage**

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -152,18 +152,14 @@ Sibling combinators (`+`, `~`) are NOT supported, including inside `:has()`.
 `:has()` scopes a component to a container by what it *contains* — invaluable
 when a row has no unique attribute of its own. Combinators inside work: `:has(x)`
 = descendant, `:has(> x)` = direct child. Example — target only the add-on row
-that holds a checkbox (not the sibling radio row), so its `text` frames the whole
-offer and feeds a `match:` split:
+that holds a checkbox (not the sibling radio row), so its `text` captures the
+whole offer:
 ```yaml
 - name: AssemblyOption
   selector: '[data-testid="form-group"]:has(input[type="checkbox"])'
   properties:
-    - name: assemblyType        # In-Store | In-Home
+    - name: label               # the whole offer, e.g. "In-Home Assembly $179.00"
       extract: text
-      transform: 'match:(In-Store|In-Home)'
-    - name: price               # FREE | $179.00
-      extract: text
-      transform: 'match:(FREE|\$[\d,.]+)'
 ```
 Always `sel-probe`/`sel-check` first — `:has()` now agrees across the live and
 offline matchers.
@@ -382,48 +378,43 @@ Two property rules are **mandatory**:
   selector: 'article.card'
   properties:
     - name: title
-      extract: '.card__title'
+      extract: attr=aria-label
 ```
 
-**Choosing an extract mode:**
+**Extract modes** — exactly one of four forms:
 
-| Mode | Use when |
-|------|----------|
-| `text` | Default for most cases |
-| `inner_text` | Adjacent inline elements concatenate without spaces (date+time+venue) |
-| `text_only` | Image alt text bleeds into the label (icon+text buttons) |
-| `attr=NAME` | Need a specific attribute (aria-label, href, data-value) |
-| `exists:SEL` | Boolean state flag — emits "true" or omits entirely |
-| CSS selector | `el.querySelector(SEL)?.textContent` for a specific child element |
+| Mode | Resolves to |
+|------|-------------|
+| `text` | the matched node's accessible text (the default) |
+| `attr=NAME` | the value of attribute `NAME` on the matched node |
+| `Child.prop` | the extracted `prop` of a descendant *component* `Child` |
+| `exists:Child` | `"true"` if descendant component `Child` matched, else omitted (a boolean flag) |
 
-**Transforms** (post-extract): `first_word`, `last_word`, `first_number`,
-`first_dollar`, `number`, `slug`, `match:REGEX`.
-
-`match:REGEX` captures an arbitrary substring or enum from the extracted value.
-If the pattern has a capture group, the value is **group 1**; otherwise the full
-match. On no match (or an invalid pattern) the value passes through unchanged.
-Use it to split one concatenated label into several structured, queryable props
-(which is also what the component-query DSL matches on):
+Extraction is **tree-closed**: `text` and `attr=` read the matched node itself;
+`Child.prop` and `exists:Child` reference a component nested beneath it. A path
+may descend through several declared children (`Row.Price.amount`), taking the
+first match at each step. There is no raw-CSS sub-selector and no text-splitting
+transform — to surface a value from a sub-element, **promote it to a child
+component** and reference it. This is also how you disambiguate a repeated
+identical leaf (rule 2): give the container a discriminator and nest the leaf.
 
 ```yaml
-# "Add In-Store Assembly / FREE"  vs  "Add In-Home Assembly / +$179.00"
-- name: AssemblyCheckbox
-  selector: '[data-testid="assembly-option"]'
+- name: ProductCard
+  selector: 'article.card'
   properties:
-    - name: assemblyType            # → "In-Store" | "In-Home"
-      extract: text
-      transform: 'match:(In-Store|In-Home)'
-    - name: price                   # → "FREE" | "$179.00"
-      extract: text
-      transform: 'match:(FREE|\$[\d,.]+)'
+    - name: title
+      extract: Title.text          # a child component, not a raw CSS sub-selector
+    - name: on_sale
+      extract: exists:SaleBadge    # boolean flag: "true" or omitted
+  children:
+    - name: Title
+      selector: '.card__title'
+      properties:
+        - name: text
+          extract: text
+    - name: SaleBadge
+      selector: '.badge--sale'
 ```
-
-Write patterns in the Go-RE2 ∩ JS-RegExp common subset (alternation, character
-classes, anchors, quantifiers, groups). Avoid inline flags like `(?i)` and
-backreferences — JS rejects them, so the live overlay would silently drop the
-prop while the offline path keeps it. For case-insensitivity use an explicit
-class (`[Ss]tore`) or alternation. Quote the whole `transform:` value in YAML so
-`$`, `|`, and `\` survive.
 
 **Text deduplication (automatic):** If a property value exactly equals the
 accessible name, the accessible name is suppressed from the annotation. Use
@@ -465,7 +456,7 @@ The HTTP status often lies: an endpoint returns `200 OK` while the real outcome
 lives inside the body. A request `properties:` entry pulls a named value out of
 the live request/response so a consumer can reason about it (the SEP-0005 "200 OK
 but the body says declined" case). Each property is resolved
-**source → field → pattern → transform**:
+**source → field → pattern**:
 
 - **`source:`** — which half to read: `rsp.body`, `req.body`, `rsp.headers`, or
   `req.headers`.
@@ -475,7 +466,6 @@ but the body says declined" case). Each property is resolved
 - **`pattern:`** *(optional)* — an RE2 regex refining what `field` resolved (or
   scanning the raw source when `field` is omitted). Capture group 1 is the value
   when present, else the whole match.
-- **`transform:`** *(optional)* — same vocabulary as component properties.
 
 ```yaml
 requests:
@@ -690,14 +680,24 @@ Check `textbox`, `combobox` nodes — if scoped inside a component but unlabeled
 add a named child for them.
 
 **2. Structured data in cards**
-If a property value is a long concatenated string containing date+time+venue
-mixed together, split it:
+If a card mixes several values (date, venue, price) into one blob, promote each
+sub-element to a child component and reference it, rather than reaching in with a
+raw selector:
 ```yaml
-properties:
-  - name: date
-    extract: inner_text
-  - name: venue
-    extract: '[data-testid="venue-name"]'
+- name: EventCard
+  selector: 'article.event'
+  properties:
+    - name: date
+      extract: DateLabel.text
+    - name: venue
+      extract: Venue.text
+  children:
+    - name: DateLabel
+      selector: 'time'
+      properties: [{ name: text, extract: text }]
+    - name: Venue
+      selector: '[data-testid="venue-name"]'
+      properties: [{ name: text, extract: text }]
 ```
 
 **3. T2 triage**


### PR DESCRIPTION
Rewrites the `sightmap-authoring` skill's component-property guidance for **SEP-0010**. Independent of the library stack (touches only `skills/` + the generated `go/skills/` copy), based on `main`.

## Changes
- **Extract modes** table now lists exactly the four tree-closed forms: `text`, `attr=NAME`, `Child.prop`, `exists:Child`. Removed `inner_text`, `text_only`, `inner_html`, and the raw-CSS-sub-selector row.
- Added the **promote-a-sub-element-to-a-child-component** pattern (with a `ProductCard` → `Title`/`SaleBadge` example) as the way to surface a sub-element value or disambiguate a repeated leaf.
- Removed the **Transforms** subsection entirely (vocabulary + `match:REGEX` + the RE2 guidance) and the `AssemblyCheckbox`/`:has()` transform examples.
- Fixed the "structured data in cards" review-pass example (was `inner_text` + raw CSS) to the child-component pattern.
- Request `properties:` guidance drops the `transform:` bullet and is now `source → field → pattern`.
- Regenerated the embedded `go/skills/sightmap-authoring/SKILL.md` (drift check green).

Changeset: `patch` (user-facing skill content ships in the package).

The `sightmap-browser` skill needed no change — it references "extracted properties" generically and never mentioned transforms or DOM extract modes.
