### PR TITLE
browser: eval awaits a returned promise

### DIFF
--- a/.changeset/eval-await-promise.md
+++ b/.changeset/eval-await-promise.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`browser eval` now awaits a returned Promise and yields its settled value instead of an opaque `{}`, so async page/tool code (e.g. an awaited `executeTool()`) can be driven directly. A per-eval timeout bounds a never-settling promise. This is a no-op for synchronous expressions.

--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -257,11 +257,17 @@ func NavigateAndWaitIdle(ctx context.Context, conn *CDPConn, url string, maxWait
 
 // EvalJSON evaluates script, unwraps Runtime.evaluate's double-envelope,
 // returns the raw JSON value. Errors on JS exception.
+//
+// awaitPromise is on: when the expression evaluates to a Promise, CDP resolves
+// it and returns the settled value (a rejection surfaces as a JS exception).
+// This is a no-op for synchronous results, so driving async page/tool code
+// (e.g. an awaited executeTool()) returns the real value instead of an opaque
+// unresolved-promise handle. Callers bound long-running work via ctx.
 func EvalJSON(ctx context.Context, conn *CDPConn, script string) (json.RawMessage, error) {
 	result, err := conn.call(ctx, "Runtime.evaluate", map[string]interface{}{
 		"expression":    script,
 		"returnByValue": true,
-		"awaitPromise":  false,
+		"awaitPromise":  true,
 	})
 	if err != nil {
 		return nil, err

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -456,6 +456,10 @@ func runNavigate(args []string) error {
 	return nil
 }
 
+// evalTimeout bounds a single `browser eval`, so an awaited promise that never
+// settles fails cleanly instead of hanging the CLI.
+const evalTimeout = 30 * time.Second
+
 func runEval(args []string) error {
 	sightmapDir, args := resolveSightmapDir(args)
 	addr, args := resolveAddr(args, sightmapDir)
@@ -471,7 +475,12 @@ func runEval(args []string) error {
 	}
 	defer conn.Close()
 
-	result, err := browser.EvalJSON(context.Background(), conn, script)
+	// EvalJSON awaits a returned Promise; bound it so a never-settling promise
+	// can't hang the CLI indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), evalTimeout)
+	defer cancel()
+
+	result, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #131. **Stacked on #301** (base is `offline-attr-capture`).

## What

`Runtime.evaluate` ran with `awaitPromise: false`, so a `browser eval` expression that evaluates to a Promise — an `async () => {...}()` IIFE, or an awaited `executeTool()` — returned an opaque `{}` instead of the resolved value. Testing async page/tool code required a stash-and-poll workaround (`window.__r = …`; second eval reads it).

## Changes

- **`EvalJSON`**: `awaitPromise: true`. CDP resolves a returned Promise and hands back the settled value (a rejection surfaces as the usual JS exception). No-op for synchronous results, so the many internal callers are unaffected.
- **`runEval`**: bounds the eval with a timeout so a never-settling promise fails cleanly instead of hanging the CLI (`conn.call` already honors `ctx`).

## Validation

- Live: `(async () => { await …; return {awaited:true} })()` now returns `{"awaited": true, …}` (was `{}`); `Promise.resolve(42)` returns `42`. Full suite green, `go vet` clean.