### PR TITLE
extract: capture rendered node text as the offline `text` fallback

### DIFF
--- a/.changeset/offline-text-parity.md
+++ b/.changeset/offline-text-parity.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Offline `text` extraction now falls back to a node's rendered text when it has no accessible name, so `extract: text` on role-less elements (custom elements, bare `<span>`s) resolves the visible value instead of silently empty. Component text is captured from `innerText` — rendered, transform- and visibility-aware, excluding `<style>`/`<script>` and non-rendered nodes — and normalized to a single clean shape (whitespace runs collapsed, ends trimmed) at the build boundary, so `snapshot`/`coverage`/`bounds` and library consumers all see the same value the runtime does. Adds a `text` field to the component-node schema.

--- a/go/conformance/component-schema.md
+++ b/go/conformance/component-schema.md
@@ -71,6 +71,7 @@ Viewport bounding box in pixels.
 | Id | string | `id` | pre-merge | Globally unique node ID. Frame-prefixed for sub-frames (`"1_5"`). |
 | Role | string | `role` | post-merge | WAI-ARIA role. `"StaticText"` for text nodes, `"none"` for ignored. |
 | Name | string | `name` | post-merge | Computed accessible name (NOT raw `textContent`). |
+| Text | string | `text` | post-merge | Rendered text content (`innerText`, `textContent` fallback), normalized to a single clean shape (whitespace runs collapsed, ends trimmed). Present for role-less nodes that have no accessible name; the fallback source for `extract: text`. Omitted when empty. |
 | Value | string | `value` | post-merge | Current value for form controls. |
 | Properties | map[string]string | `properties` | post-merge | Additional A11Y properties (`aria-*` etc.). |
 | Element | \*Element | `element` | pre-merge | Observed element identity (tag/id/classes/attrs). Nil for virtual nodes. Matched against `SelectorPart` patterns. |

--- a/go/extract/build.go
+++ b/go/extract/build.go
@@ -2,8 +2,9 @@ package extract
 
 import (
 	"fmt"
-	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // BuildTree runs the full post-probe pipeline:
@@ -109,6 +110,7 @@ func walkDOMNode(
 		Id:            pc.Id,
 		Role:          role,
 		Name:          name,
+		Text:          normalizeText(pc.Text),
 		Value:         value,
 		Properties:    props,
 		Element:       el,
@@ -122,6 +124,16 @@ func walkDOMNode(
 	}
 
 	return compNode, nil
+}
+
+// normalizeText collapses every run of whitespace (spaces, tabs, newlines) to a
+// single space and trims the ends, giving component text one clean shape
+// regardless of how the source DOM laid it out. This is what innerText and the
+// accessible-name algorithm already do for inline content, so a role-less
+// node's captured text renders the same way its accessible name would. Applied
+// once at the build boundary so every downstream consumer sees the same value.
+func normalizeText(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // elementFor parses ProbeComponent.Selector with sightmap.ParseSightmapSelector and

--- a/go/extract/build_test.go
+++ b/go/extract/build_test.go
@@ -127,6 +127,50 @@ func TestTextNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Text capture + normalization
+// ---------------------------------------------------------------------------
+
+// A role-less node has no accessible name, but its captured (rendered) text is
+// carried onto the ComponentNode and normalized to a single clean shape.
+func TestTextCapturedAndNormalized(t *testing.T) {
+	probe := &ProbeResult{
+		Success: true,
+		Results: []ProbeComponent{
+			{Id: "1", TagName: "SPAN", Selector: "span", Text: "  B6\n   123  "},
+		},
+	}
+	a11y := []A11YNode{} // role-less: no accessible name
+	domRoot := domWrapper("#document",
+		domChild(1, 10, "SPAN", "1"),
+	)
+	root, err := BuildTree(probe, a11y, domRoot)
+	if err != nil {
+		t.Fatalf("BuildTree error: %v", err)
+	}
+	if root.Name != "" {
+		t.Errorf("Name = %q, want empty (role-less)", root.Name)
+	}
+	if root.Text != "B6 123" {
+		t.Errorf("Text = %q, want %q (whitespace collapsed + trimmed)", root.Text, "B6 123")
+	}
+}
+
+func TestNormalizeText(t *testing.T) {
+	cases := map[string]string{
+		"":              "",
+		"  hi  ":        "hi",
+		"a\n\t b   c":   "a b c",
+		"Nonstop":       "Nonstop",
+		"\n  B6 123 \n": "B6 123",
+	}
+	for in, want := range cases {
+		if got := normalizeText(in); got != want {
+			t.Errorf("normalizeText(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Test 4 – Nested tree: parent > child1 > grandchild
 // ---------------------------------------------------------------------------
 

--- a/go/match/component_props.go
+++ b/go/match/component_props.go
@@ -44,7 +44,13 @@ func resolveExtract(
 ) (string, bool) {
 	switch {
 	case extract == "text":
-		return node.Name, node.Name != ""
+		// Prefer the accessible name; fall back to the node's rendered text
+		// (populated for role-less nodes that have no accessible name). Both are
+		// already whitespace-normalized to the same shape at capture time.
+		if node.Name != "" {
+			return node.Name, true
+		}
+		return node.Text, node.Text != ""
 
 	case strings.HasPrefix(extract, "attr="):
 		name := extract[len("attr="):]

--- a/go/match/component_props_test.go
+++ b/go/match/component_props_test.go
@@ -91,6 +91,23 @@ func TestResolveComponentProperties(t *testing.T) {
 		{Name: "Amount", Selectors: []string{"[data-testid=row] [data-testid=price] [data-testid=amount]"}, ParentChain: []string{"Row", "Price"}, Properties: []sightmap.ComponentPropertyDef{{Name: "text", Extract: "text"}}},
 	}
 
+	// Role-less nodes carry no accessible Name but do carry rendered Text.
+	// `extract: text` must fall back to Text, and prefer Name when both exist.
+	textOnlyCard := &sightmap.ComponentNode{
+		Id:       "card",
+		Name:     "", // role-less: no accessible name
+		Text:     "B6 123",
+		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
+		Children: []*sightmap.ComponentNode{},
+	}
+	nameWinsCard := &sightmap.ComponentNode{
+		Id:       "card",
+		Name:     "Product X", // accessible name present
+		Text:     "raw fallback text",
+		Element:  &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "pod"}},
+		Children: []*sightmap.ComponentNode{},
+	}
+
 	type check struct {
 		node *sightmap.ComponentNode
 		prop string
@@ -140,6 +157,22 @@ func TestResolveComponentProperties(t *testing.T) {
 			root: row,
 			checks: []check{
 				{row, "amount", "$5.00", true},
+			},
+		},
+		{
+			name: "text falls back to rendered Text when accessible name is empty",
+			defs: productCardDefs(),
+			root: textOnlyCard,
+			checks: []check{
+				{textOnlyCard, "label", "B6 123", true},
+			},
+		},
+		{
+			name: "text prefers accessible name over rendered Text",
+			defs: productCardDefs(),
+			root: nameWinsCard,
+			checks: []check{
+				{nameWinsCard, "label", "Product X", true},
 			},
 		},
 	}

--- a/go/probe/probe.js
+++ b/go/probe/probe.js
@@ -347,7 +347,16 @@ function computeCompProps(isLogicalRoot, useScrollOffset) {
         return {
             id: sightmapId,                                               // Map sightmapId -> id
             role: '',                                                  // Will be filled by accessibility data
-            text: noTextTags.has(tag) ? '' : (element.textContent || '').substring(0, 100), // Map textContent -> text
+            // Rendered text (innerText): reflects text-transform + visibility, is
+            // whitespace-collapsed, and — crucially — excludes non-rendered
+            // <style>/<script> descendants, matching the accessible name and what
+            // runtime consumers read. We deliberately do NOT fall back to
+            // textContent (it would re-introduce descendant style/script text on
+            // container nodes with empty innerText), and we skip non-rendered
+            // elements entirely — innerText is unreliable there (e.g. <head>
+            // returns its <style> text). Go-side normalizeText collapses any
+            // residual whitespace.
+            text: (noTextTags.has(tag) || !isVisible) ? '' : ((element.innerText || '').substring(0, 100)),
             value: '',                                                 // Will be filled by accessibility data
             properties: {},                                            // Will be filled by accessibility data
             bounds: bounds,

--- a/go/sightmap/comps_component.go
+++ b/go/sightmap/comps_component.go
@@ -110,6 +110,13 @@ type ComponentNode struct {
 	// This is NOT raw textContent. (post-merge)
 	Name string `json:"name"`
 
+	// Text is the node's rendered text content, normalized to a single clean
+	// shape (whitespace runs collapsed, ends trimmed). It is captured by the
+	// probe (innerText, with a textContent fallback) and is the fallback source
+	// for `extract: text` when the accessible Name is empty (role-less nodes).
+	// Unlike Name, it is present for role-less leaves/containers. (post-merge)
+	Text string `json:"text,omitempty"`
+
 	// Value is the current value for form controls (inputs, selects, etc.). (post-merge)
 	Value string `json:"value"`
 


### PR DESCRIPTION
Fixes #298.

## What

Offline `extract: text` resolved to the accessible **name**, which is empty for role-less nodes (custom elements, bare `<span>`s) — so card sub-fields authors pull up (e.g. a flight code, a fare cabin living in plain spans) rendered blank in `snapshot`/`coverage`/`bounds`, even though runtime consumers read the visible text fine. Authors couldn't verify these properties from the corpus tooling.

## Changes

- **`ComponentNode.Text`** — new post-merge field carrying the node's rendered text. Documented in `conformance/component-schema.md`.
- **`BuildTree`** plumbs the probe's captured text onto the node, run through a single `normalizeText` (collapse whitespace runs + trim) at the build boundary, so every consumer sees one clean shape.
- **`resolveExtract`** `text` case falls back to `Text` when the accessible `Name` is empty (Name still wins when present).
- **`probe.js`** captures `innerText` (rendered — reflects `text-transform` + visibility, excludes non-rendered `<style>`/`<script>` and hidden nodes) instead of raw `textContent`; no `textContent` fallback (it re-introduced descendant style/script text), and non-rendered elements are skipped (Chrome's `innerText` on `<head>` quirkily returns its `<style>` text).

## Validation

- Unit tests: Name→Text fallback + precedence (`match`), text capture + normalization + `normalizeText` table (`extract`). Full suite green, `go vet` clean.
- Live on a large SPA (jetblue.com booking results): 105 role-less nodes now carry populated, fully-normalized text, **0** `<style>`/`<script>`/CSS leaks; snapshot probe/extract ~2.7s (no `innerText` reflow blowup — layout is already forced per element during the walk).

## Notes

- Selectors and coverage are unaffected (they key on tag/id/class/attrs and interactive-node containment, not text).
- Captured text is `innerText`-based, so a *container's* `text` aggregates descendant text (bounded by the existing 100-char cap) — extract leaf values via child components (the tree-closed model), as the authoring guidance already recommends.