### PR TITLE
docs(webmcp): add IKEA and GitHub example manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ both websites.
 | `spec/` | Markdown + JSON Schema | Normative specification, SEP process, conformance fixtures. Source of truth. |
 | `go/` | Go | Reference implementation: `sightmap` CLI + `go get`-able library. npm: `@sightmap/sightmap`. |
 | `skills/` | Markdown | Canonical agent skills (`sightmap-authoring`, `sightmap-browser`, `sightmap-webmcp`). Installable as a plugin, embedded in the CLI, and vendored downstream. |
-| `webmcp/` | JS runtime + jsdom tests | Canonical browser runtime for generated WebMCP bundles, plus jsdom tests. Generator: `sightmap webmcp` (`go/webmcp/`). |
+| `webmcp/` | JS runtime + examples | Canonical browser runtime, jsdom tests, and worked example manifests. Generator: `sightmap webmcp` (`go/webmcp/`). |
 | `docs/` | Mintlify | Documentation site (docs.sightmap.org). |
 | `web/` | React + Vite | Marketing landing page (sightmap.org). |
 
@@ -68,9 +68,10 @@ Never change spec semantics without an SEP (`spec/seps/`).
   its extension manifest is MCP-only and has no skills concept.)
 
 ### `webmcp/`
-- Canonical browser runtime (`src/runtime/runtime.js`) plus jsdom tests.
-  The generator is `sightmap webmcp` (`go/webmcp/`). The authoring loop is
-  the `sightmap-webmcp` skill.
+- Canonical browser runtime (`src/runtime/runtime.js`) plus jsdom tests and
+  worked example manifests. See `webmcp/README.md`. The generator is
+  `sightmap webmcp` (`go/webmcp/`). The authoring loop is the
+  `sightmap-webmcp` skill.
 - `go generate ./webmcp/...` (from `go/`) copies the runtime into
   `go/webmcp/runtime.js`, writes `version_gen.go`, and regenerates
   `webmcp/test/fixtures/site/ir.json` for the jsdom tests. CI fails on drift.

--- a/webmcp/README.md
+++ b/webmcp/README.md
@@ -1,10 +1,12 @@
 # webmcp/ — the sightmap → WebMCP codegen adapter
 
 Turn any publicly accessible website into a set of **WebMCP tools** an agent
-can call, by way of its sightmap corpus. This directory holds the codegen
-adapter: a compiler from `.sightmap/` (views, components, properties,
-requests, memory) plus a small hand-authored tool manifest to a
-self-contained JS bundle that registers tools on
+can call, by way of its sightmap corpus. This directory holds the canonical
+browser runtime, jsdom tests, and worked example manifests. The compiler
+lives in `go/webmcp/` and ships as `sightmap webmcp`. It turns a `.sightmap/`
+corpus (views, components, properties, requests, memory) plus a small
+hand-authored tool manifest into a self-contained JS bundle that registers
+tools on
 [`document.modelContext`](https://github.com/webmachinelearning/webmcp) —
 the W3C Web Machine Learning CG's WebMCP proposal, in origin trial in Chrome
 149 / Edge 150 and supported by ChatGPT Desktop and Brave Leo.

--- a/webmcp/README.md
+++ b/webmcp/README.md
@@ -1,0 +1,256 @@
+# webmcp/ — the sightmap → WebMCP codegen adapter
+
+Turn any publicly accessible website into a set of **WebMCP tools** an agent
+can call, by way of its sightmap corpus. This directory holds the codegen
+adapter: a compiler from `.sightmap/` (views, components, properties,
+requests, memory) plus a small hand-authored tool manifest to a
+self-contained JS bundle that registers tools on
+[`document.modelContext`](https://github.com/webmachinelearning/webmcp) —
+the W3C Web Machine Learning CG's WebMCP proposal, in origin trial in Chrome
+149 / Edge 150 and supported by ChatGPT Desktop and Brave Leo.
+
+## The pipeline
+
+The end-to-end goal: **site URL in, distributable WebMCP implementation
+out**, with an agent in the loop exactly where judgment is needed and
+mechanical, verifiable steps everywhere else.
+
+```
+ any public site
+       │
+       │  1. MAP — sightmap atlas add <slug>, or an agent authors the corpus
+       │     against the live site (sightmap-authoring skill: coverage loop,
+       │     verified selectors, per-instance properties, requests, memory)
+       ▼
+ .sightmap/ corpus
+       │
+       │  2. SCAFFOLD — sightmap webmcp init drafts one read tool per view
+       │     and one api stub per corpus request
+       ▼
+ webmcp.tools.yaml
+       │
+       │  3. REFINE — an agent walks the site's real user goals with the
+       │     sightmap browser CLI (trajectories, network traces), picks each
+       │     tool's kind (api / fetch flow / live flow), and folds corpus
+       │     memory into tool descriptions (sightmap-webmcp skill)
+       ▼
+       │  4. GENERATE — sightmap webmcp generate compiles manifest + corpus
+       │     into a bundle (compile-time resolution of every component,
+       │     property, view, and request reference; errors, not guesses)
+       ▼
+ site.webmcp.js / .module.js / .user.js
+       │
+       │  5. VERIFY — inject the snippet into a live sightmap browser
+       │     session and execute every tool via the built-in shim
+       │
+       │  6. DISTRIBUTE — userscript for any WebMCP-enabled browser agent,
+       │     ES module for the site's own owners, snippet for harnesses;
+       │     regenerate on corpus change (generate --check gates drift)
+       ▼
+ tools callable by any WebMCP browser agent
+```
+
+Steps 1 and 3 are agent work, guided by the `sightmap-authoring` and
+`sightmap-webmcp` skills. Steps 2, 4, 5, 6 are this package.
+
+## Why route through a sightmap?
+
+WebMCP assumes the _site owner_ writes the tools. Third-party sites mostly
+won't, for a while — but an agent with the sightmap CLI can map any site
+today. The corpus is precisely the knowledge a good tool needs:
+
+| Corpus entity                                                      | Becomes                                                                      |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `views:` (route globs, representative URLs)                        | navigation targets, `require_view:` guards, URL templates                    |
+| `components:` + `children:` (verified selectors, shadow-flattened) | act/read targets, resolved by semantic name                                  |
+| `properties:` (`extract` + `transform`)                            | structured reads and query predicates (`Row[label="X"]`)                     |
+| `requests:` (+ request `properties:`)                              | api-backed tools with response extraction ("200 but the body says declined") |
+| `memory:`                                                          | the hazard lore folded into tool descriptions                                |
+| coverage discipline (0 orphaned, sel-probed)                       | tools that keep working because the map is maintained                        |
+
+The manifest references corpus entities **by name**; the compiler inlines
+selectors and extractors at generate time and fails loudly on anything that
+doesn't resolve. The corpus stays the single source of truth — improve the
+map and every regenerated tool improves with it.
+
+## Tool kinds
+
+A WebMCP tool's `execute` runs inside the page, so the fundamental
+constraint is: **a tool call dies with the document**. The three kinds work
+around that honestly:
+
+- **`api`** — replay an observed endpoint with `fetch` (first-party cookies
+  included, so signed-in state comes free). Method and result extractors
+  inherit from the corpus `requests:` entry. Preferred whenever one request
+  does the job.
+- **`flow` + `mode: fetch`** — fetch a server-rendered page with cookies,
+  parse it off-screen (DOMParser), and read components from the detached
+  document. Cross-"page" reads with no navigation. Useless on client-rendered
+  content — verify SSR first.
+- **`flow`** (live) — fill/click/wait/read on the live DOM by component
+  identity, gated by `require_view:` (off-view calls return a structured
+  error with a `navigate_to` hint). `navigate` is legal only as the final
+  step; the generator rejects mid-flow navigation at compile time.
+
+## Layout
+
+```
+webmcp/
+  src/runtime/runtime.js   browser interpreter embedded into every bundle
+  test/                    jsdom suite (root jest config)
+  test/fixtures/site/      tiny corpus + manifest + compiled ir.json
+  examples/ikea/           worked manifest against the vendored IKEA atlas
+  examples/github/         second worked manifest; verify-live.js hits
+                           github.com (manual, CI stays hermetic)
+```
+
+The generator lives in `go/webmcp/` and ships as `sightmap webmcp`.
+`go generate ./webmcp/...` (from `go/`) copies this runtime into the Go
+package and regenerates `test/fixtures/site/ir.json` for the jsdom tests.
+
+The runtime's deep-query and extraction functions are adapted from
+`go/browser/deepquery.js` and `go/observe/properties.js`, so generated tools
+resolve nodes the way the CLI that authored the corpus did.
+
+Generated bundles always install `window.__sightmapWebMCP`
+(`listTools()` / `callTool()` / `callToolAndStore()`) alongside
+`document.modelContext` registration. That is the verification surface, and
+the fallback for browsers without the origin trial.
+
+## Try it
+
+```bash
+sightmap webmcp validate --tools webmcp/examples/ikea/webmcp.tools.yaml
+sightmap webmcp generate --tools webmcp/examples/ikea/webmcp.tools.yaml --format all
+
+sightmap webmcp init --site myshop --base-url https://myshop.example \
+  --sightmap-dir path/to/.sightmap --out webmcp.tools.yaml
+
+npx jest webmcp              # browser runtime in jsdom
+(cd go && go test ./webmcp/) # compiler, emitter, examples
+```
+
+The authoring loop, including live verification via `sightmap browser eval`,
+is in [`skills/sightmap-webmcp/`](../skills/sightmap-webmcp/SKILL.md).
+
+## Manifest reference
+
+See the [skill](../skills/sightmap-webmcp/SKILL.md) for the working
+reference and the [IKEA example](examples/ikea/webmcp.tools.yaml) for a
+fully-worked manifest. In brief:
+
+```yaml
+version: 1
+site: slug # required
+base_url: https://site.example # required; resolves relative URLs
+sightmap: .sightmap # corpus path, relative to this file
+match: [https://site.example/*] # userscript @match (default: origin/*)
+tool_version: "0.1.0" # userscript @version
+tools:
+  - name: tool_name # ^[a-z][a-z0-9_-]{0,63}$
+    description: ... # required — the agent decides by it
+    read_only: true # default: GET api / interaction-free flow
+    view: ViewName # scope component-name resolution to a view
+    require_view: ViewName # live flows: runtime guard + view scope
+    params:
+      - {
+          name: q,
+          type: string|number|integer|boolean,
+          required: true,
+          description: ...,
+          enum: [...],
+          default: ...,
+        }
+    api: # exactly one of api | flow
+      request: CorpusRequestName # inherits method + result properties
+      url: "https://.../{q}" # {param} URL-encoded; {param|raw} opts out
+      query: { k: "{q}" } # appended query params
+      headers: { accept: application/json }
+      body: { k: "{q}" } # object → JSON (typed leaves); string → raw
+      result: # request-property vocabulary
+        - {
+            name: outcome,
+            source: rsp.body,
+            field: status,
+            pattern: "...",
+            transform: "...",
+          }
+    mode: fetch # flow only: fetch | live (default)
+    flow:
+      - navigate: "/path?q={q}" # fetch: first step; live: final step only
+      - wait_for: { component: Name, timeout_ms: 10000 } # or selector/url_includes
+      - fill: { target: "Query or css:SEL", value: "{q}" }
+      - click: 'Row[label="{q}"] Buy'
+      - press: Enter # optional target:
+      - sleep: 500
+      - scroll: { to: Name } # or { delta_y: N }
+      - read:
+          key: { component: Name, property: prop } # corpus extractor
+          key2: { component: Name, extract: attr=href } # inline extractor
+          key3: {
+              selector: ".x",
+              extract: text,
+              transform: first_dollar,
+              max_chars: 2000,
+            } # per-field cap (default 300)
+          rows:
+            for_each: Name # or a component query
+            max: "{limit}"
+            fields:
+              a: { property: prop } # iterated element's prop
+              b: { component: Child, property: p } # descendant, chain-relative
+              c: { selector: a, extract: attr=href }
+```
+
+Reads follow sightmap's silent-omission convention: a value that doesn't
+resolve is absent, never an error. Every read value caps at 300 chars
+unless the field sets `max_chars`; api bodies echo up to `max_body_chars`
+(default 20000) when no `result:` is declared.
+
+## Trust model
+
+Generated tools run with the page's authority, so be clear about who trusts
+whom:
+
+- **The manifest and corpus are trusted inputs.** Whoever generates a bundle
+  is asserting the tools it contains: URL templates decide where credentialed
+  (`credentials: "include"`) fetches go, and flows decide what gets clicked.
+  Review both the way you'd review code — especially a corpus installed from
+  the atlas (`atlas add` proves it loads, not that it's benign).
+- **Params are agent-supplied.** They are URL-encoded into URLs by default;
+  `{param|raw}` opts out, and the compiler warns when a template parameterizes
+  the URL's _origin_, because that hands the destination host to the caller.
+- **The shim grants no new privilege.** Any script on the page can already do
+  everything a tool does (same-origin DOM + fetch); `window.__sightmapWebMCP`
+  adds a convenient surface, not a capability. The mediated surface is
+  `document.modelContext`, where the browser controls which agents see which
+  tools. Mark mutating tools `read_only: false` so hosts can gate them.
+- **A userscript user trusts the publisher.** Installing `SITE.webmcp.user.js`
+  runs it on every matching page with their session. Publish reproducibly:
+  the banner's corpus hash lets anyone regenerate and diff.
+- **Embedded strings cannot break out.** Authored text is JSON-embedded with
+  `</` escaped (safe to inline in a `<script>`), and banner/userscript header
+  lines are collapsed to one line.
+
+Runtime limits worth knowing: every read caps at 300 chars — `for_each`
+row fields included — unless the field sets `max_chars`; un-`result:`ed
+api bodies cap at `max_body_chars`; regex
+patterns evaluate as JS RegExp — stay in the RE2∩JS subset the authoring
+skill prescribes; fetched documents are decoded as UTF-8; `press` synthesizes
+events (keydown/keyup + keyCode for common keys) that some handlers ignore —
+prefer URL-shaped actions.
+
+## Status & non-goals
+
+- The generator targets the current WebMCP shape (`document.modelContext`,
+  `registerTool`, `execute` returning any JSON-serializable value,
+  `annotations.readOnlyHint`) and also probes the older
+  `navigator.modelContext` location. As the proposal evolves,
+  `src/runtime/runtime.js` (`__smwBoot`/`__smwDescriptor`) is the single
+  place to track it.
+- Cross-document journeys inside one tool call are out of scope by design
+  (so is anything the WebMCP spec itself still leaves open — streaming,
+  elicitation, cross-document responses).
+- The user-facing entry point is `sightmap webmcp` in the published CLI.
+  This directory holds the browser runtime the generator embeds, the jsdom
+  tests for that runtime, and the worked example manifests.

--- a/webmcp/examples/github/verify-live.js
+++ b/webmcp/examples/github/verify-live.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Live verification of the generated github example against real github.com.
+//
+// Not part of the jest suite (CI is hermetic; this needs network). Run it
+// manually after regenerating, from the repo root:
+//
+//   node webmcp/examples/github/verify-live.js [owner repo pr_number]
+//
+// It executes every tool through the same compiled IR the bundle embeds, in
+// jsdom, with fetch() backed by curl (which honors HTTPS_PROXY / CA bundles
+// in proxied environments where Node's fetch does not).
+
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const ROOT = path.join(__dirname, "..", "..", "..");
+const [owner = "sightmap", repo = "sightmap", prNumber = "281"] =
+  process.argv.slice(2);
+
+async function main() {
+  // jsdom provides DOMParser for fetch-mode flows.
+  const { JSDOM } = require(
+    require.resolve("jsdom", { paths: [path.join(ROOT, "node_modules")] }),
+  );
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "https://github.com/",
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.DOMParser = dom.window.DOMParser;
+  global.location = dom.window.location;
+
+  global.fetch = async (url, init = {}) => {
+    const args = ["-sS", "--max-time", "30", "-w", "\n%{http_code}"];
+    for (const [k, v] of Object.entries(init.headers || {}))
+      args.push("-H", `${k}: ${v}`);
+    if (init.method && init.method !== "GET") args.push("-X", init.method);
+    if (init.body) args.push("--data-binary", init.body);
+    args.push(url);
+    const raw = execFileSync("curl", args, {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const cut = raw.lastIndexOf("\n");
+    const body = raw.slice(0, cut);
+    const status = parseInt(raw.slice(cut + 1), 10);
+    return {
+      status,
+      text: async () => body,
+      headers: { forEach: () => {} },
+    };
+  };
+
+  const manifestPath = path.join(__dirname, "webmcp.tools.yaml");
+  const ir = JSON.parse(
+    execFileSync("go", ["run", "./webmcp/internal/dumpir", manifestPath], {
+      cwd: path.join(ROOT, "go"),
+      encoding: "utf8",
+    }),
+  );
+  const rt = require("../../src/runtime/runtime");
+
+  const CALLS = {
+    list_pull_requests: { owner, repo },
+    list_issues: { owner, repo },
+    list_releases: { owner, repo },
+    get_repo_files: { owner, repo },
+    get_pr_diffstat: { owner, repo, number: parseInt(prNumber, 10) },
+  };
+
+  let failed = 0;
+  for (const tool of ir.tools) {
+    const args = CALLS[tool.name];
+    process.stdout.write(`\n=== ${tool.name}(${JSON.stringify(args)})\n`);
+    try {
+      const out = await rt.__smwExecuteTool(tool, ir.meta, args);
+      const rendered = JSON.stringify(out, null, 2);
+      process.stdout.write(
+        rendered.length > 1600
+          ? rendered.slice(0, 1600) + "\n  ...[truncated]\n"
+          : rendered + "\n",
+      );
+      const check = CHECKS[tool.name];
+      const problem = check ? check(out) : null;
+      if (problem) {
+        failed++;
+        process.stdout.write(`✗ ${problem}\n`);
+      } else {
+        process.stdout.write("✓ ok\n");
+      }
+    } catch (e) {
+      failed++;
+      process.stdout.write(`✗ threw: ${e.message}\n`);
+    }
+  }
+  process.stdout.write(
+    failed === 0
+      ? "\nLIVE VERIFY PASS\n"
+      : `\nLIVE VERIFY: ${failed} tool(s) failed\n`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+const CHECKS = {
+  list_pull_requests: (o) =>
+    o.status === 200 &&
+    Array.isArray(o.pull_requests) &&
+    o.pull_requests.every((r) => r.title && r.url)
+      ? null
+      : "expected 200 + rows with title+url",
+  list_issues: (o) =>
+    o.status === 200 &&
+    Array.isArray(o.issues) &&
+    o.issues.every((r) => r.title && r.url)
+      ? null
+      : "expected 200 + rows with title+url",
+  list_releases: (o) =>
+    o.status === 200 &&
+    Array.isArray(o.release_links) &&
+    o.release_links.length > 0 &&
+    o.release_links.every((r) => r.url)
+      ? null
+      : "expected 200 + at least one tag link with url",
+  get_repo_files: (o) =>
+    o.status === 200 && typeof o.files === "string" && o.files.length > 50
+      ? null
+      : "expected 200 + a file table read",
+  get_pr_diffstat: (o) =>
+    o.status === 200 &&
+    o.lines_added &&
+    o.lines_deleted != null &&
+    o.lines_changed
+      ? null
+      : "expected 200 + lines_added/deleted/changed",
+};
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/webmcp/examples/github/webmcp.tools.yaml
+++ b/webmcp/examples/github/webmcp.tools.yaml
@@ -1,0 +1,192 @@
+# WebMCP tools for github.com, authored against the community atlas corpus at
+# web/src/data/atlas/github/.sightmap. All tools are read-only and work signed
+# out; run as a userscript by a signed-in user, the same fetches carry their
+# session and see what they see.
+#
+# Which views are safe to read from a fetched (pre-hydration) document was
+# verified against live github.com HTML on 2026-08-27: /pulls, /issues, and
+# /releases render their rows into the initial document, and a repository
+# home rendered its file table there too — an update on this corpus's
+# memory, which records the file table among the deferred fragments; the
+# README, latest-commit strip, and sidebar do still arrive in follow-up
+# fetches on some loads.
+#
+# Generate bundles after editing (not committed in this repo):
+#   sightmap webmcp generate \
+#     --tools webmcp/examples/github/webmcp.tools.yaml --format all
+version: 1
+site: github
+base_url: https://github.com
+description: Read-only repository tools for github.com — pull requests, issues, releases, files, and PR diffstat.
+sightmap: ../../../web/src/data/atlas/github/.sightmap
+match:
+  - https://github.com/*
+
+tools:
+  - name: list_pull_requests
+    title: List a repository's open pull requests
+    description: >
+      Fetch /{owner}/{repo}/pulls and return the open pull-request rows
+      (server-rendered, so no browser navigation is needed). Rows deliberately
+      carry legacy issue markup (ids like issue_<number>) — both lists render
+      from one legacy row component — and each row's text concatenates title,
+      labels, author, and review state. Review-decision badges arrive in a
+      later batch fetch and are not part of this read.
+    read_only: true
+    mode: fetch
+    view: PullList
+    params:
+      - name: owner
+        type: string
+        required: true
+        description: Repository owner, e.g. "sightmap".
+      - name: repo
+        type: string
+        required: true
+        description: Repository name, e.g. "sightmap".
+    flow:
+      - navigate: "/{owner}/{repo}/pulls"
+      - read:
+          pull_requests:
+            for_each: PullRow
+            fields:
+              text:
+                property: row_text
+              title:
+                component: PullTitleLink
+                property: title
+              url:
+                component: PullTitleLink
+                property: href
+
+  - name: list_issues
+    title: List a repository's open issues
+    description: >
+      Fetch /{owner}/{repo}/issues and return the issue rows (25 per page by
+      default). This route is served by GitHub's React frontend, but the rows
+      are in the initial document. Row state (open/closed) is an icon with no
+      text, so it is not part of this read — the list defaults to open issues.
+    read_only: true
+    mode: fetch
+    view: IssueList
+    params:
+      - name: owner
+        type: string
+        required: true
+        description: Repository owner.
+      - name: repo
+        type: string
+        required: true
+        description: Repository name.
+    flow:
+      - navigate: "/{owner}/{repo}/issues"
+      - read:
+          filters:
+            component: IssueFilters
+            property: filters
+          issues:
+            for_each: IssueRowTitle
+            fields:
+              title:
+                property: title
+              url:
+                property: href
+
+  - name: list_releases
+    title: List a repository's releases
+    description: >
+      Fetch /{owner}/{repo}/releases (newest first). Each entry is a link to a
+      release tag. The same tag URL appears several times per release — tag
+      name, source links, and the anchor heading all point at it — so
+      deduplicate by url before counting releases.
+    read_only: true
+    mode: fetch
+    view: Releases
+    params:
+      - name: owner
+        type: string
+        required: true
+        description: Repository owner.
+      - name: repo
+        type: string
+        required: true
+        description: Repository name.
+    flow:
+      - navigate: "/{owner}/{repo}/releases"
+      - read:
+          release_links:
+            for_each: ReleaseTagLink
+            fields:
+              tag:
+                property: tag
+              url:
+                extract: attr=href
+
+  - name: get_repo_files
+    title: Read a repository's root file listing
+    description: >
+      Fetch a repository home page and return its root file table and (when
+      GitHub inlines it) the README text. The table is in the initial
+      document; the README, latest-commit strip, and sidebar are sometimes
+      deferred to follow-up fetches, so an absent `readme` means "deferred on
+      this load", not "no README". Use the repository's raw file URLs for
+      file contents.
+    read_only: true
+    mode: fetch
+    view: RepoHome
+    params:
+      - name: owner
+        type: string
+        required: true
+        description: Repository owner.
+      - name: repo
+        type: string
+        required: true
+        description: Repository name.
+    flow:
+      - navigate: "/{owner}/{repo}"
+      - read:
+          files:
+            component: FileTable
+            property: entries
+            max_chars: 3000
+          readme:
+            component: Readme
+            property: readme_text
+
+  - name: get_pr_diffstat
+    title: Diffstat for one pull request
+    description: >
+      Lines added, deleted, and changed for one pull request, from the same
+      page_data endpoint the PR header uses (the header's diffstat testids are
+      filled in after the document from this response). Requires the JSON
+      accept and XMLHttpRequest headers or GitHub answers 406.
+    params:
+      - name: owner
+        type: string
+        required: true
+        description: Repository owner.
+      - name: repo
+        type: string
+        required: true
+        description: Repository name.
+      - name: number
+        type: integer
+        required: true
+        description: Pull request number.
+    api:
+      request: Diffstat
+      url: "https://github.com/{owner}/{repo}/pull/{number}/page_data/diffstat"
+      headers:
+        accept: application/json
+        x-requested-with: XMLHttpRequest
+      result:
+        - name: lines_added
+          source: rsp.body
+          field: diffstat.linesAdded
+        - name: lines_deleted
+          source: rsp.body
+          field: diffstat.linesDeleted
+        - name: lines_changed
+          source: rsp.body
+          field: diffstat.linesChanged

--- a/webmcp/examples/ikea/webmcp.tools.yaml
+++ b/webmcp/examples/ikea/webmcp.tools.yaml
@@ -1,0 +1,181 @@
+# WebMCP tools for the IKEA US storefront, authored against the community
+# atlas corpus at web/src/data/atlas/ikea/.sightmap (vendored copy of the
+# `ikea` atlas entry). Every component, property, request, and hazard note
+# referenced below was verified against the live site when that corpus was
+# curated — this manifest just picks the user goals worth exposing as tools.
+#
+# Generate a bundle after editing (not committed in this repo):
+#   sightmap webmcp generate \
+#     --tools webmcp/examples/ikea/webmcp.tools.yaml --format all
+version: 1
+site: ikea
+base_url: https://www.ikea.com
+description: Search, browse, and product tools for the IKEA US storefront (/us/en/), signed out.
+sightmap: ../../../web/src/data/atlas/ikea/.sightmap
+match:
+  - https://www.ikea.com/*
+
+tools:
+  - name: search_products
+    title: Search IKEA products
+    description: >
+      Keyword search over the IKEA US catalog. Returns the result summary
+      (its count is the authoritative total — the grid renders only the first
+      page of ~22 cards) and the product cards with price and availability.
+      Product names keep their Swedish diacritics (GÖRSNYGG, PÄRKLA), so an
+      ASCII-typed name in a follow-up filter may not match. The result page is
+      server-rendered, which is why this tool can fetch it without a browser
+      navigation.
+    read_only: true
+    mode: fetch
+    view: SearchResults
+    params:
+      - name: query
+        type: string
+        required: true
+        description: Search keywords, e.g. "desk chair".
+      - name: max_results
+        type: integer
+        description: Cap on returned product cards (default 20).
+        default: 20
+    flow:
+      - navigate: "/us/en/search/?q={query}"
+      - read:
+          summary:
+            component: SearchSummary
+            property: summary
+          products:
+            for_each: ProductCard
+            max: "{max_results}"
+            fields:
+              text:
+                property: card_text
+              price:
+                component: CardPrice
+                property: price_text
+              availability:
+                component: CardAvailability
+                property: availability
+              url:
+                selector: a
+                extract: attr=href
+
+  - name: browse_category
+    title: Browse an IKEA category
+    description: >
+      Load a category page by id (the trailing token of a /cat/ URL, e.g.
+      "desk-chairs-20654" or "tables-chairs-fu002"). One route serves two page
+      shapes — a hub (subcategory carousel, no products) and a leaf (product
+      grid, no carousel) — so read whichever of `subcategories` / `products`
+      came back. A typo'd id does NOT 404: the slug half is decorative, and a
+      bad id half silently redirects to the whole catalog, so always check
+      `category_name` to confirm where you actually landed.
+    read_only: true
+    mode: fetch
+    view: CategoryBrowse
+    params:
+      - name: category_id
+        type: string
+        required: true
+        description: Category slug-and-id, e.g. "desk-chairs-20654".
+    flow:
+      - navigate: "/us/en/cat/{category_id}/"
+      - read:
+          category_name:
+            component: CategoryTitle
+            property: category_name
+          subcategories:
+            for_each: SubcategoryItem
+            fields:
+              tracking_label:
+                property: tracking_label
+              label:
+                extract: text
+              url:
+                extract: attr=href
+          products:
+            for_each: ProductCard
+            max: 24
+            fields:
+              text:
+                property: card_text
+              price:
+                component: CardPrice
+                property: price_text
+              url:
+                selector: a
+                extract: attr=href
+
+  - name: get_product
+    title: Read an IKEA product page
+    description: >
+      Fetch one product page by its full slug (e.g.
+      "goersnygg-storage-case-white-clear-40504193") and return price, rating,
+      and package text. The digits ending the slug are the article number the
+      product APIs key on. Delivery/stock render client-side after load, so
+      `fulfillment` is usually absent from this fetched read — use the
+      get_buyback_offers tool or a live session for availability.
+    read_only: true
+    mode: fetch
+    view: ProductDetail
+    params:
+      - name: product_slug
+        type: string
+        required: true
+        description: Full product slug from a /p/ URL, article number included.
+    flow:
+      - navigate: "/us/en/p/{product_slug}/"
+      - read:
+          price:
+            component: PriceModule
+            property: price
+          package:
+            component: PricePackage
+            property: package_text
+          rating:
+            component: RatingsSummary
+            property: rating_text
+          fulfillment:
+            component: FulfillmentSection
+            property: fulfillment_text
+
+  - name: get_buyback_offers
+    title: IKEA buy-back offers for an article
+    description: >
+      Query IKEA's circular buy-back API for one article number (the digits
+      ending a product URL, e.g. 40504193 from
+      /p/goersnygg-storage-case-white-clear-40504193/). The endpoint only has
+      data for articles IKEA will buy back; anything else returns a non-200 or
+      an empty body, which is an answer, not an error.
+    params:
+      - name: article
+        type: string
+        required: true
+        description: Article number, digits only, e.g. "40504193".
+    api:
+      request: CircularOffers
+      url: "https://web-api.ikea.com/circular/circular-asis/offers/articles/{article}"
+
+  - name: add_to_cart
+    title: Add the open product to the cart
+    description: >
+      On a product page in the live session, set the quantity and click the
+      add-to-cart control. Mutating: this puts a real item into the basket on
+      the storefront. Fails with a navigation hint when the current page is
+      not a product view. Quantity is a number input paired with steppers, so
+      it is written directly rather than clicked up. Returns ok once the
+      click lands; confirm the add via the header's shopping-bag counter or
+      the cart page — the page gives no same-document success signal this
+      tool could read.
+    read_only: false
+    require_view: ProductDetail
+    params:
+      - name: quantity
+        type: integer
+        description: Quantity to set before adding (default 1).
+        default: 1
+    flow:
+      - fill:
+          target: 'css:.js-add-to-cart-section input[type="number"]'
+          value: "{quantity}"
+      - click: "css:.pipf-add-to-cart-section__buttons button"

--- a/webmcp/examples/ikea/webmcp.tools.yaml
+++ b/webmcp/examples/ikea/webmcp.tools.yaml
@@ -174,6 +174,8 @@ tools:
         type: integer
         description: Quantity to set before adding (default 1).
         default: 1
+    # css: hatch: the atlas corpus names AddToCartSection / AddToCartButtons
+    # but not the quantity input. Prefer a named child if the corpus grows one.
     flow:
       - fill:
           target: 'css:.js-add-to-cart-section input[type="number"]'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Reviewers and authors need a fully worked manifest, not only the compiler fixture. These two sites use the vendored atlas corpora the rest of the repo already ships.

This is **3 of 3**. Base is `cursor/webmcp-cli-9d17` (#292).

## Scope

- `webmcp/examples/ikea/webmcp.tools.yaml` against `web/src/data/atlas/ikea/.sightmap`. `add_to_cart` documents why it uses the `css:` hatch (atlas names `AddToCartSection` / `AddToCartButtons`, not the quantity input).
- `webmcp/examples/github/webmcp.tools.yaml` against the GitHub atlas corpus, plus `verify-live.js` (manual, needs network; CI stays hermetic).
- `webmcp/README.md` for the runtime, tests, examples, and trust model. The compiler is `go/webmcp` / `sightmap webmcp`, not a package in this directory.

Generated `*.webmcp.js` files are not committed. Downstream CI can still use `sightmap webmcp generate --check`.

## Tradeoffs

Committing bundles made #281 noisy (about 8k lines of generated JS) and locked the Go emitter to byte-identical Node output. YAML plus compile tests is enough to prove the examples still resolve.

## Blast Radius

Docs and examples only. `TestExamplesCompileAndEmit` now compiles both sites.

## Verification

`go test ./webmcp/ -count=1 -run TestExamplesCompileAndEmit` passed for `github` and `ikea`. `TestScaffoldValidatesAgainstItsCorpus` still compiles a scaffolded IKEA draft against the atlas.

After #292 lands on `main`, retarget this PR at `main` and merge it. Then close #281.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04b49-ec21-7195-b681-316499fe9d17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04b49-ec21-7195-b681-316499fe9d17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

