### PR TITLE
extract: capture the full attribute set for offline matching

### DIFF
--- a/.changeset/offline-attr-capture.md
+++ b/.changeset/offline-attr-capture.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+The offline element model now captures every attribute the live DOM carries (minus injected sightmap ids and framework-internal `_`-scoping attributes like Angular's `_nghost`/`_ngcontent`), not just the curated subset that landed in the generated selector string. Offline attribute selectors (`[attr=…]`, `[attr*=…]`, …) and `extract: attr=NAME` now match the live DOM for non-standard attributes — e.g. `value` on a `role="option"` `<li>` — closing a source of live/offline divergence.

--- a/go/extract/build.go
+++ b/go/extract/build.go
@@ -155,12 +155,27 @@ func elementFor(pc *ProbeComponent) *sightmap.Element {
 		el = &sightmap.Element{Tag: strings.ToLower(pc.TagName)}
 	}
 
+	// Overlay the full observed attribute set so offline matching sees every
+	// attribute the live DOM carries, not just the subset the generated
+	// selector encoded. Raw live values win over the selector-parsed subset
+	// (they're what a live querySelector would compare against).
+	for name, val := range pc.Attributes {
+		if el.Attrs == nil {
+			el.Attrs = make(map[string]string)
+		}
+		el.Attrs[name] = val
+	}
+
 	// Duplicate classes into Attrs["class"] for attribute selector support.
+	// (pc.Attributes usually already carries "class"; this keeps the fallback
+	// path — where el came only from a parsed selector — correct too.)
 	if len(el.Classes) > 0 {
 		if el.Attrs == nil {
 			el.Attrs = make(map[string]string)
 		}
-		el.Attrs["class"] = strings.Join(el.Classes, " ")
+		if _, ok := el.Attrs["class"]; !ok {
+			el.Attrs["class"] = strings.Join(el.Classes, " ")
+		}
 	}
 
 	return el

--- a/go/extract/build_test.go
+++ b/go/extract/build_test.go
@@ -155,6 +155,35 @@ func TestTextCapturedAndNormalized(t *testing.T) {
 	}
 }
 
+// Non-standard attributes (e.g. `value` on a role=option <li>) are captured
+// into Element.Attrs so offline attribute selectors + attr= extraction match
+// the live DOM, even though they never appear in the generated selector string.
+func TestFullAttributeCapture(t *testing.T) {
+	probe := &ProbeResult{
+		Success: true,
+		Results: []ProbeComponent{{
+			Id:         "1",
+			TagName:    "LI",
+			Selector:   "li[role=\"option\"]", // selector omits the value attr
+			Attributes: map[string]string{"role": "option", "value": "JFK", "class": "opt"},
+		}},
+	}
+	domRoot := domWrapper("#document", domChild(1, 10, "LI", "1"))
+	root, err := BuildTree(probe, nil, domRoot)
+	if err != nil {
+		t.Fatalf("BuildTree error: %v", err)
+	}
+	if root.Element == nil {
+		t.Fatal("Element is nil")
+	}
+	if got := root.Element.Attrs["value"]; got != "JFK" {
+		t.Errorf("Attrs[value] = %q, want %q (non-standard attr not captured offline)", got, "JFK")
+	}
+	if got := root.Element.Attrs["class"]; got != "opt" {
+		t.Errorf("Attrs[class] = %q, want %q", got, "opt")
+	}
+}
+
 func TestNormalizeText(t *testing.T) {
 	cases := map[string]string{
 		"":              "",

--- a/go/extract/types.go
+++ b/go/extract/types.go
@@ -21,7 +21,8 @@ type ProbeComponent struct {
 	Value         string            `json:"value"` // empty pre-merge
 	Properties    map[string]string `json:"properties"`
 	Bounds        *sightmap.Bounds  `json:"bounds"`
-	Selector      string            `json:"selector"` // CSS selector string
+	Selector      string            `json:"selector"`   // CSS selector string
+	Attributes    map[string]string `json:"attributes"` // full attribute set (minus data-sightmap-*)
 	OnTop         bool              `json:"onTop"`
 	IsVisible     bool              `json:"isVisible"`
 	InViewport    bool              `json:"inViewport"`

--- a/go/probe/probe.js
+++ b/go/probe/probe.js
@@ -325,6 +325,23 @@ function computeCompProps(isLogicalRoot, useScrollOffset) {
         const metadata = extractMetadata(element);
         const selector = generateSelector(element);
 
+        // Capture the full attribute set (minus our own injected ids) so the
+        // offline model can match ANY attribute the live DOM carries — not just
+        // the curated subset that lands in the generated selector string. This
+        // is what closes offline/live divergence for non-standard attributes
+        // like `value` on a non-form element (react-aria listbox options).
+        const attributes = {};
+        if (element.hasAttributes()) {
+            for (const attr of element.attributes) {
+                // Skip our own injected ids, and framework-internal scoping
+                // attributes (Angular's valueless _nghost-*/_ngcontent-*, hashed
+                // per build) which are pure noise and never a stable selector.
+                if (attr.name.startsWith('data-sightmap-')) continue;
+                if (attr.name.charCodeAt(0) === 95 /* '_' */) continue;
+                attributes[attr.name] = attr.value;
+            }
+        }
+
         const tag = (element.tagName || '').toLowerCase();
 
         // For iframe/frame elements, use content box instead of border box so
@@ -361,6 +378,7 @@ function computeCompProps(isLogicalRoot, useScrollOffset) {
             properties: {},                                            // Will be filled by accessibility data
             bounds: bounds,
             selector: selector,
+            attributes: attributes,
             onTop: onTop,
             isVisible: isVisible,
             inViewport: inViewport,


### PR DESCRIPTION
Fixes #300. **Stacked on #299** (base is `offline-text-parity`).

## What

Offline attribute matching only saw the attributes the probe encoded into the generated **selector string** — id, classes, a fixed `keyAttrs` list, `aria-*`, `data-*`. Any other attribute was dropped, so `[value="JFK"]` and `extract: attr=value` were **offline-blind** on nodes like react-aria listbox options (`<li role="option" value="JFK">`), even though `sel-probe`'s live query matched.

## Changes

- **`probe.js`** captures the full attribute set per element, skipping only injected `data-sightmap-*` ids and framework-internal `_`-scoping attributes (Angular's valueless, per-build-hashed `_nghost-*`/`_ngcontent-*` — pure noise, never a stable selector).
- **`ProbeComponent.Attributes`** carries them; **`BuildTree`/`elementFor`** overlays them onto `Element.Attrs` (raw live values win over the selector-parsed subset).

## Validation

- Unit test: a `value` attr on a `role=option` `<li>` surfaces in `Element.Attrs` though the selector omits it. Full suite green, `go vet` clean.
- Live (jetblue booking results): **406** meaningful non-curated attributes now captured across 56 names (was 617 before filtering out the Angular `_`-scoping noise), **0** leading-underscore. Newly-visible hooks include `jbbutton`, `formcontrolname`, `jbinput`, `autocomplete`, and SVG geometry attrs — useful stable-ish selectors for this app.

## Notes

- Additive matching capability; existing selectors are unaffected.
- The "warn when `attr=` targets an uncaptured attribute" idea is obviated — the offline model now sees them all.