### PR TITLE
feat(cli): add sightmap webmcp and the authoring skill

### DIFF
--- a/.changeset/sightmap-webmcp.md
+++ b/.changeset/sightmap-webmcp.md
@@ -1,0 +1,8 @@
+---
+"@sightmap/sightmap": minor
+---
+
+WebMCP support: turn a mapped site into agent-callable tools.
+
+- **New `sightmap webmcp` command.** `webmcp init` scaffolds a draft `webmcp.tools.yaml` manifest from the corpus (one read tool per view, one api stub per request), `webmcp validate` compile-checks every component / property / view / request reference the manifest names, and `webmcp generate` emits the snippet, ES-module, and userscript bundles that register the tools on `document.modelContext` (`--check` compares against files you already generated).
+- **New `sightmap-webmcp` skill.** The authoring loop that produces the manifest: walking user-goal trajectories with the browser CLI (component queries, network traces), choosing each tool's kind (api / fetched page read / live flow), folding corpus `memory:` hazards into the tool descriptions agents decide by, and live-verifying every generated tool before publishing. Ships in the plugin, the embedded skills (`sightmap skills install`), and this package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ both websites.
 |---|---|---|
 | `spec/` | Markdown + JSON Schema | Normative specification, SEP process, conformance fixtures. Source of truth. |
 | `go/` | Go | Reference implementation: `sightmap` CLI + `go get`-able library. npm: `@sightmap/sightmap`. |
-| `skills/` | Markdown | Canonical agent skills (`sightmap-authoring`, `sightmap-browser`). Installable as a plugin, embedded in the CLI, and vendored downstream. |
-| `webmcp/` | JS runtime + jsdom tests | Canonical browser runtime for generated WebMCP bundles, plus jsdom tests. Generator library: `go/webmcp/`. |
+| `skills/` | Markdown | Canonical agent skills (`sightmap-authoring`, `sightmap-browser`, `sightmap-webmcp`). Installable as a plugin, embedded in the CLI, and vendored downstream. |
+| `webmcp/` | JS runtime + jsdom tests | Canonical browser runtime for generated WebMCP bundles, plus jsdom tests. Generator: `sightmap webmcp` (`go/webmcp/`). |
 | `docs/` | Mintlify | Documentation site (docs.sightmap.org). |
 | `web/` | React + Vite | Marketing landing page (sightmap.org). |
 
@@ -43,7 +43,8 @@ Never change spec semantics without an SEP (`spec/seps/`).
   (see below) — never hand-edit it.
 
 ### `skills/` (canonical agent skills)
-- The source of truth for the `sightmap-authoring` and `sightmap-browser` skills.
+- The source of truth for the `sightmap-authoring`, `sightmap-browser`, and
+  `sightmap-webmcp` skills.
   Edit the skill Markdown **here**, at the repo root.
 - `go:embed` can't reach outside the `go/` module or follow symlinks, so a copy
   is generated into `go/skills/<name>/` and checked in (the same generate-and-commit
@@ -68,8 +69,8 @@ Never change spec semantics without an SEP (`spec/seps/`).
 
 ### `webmcp/`
 - Canonical browser runtime (`src/runtime/runtime.js`) plus jsdom tests.
-  The generator library is `go/webmcp/` (the `sightmap webmcp` CLI command
-  is a follow-up).
+  The generator is `sightmap webmcp` (`go/webmcp/`). The authoring loop is
+  the `sightmap-webmcp` skill.
 - `go generate ./webmcp/...` (from `go/`) copies the runtime into
   `go/webmcp/runtime.js`, writes `version_gen.go`, and regenerates
   `webmcp/test/fixtures/site/ir.json` for the jsdom tests. CI fails on drift.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ implementation, and both websites in one place:
 |---|---|
 | [`spec/`](spec/) | The **normative** specification — `spec/v1/` schema + JSON Schema, the SEP process (`spec/seps/`), and language-agnostic conformance fixtures. Source of truth. |
 | [`go/`](go/) | The reference **Go implementation** — the `sightmap` CLI (live browser capture, annotated snapshots, coverage) plus a `go get`-able library for the component model and selector matching. Published to npm as [`@sightmap/sightmap`](https://www.npmjs.com/package/@sightmap/sightmap). |
-| [`skills/`](skills/) | The **agent skills** — `sightmap-authoring` and `sightmap-browser`. This is the canonical, standalone skills directory; the CLI embeds a committed copy under `go/skills/` (regenerated via `go generate`). |
+| [`skills/`](skills/) | The **agent skills** — `sightmap-authoring`, `sightmap-browser`, and `sightmap-webmcp`. This is the canonical, standalone skills directory; the CLI embeds a committed copy under `go/skills/` (regenerated via `go generate`). |
+| [`webmcp/`](webmcp/) | Browser runtime, jsdom tests, and example manifests for `sightmap webmcp`. The generator lives in the Go CLI. |
 | [`docs/`](docs/) | The documentation site at [docs.sightmap.org](https://docs.sightmap.org) (Mintlify). |
 | [`web/`](web/) | The marketing landing page at [sightmap.org](https://sightmap.org) (React + Vite). |
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ browser.
 ## Skills & plugin
 
 The [`skills/`](skills/) directory is a first-class, installable skill set for
-coding agents — `sightmap-authoring` (build and maintain a corpus) and
-`sightmap-browser` (drive a live session). It reaches agents three ways, all
+coding agents — `sightmap-authoring` (build and maintain a corpus),
+`sightmap-browser` (drive a live session), and `sightmap-webmcp` (turn a map
+into in-page WebMCP tools). It reaches agents three ways, all
 from the same source:
 
 - **As a plugin** — install this repo like any other (Claude Code:

--- a/docs/cli/integrate.mdx
+++ b/docs/cli/integrate.mdx
@@ -295,10 +295,11 @@ The `properties` entries reflect property extraction (`properties:` on component
 
 ### `sightmap skills install`
 
-Extracts the two agent skills embedded in the binary, each into its own subdirectory of the target directory:
+Extracts the agent skills embedded in the binary, each into its own subdirectory of the target directory:
 
 - **`sightmap-authoring`**: the corpus authoring playbook, including the edit-verify loop, coverage tiers, selector rules, and quality checks.
 - **`sightmap-browser`**: instructions for reading annotated snapshots and interacting with a live browser by component query.
+- **`sightmap-webmcp`**: turn a mapped site into WebMCP tools (`sightmap webmcp`). See [WebMCP](/cli/webmcp).
 
 The default target is `~/.agents/skills/`. The command removes any existing directory for each bundled skill before extracting the new copy.
 
@@ -313,9 +314,10 @@ sightmap skills install
 ```
 
 ```text
-installed 2 sightmap skill(s) → /Users/you/.agents/skills
+installed 3 sightmap skill(s) → /Users/you/.agents/skills
   sightmap-authoring
   sightmap-browser
+  sightmap-webmcp
   version: 0.13.1
 ```
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -45,7 +45,7 @@ Several flags appear in multiple command groups:
 
 ## Exit codes
 
-Commands exit `0` on success and `1` when command execution returns an error. Errors print to stderr as `sightmap <command>: <message>`.
+Commands exit `0` on success and `1` when command execution returns an error. Errors print to stderr as `sightmap <command>: <message>`. `webmcp generate --check` is the exception: it exits **2** when a committed bundle does not match a fresh emit (and writes nothing).
 
 What counts as failure for the check-style commands:
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -92,6 +92,9 @@ A page with no interactive nodes renders the `∅` mark (rather than `✓`/`✗`
   <Card title="Integration" icon="network-wired" href="/cli/integrate">
     Find and install corpora with `atlas`, run the overlay server, and install the bundled agent skills.
   </Card>
+  <Card title="WebMCP" icon="puzzle-piece" href="/cli/webmcp">
+    Generate in-page `document.modelContext` tools from a corpus and a `webmcp.tools.yaml` manifest.
+  </Card>
 </CardGroup>
 
 ---

--- a/docs/cli/webmcp.mdx
+++ b/docs/cli/webmcp.mdx
@@ -1,0 +1,137 @@
+---
+title: "Sightmap CLI: WebMCP Generator Reference"
+sidebarTitle: "WebMCP"
+description: "Generate WebMCP tool bundles (document.modelContext) for any mapped site from its corpus and a small tool manifest — scaffold, validate, and emit publishable snippet, module, and userscript formats."
+---
+
+`sightmap webmcp` turns a corpus into **WebMCP tools** — functions a page
+registers on [`document.modelContext`](https://github.com/webmachinelearning/webmcp)
+so AI agents can call them instead of clicking through the UI. WebMCP assumes
+the site's owner writes those tools; for every site that hasn't, the corpus
+already holds what a good tool needs (verified selectors, per-instance
+properties, view routes, observed API endpoints, hazard memory), and this
+command compiles it into a publishable bundle.
+
+The division of labor: the corpus stays the single source of truth for *how
+to address the site*, and a small hand-authored manifest
+(`webmcp.tools.yaml`) says *which user goals become tools*. The compiler
+resolves every component, property, view, and request the manifest names —
+by name, against the corpus — and fails loudly on anything that doesn't
+resolve. Nothing in a generated bundle is guessed.
+
+| Command | What it does |
+| --- | --- |
+| `sightmap webmcp init` | Scaffold a draft manifest from the corpus: one read tool per view, one API stub per request |
+| `sightmap webmcp validate` | Compile the manifest against the corpus; errors name the unresolved reference and the candidates |
+| `sightmap webmcp generate` | Emit the bundle — snippet, ES module, and userscript formats; `--check` gates drift in CI |
+
+<Note>
+The full authoring loop — walking user-goal trajectories with the [browser
+CLI](/cli/browser), watching `network list` for the request that carries the
+real work, verifying tools in the live session — is the `sightmap-webmcp`
+agent skill (`sightmap skills install`). This page is the command reference.
+</Note>
+
+---
+
+### The manifest
+
+A tool is a user goal ("search products", "what does this item cost"), not a
+page. Each declares its `params` (compiled into a JSON Schema `inputSchema`),
+a `description` the agent decides by, and one of three implementations:
+
+| Kind | Manifest shape | When |
+| --- | --- | --- |
+| API replay | `api:` | One observed endpoint does the whole job. Runs with the page's cookies, so signed-in state comes free; result values extract via the corpus request's `properties:`. |
+| Fetched read | `flow:` + `mode: fetch` | Read-only, and the target page is server-rendered. Fetches the URL with cookies and reads components from the parsed document — no navigation, works from any page. |
+| Live flow | `flow:` | Mutating or same-page interactions: fill, click, wait, read by component identity, gated by `require_view:`. |
+
+The split exists because **a WebMCP tool call dies with the document it runs
+in**. A live flow therefore cannot navigate mid-flow — the generator rejects
+it at compile time — and cross-page journeys become per-page tools the agent
+sequences itself. Component references use the same query DSL as the
+[interaction commands](/cli/interaction) (`Row[label="X"] Buy`), so a query
+verified against the live session transfers into the manifest verbatim.
+
+```yaml
+version: 1
+site: ikea
+base_url: https://www.ikea.com
+tools:
+  - name: search_products
+    description: >
+      Keyword search over the catalog. The summary count is the
+      authoritative total — the grid renders only the first page.
+    mode: fetch
+    view: SearchResults          # scopes component-name resolution
+    params:
+      - { name: query, type: string, required: true, description: Keywords. }
+    flow:
+      - navigate: "/us/en/search/?q={query}"
+      - read:
+          summary: { component: SearchSummary, property: summary }
+          products:
+            for_each: ProductCard
+            fields:
+              text:  { property: card_text }
+              price: { component: CardPrice, property: price_text }
+```
+
+Worked examples live in the sightmap repo under
+[`webmcp/examples/`](https://github.com/sightmap/sightmap/tree/main/webmcp/examples)
+— IKEA and GitHub, each generated from its community-atlas corpus.
+
+### `sightmap webmcp init`
+
+```bash
+sightmap webmcp init --site myshop --base-url https://myshop.example
+```
+
+Reads the corpus and writes a draft `webmcp.tools.yaml`: a fetch-read tool
+for every view that has a representative `url:`, and an API stub for every
+corpus request. Every entry is marked TODO — the draft is where the
+authoring loop starts, not where it ends. Refuses to overwrite an existing
+manifest.
+
+**Flags:** `--site` and `--base-url` (both required), `--sightmap-dir`
+(default `.sightmap`), `--out` (default `webmcp.tools.yaml`).
+
+### `sightmap webmcp validate`
+
+Compiles without writing. Every diagnostic is written to be acted on: an
+ambiguous component name lists its breadcrumb candidates, a missing
+property lists the properties the component does declare, an unknown
+request or view lists the corpus's, and a name defined only per view tells
+you to set the tool's `view:`.
+
+**Flags:** `--tools` (default `webmcp.tools.yaml`), `--sightmap-dir`
+(default: the manifest's `sightmap:` field, else `.sightmap` next to it).
+
+### `sightmap webmcp generate`
+
+```bash
+sightmap webmcp generate --tools webmcp.tools.yaml --format all
+```
+
+Emits up to three files, one per format:
+
+| Format | File | For |
+| --- | --- | --- |
+| `snippet` | `SITE.webmcp.js` | Injection — `sightmap browser eval "$(cat SITE.webmcp.js)"` to verify tools in a live session |
+| `module` | `SITE.webmcp.module.js` | Site owners — `<script type="module">` makes the site itself WebMCP-enabled |
+| `userscript` | `SITE.webmcp.user.js` | Third-party publishing — Tampermonkey/Violentmonkey, `@match` from the manifest |
+
+Every bundle registers its tools with `document.modelContext` where the
+browser provides it, and always installs a `window.__sightmapWebMCP` shim
+(`listTools()`, `callTool()`, `callToolAndStore()` for eval bridges that
+cannot await) — the verification surface, and the fallback in browsers
+without the origin trial.
+
+Output is deterministic: no timestamps, and the banner carries a content
+hash of the corpus, so a committed bundle can be drift-checked. `--check`
+regenerates in memory, compares, exits **2** on drift, and writes nothing.
+Use it in your own CI if you commit generated bundles next to a manifest.
+
+**Flags:** `--tools`, `--sightmap-dir` (as above), `--format`
+(`snippet|module|userscript|all`, default `snippet`), `--out FILE` (single
+format), `--out-dir DIR` (default: the manifest's directory), `--check`.

--- a/docs/cli/webmcp.mdx
+++ b/docs/cli/webmcp.mdx
@@ -81,6 +81,8 @@ Worked examples live in the sightmap repo under
 [`webmcp/examples/`](https://github.com/sightmap/sightmap/tree/main/webmcp/examples)
 — IKEA and GitHub, each generated from its community-atlas corpus.
 
+---
+
 ### `sightmap webmcp init`
 
 ```bash
@@ -89,12 +91,24 @@ sightmap webmcp init --site myshop --base-url https://myshop.example
 
 Reads the corpus and writes a draft `webmcp.tools.yaml`: a fetch-read tool
 for every view that has a representative `url:`, and an API stub for every
-corpus request. Every entry is marked TODO — the draft is where the
+corpus request. Every entry is marked TODO. The draft is where the
 authoring loop starts, not where it ends. Refuses to overwrite an existing
 manifest.
 
-**Flags:** `--site` and `--base-url` (both required), `--sightmap-dir`
-(default `.sightmap`), `--out` (default `webmcp.tools.yaml`).
+**Flags:**
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--site` | (required) | Site slug (`^[a-z0-9][a-z0-9-]*$`) |
+| `--base-url` | (required) | Site origin used to resolve relative URLs |
+| `--sightmap-dir` | `.sightmap` | Corpus to scaffold from |
+| `--out` | `webmcp.tools.yaml` | Manifest path to write |
+
+```text
+wrote webmcp.tools.yaml — a draft; see the sightmap-webmcp skill for the authoring loop
+```
+
+---
 
 ### `sightmap webmcp validate`
 
@@ -104,8 +118,22 @@ property lists the properties the component does declare, an unknown
 request or view lists the corpus's, and a name defined only per view tells
 you to set the tool's `view:`.
 
-**Flags:** `--tools` (default `webmcp.tools.yaml`), `--sightmap-dir`
-(default: the manifest's `sightmap:` field, else `.sightmap` next to it).
+**Flags:**
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--tools` | `webmcp.tools.yaml` | Manifest to compile |
+| `--sightmap-dir` | manifest `sightmap:`, else `.sightmap` next to it | Corpus directory |
+
+```bash
+sightmap webmcp validate --tools webmcp.tools.yaml
+```
+
+```text
+✓ 4 tool(s) compile against 2 corpus file(s): search, search_api, stock, buy_first_match
+```
+
+---
 
 ### `sightmap webmcp generate`
 
@@ -117,21 +145,38 @@ Emits up to three files, one per format:
 
 | Format | File | For |
 | --- | --- | --- |
-| `snippet` | `SITE.webmcp.js` | Injection — `sightmap browser eval "$(cat SITE.webmcp.js)"` to verify tools in a live session |
-| `module` | `SITE.webmcp.module.js` | Site owners — `<script type="module">` makes the site itself WebMCP-enabled |
-| `userscript` | `SITE.webmcp.user.js` | Third-party publishing — Tampermonkey/Violentmonkey, `@match` from the manifest |
+| `snippet` | `SITE.webmcp.js` | Injection. `sightmap browser eval "$(cat SITE.webmcp.js)"` verifies tools in a live session |
+| `module` | `SITE.webmcp.module.js` | Site owners. `<script type="module">` makes the site itself WebMCP-enabled |
+| `userscript` | `SITE.webmcp.user.js` | Third-party publishing. Tampermonkey/Violentmonkey, `@match` from the manifest |
 
 Every bundle registers its tools with `document.modelContext` where the
 browser provides it, and always installs a `window.__sightmapWebMCP` shim
 (`listTools()`, `callTool()`, `callToolAndStore()` for eval bridges that
-cannot await) — the verification surface, and the fallback in browsers
-without the origin trial.
+cannot await). That shim is the verification surface, and the fallback in
+browsers without the origin trial.
 
-Output is deterministic: no timestamps, and the banner carries a content
-hash of the corpus, so a committed bundle can be drift-checked. `--check`
+Output is deterministic. No timestamps. The banner carries a content hash
+of the corpus, so a committed bundle can be drift-checked. `--check`
 regenerates in memory, compares, exits **2** on drift, and writes nothing.
 Use it in your own CI if you commit generated bundles next to a manifest.
 
-**Flags:** `--tools`, `--sightmap-dir` (as above), `--format`
-(`snippet|module|userscript|all`, default `snippet`), `--out FILE` (single
-format), `--out-dir DIR` (default: the manifest's directory), `--check`.
+**Flags:**
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--tools` | `webmcp.tools.yaml` | Manifest to compile |
+| `--sightmap-dir` | manifest `sightmap:`, else `.sightmap` next to it | Corpus directory |
+| `--format` | `snippet` | `snippet`, `module`, `userscript`, or `all` |
+| `--out` | (unset) | Output file. Single format only |
+| `--out-dir` | the manifest's directory | Output directory |
+| `--check` | off | Compare against existing files. Exit 2 on drift. Write nothing |
+
+```text
+wrote fixture.webmcp.js (32651 bytes, 4 tools)
+```
+
+`--check` against a matching file:
+
+```text
+✓ fixture.webmcp.js is up to date
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,7 +96,8 @@
           {
             "group": "Integrations",
             "pages": [
-              "cli/integrate"
+              "cli/integrate",
+              "cli/webmcp"
             ]
           }
         ]

--- a/docs/start/install.mdx
+++ b/docs/start/install.mdx
@@ -24,10 +24,11 @@ Most commands accept `--sightmap-dir <dir>` to point at a corpus outside the cur
 sightmap skills install
 ```
 
-This installs two skills in `~/.agents/skills`. Pass `--target <dir>` to use another directory.
+This installs three skills in `~/.agents/skills`. Pass `--target <dir>` to use another directory.
 
 - **`sightmap-authoring`** builds and maintains a corpus.
 - **`sightmap-browser`** drives a live session using a finished corpus.
+- **`sightmap-webmcp`** turns a mapped site into WebMCP tools. See [WebMCP](/cli/webmcp).
 
 ## The browser
 

--- a/go/cmd/sightmap/cmd_webmcp.go
+++ b/go/cmd/sightmap/cmd_webmcp.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -14,6 +15,10 @@ import (
 
 	"github.com/sightmap/sightmap/go/webmcp"
 )
+
+// errGenerateDrift is returned by `sightmap webmcp generate --check` when a
+// committed bundle does not match a fresh emit. main maps it to exit 2.
+var errGenerateDrift = errors.New("generated output is stale")
 
 var initSiteRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
@@ -139,6 +144,24 @@ func joinNames(names []string) string {
 	return out
 }
 
+// displayPath prefers a path under the working directory so generate/init
+// output is readable and matches the docs samples.
+func displayPath(p string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return p
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return p
+	}
+	return rel
+}
+
 func runWebmcpGenerate(args []string) error {
 	fs := flag.NewFlagSet("webmcp generate", flag.ContinueOnError)
 	tools := fs.String("tools", "webmcp.tools.yaml", "Tool manifest to compile")
@@ -223,10 +246,10 @@ func runWebmcpGenerate(args []string) error {
 		if *check {
 			existing, readErr := os.ReadFile(outFile)
 			if readErr != nil || string(existing) != content {
-				fmt.Fprintf(os.Stderr, "drift: %s is stale — regenerate with sightmap webmcp generate\n", outFile)
+				fmt.Fprintf(os.Stderr, "drift: %s is stale — regenerate with sightmap webmcp generate\n", displayPath(outFile))
 				drift = true
 			} else {
-				fmt.Printf("✓ %s is up to date\n", outFile)
+				fmt.Printf("✓ %s is up to date\n", displayPath(outFile))
 			}
 		} else {
 			if err := os.MkdirAll(filepath.Dir(outFile), 0o755); err != nil {
@@ -235,11 +258,11 @@ func runWebmcpGenerate(args []string) error {
 			if err := os.WriteFile(outFile, []byte(content), 0o644); err != nil {
 				return err
 			}
-			fmt.Printf("wrote %s (%d bytes, %d tools)\n", outFile, len(content), len(webmcp.ToolNames(ir)))
+			fmt.Printf("wrote %s (%d bytes, %d tools)\n", displayPath(outFile), len(content), len(webmcp.ToolNames(ir)))
 		}
 	}
 	if drift {
-		os.Exit(2)
+		return errGenerateDrift
 	}
 	return nil
 }
@@ -291,6 +314,6 @@ func runWebmcpInit(args []string) error {
 	if err := os.WriteFile(outFile, []byte(content), 0o644); err != nil {
 		return err
 	}
-	fmt.Printf("wrote %s — a draft; see the sightmap-webmcp skill for the authoring loop\n", outFile)
+	fmt.Printf("wrote %s — a draft; see the sightmap-webmcp skill for the authoring loop\n", displayPath(outFile))
 	return nil
 }

--- a/go/cmd/sightmap/cmd_webmcp.go
+++ b/go/cmd/sightmap/cmd_webmcp.go
@@ -1,0 +1,296 @@
+// webmcp generates WebMCP tool bundles (document.modelContext) from a
+// sightmap corpus + a webmcp.tools.yaml manifest. The compiler, emitter, and
+// embedded browser runtime live in the webmcp package; this file is flags in,
+// files out.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/sightmap/sightmap/go/webmcp"
+)
+
+var initSiteRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+func runWebmcp(args []string) error {
+	if len(args) == 0 {
+		webmcpUsage()
+		return nil
+	}
+	switch args[0] {
+	case "validate":
+		return runWebmcpValidate(args[1:])
+	case "generate":
+		return runWebmcpGenerate(args[1:])
+	case "init":
+		return runWebmcpInit(args[1:])
+	case "help", "--help", "-h":
+		webmcpUsage()
+		return nil
+	default:
+		webmcpUsage()
+		return fmt.Errorf("unknown subcommand %q", args[0])
+	}
+}
+
+func webmcpUsage() {
+	fmt.Fprint(os.Stderr, `sightmap webmcp — generate WebMCP tools (document.modelContext) from a corpus
+
+  validate [--tools FILE] [--sightmap-dir DIR]
+  generate [--tools FILE] [--sightmap-dir DIR] [--format snippet|module|userscript|all]
+           [--out FILE | --out-dir DIR] [--check]
+  init     --site SLUG --base-url URL [--sightmap-dir DIR] [--out FILE]
+
+The tools manifest defaults to ./webmcp.tools.yaml; the corpus defaults to the
+manifest's "sightmap:" field (relative to the manifest), then to a .sightmap/
+directory next to the manifest. See the sightmap-webmcp skill for the
+authoring loop.
+`)
+}
+
+// resolveWebmcpInputs loads and validates the manifest, then the corpus.
+func resolveWebmcpInputs(toolsFlag, dirFlag string) (toolsFile string, manifest any, corpus *webmcp.Corpus, err error) {
+	toolsFile, err = filepath.Abs(toolsFlag)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if _, statErr := os.Stat(toolsFile); statErr != nil {
+		return "", nil, nil, fmt.Errorf("tools manifest not found: %s (pass --tools, or run \"sightmap webmcp init\" to scaffold one)", toolsFile)
+	}
+	manifest, errs, warns, err := webmcp.LoadManifest(toolsFile)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	for _, w := range warns {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	if len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "error: %s\n", e)
+		}
+		return "", nil, nil, fmt.Errorf("%d manifest error(s)", len(errs))
+	}
+	var sightmapDir string
+	switch {
+	case dirFlag != "":
+		sightmapDir, err = filepath.Abs(dirFlag)
+	case webmcp.ManifestSightmapDir(manifest) != "":
+		sightmapDir = filepath.Join(filepath.Dir(toolsFile), webmcp.ManifestSightmapDir(manifest))
+	default:
+		sightmapDir = filepath.Join(filepath.Dir(toolsFile), ".sightmap")
+	}
+	if err != nil {
+		return "", nil, nil, err
+	}
+	corpus, err = webmcp.LoadCorpus(sightmapDir)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return toolsFile, manifest, corpus, nil
+}
+
+func compileWebmcp(manifest any, corpus *webmcp.Corpus) (*webmcp.OM, error) {
+	ir, errs, warns := webmcp.Compile(corpus, manifest)
+	for _, w := range warns {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	if len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "error: %s\n", e)
+		}
+		return nil, fmt.Errorf("%d compile error(s)", len(errs))
+	}
+	return ir, nil
+}
+
+func runWebmcpValidate(args []string) error {
+	fs := flag.NewFlagSet("webmcp validate", flag.ContinueOnError)
+	tools := fs.String("tools", "webmcp.tools.yaml", "Tool manifest to validate")
+	dir := fs.String("sightmap-dir", "", "Corpus directory (default: manifest's sightmap: field, else .sightmap next to it)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	_, manifest, corpus, err := resolveWebmcpInputs(*tools, *dir)
+	if err != nil {
+		return err
+	}
+	ir, err := compileWebmcp(manifest, corpus)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %d tool(s) compile against %d corpus file(s): %s\n",
+		len(webmcp.ToolNames(ir)), len(corpus.Files), joinNames(webmcp.ToolNames(ir)))
+	return nil
+}
+
+func joinNames(names []string) string {
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += n
+	}
+	return out
+}
+
+func runWebmcpGenerate(args []string) error {
+	fs := flag.NewFlagSet("webmcp generate", flag.ContinueOnError)
+	tools := fs.String("tools", "webmcp.tools.yaml", "Tool manifest to compile")
+	dir := fs.String("sightmap-dir", "", "Corpus directory (default: manifest's sightmap: field, else .sightmap next to it)")
+	format := fs.String("format", "snippet", "Output format: snippet|module|userscript|all")
+	out := fs.String("out", "", "Output file (single format only)")
+	outDir := fs.String("out-dir", "", "Output directory (default: the manifest's directory)")
+	check := fs.Bool("check", false, "Compare against existing output files; exit 2 on drift, write nothing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	toolsFile, manifest, corpus, err := resolveWebmcpInputs(*tools, *dir)
+	if err != nil {
+		return err
+	}
+	ir, err := compileWebmcp(manifest, corpus)
+	if err != nil {
+		return err
+	}
+
+	formats := []string{*format}
+	if *format == "all" {
+		formats = webmcp.Formats
+	}
+	for _, f := range formats {
+		ok := false
+		for _, known := range webmcp.Formats {
+			if f == known {
+				ok = true
+			}
+		}
+		if !ok {
+			return fmt.Errorf("unknown format %q (snippet|module|userscript|all)", f)
+		}
+	}
+	if *out != "" && len(formats) > 1 {
+		return fmt.Errorf("--out only works with a single --format; use --out-dir for several")
+	}
+	if *out != "" && *outDir != "" {
+		return fmt.Errorf("pass --out or --out-dir, not both")
+	}
+	baseDir := filepath.Dir(toolsFile)
+	if *outDir != "" {
+		baseDir, err = filepath.Abs(*outDir)
+		if err != nil {
+			return err
+		}
+	} else if *out != "" {
+		abs, err := filepath.Abs(*out)
+		if err != nil {
+			return err
+		}
+		baseDir = filepath.Dir(abs)
+	}
+
+	hash, err := webmcp.CorpusHash(corpus.Dir, corpus.Files)
+	if err != nil {
+		return err
+	}
+	site := webmcp.SiteOf(ir)
+	drift := false
+	for _, f := range formats {
+		outFile := filepath.Join(baseDir, webmcp.DefaultFileName(site, f))
+		if *out != "" {
+			outFile, _ = filepath.Abs(*out)
+		}
+		manifestRel, _ := filepath.Rel(filepath.Dir(outFile), toolsFile)
+		if manifestRel == "" {
+			manifestRel = filepath.Base(toolsFile)
+		}
+		corpusRel, _ := filepath.Rel(filepath.Dir(outFile), corpus.Dir)
+		content, err := webmcp.Emit(ir, f, webmcp.Provenance{
+			GeneratorVersion: webmcp.GeneratorVersion,
+			Manifest:         manifestRel,
+			Corpus:           corpusRel,
+			CorpusFiles:      len(corpus.Files),
+			CorpusHash:       hash,
+		})
+		if err != nil {
+			return err
+		}
+		if *check {
+			existing, readErr := os.ReadFile(outFile)
+			if readErr != nil || string(existing) != content {
+				fmt.Fprintf(os.Stderr, "drift: %s is stale — regenerate with sightmap webmcp generate\n", outFile)
+				drift = true
+			} else {
+				fmt.Printf("✓ %s is up to date\n", outFile)
+			}
+		} else {
+			if err := os.MkdirAll(filepath.Dir(outFile), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(outFile, []byte(content), 0o644); err != nil {
+				return err
+			}
+			fmt.Printf("wrote %s (%d bytes, %d tools)\n", outFile, len(content), len(webmcp.ToolNames(ir)))
+		}
+	}
+	if drift {
+		os.Exit(2)
+	}
+	return nil
+}
+
+func runWebmcpInit(args []string) error {
+	fs := flag.NewFlagSet("webmcp init", flag.ContinueOnError)
+	site := fs.String("site", "", "Site slug for the manifest (required)")
+	baseURL := fs.String("base-url", "", "Site base URL (required)")
+	dir := fs.String("sightmap-dir", ".sightmap", "Corpus directory to scaffold from")
+	out := fs.String("out", "webmcp.tools.yaml", "Output manifest path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *site == "" || *baseURL == "" {
+		return fmt.Errorf("init needs --site SLUG and --base-url URL")
+	}
+	if !initSiteRe.MatchString(*site) {
+		return fmt.Errorf("--site must be a slug matching ^[a-z0-9][a-z0-9-]*$ (got %q)", *site)
+	}
+	if !strings.HasPrefix(*baseURL, "http://") && !strings.HasPrefix(*baseURL, "https://") {
+		return fmt.Errorf("--base-url must be an absolute http(s) URL (got %q)", *baseURL)
+	}
+	corpus, err := webmcp.LoadCorpus(*dir)
+	if err != nil {
+		return err
+	}
+	outFile, err := filepath.Abs(*out)
+	if err != nil {
+		return err
+	}
+	if _, statErr := os.Stat(outFile); statErr == nil {
+		return fmt.Errorf("%s already exists — delete it first if you meant to re-scaffold", outFile)
+	}
+	absDir, err := filepath.Abs(*dir)
+	if err != nil {
+		return err
+	}
+	sightmapRel, err := filepath.Rel(filepath.Dir(outFile), absDir)
+	if err != nil || sightmapRel == "" {
+		sightmapRel = "."
+	}
+	content, err := webmcp.Scaffold(corpus, *site, *baseURL, sightmapRel)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(outFile), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(outFile, []byte(content), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s — a draft; see the sightmap-webmcp skill for the authoring loop\n", outFile)
+	return nil
+}

--- a/go/cmd/sightmap/cmd_webmcp_test.go
+++ b/go/cmd/sightmap/cmd_webmcp_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,26 @@ func fixtureSiteDir(t *testing.T) string {
 		t.Skip("webmcp fixture not present (not a full repo checkout)")
 	}
 	return dir
+}
+
+func TestDisplayPathPrefersCwdRelative(t *testing.T) {
+	dir := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	abs := filepath.Join(dir, "fixture.webmcp.js")
+	if got := displayPath(abs); got != "fixture.webmcp.js" {
+		t.Fatalf("displayPath(%q) = %q, want fixture.webmcp.js", abs, got)
+	}
+	outside := filepath.Join(filepath.Dir(dir), "elsewhere.js")
+	if got := displayPath(outside); got != outside {
+		t.Fatalf("outside path: got %q, want %q", got, outside)
+	}
 }
 
 func TestWebmcpUnknownSubcommand(t *testing.T) {
@@ -77,6 +98,48 @@ func TestWebmcpGenerateWritesAllFormats(t *testing.T) {
 		if !strings.Contains(string(data), "__smwBoot(__SMW_META, __SMW_TOOLS);") {
 			t.Fatalf("%s does not look like a generated bundle", name)
 		}
+		if !strings.Contains(string(data), "sightmap webmcp generate") {
+			t.Fatalf("%s banner missing shipped CLI", name)
+		}
+	}
+}
+
+func TestWebmcpGenerateCheckFreshAndStale(t *testing.T) {
+	site := fixtureSiteDir(t)
+	out := t.TempDir()
+	args := []string{"generate",
+		"--tools", filepath.Join(site, "webmcp.tools.yaml"),
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+		"--format", "snippet",
+		"--out-dir", out,
+	}
+	if err := runWebmcp(args); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	check := append(args, "--check")
+	if err := runWebmcp(check); err != nil {
+		t.Fatalf("fresh --check: %v", err)
+	}
+	stale := filepath.Join(out, "fixture.webmcp.js")
+	if err := os.WriteFile(stale, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runWebmcp(check)
+	if !errors.Is(err, errGenerateDrift) {
+		t.Fatalf("stale --check err = %v, want errGenerateDrift", err)
+	}
+}
+
+func TestWebmcpGenerateRejectsOutWithAllFormats(t *testing.T) {
+	site := fixtureSiteDir(t)
+	err := runWebmcp([]string{"generate",
+		"--tools", filepath.Join(site, "webmcp.tools.yaml"),
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+		"--format", "all",
+		"--out", filepath.Join(t.TempDir(), "one.js"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--out only works with a single --format") {
+		t.Fatalf("err = %v, want --out vs all", err)
 	}
 }
 

--- a/go/cmd/sightmap/cmd_webmcp_test.go
+++ b/go/cmd/sightmap/cmd_webmcp_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixtureSiteDir returns <repo>/webmcp/test/fixtures/site, skipping when the
+// test runs outside a full repo checkout.
+func fixtureSiteDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", "..", "..", "webmcp", "test", "fixtures", "site"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "webmcp.tools.yaml")); err != nil {
+		t.Skip("webmcp fixture not present (not a full repo checkout)")
+	}
+	return dir
+}
+
+func TestWebmcpUnknownSubcommand(t *testing.T) {
+	if err := runWebmcp([]string{"bogus"}); err == nil || !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("err = %v, want unknown subcommand", err)
+	}
+}
+
+func TestWebmcpValidateFixture(t *testing.T) {
+	site := fixtureSiteDir(t)
+	err := runWebmcp([]string{"validate",
+		"--tools", filepath.Join(site, "webmcp.tools.yaml"),
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+	})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestWebmcpValidateMissingManifest(t *testing.T) {
+	err := runWebmcp([]string{"validate", "--tools", filepath.Join(t.TempDir(), "nope.yaml")})
+	if err == nil || !strings.Contains(err.Error(), "tools manifest not found") {
+		t.Fatalf("err = %v, want manifest-not-found", err)
+	}
+}
+
+func TestWebmcpGenerateRejectsUnknownFormat(t *testing.T) {
+	site := fixtureSiteDir(t)
+	err := runWebmcp([]string{"generate",
+		"--tools", filepath.Join(site, "webmcp.tools.yaml"),
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+		"--format", "wasm",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown format") {
+		t.Fatalf("err = %v, want unknown format", err)
+	}
+}
+
+func TestWebmcpGenerateWritesAllFormats(t *testing.T) {
+	site := fixtureSiteDir(t)
+	out := t.TempDir()
+	err := runWebmcp([]string{"generate",
+		"--tools", filepath.Join(site, "webmcp.tools.yaml"),
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+		"--format", "all",
+		"--out-dir", out,
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	for _, name := range []string{"fixture.webmcp.js", "fixture.webmcp.module.js", "fixture.webmcp.user.js"} {
+		data, err := os.ReadFile(filepath.Join(out, name))
+		if err != nil {
+			t.Fatalf("missing %s: %v", name, err)
+		}
+		if !strings.Contains(string(data), "__smwBoot(__SMW_META, __SMW_TOOLS);") {
+			t.Fatalf("%s does not look like a generated bundle", name)
+		}
+	}
+}
+
+func TestWebmcpInitRoundTrips(t *testing.T) {
+	site := fixtureSiteDir(t)
+	out := filepath.Join(t.TempDir(), "draft.yaml")
+	if err := runWebmcp([]string{"init",
+		"--site", "fixture", "--base-url", "https://shop.example",
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+		"--out", out,
+	}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := runWebmcp([]string{"validate",
+		"--tools", out,
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+	}); err != nil {
+		t.Fatalf("validate of scaffolded draft: %v", err)
+	}
+	// init refuses to overwrite.
+	err := runWebmcp([]string{"init",
+		"--site", "fixture", "--base-url", "https://shop.example",
+		"--sightmap-dir", filepath.Join(site, ".sightmap"),
+		"--out", out,
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("err = %v, want already-exists refusal", err)
+	}
+}

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -90,6 +90,8 @@ func main() {
 		err = runNetwork(args)
 	case "skills":
 		err = runSkills(args)
+	case "webmcp":
+		err = runWebmcp(args)
 	case "version", "--version", "-v":
 		fmt.Printf("sightmap version %s\n", Version)
 	case "help", "--help", "-h":
@@ -153,6 +155,7 @@ Commands:
   atlas add SLUG [--target DIR]                             install a published corpus into .sightmap/
   init     [--sightmap-dir DIR]                             scaffold a schema-correct .sightmap/ corpus
   skills install [--target DIR]                             install sightmap authoring skill to ~/.agents/skills/
+  webmcp init/validate/generate                             WebMCP tools (document.modelContext) from a corpus + manifest
   version                                                    print version and exit
 
 Run 'sightmap <command> --help' for full flag list.

--- a/go/cmd/sightmap/main.go
+++ b/go/cmd/sightmap/main.go
@@ -108,6 +108,11 @@ func main() {
 		if errors.Is(err, flag.ErrHelp) {
 			return
 		}
+		// generate --check already printed per-file drift lines; map to exit 2
+		// without a second generic "sightmap webmcp: …" wrapper.
+		if errors.Is(err, errGenerateDrift) {
+			os.Exit(2)
+		}
 		fmt.Fprintf(os.Stderr, "sightmap %s: %v\n", cmd, err)
 		os.Exit(1)
 	}
@@ -154,7 +159,7 @@ Commands:
   atlas list [--category C] [--limit N] [--json]            browse the community atlas
   atlas add SLUG [--target DIR]                             install a published corpus into .sightmap/
   init     [--sightmap-dir DIR]                             scaffold a schema-correct .sightmap/ corpus
-  skills install [--target DIR]                             install sightmap authoring skill to ~/.agents/skills/
+  skills install [--target DIR]                             install bundled agent skills to ~/.agents/skills/
   webmcp init/validate/generate                             WebMCP tools (document.modelContext) from a corpus + manifest
   version                                                    print version and exit
 

--- a/go/skills/embed.go
+++ b/go/skills/embed.go
@@ -15,5 +15,5 @@ import "embed"
 
 // FS contains the embedded skill directories (one per top-level directory).
 //
-//go:embed sightmap-authoring sightmap-browser
+//go:embed sightmap-authoring sightmap-browser sightmap-webmcp
 var FS embed.FS

--- a/go/skills/sightmap-webmcp/SKILL.md
+++ b/go/skills/sightmap-webmcp/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: sightmap-webmcp
+description: Use when turning a mapped site into WebMCP tools — walking user-goal trajectories with the sightmap browser CLI, authoring a webmcp.tools.yaml manifest against the .sightmap/ corpus, generating a publishable document.modelContext tool bundle, and verifying it in the live session. Activate when the goal is to build, generate, or publish WebMCP tools for a website.
+activation:
+  - building or publishing WebMCP tools for a site
+  - webmcp.tools.yaml present in project
+---
+
+# Sightmap → WebMCP: generate in-page tools for any site
+
+WebMCP lets a page expose **tools** to AI agents via
+`document.modelContext.registerTool({name, description, inputSchema, execute})`
+(W3C Web Machine Learning CG proposal; origin trials live in Chrome 149 and
+Edge 150, supported by ChatGPT Desktop and Brave Leo). Sites that register
+tools let agents act through one reliable call instead of a fragile
+click-path. Almost no third-party site does this yet — but if a site has a
+sightmap corpus, you already hold everything a tool needs: verified
+selectors, per-instance properties, view routes, API endpoints, and the
+hazard lore in `memory:`.
+
+This skill is the loop that turns that corpus into a **generated, publishable
+WebMCP bundle**: map → walk trajectories → author a tool manifest → generate
+→ verify live → publish. The generator is `sightmap webmcp`. Each generated
+bundle registers its tools with `document.modelContext` where available
+**and** always installs `window.__sightmapWebMCP` — a shim with the same
+tools, used for verification below and by non-WebMCP browsers.
+
+```
+.sightmap/ corpus  ──┐
+                     ├─ sightmap webmcp generate ──► site.webmcp.js        (snippet — inject & verify)
+webmcp.tools.yaml  ──┘                              site.webmcp.module.js  (ES module — site owners)
+   (you author this)                                site.webmcp.user.js    (userscript — third-party publish)
+```
+
+## Phase 0: a corpus, and the codegen CLI
+
+- **Corpus**: `sightmap atlas find <domain>` → `atlas add`, or author one with
+  the `sightmap-authoring` skill. Every component/property/request a tool
+  references must exist in the corpus — the manifest names corpus entities,
+  it never contains raw selectors except as a deliberate `css:` escape hatch.
+- **Codegen**: ships in the `sightmap` CLI you already have:
+  `sightmap webmcp <init|validate|generate>`.
+
+## Phase 1: pick tools by walking trajectories
+
+A tool is a **user goal**, not a page. "Search products", "what does this
+item cost", "add to cart" — not "click the third button". For each candidate
+goal, perform the trajectory once with the `sightmap-browser` skill and
+record what the tool will need:
+
+1. **Drive it**: `browser navigate` → `snapshot` → `click`/`fill` by
+   component query → `wait-for`. Every component query you use here
+   transfers verbatim into the manifest (`Row[label="X"] Buy`).
+2. **Watch the network while you do it**: `sightmap network list --type XHR`,
+   then `network get <index>` on anything that carried the real work. If one
+   request does the whole job (a search API, a stock endpoint), the tool
+   should probably call **it** rather than drive the DOM. Corpus `requests:`
+   entries with `properties:` are pre-wired result extractors.
+3. **Note what varied**: the query text, the category id, the article number
+   — those are the tool's `params`. Corpus `memory:` often tells you how
+   params map to URLs ("the article number ends the product slug").
+4. **Note the outcome signal**: a component property that changed, or a
+   response-body field (`{first_action_state=SUCCESS}` style) — that is the
+   tool's read-back / `result:`.
+
+Then choose each tool's kind — this decision is the heart of the manifest:
+
+| Kind                   | When                                                  | Why                                                                                                                                                                                                                                                                                                                                                 |
+| ---------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api`                  | one observed endpoint does the job                    | Most reliable; runs with the page's cookies (first-party auth for free). Cross-subdomain calls need CORS — check with `network get` that the browser itself made the call from this origin.                                                                                                                                                         |
+| `flow` + `mode: fetch` | read-only, and the target page is **server-rendered** | Fetches the URL with cookies, parses it off-screen (DOMParser), reads components — works from any page, never navigates. Verify SSR first: corpus memory often says ("everything here is already in the document"), else `browser eval` a `fetch(url).then(r=>r.text())` and check the markup is there. Client-rendered content is invisible to it. |
+| `flow` (live)          | mutating or same-page interactions                    | Fills/clicks on the live DOM by component identity. **A WebMCP tool call dies with the document**, so a live flow must stay on one page — `navigate` is only legal as the _final_ step, and cross-page journeys must be split into per-page tools gated by `require_view:`.                                                                         |
+
+## Phase 2: author `webmcp.tools.yaml`
+
+Scaffold, then edit: `sightmap webmcp init --site SLUG --base-url URL`
+drafts one fetch-read tool per corpus view and one api stub per corpus
+request — keep what maps to real goals, delete the rest.
+
+```yaml
+version: 1
+site: ikea
+base_url: https://www.ikea.com
+sightmap: .sightmap # path to the corpus, relative to this file
+tools:
+  # description is REQUIRED and load-bearing: fold the relevant memory:
+  # hazards into it — inside a folded scalar a "#" is literal text, so keep
+  # comments out here.
+  - name: search_products # snake_case; the agent-facing tool name
+    description: >
+      Keyword search... The summary count is the authoritative total —
+      the grid renders only the first page.
+    read_only: true
+    mode: fetch
+    view: SearchResults # scopes component-name resolution to a view
+    params:
+      - { name: query, type: string, required: true, description: Keywords. }
+      - {
+          name: max_results,
+          type: integer,
+          default: 20,
+          description: Card cap.,
+        }
+    flow:
+      - navigate: "/us/en/search/?q={query}"
+      - read:
+          summary: { component: SearchSummary, property: summary }
+          products:
+            for_each: ProductCard # every match, scoped fields below
+            max: "{max_results}"
+            fields:
+              text: { property: card_text } # iterated element's prop
+              price: { component: CardPrice, property: price_text } # child
+              url: { selector: a, extract: attr=href } # raw escape hatch
+
+  - name: get_buyback_offers
+    description: Buy-back offers for one article number.
+    params:
+      - {
+          name: article,
+          type: string,
+          required: true,
+          description: Digits only.,
+        }
+    api:
+      request: CircularOffers # corpus request — method + result props inherited
+      url: "https://web-api.ikea.com/circular/circular-asis/offers/articles/{article}"
+```
+
+Semantics that do the heavy lifting:
+
+- **Everything resolves through the corpus.** `component:` values are
+  component names or component queries (`Row[label="{x}"] Buy`, predicates
+  `=`/`^=`/`*=` + ` i`, `#N` index, whitespace descendant — same DSL as the
+  CLI). `property:` pulls the corpus-declared `extract`/`transform`. The
+  compiler errors on anything that doesn't resolve (ambiguous names list
+  their breadcrumb candidates; missing properties list what the component
+  does declare) — fix the manifest or improve the corpus, never paste
+  selectors around the model.
+- **`view:` disambiguates per-view names.** IKEA's `ProductCard` subtree
+  differs on search vs category — its `CardPrice` child resolves to a
+  different selector per view; a tool sets `view: SearchResults` and gets
+  that view's definition (globals stay visible). `require_view:` implies it for live
+  flows and adds the runtime guard: off-view calls return a structured
+  `{error, expected_view, navigate_to}` instead of flailing.
+- **`api` tools inherit the corpus request's `method` and `properties:`** as
+  their result extractors (`source`/`field`/`pattern`/`transform` — the
+  "200 OK but the body says declined" machinery). No `result:` and no
+  request properties → the tool echoes `{status, url, body}` (body capped).
+- **Templates**: `{param}` in URLs (URL-encoded; `{param|raw}` opts out),
+  query/header/body values, predicate values, and `max:`. A JSON body leaf
+  that is exactly `"{param}"` keeps the param's number/boolean type.
+- **Descriptions are the product.** Distill the corpus `memory:` hazards the
+  agent needs ("a bad id silently redirects to the whole catalog — check
+  category_name") into each tool's description. That lore is why a generated
+  tool beats a naive one.
+- Missing reads are **silently omitted** (sightmap's own convention) — say in
+  the description what absence means when it means something.
+
+## Phase 3: generate and verify in the live session
+
+```bash
+sightmap webmcp validate --tools webmcp.tools.yaml
+sightmap webmcp generate --tools webmcp.tools.yaml --format all
+```
+
+Fix every validate error before generating — they are compile-time proof
+that each tool's selectors, properties, views, and params all resolve.
+
+Then prove the tools work where they will run, in the sightmap browser
+session (the shim makes this possible in any Chrome, no origin trial
+needed):
+
+```bash
+sightmap browser start --detach
+sightmap browser navigate 'https://www.ikea.com/us/en/'
+# inject the generated snippet into the page:
+sightmap browser eval "$(cat ikea.webmcp.js)"
+sightmap browser eval '__sightmapWebMCP.listTools().map(t => t.name)'
+# call a tool; the eval bridge can't await, so park the result and poll:
+sightmap browser eval '__sightmapWebMCP.callToolAndStore("search_products", {query: "desk chair"})'
+sightmap browser eval '__sightmapWebMCP.last'          # repeat until done: true
+```
+
+Judge the result like an agent would: is the answer complete, is a failure
+actionable, does an empty result distinguish "none" from "wrong page"?
+Iterate manifest → generate → re-inject until every tool passes on the live
+site. Re-verify mutating tools on a page where mutation is acceptable.
+
+## Phase 4: publish
+
+- **Userscript** (`site.webmcp.user.js`): the third-party path — installable
+  via Tampermonkey/Violentmonkey and publishable (Greasy Fork etc.); it
+  registers the tools on every matching page. `@match` comes from the
+  manifest's `match:` (default: the base_url origin).
+- **ES module** (`site.webmcp.module.js`): hand to the site's owners —
+  `<script type="module" src="...">` makes the site itself WebMCP-enabled,
+  the outcome the proposal actually wants. Suggest it upstream when the site
+  has a public repo or feedback channel.
+- **Snippet** (`site.webmcp.js`): for injection by agent harnesses (as in
+  Phase 3) or extensions.
+- Commit the manifest next to the corpus and check the generated bundles'
+  freshness in CI with `generate --check` (exit 2 on drift). Regenerate
+  whenever the corpus changes — the bundle's banner carries the corpus
+  content hash, so drift is detectable, and the map staying honest is what
+  keeps the tools honest.
+
+## Hard rules
+
+- **Never hand-edit a generated bundle** — edit the manifest or the corpus
+  and regenerate.
+- **Never ship a tool you didn't execute** against the live site in Phase 3.
+- **Component queries in manifests must come from the corpus** (or be
+  explicit `css:` escapes). If a query can't disambiguate an instance, the
+  corpus is missing a property — fix it there (see `sightmap-authoring`,
+  property rules), and every future tool benefits.
+- **Live flows never navigate mid-flow** (the generator rejects it): a
+  WebMCP tool call cannot outlive its document. Split cross-page journeys
+  into per-page tools with `require_view:`; the agent (or the final
+  `navigate` step) moves between pages.
+- **Mark mutating tools** `read_only: false` and say in the description what
+  they mutate — hosts surface `readOnlyHint` to users.
+- **The manifest is trusted input** — its URL templates decide where the
+  page's credentialed fetches go. Review an installed corpus before
+  generating from it, keep api origins fixed (the compiler warns when a
+  template parameterizes the host), and publish userscripts reproducibly:
+  the banner's corpus hash lets anyone regenerate and diff.

--- a/skills/sightmap-webmcp/SKILL.md
+++ b/skills/sightmap-webmcp/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: sightmap-webmcp
+description: Use when turning a mapped site into WebMCP tools — walking user-goal trajectories with the sightmap browser CLI, authoring a webmcp.tools.yaml manifest against the .sightmap/ corpus, generating a publishable document.modelContext tool bundle, and verifying it in the live session. Activate when the goal is to build, generate, or publish WebMCP tools for a website.
+activation:
+  - building or publishing WebMCP tools for a site
+  - webmcp.tools.yaml present in project
+---
+
+# Sightmap → WebMCP: generate in-page tools for any site
+
+WebMCP lets a page expose **tools** to AI agents via
+`document.modelContext.registerTool({name, description, inputSchema, execute})`
+(W3C Web Machine Learning CG proposal; origin trials live in Chrome 149 and
+Edge 150, supported by ChatGPT Desktop and Brave Leo). Sites that register
+tools let agents act through one reliable call instead of a fragile
+click-path. Almost no third-party site does this yet — but if a site has a
+sightmap corpus, you already hold everything a tool needs: verified
+selectors, per-instance properties, view routes, API endpoints, and the
+hazard lore in `memory:`.
+
+This skill is the loop that turns that corpus into a **generated, publishable
+WebMCP bundle**: map → walk trajectories → author a tool manifest → generate
+→ verify live → publish. The generator is `sightmap webmcp`. Each generated
+bundle registers its tools with `document.modelContext` where available
+**and** always installs `window.__sightmapWebMCP` — a shim with the same
+tools, used for verification below and by non-WebMCP browsers.
+
+```
+.sightmap/ corpus  ──┐
+                     ├─ sightmap webmcp generate ──► site.webmcp.js        (snippet — inject & verify)
+webmcp.tools.yaml  ──┘                              site.webmcp.module.js  (ES module — site owners)
+   (you author this)                                site.webmcp.user.js    (userscript — third-party publish)
+```
+
+## Phase 0: a corpus, and the codegen CLI
+
+- **Corpus**: `sightmap atlas find <domain>` → `atlas add`, or author one with
+  the `sightmap-authoring` skill. Every component/property/request a tool
+  references must exist in the corpus — the manifest names corpus entities,
+  it never contains raw selectors except as a deliberate `css:` escape hatch.
+- **Codegen**: ships in the `sightmap` CLI you already have:
+  `sightmap webmcp <init|validate|generate>`.
+
+## Phase 1: pick tools by walking trajectories
+
+A tool is a **user goal**, not a page. "Search products", "what does this
+item cost", "add to cart" — not "click the third button". For each candidate
+goal, perform the trajectory once with the `sightmap-browser` skill and
+record what the tool will need:
+
+1. **Drive it**: `browser navigate` → `snapshot` → `click`/`fill` by
+   component query → `wait-for`. Every component query you use here
+   transfers verbatim into the manifest (`Row[label="X"] Buy`).
+2. **Watch the network while you do it**: `sightmap network list --type XHR`,
+   then `network get <index>` on anything that carried the real work. If one
+   request does the whole job (a search API, a stock endpoint), the tool
+   should probably call **it** rather than drive the DOM. Corpus `requests:`
+   entries with `properties:` are pre-wired result extractors.
+3. **Note what varied**: the query text, the category id, the article number
+   — those are the tool's `params`. Corpus `memory:` often tells you how
+   params map to URLs ("the article number ends the product slug").
+4. **Note the outcome signal**: a component property that changed, or a
+   response-body field (`{first_action_state=SUCCESS}` style) — that is the
+   tool's read-back / `result:`.
+
+Then choose each tool's kind — this decision is the heart of the manifest:
+
+| Kind                   | When                                                  | Why                                                                                                                                                                                                                                                                                                                                                 |
+| ---------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api`                  | one observed endpoint does the job                    | Most reliable; runs with the page's cookies (first-party auth for free). Cross-subdomain calls need CORS — check with `network get` that the browser itself made the call from this origin.                                                                                                                                                         |
+| `flow` + `mode: fetch` | read-only, and the target page is **server-rendered** | Fetches the URL with cookies, parses it off-screen (DOMParser), reads components — works from any page, never navigates. Verify SSR first: corpus memory often says ("everything here is already in the document"), else `browser eval` a `fetch(url).then(r=>r.text())` and check the markup is there. Client-rendered content is invisible to it. |
+| `flow` (live)          | mutating or same-page interactions                    | Fills/clicks on the live DOM by component identity. **A WebMCP tool call dies with the document**, so a live flow must stay on one page — `navigate` is only legal as the _final_ step, and cross-page journeys must be split into per-page tools gated by `require_view:`.                                                                         |
+
+## Phase 2: author `webmcp.tools.yaml`
+
+Scaffold, then edit: `sightmap webmcp init --site SLUG --base-url URL`
+drafts one fetch-read tool per corpus view and one api stub per corpus
+request — keep what maps to real goals, delete the rest.
+
+```yaml
+version: 1
+site: ikea
+base_url: https://www.ikea.com
+sightmap: .sightmap # path to the corpus, relative to this file
+tools:
+  # description is REQUIRED and load-bearing: fold the relevant memory:
+  # hazards into it — inside a folded scalar a "#" is literal text, so keep
+  # comments out here.
+  - name: search_products # snake_case; the agent-facing tool name
+    description: >
+      Keyword search... The summary count is the authoritative total —
+      the grid renders only the first page.
+    read_only: true
+    mode: fetch
+    view: SearchResults # scopes component-name resolution to a view
+    params:
+      - { name: query, type: string, required: true, description: Keywords. }
+      - {
+          name: max_results,
+          type: integer,
+          default: 20,
+          description: Card cap.,
+        }
+    flow:
+      - navigate: "/us/en/search/?q={query}"
+      - read:
+          summary: { component: SearchSummary, property: summary }
+          products:
+            for_each: ProductCard # every match, scoped fields below
+            max: "{max_results}"
+            fields:
+              text: { property: card_text } # iterated element's prop
+              price: { component: CardPrice, property: price_text } # child
+              url: { selector: a, extract: attr=href } # raw escape hatch
+
+  - name: get_buyback_offers
+    description: Buy-back offers for one article number.
+    params:
+      - {
+          name: article,
+          type: string,
+          required: true,
+          description: Digits only.,
+        }
+    api:
+      request: CircularOffers # corpus request — method + result props inherited
+      url: "https://web-api.ikea.com/circular/circular-asis/offers/articles/{article}"
+```
+
+Semantics that do the heavy lifting:
+
+- **Everything resolves through the corpus.** `component:` values are
+  component names or component queries (`Row[label="{x}"] Buy`, predicates
+  `=`/`^=`/`*=` + ` i`, `#N` index, whitespace descendant — same DSL as the
+  CLI). `property:` pulls the corpus-declared `extract`/`transform`. The
+  compiler errors on anything that doesn't resolve (ambiguous names list
+  their breadcrumb candidates; missing properties list what the component
+  does declare) — fix the manifest or improve the corpus, never paste
+  selectors around the model.
+- **`view:` disambiguates per-view names.** IKEA's `ProductCard` subtree
+  differs on search vs category — its `CardPrice` child resolves to a
+  different selector per view; a tool sets `view: SearchResults` and gets
+  that view's definition (globals stay visible). `require_view:` implies it for live
+  flows and adds the runtime guard: off-view calls return a structured
+  `{error, expected_view, navigate_to}` instead of flailing.
+- **`api` tools inherit the corpus request's `method` and `properties:`** as
+  their result extractors (`source`/`field`/`pattern`/`transform` — the
+  "200 OK but the body says declined" machinery). No `result:` and no
+  request properties → the tool echoes `{status, url, body}` (body capped).
+- **Templates**: `{param}` in URLs (URL-encoded; `{param|raw}` opts out),
+  query/header/body values, predicate values, and `max:`. A JSON body leaf
+  that is exactly `"{param}"` keeps the param's number/boolean type.
+- **Descriptions are the product.** Distill the corpus `memory:` hazards the
+  agent needs ("a bad id silently redirects to the whole catalog — check
+  category_name") into each tool's description. That lore is why a generated
+  tool beats a naive one.
+- Missing reads are **silently omitted** (sightmap's own convention) — say in
+  the description what absence means when it means something.
+
+## Phase 3: generate and verify in the live session
+
+```bash
+sightmap webmcp validate --tools webmcp.tools.yaml
+sightmap webmcp generate --tools webmcp.tools.yaml --format all
+```
+
+Fix every validate error before generating — they are compile-time proof
+that each tool's selectors, properties, views, and params all resolve.
+
+Then prove the tools work where they will run, in the sightmap browser
+session (the shim makes this possible in any Chrome, no origin trial
+needed):
+
+```bash
+sightmap browser start --detach
+sightmap browser navigate 'https://www.ikea.com/us/en/'
+# inject the generated snippet into the page:
+sightmap browser eval "$(cat ikea.webmcp.js)"
+sightmap browser eval '__sightmapWebMCP.listTools().map(t => t.name)'
+# call a tool; the eval bridge can't await, so park the result and poll:
+sightmap browser eval '__sightmapWebMCP.callToolAndStore("search_products", {query: "desk chair"})'
+sightmap browser eval '__sightmapWebMCP.last'          # repeat until done: true
+```
+
+Judge the result like an agent would: is the answer complete, is a failure
+actionable, does an empty result distinguish "none" from "wrong page"?
+Iterate manifest → generate → re-inject until every tool passes on the live
+site. Re-verify mutating tools on a page where mutation is acceptable.
+
+## Phase 4: publish
+
+- **Userscript** (`site.webmcp.user.js`): the third-party path — installable
+  via Tampermonkey/Violentmonkey and publishable (Greasy Fork etc.); it
+  registers the tools on every matching page. `@match` comes from the
+  manifest's `match:` (default: the base_url origin).
+- **ES module** (`site.webmcp.module.js`): hand to the site's owners —
+  `<script type="module" src="...">` makes the site itself WebMCP-enabled,
+  the outcome the proposal actually wants. Suggest it upstream when the site
+  has a public repo or feedback channel.
+- **Snippet** (`site.webmcp.js`): for injection by agent harnesses (as in
+  Phase 3) or extensions.
+- Commit the manifest next to the corpus and check the generated bundles'
+  freshness in CI with `generate --check` (exit 2 on drift). Regenerate
+  whenever the corpus changes — the bundle's banner carries the corpus
+  content hash, so drift is detectable, and the map staying honest is what
+  keeps the tools honest.
+
+## Hard rules
+
+- **Never hand-edit a generated bundle** — edit the manifest or the corpus
+  and regenerate.
+- **Never ship a tool you didn't execute** against the live site in Phase 3.
+- **Component queries in manifests must come from the corpus** (or be
+  explicit `css:` escapes). If a query can't disambiguate an instance, the
+  corpus is missing a property — fix it there (see `sightmap-authoring`,
+  property rules), and every future tool benefits.
+- **Live flows never navigate mid-flow** (the generator rejects it): a
+  WebMCP tool call cannot outlive its document. Split cross-page journeys
+  into per-page tools with `require_view:`; the agent (or the final
+  `navigate` step) moves between pages.
+- **Mark mutating tools** `read_only: false` and say in the description what
+  they mutate — hosts surface `readOnlyHint` to users.
+- **The manifest is trusted input** — its URL templates decide where the
+  page's credentialed fetches go. Review an installed corpus before
+  generating from it, keep api origins fixed (the compiler warns when a
+  template parameterizes the host), and publish userscripts reproducibly:
+  the banner's corpus hash lets anyone regenerate and diff.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The library in #293 has no user entry point. This PR adds `sightmap webmcp init|validate|generate` and the `sightmap-webmcp` skill that walks the authoring loop: trajectories with the browser CLI, kind choice (api / fetch / live), live verify, publish.

This is **2 of 3**. Base is `cursor/webmcp-lib-9d17` (#293).

## Scope

- `go/cmd/sightmap/cmd_webmcp.go` plus `cmd_webmcp_test.go`. `main.go` dispatch and usage line.
- Docs page `docs/cli/webmcp.mdx` (per-command flags tables and captured `text` samples), linked from `docs/docs.json` and the CLI overview card map. Overview notes that `generate --check` exits **2** on drift.
- Canonical skill `skills/sightmap-webmcp/`, embedded copy under `go/skills/`, `//go:embed` list in `go/skills/embed.go`.
- `sightmap skills install` docs now list three skills (`docs/cli/integrate.mdx`, `docs/start/install.mdx`, root README).
- Changeset for `@sightmap/sightmap` (minor).

`--check` stays for callers who commit their own bundles. This repo does not commit generated example JS. `runWebmcpGenerate` returns `errGenerateDrift` on stale output; `main` maps that to exit 2. Output paths print cwd-relative when the file is under the working directory.

## Tradeoffs

The skill is the product loop. The CLI is flags in, files out. Putting both in one PR means `sightmap skills install` has the authoring instructions on the same release as the command.

## Blast Radius

New CLI command in the published binary. The skill ships via the plugin glob (`skills/`), `sightmap skills install`, and the npm package's embedded skills. Minor changeset. Getting-started pages still describe the mapping loop as authoring + browser; they do not walk WebMCP.

## Verification

`go test ./cmd/sightmap/ -count=1` passed, including `TestWebmcpGenerateCheckFreshAndStale` (`errors.Is(err, errGenerateDrift)`) and `TestDisplayPathPrefersCwdRelative`. `go test ./webmcp/ -count=1` passed. `go generate ./skills/...` from `go/` left `skills/` and `go/skills` clean. Docs samples were captured from the fixture: `wrote fixture.webmcp.js (32651 bytes, 4 tools)` and `✓ fixture.webmcp.js is up to date`.

After #293 merges to `main`, retarget this PR at `main` (or rebase) and merge it next. Examples are #294. Close #281 once the command is on `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04b49-ec21-7195-b681-316499fe9d17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04b49-ec21-7195-b681-316499fe9d17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

