### PR TITLE
web: add /building, an immersive 3D tour of how Sightmap works

### DIFF
--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -295,6 +295,57 @@ views:
         source: src/pages/Developers.tsx
         description: One developer resource — title, what it is, and its URL
 
+  - name: Building
+    route: /building
+    description: Scroll-driven 3D tour of the app-as-a-building metaphor — code as blueprint, the running app as the building, the sightmap as its wayfinding, agents as the people inside
+    source: src/pages/Building.tsx
+    dependencies:
+      - src/components/building/**
+      - src/building.css
+    memory:
+      - The WebGL scene (src/components/building/Scene.tsx) mounts only after a client effect and is code-split; the prerendered HTML carries the SVG poster and the full chapter text, so the page reads without JS or WebGL
+      - Scroll position drives the scene — each `.bld-chapter` section is one chapter and the active one carries `data-active="true"`; the canvas itself is aria-hidden and has no interactive nodes
+      - Chapter copy lives in src/components/building/chapters.ts, not in the page component
+      - "Chapters 05–07 (self-healing tests, trajectories, Web MCP tools) describe exploratory work and carry the `exploratory` badge; they are not shipped features"
+    components:
+      - name: BuildingNav
+        selector: '[data-component="BuildingNav"]'
+        source: src/components/building/BuildingNav.tsx
+        description: Page-local header — logo home link plus Home, Docs and GitHub; swaps to a dark treatment at nightfall
+      - name: BuildingStage
+        selector: '[data-component="BuildingStage"]'
+        source: src/components/building/BuildingExperience.tsx
+        description: Fixed full-viewport stage holding the SVG poster and, once mounted, the WebGL canvas
+        children:
+          - name: BuildingPoster
+            selector: '[data-component="BuildingPoster"]'
+            description: Static isometric blueprint illustration — the prerendered fallback, faded out once the scene renders
+      - name: BuildingChapter
+        selector: '[data-component="BuildingChapter"]'
+        source: src/components/building/BuildingExperience.tsx
+        description: One scroll chapter of the story — eyebrow, heading, body, and an optional call to action
+        properties:
+          - name: chapter
+            extract: attr=data-chapter
+          - name: active
+            extract: attr=data-active
+        children:
+          - name: bld-card
+            selector: '.bld-card'
+          - name: bld-card-ctas
+            selector: '.bld-card__ctas'
+      - name: BuildingHud
+        selector: '[data-component="BuildingHud"]'
+        source: src/components/building/BuildingExperience.tsx
+        description: Desktop-only readout in the top right — three live-looking figures that change with the chapter
+      - name: BuildingRail
+        selector: '[data-component="BuildingRail"]'
+        source: src/components/building/BuildingExperience.tsx
+        description: Bottom progress rail — one button per chapter, the current one pressed; clicking scrolls to that chapter
+        children:
+          - name: bld-rail-dot
+            selector: '.bld-rail__dot'
+
   - name: NotFound
     route: '*'
     description: Catch-all 404 page for any unmatched route

--- a/web/package.json
+++ b/web/package.json
@@ -18,11 +18,14 @@
     "og:card": "node og/render.mjs --post"
   },
   "dependencies": {
+    "@react-three/drei": "10.7.8",
+    "@react-three/fiber": "9.7.0",
     "html-react-parser": "^6.1.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.0",
-    "react-syntax-highlighter": "^16.1.1"
+    "react-syntax-highlighter": "^16.1.1",
+    "three": "0.185.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
@@ -30,6 +33,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/three": "0.185.4",
     "@vitejs/plugin-react": "^4.3.0",
     "gray-matter": "^4.0.3",
     "marked": "^15.0.12",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@react-three/drei':
+        specifier: 10.7.8
+        version: 10.7.8(@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1))(@types/react@19.2.14)(@types/three@0.185.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1)
+      '@react-three/fiber':
+        specifier: 9.7.0
+        version: 9.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1)
       html-react-parser:
         specifier: ^6.1.5
         version: 6.1.5(@types/react@19.2.14)(react@19.2.4)
@@ -23,6 +29,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^16.1.1
         version: 16.1.1(react@19.2.4)
+      three:
+        specifier: 0.185.1
+        version: 0.185.1
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
@@ -39,6 +48,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@types/three':
+        specifier: 0.185.4
+        version: 0.185.4
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.2(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.23.1))
@@ -155,6 +167,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -484,6 +499,50 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  '@react-three/drei@10.7.8':
+    resolution: {integrity: sha512-rJXyuzLm2Xq0kafHuR47ajDGbOe/pEhzIr4m8E8zwzQs0iNjloFDqBwRhrXmP/w+onLeYyN3EYPFW/cwWK/4yA==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  '@react-three/fiber@9.7.0':
+    resolution: {integrity: sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -719,6 +778,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -737,6 +799,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -746,6 +811,9 @@ packages:
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
@@ -754,17 +822,39 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.185.4':
+    resolution: {integrity: sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -808,19 +898,34 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.0:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
+    peerDependencies:
+      three: '>=0.126.1'
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
@@ -852,6 +957,15 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -870,6 +984,9 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -890,6 +1007,9 @@ packages:
   domutils@4.0.2:
     resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
     engines: {node: '>=20.19.0'}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
@@ -947,6 +1067,12 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.6.11:
+    resolution: {integrity: sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
@@ -959,6 +1085,9 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -979,6 +1108,9 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hls.js@1.7.1:
+    resolution: {integrity: sha512-DlzIkeBAS9IIQ432k3BUf3HlwbsR0+trB1i2lDdN2gUkNkrehFurh0/48M5c1/EjlDkdGng1gwZIpwyPxvdZ/g==}
+
   html-dom-parser@8.0.0:
     resolution: {integrity: sha512-cWLJ8mt930VceOzVfY/J+T1ou9v3ENT0BgWqy5aEZjdFp37TYLXULjX8u0vD2rBpFAkK5IofOPl0y4Gq0QLIyA==}
 
@@ -994,6 +1126,12 @@ packages:
   htmlparser2@12.0.0:
     resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
     engines: {node: '>=20.19.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   inline-style-parser@0.2.9:
     resolution: {integrity: sha512-IttN8BqKLxzUrnTqHI+/hwAJQItBAUjdoHERCDv+oOuX48VP6bzW8+QjOXSfoevzq3YrYAwX1uLHp8TqO9yIeg==}
@@ -1013,6 +1151,17 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1041,6 +1190,9 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -1125,6 +1277,12 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1132,6 +1290,14 @@ packages:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
     hasBin: true
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1146,6 +1312,10 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1165,9 +1335,15 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -1200,12 +1376,25 @@ packages:
     peerDependencies:
       react: '>= 0.14.0'
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
@@ -1226,6 +1415,14 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1241,6 +1438,15 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1258,12 +1464,30 @@ packages:
   style-to-object@2.0.2:
     resolution: {integrity: sha512-QmbXPUylqU80HAgTOJeEOdbA40W9KtxmjMhQy+tq+b8F2aoh3aQLuy82hh2jm2qsC9hR9eI0+eQidTMydKcqRA==}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   tailwindcss@4.2.0:
     resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1287,10 +1511,26 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  troika-three-text@0.52.5:
+    resolution: {integrity: sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.5:
+    resolution: {integrity: sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
+
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -1305,6 +1545,15 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1379,6 +1628,17 @@ packages:
       jsdom:
         optional: true
 
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1389,6 +1649,39 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+  zustand@5.0.15:
+    resolution: {integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -1505,6 +1798,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1681,6 +1976,66 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@monogrid/gainmap-js@3.4.0(three@0.185.1)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.185.1
+
+  '@react-three/drei@10.7.8(@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1))(@types/react@19.2.14)(@types/three@0.185.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.185.1)
+      '@react-three/fiber': 9.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1)
+      '@use-gesture/react': 10.3.1(react@19.2.4)
+      camera-controls: 3.1.2(three@0.185.1)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.7.1
+      maath: 0.10.8(@types/three@0.185.4)(three@0.185.1)
+      meshline: 3.3.1(three@0.185.1)
+      react: 19.2.4
+      stats-gl: 2.4.2(@types/three@0.185.4)(three@0.185.1)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.2.4)
+      three: 0.185.1
+      three-mesh-bvh: 0.8.3(three@0.185.1)
+      three-stdlib: 2.36.1(three@0.185.1)
+      troika-three-text: 0.52.5(three@0.185.1)
+      tunnel-rat: 0.1.2(@types/react@19.2.14)(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      utility-types: 3.11.0
+      zustand: 5.0.15(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+
+  '@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-use-measure: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.4)
+      three: 0.185.1
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      zustand: 5.0.15(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
@@ -1826,6 +2181,8 @@ snapshots:
       tailwindcss: 4.2.0
       vite: 6.4.2(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.23.1)
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -1854,6 +2211,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.5':
@@ -1864,9 +2223,15 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/prismjs@1.26.6': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react-reconciler@0.28.9(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
 
@@ -1878,9 +2243,29 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.185.4':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.2.4)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.2.4
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.23.1))':
     dependencies:
@@ -1942,7 +2327,13 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   browserslist@4.28.1:
     dependencies:
@@ -1952,7 +2343,16 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   cac@6.7.14: {}
+
+  camera-controls@3.1.2(three@0.185.1):
+    dependencies:
+      three: 0.185.1
 
   caniuse-lite@1.0.30001770: {}
 
@@ -1978,6 +2378,16 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -1989,6 +2399,10 @@ snapshots:
       character-entities: 2.0.2
 
   deep-eql@5.0.2: {}
+
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
 
   detect-libc@2.1.2: {}
 
@@ -2009,6 +2423,8 @@ snapshots:
       dom-serializer: 3.1.1
       domelementtype: 3.0.0
       domhandler: 6.0.1
+
+  draco3d@1.5.7: {}
 
   electron-to-chromium@1.5.286: {}
 
@@ -2101,12 +2517,18 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.6.11: {}
+
+  fflate@0.8.3: {}
+
   format@0.2.2: {}
 
   fsevents@2.3.3:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  glsl-noise@0.0.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -2133,6 +2555,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hls.js@1.7.1: {}
+
   html-dom-parser@8.0.0:
     dependencies:
       domhandler: 6.0.1
@@ -2155,6 +2579,10 @@ snapshots:
       domutils: 4.0.2
       entities: 8.0.0
 
+  ieee754@1.2.1: {}
+
+  immediate@3.0.6: {}
+
   inline-style-parser@0.2.9: {}
 
   is-alphabetical@2.0.1: {}
@@ -2169,6 +2597,17 @@ snapshots:
   is-extendable@0.1.1: {}
 
   is-hexadecimal@2.0.1: {}
+
+  is-promise@2.2.2: {}
+
+  isexe@2.0.0: {}
+
+  its-fine@2.0.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
 
   jiti@2.6.1: {}
 
@@ -2186,6 +2625,10 @@ snapshots:
   json5@2.2.3: {}
 
   kind-of@6.0.3: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -2247,11 +2690,22 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  maath@0.10.8(@types/three@0.185.4)(three@0.185.1):
+    dependencies:
+      '@types/three': 0.185.4
+      three: 0.185.1
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
+
+  meshline@3.3.1(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  meshoptimizer@1.1.1: {}
 
   ms@2.1.3: {}
 
@@ -2269,6 +2723,8 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  path-key@3.1.1: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -2283,7 +2739,14 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@1.0.2: {}
+
   prismjs@1.30.0: {}
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   property-information@7.2.0: {}
 
@@ -2314,6 +2777,12 @@ snapshots:
       react: 19.2.4
       refractor: 5.0.0
 
+  react-use-measure@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   refractor@5.0.0:
@@ -2322,6 +2791,8 @@ snapshots:
       '@types/prismjs': 1.26.6
       hastscript: 9.0.1
       parse-entities: 4.0.2
+
+  require-from-string@2.0.2: {}
 
   rollup@4.57.1:
     dependencies:
@@ -2365,6 +2836,12 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -2374,6 +2851,13 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  stats-gl@2.4.2(@types/three@0.185.4)(three@0.185.1):
+    dependencies:
+      '@types/three': 0.185.4
+      three: 0.185.1
+
+  stats.js@0.17.0: {}
 
   std-env@3.10.0: {}
 
@@ -2391,9 +2875,29 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.9
 
+  suspend-react@0.1.3(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   tailwindcss@4.2.0: {}
 
   tapable@2.3.0: {}
+
+  three-mesh-bvh@0.8.3(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  three-stdlib@2.36.1(three@0.185.1):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.24
+      draco3d: 1.5.7
+      fflate: 0.6.11
+      potpack: 1.0.2
+      three: 0.185.1
+
+  three@0.185.1: {}
 
   tinybench@2.9.0: {}
 
@@ -2410,11 +2914,33 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  troika-three-text@0.52.5(three@0.185.1):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.185.1
+      troika-three-utils: 0.52.5(three@0.185.1)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.5(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  troika-worker-utils@0.52.0: {}
+
   tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   typescript@5.7.3: {}
 
@@ -2425,6 +2951,12 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  utility-types@3.11.0: {}
 
   vite-node@3.2.4(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.23.1):
     dependencies:
@@ -2503,6 +3035,14 @@ snapshots:
       - tsx
       - yaml
 
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2511,3 +3051,16 @@ snapshots:
   yallist@3.1.1: {}
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+
+  zustand@5.0.15(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)

--- a/web/scripts/generate-agent-files.ts
+++ b/web/scripts/generate-agent-files.ts
@@ -19,6 +19,7 @@ import {
   buildAtlasIndexMarkdown,
   buildBlogIndexMarkdown,
   buildBlogPostMarkdown,
+  buildBuildingMarkdown,
   buildDevelopersMarkdown,
   buildHomeMarkdown,
   buildNotFoundMarkdown,
@@ -82,6 +83,7 @@ async function main() {
   write('blog.md', buildBlogIndexMarkdown(posts))
   write('atlas.md', buildAtlasIndexMarkdown(atlas))
   write('developers.md', buildDevelopersMarkdown())
+  write('building.md', buildBuildingMarkdown())
 
   for (const post of loaded) {
     write(

--- a/web/scripts/generate-feeds.test.ts
+++ b/web/scripts/generate-feeds.test.ts
@@ -103,7 +103,8 @@ describe('buildSitemap', () => {
     expect(xml).toContain('<loc>https://sightmap.org/atlas/sightmap-org</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/atlas/example-shop</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/developers</loc>')
-    expect(xml.match(/<url>/g)).toHaveLength(8)
+    expect(xml).toContain('<loc>https://sightmap.org/building</loc>')
+    expect(xml.match(/<url>/g)).toHaveLength(9)
   })
 
   it('uses the post date as lastmod for post URLs', () => {
@@ -124,7 +125,8 @@ describe('buildSitemap', () => {
     expect(xml).toContain('<loc>https://sightmap.org/blog</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/atlas</loc>')
     expect(xml).toContain('<loc>https://sightmap.org/developers</loc>')
-    expect(xml.match(/<url>/g)).toHaveLength(4)
+    expect(xml).toContain('<loc>https://sightmap.org/building</loc>')
+    expect(xml.match(/<url>/g)).toHaveLength(5)
     expect(xml).not.toContain('undefined')
     expect(xml).toContain('<lastmod>2026-07-28</lastmod>')
   })

--- a/web/scripts/generate-feeds.ts
+++ b/web/scripts/generate-feeds.ts
@@ -22,6 +22,7 @@ import {
   BLOG_DESCRIPTION,
   ATLAS_DESCRIPTION,
   escXml,
+  BUILDING_DESCRIPTION,
 } from './lib/site'
 
 const DIST = path.resolve('dist')
@@ -92,6 +93,7 @@ export function buildSitemap(posts: FeedPost[], atlas: FeedAtlasEntry[], now: Da
   const urls = [
     { loc: `${SITE_URL}/`, lastmod: today, priority: '1.0' },
     { loc: `${SITE_URL}/developers`, lastmod: today, priority: '0.8' },
+    { loc: `${SITE_URL}/building`, lastmod: today, priority: '0.8' },
     { loc: `${SITE_URL}/blog`, lastmod: posts[0]?.date ?? today, priority: '0.8' },
     ...posts.map((p) => ({
       loc: `${SITE_URL}/blog/${p.slug}`,
@@ -195,6 +197,7 @@ export function buildLlmsTxt(posts: FeedPost[], atlas: FeedAtlasEntry[]): string
     '',
     `- [Documentation](https://docs.sightmap.org): Guides, CLI reference, and the schema reference.`,
     `- [Specification](https://github.com/sightmap/sightmap/tree/main/spec): The normative spec, JSON Schema, and conformance fixtures.`,
+    `- [The Building](${SITE_URL}/building): ${oneLine(BUILDING_DESCRIPTION)}`,
     '',
     '## Sightmap developer resources',
     '',

--- a/web/scripts/lib/agent.ts
+++ b/web/scripts/lib/agent.ts
@@ -3,6 +3,8 @@
 // writes them into dist/; the negotiate edge function serves the twins
 // when Accept prefers text/markdown.
 import {
+  BUILDING_DESCRIPTION,
+  BUILDING_TITLE,
   DEVELOPERS_DESCRIPTION,
   DEVELOPERS_TITLE,
   SITE_DESCRIPTION,
@@ -55,6 +57,7 @@ This is the ${SITE_NAME} homepage at ${SITE_URL}. ${SITE_NAME} is an open YAML s
 ## Start here
 
 - [Sightmap developer resources](${SITE_URL}${DEVELOPERS_PATH})
+- [The Building — how Sightmap works](${SITE_URL}/building)
 - [OpenAPI specification](${SITE_URL}/openapi.json)
 - [llms.txt](${SITE_URL}/llms.txt)
 - [Documentation](https://docs.sightmap.org)
@@ -112,6 +115,35 @@ Machine index: ${SITE_URL}/atlas/index.json
 HTTP API: ${SITE_URL}/api/atlas
 
 ${items}
+`
+}
+
+export function buildBuildingMarkdown(): string {
+  return `# ${BUILDING_TITLE}
+
+${BUILDING_DESCRIPTION}
+
+The interactive version at ${SITE_URL}/building is a scroll-driven 3D scene. This is the same story in text.
+
+## The metaphor
+
+- **Code is the blueprint.** Source files describe every wall: components, routes, API handlers. They are complete and exact, and almost useless to someone standing in the lobby.
+- **The running app is the building.** Each view is a floor with its own route. Components are the rooms on that floor. API requests are the service risers running up the core.
+- **A sightmap is the wayfinding.** A \`.sightmap/\` directory names every floor, room, and riser, links each back to its source file, and keeps memory notes for the quirks the drawings never recorded.
+- **Users and agents are the people.** Every session is a journey through rooms and floors. Subtext records those journeys against the map, so a replay reads as named components rather than a list of divs.
+
+## Built on top (exploratory)
+
+- **Self-healing tests.** A test written against the map asks the building where a room went when a selector changes; the name stays stable and the run finishes.
+- **Trajectories.** Codified journeys: the views a flow visits, the components it touches, and the requests it expects on the way.
+- **Web MCP tools.** Tools generated from the map, each backed by a real view and a real request, so an agent walks up to the front desk instead of wandering the halls.
+
+## Next
+
+- [Homepage](${SITE_URL}/)
+- [Quickstart](https://docs.sightmap.org/start/quickstart)
+- [Documentation](https://docs.sightmap.org)
+- [GitHub](https://github.com/sightmap/sightmap)
 `
 }
 

--- a/web/scripts/lib/site.ts
+++ b/web/scripts/lib/site.ts
@@ -49,6 +49,12 @@ export const NOT_FOUND_DESCRIPTION = "This page doesn't exist."
 export const DEVELOPERS_TITLE = `${SITE_NAME} developer resources`
 export const DEVELOPERS_DESCRIPTION =
   'OpenAPI, the Atlas HTTP API, documentation, CLI, and agent skills for the Sightmap spec.'
+// The immersive tour at /building: the app-as-a-building metaphor, rendered as
+// a scroll-driven 3D scene. Read by scripts/prerender.tsx, src/pages/Building.tsx,
+// and the sitemap / llms.txt / markdown-twin generators.
+export const BUILDING_TITLE = `The Building — how ${SITE_NAME} works`
+export const BUILDING_DESCRIPTION =
+  'An interactive tour of how Sightmap works: code is the blueprint, the running app is the building, a sightmap is its wayfinding, and agents are the people moving through it.'
 export const postTitle = (title: string): string => `${title} — ${SITE_NAME}`
 // An atlas entry's own title carries the mapped site's name, so the suffix
 // says which gallery it came from rather than repeating the site name twice.

--- a/web/scripts/prerender.tsx
+++ b/web/scripts/prerender.tsx
@@ -27,6 +27,8 @@ import {
   NOT_FOUND_DESCRIPTION,
   DEVELOPERS_TITLE,
   DEVELOPERS_DESCRIPTION,
+  BUILDING_TITLE,
+  BUILDING_DESCRIPTION,
   postTitle,
   atlasTitle,
   esc,
@@ -553,8 +555,31 @@ async function main() {
     )
   )
 
+  // The 3D scene mounts client-side only (see src/pages/Building.tsx), so this
+  // file carries the full narrative text plus the static SVG poster — which is
+  // what crawlers, unfurlers, and a no-JS visitor get.
+  write(
+    'building',
+    renderRoute(
+      shell,
+      '/building',
+      {
+        url: `${SITE_URL}/building`,
+        ogUrl: `${DEPLOY_URL}/building`,
+        title: BUILDING_TITLE,
+        description: BUILDING_DESCRIPTION,
+        image: `${SITE_URL}/og-image.png`,
+        ogImage: `${DEPLOY_URL}/og-image.png`,
+        imageAlt: DEFAULT_IMAGE_ALT,
+        imageDimensionsKnown: true,
+        type: 'website',
+      },
+      [mdAlternate(`${SITE_URL}/building.md`), siteJsonLd].join('\n    ')
+    )
+  )
+
   console.log(
-    `\n  prerender complete: ${posts.length + atlas.entries.length + 5} page(s)`
+    `\n  prerender complete: ${posts.length + atlas.entries.length + 6} page(s)`
   )
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import BlogPost from '@/pages/BlogPost'
 import AtlasIndex from '@/pages/AtlasIndex'
 import AtlasEntry from '@/pages/AtlasEntry'
 import Developers from '@/pages/Developers'
+import Building from '@/pages/Building'
 import NotFound from '@/pages/NotFound'
 import { ConsentProvider } from '@/components/consent/ConsentContext'
 import ConsentUI from '@/components/consent/ConsentUI'
@@ -23,6 +24,7 @@ export default function App() {
         <Route path="/atlas" element={<AtlasIndex />} />
         <Route path="/atlas/:slug" element={<AtlasEntry />} />
         <Route path="/developers" element={<Developers />} />
+        <Route path="/building" element={<Building />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <ConsentUI />

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -1,0 +1,673 @@
+/* ---- /building: the immersive tour ------------------------------------
+   Scoped under .bld. Two moods: day (cream, matches the rest of the site)
+   and night, toggled by [data-night] on the root when the last chapter is
+   active. The stage is fixed behind everything; chapters scroll over it. */
+
+.bld {
+  --bld-ink: var(--text-bright);
+  --bld-body: #5b564a;
+  --bld-dim: var(--text-dim);
+  --bld-card-bg: rgba(250, 248, 246, 0.74);
+  --bld-card-border: rgba(255, 255, 255, 0.7);
+  --bld-card-shadow: 0 24px 70px rgba(24, 44, 92, 0.14);
+  --bld-chrome-bg: rgba(250, 248, 246, 0.66);
+  --bld-chrome-border: rgba(61, 57, 41, 0.12);
+  --bld-code-bg: rgba(255, 255, 255, 0.7);
+  position: relative;
+  min-height: 100vh;
+  color: var(--bld-body);
+}
+
+.bld[data-night='true'] {
+  --bld-ink: #f5f1ea;
+  --bld-body: #c3cadb;
+  --bld-dim: #8f9ab8;
+  --bld-card-bg: rgba(12, 22, 50, 0.66);
+  --bld-card-border: rgba(255, 255, 255, 0.12);
+  --bld-card-shadow: 0 24px 70px rgba(0, 0, 0, 0.45);
+  --bld-chrome-bg: rgba(12, 22, 50, 0.6);
+  --bld-chrome-border: rgba(255, 255, 255, 0.14);
+  --bld-code-bg: rgba(255, 255, 255, 0.08);
+}
+
+/* Stage ------------------------------------------------------------------ */
+
+.bld-stage {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.bld-stage::before,
+.bld-stage::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  transition: opacity 1.4s ease;
+}
+
+.bld-stage::before {
+  background:
+    radial-gradient(120% 90% at 72% 8%, #e9eefb 0%, rgba(250, 248, 246, 0) 55%),
+    linear-gradient(180deg, #f7f4ef 0%, #f1ece4 100%);
+  opacity: 1;
+}
+
+.bld-stage::after {
+  background:
+    radial-gradient(120% 90% at 72% 8%, #22346b 0%, rgba(9, 16, 38, 0) 60%),
+    linear-gradient(180deg, #0c1531 0%, #070d22 100%);
+  opacity: 0;
+}
+
+.bld[data-night='true'] .bld-stage::after { opacity: 1; }
+.bld[data-night='true'] .bld-stage::before { opacity: 0; }
+
+.bld-stage > div,
+.bld-stage canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.bld-poster {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  padding: 8vh 4vw 12vh 34vw;
+  transition: opacity 1.1s ease 0.2s;
+  filter: drop-shadow(0 30px 40px rgba(20, 40, 90, 0.25));
+}
+
+.bld-poster[data-hidden='true'] { opacity: 0; }
+
+/* Nav -------------------------------------------------------------------- */
+
+.bld-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  height: 56px;
+  padding: 0 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--bld-chrome-bg);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--bld-chrome-border);
+  transition: background 0.8s ease, border-color 0.8s ease;
+}
+
+.bld-nav__logo {
+  display: inline-flex;
+  align-items: center;
+  color: var(--bld-ink);
+}
+
+.bld-nav__logo svg {
+  height: 20px;
+  width: auto;
+  display: block;
+}
+
+.bld-nav__title {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--bld-dim);
+  padding-left: 1rem;
+  border-left: 1px solid var(--bld-chrome-border);
+}
+
+.bld-nav__links {
+  margin-left: auto;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.bld-nav__links a {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--bld-dim);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.bld-nav__links a:hover { color: var(--bld-ink); }
+
+/* Story ------------------------------------------------------------------ */
+
+.bld-story {
+  position: relative;
+  z-index: 1;
+}
+
+.bld-chapter {
+  min-height: 100vh;
+  min-height: 100svh;
+  display: flex;
+  align-items: center;
+  padding: 5rem 0 5rem clamp(1.5rem, 6vw, 7rem);
+}
+
+.bld-card {
+  max-width: 470px;
+  padding: 1.75rem 2rem 1.9rem;
+  background: var(--bld-card-bg);
+  border: 1px solid var(--bld-card-border);
+  border-radius: 18px;
+  box-shadow: var(--bld-card-shadow);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  opacity: 0.32;
+  transform: translateY(14px);
+  transition: opacity 0.55s ease, transform 0.55s ease, background 0.8s ease, border-color 0.8s ease;
+}
+
+.bld-chapter[data-active='true'] .bld-card {
+  opacity: 1;
+  transform: none;
+}
+
+.bld-card__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.9rem;
+}
+
+.bld-card__badge {
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  padding: 0.12rem 0.5rem;
+  border-radius: 100px;
+  border: 1px solid currentColor;
+  color: var(--yellow);
+}
+
+.bld .bld-card__title {
+  font-family: var(--sans);
+  font-weight: 700;
+  color: var(--bld-ink);
+  letter-spacing: -0.03em;
+  line-height: 1.08;
+  margin: 0 0 1rem;
+  font-size: clamp(1.7rem, 2.6vw, 2.35rem);
+  text-wrap: balance;
+  transition: color 0.8s ease;
+}
+
+.bld .bld-chapter[data-chapter='arrival'] .bld-card__title {
+  font-size: clamp(2.2rem, 3.6vw, 3.2rem);
+}
+
+.bld-card__body {
+  font-size: 1rem;
+  line-height: 1.62;
+  color: var(--bld-body);
+  margin: 0;
+  transition: color 0.8s ease;
+}
+
+.bld-card__body code {
+  font-family: var(--mono);
+  font-size: 0.84em;
+  color: var(--bld-ink);
+  background: var(--bld-code-bg);
+  border: 1px solid var(--bld-chrome-border);
+  padding: 0.08em 0.35em;
+  border-radius: 4px;
+}
+
+.bld-card__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1.4rem;
+}
+
+.bld[data-night='true'] .bld-card__ctas .btn-primary {
+  background: #f5f1ea;
+  color: #0c1531;
+}
+
+.bld[data-night='true'] .bld-card__ctas .btn-secondary {
+  color: #f5f1ea;
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.bld[data-night='true'] .bld-card__ctas .btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.bld-hint {
+  margin-top: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bld-dim);
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+.bld-hint span {
+  display: inline-block;
+  animation: bld-bob 1.8s ease-in-out infinite;
+}
+
+.bld-hint:hover { color: var(--bld-ink); }
+
+@keyframes bld-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(4px); }
+}
+
+/* HUD -------------------------------------------------------------------- */
+
+.bld-hud {
+  position: fixed;
+  top: 80px;
+  right: 2rem;
+  z-index: 15;
+  width: 232px;
+  padding: 0.85rem 1rem 0.9rem;
+  border-radius: 12px;
+  background: var(--bld-chrome-bg);
+  border: 1px solid var(--bld-chrome-border);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--bld-body);
+  animation: bld-fade 0.5s ease both;
+  transition: background 0.8s ease, border-color 0.8s ease;
+}
+
+@keyframes bld-fade {
+  from { opacity: 0; transform: translateY(5px); }
+}
+
+.bld-hud__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.64rem;
+  color: var(--bld-dim);
+  padding-bottom: 0.55rem;
+  margin-bottom: 0.45rem;
+  border-bottom: 1px solid var(--bld-chrome-border);
+}
+
+.bld-hud__live {
+  color: var(--green);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.bld-hud__live::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 8px rgba(45, 138, 94, 0.6);
+  animation: bld-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes bld-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.bld-hud__row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.22rem 0;
+}
+
+.bld-hud__row i {
+  flex: 1;
+  border-bottom: 1px dotted var(--bld-chrome-border);
+  transform: translateY(-3px);
+}
+
+.bld-hud__row b {
+  color: var(--bld-ink);
+  font-weight: 600;
+}
+
+/* Rail ------------------------------------------------------------------- */
+
+.bld-rail {
+  position: fixed;
+  left: 50%;
+  bottom: 1.1rem;
+  z-index: 15;
+  transform: translateX(-50%);
+  width: min(880px, calc(100vw - 2.5rem));
+  padding: 0.8rem 1.4rem 1.7rem;
+  border-radius: 100px;
+  background: var(--bld-chrome-bg);
+  border: 1px solid var(--bld-chrome-border);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  transition: background 0.8s ease, border-color 0.8s ease;
+}
+
+.bld-rail__track {
+  position: relative;
+  height: 2px;
+  margin: 0.4rem 0.25rem;
+  background: var(--bld-chrome-border);
+  border-radius: 2px;
+}
+
+.bld-rail__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.bld-rail__dots {
+  position: absolute;
+  left: 1.4rem;
+  right: 1.4rem;
+  top: calc(0.8rem + 0.4rem + 1px);
+  display: flex;
+  justify-content: space-between;
+  transform: translateY(-50%);
+}
+
+.bld-rail__dot {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border-radius: 50%;
+  border: 2px solid var(--bld-dim);
+  background: var(--bg);
+  cursor: pointer;
+  transition: border-color 0.3s, background 0.3s, box-shadow 0.3s;
+}
+
+.bld[data-night='true'] .bld-rail__dot { background: #0c1531; }
+
+.bld-rail__dot[aria-pressed='true'] {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(201, 69, 109, 0.18), 0 0 14px rgba(201, 69, 109, 0.5);
+}
+
+.bld-rail__label {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-family: var(--mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--bld-dim);
+  transition: color 0.3s;
+}
+
+.bld-rail__dot[aria-pressed='true'] .bld-rail__label { color: var(--bld-ink); }
+
+/* Footer ----------------------------------------------------------------- */
+
+.bld .bld-footer {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+  padding: 1.5rem 1rem 6rem;
+  border-top: 0;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--bld-dim);
+}
+
+.bld-footer a {
+  color: var(--bld-dim);
+  text-decoration: none;
+}
+
+.bld-footer a:hover { color: var(--bld-ink); }
+
+/* In-scene HTML (labels anchored in 3D by the scene) --------------------- */
+
+.bld-tag {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  line-height: 1.2;
+  white-space: nowrap;
+  padding: 0.28rem 0.55rem;
+  border-radius: 6px;
+  background: rgba(26, 23, 20, 0.86);
+  color: #fbf8f2;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  will-change: opacity, transform;
+}
+
+.bld-tag--floor {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: 26px;
+  position: relative;
+}
+
+.bld-tag--floor::before {
+  content: '';
+  position: absolute;
+  left: -26px;
+  top: 50%;
+  width: 22px;
+  height: 1px;
+  background: rgba(26, 23, 20, 0.6);
+}
+
+.bld[data-night='true'] .bld-tag--floor::before { background: rgba(255, 255, 255, 0.45); }
+
+.bld-tag--floor b {
+  color: #e87da0;
+  font-weight: 600;
+}
+
+.bld-tag--floor span { color: #9aa3b2; }
+
+.bld-tag--tag {
+  font-size: 0.62rem;
+  padding: 0.2rem 0.45rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-bright);
+  border: 1px solid rgba(61, 57, 41, 0.18);
+  box-shadow: 0 4px 14px rgba(20, 40, 90, 0.16);
+}
+
+.bld-tag--memory {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  white-space: normal;
+  width: 168px;
+  padding: 0.5rem 0.6rem;
+  background: #ffe27a;
+  color: #3d3929;
+  border-radius: 3px;
+  transform-origin: top left;
+  rotate: -3deg;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
+  font-size: 0.64rem;
+  line-height: 1.35;
+}
+
+.bld-tag--memory em {
+  font-style: normal;
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #8a6d00;
+}
+
+.bld-pin {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--mono);
+  font-size: 0.64rem;
+  padding: 0.2rem 0.55rem 0.2rem 0.25rem;
+  border-radius: 100px;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--text-bright);
+  border: 1px solid rgba(201, 69, 109, 0.4);
+  box-shadow: 0 6px 18px rgba(201, 69, 109, 0.25);
+  white-space: nowrap;
+  transform-origin: center;
+}
+
+.bld-pin b {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.6rem;
+}
+
+.bld-status {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  white-space: nowrap;
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(26, 23, 20, 0.9);
+  color: #fbf8f2;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.25);
+  transition: background 0.3s, border-color 0.3s;
+}
+
+.bld-status--fail { background: #b8324f; border-color: #e87da0; }
+.bld-status--pass { background: #1f7a50; border-color: #7ee8a8; }
+.bld-status--map { background: #7a5b00; border-color: #f0c674; }
+
+.bld-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  white-space: nowrap;
+  padding: 0.45rem 0.7rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--text-bright);
+  border: 1px solid rgba(45, 138, 94, 0.45);
+  box-shadow: 0 8px 22px rgba(20, 40, 90, 0.18);
+}
+
+.bld-tool b { font-weight: 600; color: #1f7a50; }
+.bld-tool b span { color: var(--text-dim); font-weight: 400; }
+.bld-tool small { font-size: 0.58rem; color: var(--text-dim); }
+
+.bld-titleblock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  font-family: var(--mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  padding: 0.35rem 0.6rem;
+  white-space: nowrap;
+  transform: translate(-50%, 8px);
+}
+
+/* Mobile ----------------------------------------------------------------- */
+
+@media (max-width: 899px) {
+  .bld-nav { padding: 0 1rem; }
+  .bld-nav__title { display: none; }
+  .bld-nav__links { gap: 1rem; }
+  .bld-hud { display: none; }
+
+  .bld-poster { padding: 10vh 2vw 46vh; }
+
+  .bld-chapter {
+    align-items: flex-end;
+    padding: 6rem 0.9rem 5.6rem;
+  }
+
+  .bld-card {
+    max-width: none;
+    width: 100%;
+    padding: 1.2rem 1.25rem 1.3rem;
+    border-radius: 14px;
+  }
+
+  .bld .bld-card__title { font-size: 1.45rem; }
+  .bld .bld-chapter[data-chapter='arrival'] .bld-card__title { font-size: 1.9rem; }
+  .bld-card__body { font-size: 0.92rem; line-height: 1.55; }
+
+  .bld-rail {
+    bottom: 0.7rem;
+    width: calc(100vw - 1.8rem);
+    padding: 0.7rem 1rem 1.5rem;
+  }
+
+  .bld-rail__dots { left: 1rem; right: 1rem; top: calc(0.7rem + 0.4rem + 1px); }
+  .bld-rail__dot { width: 12px; height: 12px; }
+  .bld-rail__label { display: none; }
+  .bld-rail__dot[aria-pressed='true'] .bld-rail__label { display: block; }
+
+  .bld-tag { font-size: 0.6rem; }
+  .bld-tag--tag,
+  .bld-tag--floor span,
+  .bld-titleblock { display: none; }
+  .bld-tag--memory { width: 118px; font-size: 0.56rem; padding: 0.35rem 0.45rem; }
+  .bld-tag--floor { font-size: 0.56rem; margin-left: 16px; }
+  .bld-tag--floor::before { left: -16px; width: 12px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bld-card,
+  .bld-rail__fill,
+  .bld-poster { transition: none; }
+  .bld-hint span,
+  .bld-hud__live::before { animation: none; }
+}

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -12,6 +12,7 @@ export default function Footer() {
           <div className="footer-links">
             <a href="/atlas">Atlas</a>
             <a href="/blog">Blog</a>
+            <a href="/building">The Building</a>
             <a href="/developers">Developers</a>
             <a href="https://docs.sightmap.org">Docs</a>
             <a href="https://docs.sightmap.org/start/quickstart">Quickstart</a>

--- a/web/src/components/building/Agents.tsx
+++ b/web/src/components/building/Agents.tsx
@@ -1,0 +1,139 @@
+import { useFrame } from '@react-three/fiber'
+import { Trail } from '@react-three/drei'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { JOURNEYS, TRAVELLER_COLORS, type Journey } from './model'
+import { buildPath, pointAt, type Path } from './geometry'
+import { smoothstep } from './chapters'
+import { useShared } from './state'
+
+// The people: one walker per journey, looping through its stops, riding the
+// core between floors. Users are pink, coding agents green, tests gold.
+const WALK = 1.75
+const DWELL = 0.9
+const RESET = 1.4
+
+interface Runner {
+  d: number
+  dwell: number
+  next: number
+  wait: number
+  fade: number
+}
+
+export function Walker({
+  color,
+  group,
+  trailRef,
+  scale = 1,
+  trail = true,
+  trailLength = 3,
+}: {
+  color: string
+  group: React.RefObject<THREE.Group | null>
+  /** drei portals the trail mesh to the scene root, so it has to be hidden
+   *  through its own ref rather than through the walker's group. */
+  trailRef?: React.RefObject<THREE.Mesh | null>
+  scale?: number
+  trail?: boolean
+  trailLength?: number
+}) {
+  return (
+    <>
+      <group ref={group} scale={scale}>
+        <group scale={1.35}>
+        <mesh position={[0, 0.2, 0]} castShadow>
+          <capsuleGeometry args={[0.1, 0.2, 4, 10]} />
+          <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.35} roughness={0.5} />
+        </mesh>
+        <mesh position={[0, 0.5, 0]} castShadow>
+          <sphereGeometry args={[0.12, 14, 14]} />
+          <meshStandardMaterial color="#fbf8f2" roughness={0.6} />
+        </mesh>
+        <mesh position={[0, 0.012, 0]} rotation-x={-Math.PI / 2}>
+          <ringGeometry args={[0.18, 0.28, 24]} />
+          <meshBasicMaterial color={color} transparent opacity={0.55} depthWrite={false} />
+        </mesh>
+        </group>
+      </group>
+      {trail && (
+        <Trail
+          // drei types the ref as the geometry; at runtime it is the trail mesh.
+          ref={trailRef as unknown as React.ComponentProps<typeof Trail>['ref']}
+          width={0.7}
+          length={trailLength}
+          color={color}
+          attenuation={(w) => w * w}
+          decay={1.2}
+          target={group as React.RefObject<THREE.Object3D>}
+        />
+      )}
+    </>
+  )
+}
+
+function Agent({ journey, path }: { journey: Journey; path: Path }) {
+  const s = useShared()
+  const g = useRef<THREE.Group>(null)
+  const tg = useRef<THREE.Mesh>(null)
+  const run = useRef<Runner>({ d: 0, dwell: DWELL, next: 1, wait: journey.delay, fade: 0 })
+  const tmp = useMemo(() => new THREE.Vector3(), [])
+  const color = TRAVELLER_COLORS[journey.who]
+
+  useFrame((_, dt) => {
+    const r = run.current
+    const d = Math.min(dt, 0.2)
+    const c = s.cur
+    if (!s.reduced) {
+      if (r.wait > 0) {
+        r.wait -= d
+        r.fade = Math.max(0, r.fade - d * 2)
+      } else if (r.dwell > 0) {
+        r.dwell -= d
+        r.fade = Math.min(1, r.fade + d * 2.5)
+      } else if (r.next < path.stops.length) {
+        const target = path.cum[path.stops[r.next]]
+        r.d = Math.min(target, r.d + WALK * d)
+        if (r.d >= target - 1e-4) {
+          r.next += 1
+          r.dwell = DWELL
+        }
+      } else {
+        // Journey complete: fade out, go back to the start.
+        r.fade = Math.max(0, r.fade - d * 2.5)
+        if (r.fade <= 0) {
+          r.d = 0
+          r.next = 1
+          r.dwell = DWELL
+          r.wait = RESET
+        }
+      }
+    } else {
+      r.fade = 1
+    }
+    if (!g.current) return
+    pointAt(path, r.d, tmp)
+    g.current.position.copy(tmp)
+    const focus = s.focus && s.focus !== journey.name ? 0.3 : 1
+    const rise = smoothstep(Math.min(1, c.rise * 1.3 - 0.3))
+    const sc = c.agents * focus * smoothstep(r.fade) * rise
+    g.current.scale.setScalar(Math.max(sc, 0.001))
+    g.current.visible = sc > 0.02
+    if (tg.current) tg.current.visible = sc > 0.4 && r.fade > 0.5 && r.dwell <= 0
+  })
+
+  return <Walker color={color} group={g} trailRef={tg} trail={!s.reduced} trailLength={s.mobile ? 2 : 3.5} />
+}
+
+export default function Agents() {
+  const s = useShared()
+  const journeys = useMemo(() => (s.mobile ? JOURNEYS.slice(0, 5) : JOURNEYS), [s.mobile])
+  const paths = useMemo(() => journeys.map((j) => buildPath(j)), [journeys])
+  return (
+    <>
+      {journeys.map((j, k) => (
+        <Agent key={j.name} journey={j} path={paths[k]} />
+      ))}
+    </>
+  )
+}

--- a/web/src/components/building/BuildingExperience.tsx
+++ b/web/src/components/building/BuildingExperience.tsx
@@ -1,0 +1,221 @@
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { CHAPTERS } from './chapters'
+import { createSharedState, SharedStateContext } from './state'
+import Poster from './Poster'
+import BuildingNav from './BuildingNav'
+
+// The page: a fixed stage (poster, then the WebGL scene once it loads) behind
+// a column of scroll chapters. Scroll position is measured against the
+// chapter sections and written into the shared mutable state that the scene
+// reads each frame; React only re-renders when the active chapter changes.
+//
+// Everything a crawler or a no-JS visitor needs is in the DOM: the chapter
+// text is real markup and the poster is inline SVG. The scene is decoration
+// on top — aria-hidden, lazy, and skipped entirely when WebGL is missing.
+const Scene = lazy(() => import('./Scene'))
+
+function webglAvailable(): boolean {
+  try {
+    const c = document.createElement('canvas')
+    return !!(c.getContext('webgl2') || c.getContext('webgl'))
+  } catch {
+    return false
+  }
+}
+
+/** Renders `code` spans in chapter copy. */
+function inline(text: string): ReactNode[] {
+  return text.split('`').map((part, i) => (i % 2 === 1 ? <code key={i}>{part}</code> : part))
+}
+
+export default function BuildingExperience() {
+  const shared = useMemo(createSharedState, [])
+  const [mounted, setMounted] = useState(false)
+  const [webgl, setWebgl] = useState(false)
+  const [ready, setReady] = useState(false)
+  const [active, setActive] = useState(0)
+  const sections = useRef<(HTMLElement | null)[]>([])
+
+  useEffect(() => {
+    setMounted(true)
+    setWebgl(webglAvailable())
+    shared.reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    shared.mobile = window.innerWidth < 900
+
+    let raf = 0
+    const measure = () => {
+      const vh = window.innerHeight
+      const y = window.scrollY + vh * 0.5
+      const n = CHAPTERS.length
+      let p = n - 1
+      for (let i = 0; i < n; i++) {
+        const el = sections.current[i]
+        if (!el) continue
+        const top = el.offsetTop
+        const h = el.offsetHeight
+        if (y < top) {
+          p = Math.max(0, i - 0.5)
+          break
+        }
+        if (y < top + h) {
+          p = i - 0.5 + (y - top) / h
+          break
+        }
+      }
+      p = Math.min(Math.max(p, 0), n - 1)
+      shared.progress = p
+      const a = Math.round(p)
+      setActive((prev) => (prev === a ? prev : a))
+    }
+    const onScroll = () => {
+      if (!raf) {
+        raf = requestAnimationFrame(() => {
+          raf = 0
+          measure()
+        })
+      }
+    }
+    const onResize = () => {
+      shared.mobile = window.innerWidth < 900
+      onScroll()
+    }
+    const onMove = (e: PointerEvent) => {
+      if (shared.reduced || shared.mobile) return
+      shared.pointer.x = (e.clientX / window.innerWidth) * 2 - 1
+      shared.pointer.y = (e.clientY / window.innerHeight) * 2 - 1
+    }
+    measure()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onResize)
+    window.addEventListener('pointermove', onMove, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('pointermove', onMove)
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [shared])
+
+  useEffect(() => {
+    shared.focus = CHAPTERS[active].focus ?? null
+  }, [active, shared])
+
+  const night = CHAPTERS[active].scene.night >= 0.5
+  const hud = CHAPTERS[active].hud
+
+  const goTo = (i: number) => {
+    sections.current[i]?.scrollIntoView({ behavior: shared.reduced ? 'auto' : 'smooth', block: 'start' })
+  }
+
+  return (
+    <SharedStateContext.Provider value={shared}>
+      <div className="bld" data-night={night ? 'true' : 'false'} data-ready={ready ? 'true' : 'false'}>
+        <BuildingNav />
+
+        <div className="bld-stage" data-component="BuildingStage" aria-hidden="true">
+          <Poster hidden={ready} />
+          {mounted && webgl && (
+            <Suspense fallback={null}>
+              <Scene shared={shared} onReady={() => setReady(true)} />
+            </Suspense>
+          )}
+        </div>
+
+        <main className="bld-story">
+          {CHAPTERS.map((ch, i) => {
+            const isActive = i === active
+            const Heading = i === 0 ? 'h1' : 'h2'
+            return (
+              <section
+                key={ch.id}
+                id={ch.id}
+                ref={(el) => {
+                  sections.current[i] = el
+                }}
+                className="bld-chapter"
+                data-component="BuildingChapter"
+                data-chapter={ch.id}
+                data-active={isActive ? 'true' : 'false'}
+              >
+                <div className="bld-card">
+                  <div className="bld-card__eyebrow">
+                    {ch.eyebrow}
+                    {ch.badge && <span className="bld-card__badge">{ch.badge}</span>}
+                  </div>
+                  <Heading className="bld-card__title">{ch.title}</Heading>
+                  <p className="bld-card__body">{inline(ch.body)}</p>
+                  {ch.ctas && (
+                    <div className="bld-card__ctas">
+                      {ch.ctas.map((c) => (
+                        <a
+                          key={c.href}
+                          href={c.href}
+                          className={c.primary ? 'btn-primary' : 'btn-secondary'}
+                          {...(c.external ? { target: '_blank', rel: 'noreferrer' } : {})}
+                        >
+                          {c.label}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                  {i === 0 && (
+                    <button type="button" className="bld-hint" onClick={() => goTo(1)}>
+                      Scroll to build <span aria-hidden="true">↓</span>
+                    </button>
+                  )}
+                </div>
+              </section>
+            )
+          })}
+        </main>
+
+        <aside className="bld-hud" data-component="BuildingHud" aria-hidden="true" key={active}>
+          <div className="bld-hud__title">
+            {hud.title}
+            <span className="bld-hud__live">live</span>
+          </div>
+          {hud.rows.map(([k, v]) => (
+            <div key={k} className="bld-hud__row">
+              <span>{k}</span>
+              <i />
+              <b>{v}</b>
+            </div>
+          ))}
+        </aside>
+
+        <div className="bld-rail" data-component="BuildingRail" role="navigation" aria-label="Chapters">
+          <div className="bld-rail__track">
+            <div className="bld-rail__fill" style={{ width: `${(active / (CHAPTERS.length - 1)) * 100}%` }} />
+          </div>
+          <div className="bld-rail__dots">
+            {CHAPTERS.map((ch, i) => (
+              <button
+                key={ch.id}
+                type="button"
+                className="bld-rail__dot"
+                aria-pressed={i === active}
+                aria-label={ch.eyebrow}
+                onClick={() => goTo(i)}
+              >
+                <span className="bld-rail__label">{ch.short}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <footer className="bld-footer">
+          <span>
+            sightmap · open-source spec by{' '}
+            <a href="https://subtext.fullstory.com" target="_blank" rel="noreferrer">
+              Subtext
+            </a>
+          </span>
+          <a href="/">Home</a>
+          <a href="/atlas">Atlas</a>
+          <a href="/blog">Blog</a>
+          <a href="https://docs.sightmap.org">Docs</a>
+        </footer>
+      </div>
+    </SharedStateContext.Provider>
+  )
+}

--- a/web/src/components/building/BuildingNav.tsx
+++ b/web/src/components/building/BuildingNav.tsx
@@ -1,0 +1,22 @@
+import Logo from '@/components/Logo'
+
+// Page-local header. Not a <nav> element on purpose: src/index.css styles the
+// bare `nav` tag as the cream site header, and this page swaps to a dark
+// treatment at nightfall.
+export default function BuildingNav() {
+  return (
+    <header className="bld-nav" data-component="BuildingNav">
+      <a href="/" className="bld-nav__logo" aria-label="sightmap home">
+        <Logo />
+      </a>
+      <span className="bld-nav__title">The Building</span>
+      <div className="bld-nav__links" role="navigation" aria-label="Site">
+        <a href="/">Home</a>
+        <a href="https://docs.sightmap.org">Docs</a>
+        <a href="https://github.com/sightmap/sightmap" target="_blank" rel="noreferrer">
+          GitHub
+        </a>
+      </div>
+    </header>
+  )
+}

--- a/web/src/components/building/Core.tsx
+++ b/web/src/components/building/Core.tsx
@@ -1,0 +1,127 @@
+import { useFrame } from '@react-three/fiber'
+import { Edges, Instance, Instances } from '@react-three/drei'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { CORE, FLOORS, FLOOR_H, RISERS, SLAB_T, floorY } from './model'
+import { smoothstep } from './chapters'
+import { useShared } from './state'
+
+// The service core: a glass elevator shaft in the back corner with the API
+// risers running up inside it. Pulses travel the risers — requests in flight.
+const TOP = FLOORS.length * FLOOR_H + 0.55
+const stepGeom = new THREE.BoxGeometry(1, 1, 1)
+
+// A switchback stair climbing the shaft next to the elevator.
+function Stairs() {
+  const steps = useMemo(() => {
+    const out: { p: [number, number, number]; s: [number, number, number] }[] = []
+    const perFlight = 7
+    const x0 = CORE.x - CORE.w / 2 + 0.22
+    for (let f = 0; f < FLOORS.length; f++) {
+      const base = floorY(f) + SLAB_T
+      for (let k = 0; k < perFlight; k++) {
+        const t = k / perFlight
+        const y = base + 0.15 + t * (FLOOR_H - 0.3)
+        const z = f % 2 === 0 ? CORE.z - CORE.d / 2 + 0.2 + t * (CORE.d - 0.4) : CORE.z + CORE.d / 2 - 0.2 - t * (CORE.d - 0.4)
+        out.push({ p: [x0, y, z], s: [0.36, 0.05, 0.2] })
+      }
+    }
+    return out
+  }, [])
+  return (
+    <Instances limit={steps.length} range={steps.length} geometry={stepGeom} castShadow>
+      <meshStandardMaterial color="#d8bf9a" roughness={0.7} />
+      {steps.map((st, k) => (
+        <Instance key={k} position={st.p} scale={st.s} />
+      ))}
+    </Instances>
+  )
+}
+
+function Pulses() {
+  const s = useShared()
+  const refs = useRef<(THREE.Mesh | null)[]>([])
+  const heights = useMemo(() => RISERS.map((r) => floorY(Math.max(...r.floors)) + SLAB_T + 0.6), [])
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime()
+    RISERS.forEach((_, k) => {
+      const m = refs.current[k]
+      if (!m) return
+      const speed = s.reduced ? 0 : 0.34 + k * 0.03
+      const phase = ((t * speed + k * 0.37) % 1 + 1) % 1
+      m.position.y = 0.1 + phase * (heights[k] - 0.2)
+      const fade = Math.sin(phase * Math.PI)
+      m.scale.setScalar(0.6 + 0.6 * fade)
+      m.visible = s.cur.rise > 0.85
+    })
+  })
+  return (
+    <>
+      {RISERS.map((r, k) => (
+        <mesh
+          key={r.name}
+          ref={(el) => {
+            refs.current[k] = el
+          }}
+          position={[riserX(k), 0, riserZ()]}
+        >
+          <sphereGeometry args={[0.085, 12, 12]} />
+          <meshStandardMaterial color={r.color} emissive={r.color} emissiveIntensity={1.4} roughness={0.4} />
+        </mesh>
+      ))}
+    </>
+  )
+}
+
+const riserX = (k: number): number => CORE.x - CORE.w / 2 + 0.24 + k * 0.28
+const riserZ = (): number => CORE.z - CORE.d / 2 + 0.22
+
+export default function Core() {
+  const s = useShared()
+  const g = useRef<THREE.Group>(null)
+  const car = useRef<THREE.Mesh>(null)
+  useFrame(({ clock }) => {
+    const rise = smoothstep(THREE.MathUtils.clamp(s.cur.rise * 1.6 - 0.3, 0, 1))
+    if (g.current) {
+      g.current.visible = rise > 0.01
+      g.current.scale.set(1, Math.max(rise, 0.001), 1)
+    }
+    if (car.current) {
+      const t = s.reduced ? 0.4 : (Math.sin(clock.getElapsedTime() * 0.35) + 1) / 2
+      car.current.position.y = 0.6 + t * (TOP - 1.9)
+    }
+  })
+  return (
+    <group ref={g}>
+      <mesh position={[CORE.x, TOP / 2, CORE.z]}>
+        <boxGeometry args={[CORE.w, TOP, CORE.d]} />
+        <meshStandardMaterial color="#b7c9ee" transparent opacity={0.16} roughness={0.15} depthWrite={false} />
+        <Edges color="#d5e2fb" threshold={20} lineWidth={1} transparent opacity={0.6} />
+      </mesh>
+      {/* Elevator car. */}
+      <mesh ref={car} position={[CORE.x + 0.3, 0.6, CORE.z + 0.1]} castShadow>
+        <boxGeometry args={[0.8, 1.05, 0.9]} />
+        <meshStandardMaterial color="#fbf8f2" roughness={0.6} />
+      </mesh>
+      {RISERS.map((r, k) => {
+        const h = floorY(Math.max(...r.floors)) + SLAB_T + 0.6
+        return (
+          <group key={r.name}>
+            <mesh position={[riserX(k), h / 2, riserZ()]}>
+              <cylinderGeometry args={[0.045, 0.045, h, 10]} />
+              <meshStandardMaterial color={r.color} emissive={r.color} emissiveIntensity={0.35} roughness={0.5} />
+            </mesh>
+            {r.floors.map((f) => (
+              <mesh key={f} position={[riserX(k), floorY(f) + SLAB_T + 0.35, riserZ() + 0.12]}>
+                <boxGeometry args={[0.16, 0.16, 0.24]} />
+                <meshStandardMaterial color={r.color} emissive={r.color} emissiveIntensity={0.5} roughness={0.5} />
+              </mesh>
+            ))}
+          </group>
+        )
+      })}
+      <Stairs />
+      <Pulses />
+    </group>
+  )
+}

--- a/web/src/components/building/FrontDesk.tsx
+++ b/web/src/components/building/FrontDesk.tsx
@@ -1,0 +1,97 @@
+import { useFrame } from '@react-three/fiber'
+import { Html, RoundedBox } from '@react-three/drei'
+import { useRef } from 'react'
+import * as THREE from 'three'
+import { SLAB_T, TOOLS, TRAVELLER_COLORS } from './model'
+import { smoothstep } from './chapters'
+import { useShared } from './state'
+import { Walker } from './Agents'
+
+// Chapter 07. A front desk in the lobby with the tools the building offers,
+// and an agent at the door about to use one.
+const DESK: [number, number, number] = [4.05, SLAB_T, -1.2]
+
+export default function FrontDesk() {
+  const s = useShared()
+  const g = useRef<THREE.Group>(null)
+  const visitor = useRef<THREE.Group>(null)
+  const cards = useRef<(HTMLDivElement | null)[]>([])
+  const desk = useRef<THREE.Group>(null)
+  useFrame(({ clock }) => {
+    const o = smoothstep(s.cur.desk)
+    const rise = smoothstep(Math.min(1, s.cur.rise * 1.6 - 0.3))
+    if (desk.current) {
+      desk.current.scale.set(1, Math.max(rise, 0.001), 1)
+      desk.current.visible = rise > 0.01
+    }
+    if (g.current) {
+      g.current.scale.setScalar(Math.max(o, 0.001))
+      g.current.visible = o > 0.01
+    }
+    if (visitor.current) {
+      const t = clock.getElapsedTime()
+      visitor.current.position.set(6.1 + (s.reduced ? 0 : Math.sin(t * 0.8) * 0.05), 0, -1.2)
+      visitor.current.scale.setScalar(Math.max(o, 0.001))
+      visitor.current.visible = o > 0.01
+    }
+    cards.current.forEach((el, k) => {
+      if (!el) return
+      const po = Math.min(1, Math.max(0, o * 1.8 - k * 0.25))
+      el.style.opacity = po.toFixed(2)
+      el.style.visibility = po > 0.02 ? 'visible' : 'hidden'
+      el.style.transform = `translateY(${((1 - po) * 14).toFixed(1)}px)`
+    })
+  })
+  return (
+    <>
+      <group ref={desk} position={DESK}>
+        <RoundedBox args={[0.9, 0.8, 2.1]} radius={0.05} position={[0, 0.4, 0]} castShadow receiveShadow>
+          <meshStandardMaterial color="#6b4a2f" roughness={0.7} />
+        </RoundedBox>
+        <RoundedBox args={[1.1, 0.06, 2.3]} radius={0.03} position={[0, 0.83, 0]} castShadow receiveShadow>
+          <meshStandardMaterial color="#fbf8f2" roughness={0.5} />
+        </RoundedBox>
+        <mesh position={[-0.55, 0.3, 0.2]} castShadow>
+          <capsuleGeometry args={[0.13, 0.32, 4, 10]} />
+          <meshStandardMaterial color="#4f5d75" roughness={0.8} />
+        </mesh>
+        <mesh position={[-0.55, 0.66, 0.2]} castShadow>
+          <sphereGeometry args={[0.085, 12, 10]} />
+          <meshStandardMaterial color="#c9976f" roughness={0.8} />
+        </mesh>
+        <mesh position={[0.25, 0.98, -0.7]} castShadow>
+          <cylinderGeometry args={[0.13, 0.13, 0.26, 12]} />
+          <meshStandardMaterial color="#c7b299" roughness={0.9} />
+        </mesh>
+        <mesh position={[0.25, 1.28, -0.7]} castShadow>
+          <sphereGeometry args={[0.24, 12, 10]} />
+          <meshStandardMaterial color="#67a05a" roughness={1} />
+        </mesh>
+      </group>
+      <group ref={g} position={DESK}>
+        <mesh position={[0, 1.45, 0]}>
+          <cylinderGeometry args={[0.03, 0.03, 1.2, 8]} />
+          <meshStandardMaterial color="#8a8272" roughness={0.6} />
+        </mesh>
+        {TOOLS.map((tool, k) => (
+          <Html key={tool.name} position={[1.0, 0.9 + k * 0.7, -1.4]} center zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
+            <div
+              ref={(el) => {
+                cards.current[k] = el
+              }}
+              className="bld-tool"
+              style={{ opacity: 0, visibility: 'hidden' }}
+            >
+              <b>
+                {tool.name}
+                <span>({tool.args})</span>
+              </b>
+              <small>{tool.via}</small>
+            </div>
+          </Html>
+        ))}
+      </group>
+      <Walker color={TRAVELLER_COLORS.agent} group={visitor} trail={false} />
+    </>
+  )
+}

--- a/web/src/components/building/HealDemo.tsx
+++ b/web/src/components/building/HealDemo.tsx
@@ -1,0 +1,130 @@
+import { useFrame } from '@react-three/fiber'
+import { Html } from '@react-three/drei'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { KIOSK_H, PLATE, SLAB_T, TRAVELLER_COLORS, findRoom, floorY, roomStand } from './model'
+import { smoothstep } from './chapters'
+import { useShared } from './state'
+import { Walker } from './Agents'
+
+// Chapter 05. A looping vignette on the Checkout floor: the ContinueButton
+// room slides to a new position (a redesign), a test walks to where the room
+// used to be and finds nothing, the map updates, and the test walks on to the
+// room's new position. Timings below are seconds into an 8.4s loop.
+const FLOOR = 3
+const PERIOD = 8.4
+const T = {
+  slideStart: 1.0,
+  slideEnd: 1.8,
+  walkEnd: 2.6,
+  failEnd: 3.9,
+  updateEnd: 4.7,
+  walk2End: 6.0,
+  passEnd: 7.8,
+}
+
+type Phase = 'idle' | 'walk' | 'fail' | 'update' | 'walk2' | 'pass' | 'reset'
+
+function phaseAt(t: number): Phase {
+  if (t < T.slideStart) return 'idle'
+  if (t < T.walkEnd) return 'walk'
+  if (t < T.failEnd) return 'fail'
+  if (t < T.updateEnd) return 'update'
+  if (t < T.walk2End) return 'walk2'
+  if (t < T.passEnd) return 'pass'
+  return 'reset'
+}
+
+const STATUS: Record<Phase, { cls: string; text: string }> = {
+  idle: { cls: 'run', text: 'test Regression · step 4 of 5' },
+  walk: { cls: 'run', text: 'click ContinueButton' },
+  fail: { cls: 'fail', text: '✗ [data-testid="continue-btn"] not found' },
+  update: { cls: 'map', text: 'sightmap: ContinueButton moved · selector updated' },
+  walk2: { cls: 'run', text: 'retry via ContinueButton' },
+  pass: { cls: 'pass', text: '✓ ContinueButton clicked · run passed' },
+  reset: { cls: 'run', text: '' },
+}
+
+export default function HealDemo() {
+  const s = useShared()
+  const walker = useRef<THREE.Group>(null)
+  const ghost = useRef<THREE.Mesh>(null)
+  const status = useRef<HTMLDivElement>(null)
+  const room = useMemo(() => findRoom(FLOOR, 'ContinueButton'), [])
+  const from = useMemo(() => new THREE.Vector3(...roomStand(FLOOR, findRoom(FLOOR, 'PaymentForm'))), [])
+  const oldPos = useMemo(() => new THREE.Vector3(...roomStand(FLOOR, room, 0)), [room])
+  const newPos = useMemo(() => new THREE.Vector3(...roomStand(FLOOR, room, 1)), [room])
+  const tmp = useMemo(() => new THREE.Vector3(), [])
+  const start = useRef<number | null>(null)
+  const lastPhase = useRef<Phase>('reset')
+
+  useFrame(({ clock }) => {
+    const c = s.cur
+    const active = c.heal > 0.5
+    const now = clock.getElapsedTime()
+    if (!active) {
+      start.current = null
+      s.healShift = THREE.MathUtils.damp(s.healShift, 0, 6, 0.016)
+    } else if (start.current === null) {
+      start.current = now
+    }
+    const t = start.current === null ? 0 : (now - start.current) % PERIOD
+    const phase: Phase = active ? phaseAt(t) : 'reset'
+    if (active) {
+      const slide = smoothstep((t - T.slideStart) / (T.slideEnd - T.slideStart))
+      s.healShift = phase === 'reset' ? 1 - smoothstep((t - T.passEnd) / (PERIOD - T.passEnd)) : slide
+    }
+    // Walker position along the two legs.
+    if (walker.current) {
+      let p = from
+      if (phase === 'walk') {
+        p = tmp.copy(from).lerp(oldPos, smoothstep((t - T.slideStart) / (T.walkEnd - T.slideStart)))
+      } else if (phase === 'fail' || phase === 'update') {
+        p = oldPos
+      } else if (phase === 'walk2') {
+        p = tmp.copy(oldPos).lerp(newPos, smoothstep((t - T.updateEnd) / (T.walk2End - T.updateEnd)))
+      } else if (phase === 'pass') {
+        p = newPos
+      }
+      walker.current.position.copy(p)
+      const bob = phase === 'walk' || phase === 'walk2' ? Math.abs(Math.sin(t * 14)) * 0.05 : 0
+      walker.current.position.y += bob
+      const sc = c.heal * (phase === 'reset' ? 1 - smoothstep((t - T.passEnd) / (PERIOD - T.passEnd)) : 1)
+      walker.current.scale.setScalar(Math.max(sc, 0.001))
+      walker.current.visible = sc > 0.02
+    }
+    // Ghost of the old room position once it has moved.
+    if (ghost.current) {
+      const m = ghost.current.material as THREE.MeshStandardMaterial
+      const show = active && (phase === 'walk' || phase === 'fail' || phase === 'update') ? s.healShift : 0
+      m.opacity = show * 0.5
+      ghost.current.visible = show > 0.02
+      m.color.set(phase === 'fail' ? '#e04d6a' : '#ffffff')
+      m.emissive.set(phase === 'fail' ? '#e04d6a' : '#ffffff')
+    }
+    if (status.current) {
+      const st = STATUS[phase]
+      if (phase !== lastPhase.current) {
+        status.current.textContent = st.text
+        status.current.className = `bld-status bld-status--${st.cls}`
+        lastPhase.current = phase
+      }
+      const o = active && phase !== 'reset' ? c.heal : 0
+      status.current.style.opacity = o.toFixed(2)
+      status.current.style.visibility = o > 0.02 ? 'visible' : 'hidden'
+    }
+  })
+
+  return (
+    <>
+      <Walker color={TRAVELLER_COLORS.test} group={walker} trail={false} />
+      <mesh ref={ghost} position={[room.x, floorY(FLOOR) + SLAB_T + PLATE + KIOSK_H / 2, room.z]} visible={false}>
+        <boxGeometry args={[room.w, KIOSK_H, room.d]} />
+        <meshStandardMaterial color="#ffffff" transparent opacity={0} wireframe emissive="#ffffff" emissiveIntensity={0.6} />
+      </mesh>
+      <Html position={[room.x - 1.6, floorY(FLOOR) + SLAB_T + KIOSK_H + 1.15, room.z - 0.4]} zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
+        <div ref={status} className="bld-status bld-status--run" style={{ opacity: 0, visibility: 'hidden' }} />
+      </Html>
+    </>
+  )
+}

--- a/web/src/components/building/Lights.tsx
+++ b/web/src/components/building/Lights.tsx
@@ -1,0 +1,52 @@
+import { useFrame } from '@react-three/fiber'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { useShared } from './state'
+
+// Daylight from the front-right, softening to moonlight at nightfall. One
+// shadow-casting directional light covers the whole table.
+export default function Lights() {
+  const s = useShared()
+  const dir = useRef<THREE.DirectionalLight>(null)
+  const amb = useRef<THREE.AmbientLight>(null)
+  const hemi = useRef<THREE.HemisphereLight>(null)
+  const col = useMemo(
+    () => ({
+      day: new THREE.Color('#fff2dc'),
+      night: new THREE.Color('#7d95e6'),
+      ambDay: new THREE.Color('#ffffff'),
+      ambNight: new THREE.Color('#5468b3'),
+    }),
+    []
+  )
+  useFrame(() => {
+    const n = s.cur.night
+    if (dir.current) {
+      dir.current.intensity = THREE.MathUtils.lerp(1.85, 0.45, n)
+      dir.current.color.copy(col.day).lerp(col.night, n)
+    }
+    if (amb.current) {
+      amb.current.intensity = THREE.MathUtils.lerp(0.72, 0.32, n)
+      amb.current.color.copy(col.ambDay).lerp(col.ambNight, n)
+    }
+    if (hemi.current) hemi.current.intensity = THREE.MathUtils.lerp(0.7, 0.28, n)
+  })
+  const mapSize = s.mobile ? 1024 : 2048
+  return (
+    <>
+      <ambientLight ref={amb} intensity={0.72} />
+      <hemisphereLight ref={hemi} args={['#ffffff', '#5a7ac9', 0.7]} />
+      <directionalLight
+        ref={dir}
+        position={[13, 15, -7]}
+        intensity={1.85}
+        castShadow
+        shadow-mapSize={[mapSize, mapSize]}
+        shadow-bias={-0.0004}
+        shadow-normalBias={0.03}
+      >
+        <orthographicCamera attach="shadow-camera" args={[-15, 15, 15, -15, 1, 50]} />
+      </directionalLight>
+    </>
+  )
+}

--- a/web/src/components/building/Poster.tsx
+++ b/web/src/components/building/Poster.tsx
@@ -1,0 +1,98 @@
+// Static isometric blueprint of the building, as inline SVG. This is what the
+// prerender ships and what a visitor sees before the WebGL chunk arrives (or
+// instead of it, when WebGL is unavailable). The same model data draws it, so
+// it is a faithful line drawing of the scene rather than a placeholder.
+import { CORE, FLOORS, FLOOR_D, FLOOR_H, FLOOR_W } from './model'
+
+const COS30 = Math.cos(Math.PI / 6)
+const SIN30 = 0.5
+const S = 26 // px per world unit
+
+function iso(x: number, y: number, z: number): [number, number] {
+  return [(x - z) * COS30 * S, (x + z) * SIN30 * S - y * S]
+}
+
+const pt = (p: [number, number]) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`
+
+function rect(x: number, z: number, w: number, d: number, y: number): string {
+  const a = iso(x - w / 2, y, z - d / 2)
+  const b = iso(x + w / 2, y, z - d / 2)
+  const c = iso(x + w / 2, y, z + d / 2)
+  const e = iso(x - w / 2, y, z + d / 2)
+  return `M${pt(a)}L${pt(b)}L${pt(c)}L${pt(e)}Z`
+}
+
+function box(x: number, z: number, w: number, d: number, y0: number, h: number): string {
+  // Only the three edges of a box that face the camera, plus its top.
+  const top = rect(x, z, w, d, y0 + h)
+  const fr = iso(x + w / 2, y0, z + d / 2)
+  const frT = iso(x + w / 2, y0 + h, z + d / 2)
+  const r = iso(x + w / 2, y0, z - d / 2)
+  const rT = iso(x + w / 2, y0 + h, z - d / 2)
+  const l = iso(x - w / 2, y0, z + d / 2)
+  const lT = iso(x - w / 2, y0 + h, z + d / 2)
+  return `${top}M${pt(fr)}L${pt(frT)}M${pt(r)}L${pt(rT)}M${pt(l)}L${pt(lT)}M${pt(l)}L${pt(fr)}L${pt(r)}`
+}
+
+function build(): { floors: string; rooms: string; core: string; table: string; grid: string } {
+  let floors = ''
+  let rooms = ''
+  for (let i = 0; i < FLOORS.length; i++) {
+    const y = i * FLOOR_H
+    floors += rect(0, 0, FLOOR_W, FLOOR_D, y)
+    for (const r of FLOORS[i].rooms) {
+      const blocks = r.blocks ?? [{ x: r.x, z: r.z, w: r.w, d: r.d }]
+      for (const b of blocks) rooms += box(b.x, b.z, b.w, b.d, y + 0.18 + (r.base ?? 0), r.h * 1.25)
+    }
+  }
+  const topY = FLOORS.length * FLOOR_H
+  floors += rect(0, 0, FLOOR_W, FLOOR_D, topY)
+  // Front corner verticals of the shell.
+  const corners: [number, number][] = [
+    [FLOOR_W / 2, FLOOR_D / 2],
+    [FLOOR_W / 2, -FLOOR_D / 2],
+    [-FLOOR_W / 2, FLOOR_D / 2],
+    [-FLOOR_W / 2, -FLOOR_D / 2],
+  ]
+  for (const [cx, cz] of corners) floors += `M${pt(iso(cx, 0, cz))}L${pt(iso(cx, topY, cz))}`
+  const core = box(CORE.x, CORE.z, CORE.w, CORE.d, 0, topY + 0.6)
+  const table = rect(0, 0, 17.5, 14.5, -0.02)
+  let grid = ''
+  for (let gx = -8; gx <= 8; gx += 2) grid += `M${pt(iso(gx, 0, -7))}L${pt(iso(gx, 0, 7))}`
+  for (let gz = -6; gz <= 6; gz += 2) grid += `M${pt(iso(-8.5, 0, gz))}L${pt(iso(8.5, 0, gz))}`
+  return { floors, rooms, core, table, grid }
+}
+
+const D = build()
+
+export default function Poster({ hidden }: { hidden: boolean }) {
+  return (
+    <svg
+      className="bld-poster"
+      data-component="BuildingPoster"
+      data-hidden={hidden ? 'true' : 'false'}
+      viewBox="-420 -400 840 690"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <linearGradient id="bld-poster-table" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#1c4a94" />
+          <stop offset="1" stopColor="#12336c" />
+        </linearGradient>
+        <clipPath id="bld-poster-clip">
+          <path d={D.table} />
+        </clipPath>
+      </defs>
+      <g transform="translate(0,60)">
+        <path d={D.table} fill="url(#bld-poster-table)" />
+        <path d={D.grid} stroke="#3e6fc4" strokeWidth="0.6" fill="none" clipPath="url(#bld-poster-clip)" />
+        <path d={D.table} stroke="#8fb0ea" strokeWidth="1.2" fill="none" />
+        <path d={D.rooms} stroke="#ffffff" strokeOpacity="0.55" strokeWidth="0.8" fill="none" strokeLinejoin="round" />
+        <path d={D.floors} stroke="#ffffff" strokeOpacity="0.9" strokeWidth="1.1" fill="none" strokeLinejoin="round" />
+        <path d={D.core} stroke="#9fd1ff" strokeOpacity="0.9" strokeWidth="1" fill="none" />
+      </g>
+    </svg>
+  )
+}

--- a/web/src/components/building/Scene.tsx
+++ b/web/src/components/building/Scene.tsx
@@ -1,0 +1,155 @@
+// The WebGL scene. Loaded lazily by BuildingExperience, client-only.
+//
+// One orthographic camera at an isometric-ish angle looks at an architect's
+// model on a drafting table. Scroll position (shared.progress) picks a blend
+// of two neighbouring chapters' parameters; the updater damps toward it every
+// frame and every other component reads the damped values, so nothing here
+// re-renders on scroll.
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { PARAM_KEYS, paramsAt } from './chapters'
+import { SharedStateContext, useShared, type SharedState } from './state'
+import Lights from './Lights'
+import Table from './Table'
+import Tower from './Tower'
+import Core from './Core'
+import Wayfinding from './Wayfinding'
+import Agents from './Agents'
+import HealDemo from './HealDemo'
+import Trajectory from './Trajectory'
+import FrontDesk from './FrontDesk'
+
+const CAMERA_DISTANCE = 42
+
+function Updater({ onReady }: { onReady: () => void }) {
+  const s = useShared()
+  const fired = useRef(false)
+  useEffect(() => {
+    // Start on the chapter the page loaded at, not on a morph from chapter 0.
+    paramsAt(s.progress, s.cur)
+  }, [s])
+  useFrame((_, dt) => {
+    paramsAt(s.progress, s.target)
+    const d = Math.min(dt, 0.25)
+    const lambda = s.reduced ? 16 : 4.5
+    for (const k of PARAM_KEYS) s.cur[k] = THREE.MathUtils.damp(s.cur[k], s.target[k], lambda, d)
+    if (!fired.current) {
+      fired.current = true
+      onReady()
+    }
+  }, -100)
+  return null
+}
+
+function Stats() {
+  // Exposes draw calls / triangles / fps for the headless verification loop.
+  const { gl } = useThree()
+  const frames = useRef(0)
+  const t0 = useRef(performance.now())
+  useFrame(() => {
+    frames.current++
+    const now = performance.now()
+    if (now - t0.current > 1000) {
+      const w = window as unknown as { __bldStats?: Record<string, number> }
+      w.__bldStats = {
+        fps: Math.round((frames.current * 1000) / (now - t0.current)),
+        calls: gl.info.render.calls,
+        triangles: gl.info.render.triangles,
+        geometries: gl.info.memory.geometries,
+        textures: gl.info.memory.textures,
+        shadows: gl.shadowMap.enabled ? 1 : 0,
+      }
+      frames.current = 0
+      t0.current = now
+    }
+  })
+  return null
+}
+
+function Rig() {
+  const s = useShared()
+  const { camera, size } = useThree()
+  const az = useRef(s.cur.az)
+  const el = useRef(s.cur.el)
+  const v = useMemo(
+    () => ({
+      dir: new THREE.Vector3(),
+      right: new THREE.Vector3(),
+      up: new THREE.Vector3(),
+      target: new THREE.Vector3(),
+    }),
+    []
+  )
+  useFrame((_, dt) => {
+    const c = s.cur
+    const d = Math.min(dt, 0.25)
+    const drift = s.reduced ? 0 : Math.sin(performance.now() * 0.00018) * 1.4
+    const tAz = c.az + drift + s.pointer.x * 3
+    const tEl = c.el - s.pointer.y * 2
+    az.current = THREE.MathUtils.damp(az.current, tAz, 3, d)
+    el.current = THREE.MathUtils.damp(el.current, tEl, 3, d)
+    const a = THREE.MathUtils.degToRad(az.current)
+    const e = THREE.MathUtils.degToRad(el.current)
+
+    // Frame the model: the table's isometric footprint is ~27 world units
+    // wide and, with the tower on it, ~18 tall, whatever the viewport.
+    const fit = Math.min(size.width / 27, size.height / 22)
+    const zoom = fit * c.zoom * (s.mobile ? 1.3 : 1)
+
+    v.dir.set(Math.cos(e) * Math.sin(a), Math.sin(e), Math.cos(e) * Math.cos(a))
+    v.right.set(Math.cos(a), 0, -Math.sin(a))
+    v.up.crossVectors(v.dir, v.right).normalize()
+
+    // Desktop: the story card sits on the left, so push the model right.
+    // Mobile: the card sits at the bottom, so push the model up.
+    const shiftRight = s.mobile ? (-size.width * 0.12) / zoom : (size.width * 0.13) / zoom
+    const shiftUp = s.mobile ? (size.height * 0.11) / zoom : 0
+    v.target.set(0, c.lookY, 0).addScaledVector(v.right, -shiftRight).addScaledVector(v.up, -shiftUp)
+
+    camera.position.copy(v.target).addScaledVector(v.dir, CAMERA_DISTANCE)
+    camera.up.copy(v.up)
+    camera.lookAt(v.target)
+    const ortho = camera as THREE.OrthographicCamera
+    if (Math.abs(ortho.zoom - zoom) > 1e-3) {
+      ortho.zoom = zoom
+      ortho.updateProjectionMatrix()
+    }
+  }, -90)
+  return null
+}
+
+export interface SceneProps {
+  shared: SharedState
+  onReady: () => void
+}
+
+export default function Scene({ shared, onReady }: SceneProps) {
+  return (
+    <Canvas
+      orthographic
+      shadows="percentage"
+      flat
+      dpr={shared.mobile ? [1, 1.5] : [1, 1.75]}
+      gl={{ antialias: true, alpha: true, powerPreference: 'high-performance' }}
+      camera={{ position: [24, 24, 24], zoom: 50, near: 0.1, far: 140 }}
+      style={{ position: 'absolute', inset: 0 }}
+      onCreated={({ gl }) => gl.setClearColor(0x000000, 0)}
+    >
+      <SharedStateContext.Provider value={shared}>
+        <Updater onReady={onReady} />
+        <Stats />
+        <Rig />
+        <Lights />
+        <Table />
+        <Tower />
+        <Core />
+        <Wayfinding />
+        <Agents />
+        <HealDemo />
+        <Trajectory />
+        <FrontDesk />
+      </SharedStateContext.Provider>
+    </Canvas>
+  )
+}

--- a/web/src/components/building/Table.tsx
+++ b/web/src/components/building/Table.tsx
@@ -1,0 +1,49 @@
+import { useFrame } from '@react-three/fiber'
+import { Html, Line, RoundedBox } from '@react-three/drei'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { TABLE } from './model'
+import { useShared } from './state'
+
+// The drafting table: a blueprint-blue slab with a faint grid, on which the
+// sheets lie and the model stands.
+export default function Table() {
+  const s = useShared()
+  const mat = useRef<THREE.MeshStandardMaterial>(null)
+  const col = useMemo(() => ({ day: new THREE.Color('#12315f'), night: new THREE.Color('#091a3d') }), [])
+  const grid = useMemo(() => {
+    const pts: [number, number, number][] = []
+    const hw = TABLE.w / 2 - 0.5
+    const hd = TABLE.d / 2 - 0.5
+    for (let x = -Math.floor(hw); x <= hw; x += 1) pts.push([x, 0.006, -hd], [x, 0.006, hd])
+    for (let z = -Math.floor(hd); z <= hd; z += 1) pts.push([-hw, 0.006, z], [hw, 0.006, z])
+    return pts
+  }, [])
+  useFrame(() => {
+    if (mat.current) mat.current.color.copy(col.day).lerp(col.night, s.cur.night)
+  })
+  return (
+    <group>
+      <RoundedBox
+        args={[TABLE.w, TABLE.t, TABLE.d]}
+        radius={0.1}
+        smoothness={3}
+        position={[0, -TABLE.t / 2, 0]}
+        receiveShadow
+      >
+        <meshStandardMaterial ref={mat} color="#12315f" roughness={0.96} />
+      </RoundedBox>
+      <Line points={grid} segments color="#2f62b8" lineWidth={1} transparent opacity={0.5} depthWrite={false} />
+      <Html
+        position={[-TABLE.w / 2 + 0.6, 0.02, TABLE.d / 2 - 0.6]}
+        zIndexRange={[4, 0]}
+        style={{ pointerEvents: 'none' }}
+      >
+        <div className="bld-titleblock">
+          <span>Drawing set A-101</span>
+          <span>northwind-air · .sightmap/ · v1</span>
+        </div>
+      </Html>
+    </group>
+  )
+}

--- a/web/src/components/building/Tower.tsx
+++ b/web/src/components/building/Tower.tsx
@@ -1,0 +1,562 @@
+import { useFrame } from '@react-three/fiber'
+import { Instance, Instances, Line, RoundedBox } from '@react-three/drei'
+import { useMemo, useRef, type ComponentRef } from 'react'
+import * as THREE from 'three'
+import {
+  FLOORS,
+  FLOOR_D,
+  FLOOR_H,
+  FLOOR_W,
+  KIND_COLORS,
+  KIOSK_H,
+  PLATE,
+  SHEET,
+  SLAB_T,
+  WALL_T,
+  floorY,
+  type Kind,
+  type Room,
+} from './model'
+import { furnish, type Item, type ItemType } from './furnish'
+import { sheetLinePoints } from './geometry'
+import { smoothstep } from './chapters'
+import { useShared } from './state'
+
+// Each floor starts life as a blueprint sheet lying on the table. As `rise`
+// climbs, the sheet lifts to its floor height, fades into a slab, and the
+// floor's zones, furniture, glass and people grow out of the drawing. The
+// curtain walls, roof garden and structural frame follow.
+
+type LineRef = ComponentRef<typeof Line>
+
+const WALL_H = FLOOR_H - SLAB_T
+const N = FLOORS.length
+const STEEL = '#26272c'
+
+/** Where sheet i lies when fanned across the table. */
+function fan(i: number): { x: number; z: number; r: number } {
+  const k = i - (N - 1) / 2
+  return { x: k * 1.05 - 0.3, z: -k * 0.85 + 0.3, r: k * 0.09 }
+}
+
+const stagger = (rise: number, i: number): number => smoothstep(THREE.MathUtils.clamp(rise * 1.6 - i * 0.11, 0, 1))
+
+// ---------------------------------------------------------------------------
+// Shared materials, retinted at nightfall.
+
+interface Mats {
+  kinds: Record<Kind, THREE.MeshStandardMaterial>
+  slab: THREE.MeshStandardMaterial
+  steel: THREE.MeshStandardMaterial
+  glass: THREE.MeshStandardMaterial
+  spandrel: THREE.MeshStandardMaterial
+  furniture: Record<ItemType, THREE.MeshStandardMaterial>
+}
+
+function useMaterials(): Mats {
+  const s = useShared()
+  const mats = useMemo<Mats>(() => {
+    const kinds = {} as Record<Kind, THREE.MeshStandardMaterial>
+    for (const k of Object.keys(KIND_COLORS) as Kind[]) {
+      kinds[k] = new THREE.MeshStandardMaterial({
+        color: KIND_COLORS[k],
+        roughness: 0.92,
+        emissive: new THREE.Color(KIND_COLORS[k]),
+        emissiveIntensity: 0,
+      })
+    }
+    const plain = (opts: THREE.MeshStandardMaterialParameters = {}) =>
+      new THREE.MeshStandardMaterial({ color: '#ffffff', roughness: 0.85, ...opts })
+    const furniture: Record<ItemType, THREE.MeshStandardMaterial> = {
+      desk: plain({ roughness: 0.7 }),
+      monitor: plain({ roughness: 0.4, emissive: new THREE.Color('#bcd4ff'), emissiveIntensity: 0.25 }),
+      chair: plain(),
+      sofa: plain(),
+      table: plain({ roughness: 0.6 }),
+      pot: plain(),
+      leaf: plain({ roughness: 1 }),
+      shelf: plain(),
+      book: plain(),
+      screen: plain({ roughness: 0.3, emissive: new THREE.Color('#9fc2ff'), emissiveIntensity: 0.3 }),
+      body: plain(),
+      head: plain(),
+      partition: plain({ transparent: true, opacity: 0.22, roughness: 0.1, depthWrite: false }),
+      rail: plain({ roughness: 0.5 }),
+      counter: plain({ roughness: 0.6 }),
+    }
+    return {
+      kinds,
+      slab: new THREE.MeshStandardMaterial({ color: '#f2ece3', roughness: 0.92 }),
+      steel: new THREE.MeshStandardMaterial({ color: STEEL, roughness: 0.55, metalness: 0.2 }),
+      glass: new THREE.MeshStandardMaterial({
+        color: '#cfe3f5',
+        transparent: true,
+        opacity: 0.22,
+        roughness: 0.1,
+        metalness: 0.1,
+        depthWrite: false,
+        emissive: new THREE.Color('#ffc36a'),
+        emissiveIntensity: 0,
+        side: THREE.DoubleSide,
+      }),
+      spandrel: new THREE.MeshStandardMaterial({ color: '#e9e2d6', roughness: 0.95 }),
+      furniture,
+    }
+  }, [])
+  const col = useMemo(
+    () => ({
+      slabDay: new THREE.Color('#f2ece3'),
+      slabNight: new THREE.Color('#7b86ad'),
+      spDay: new THREE.Color('#e9e2d6'),
+      spNight: new THREE.Color('#5d6a94'),
+      glassDay: new THREE.Color('#cfe3f5'),
+      glassNight: new THREE.Color('#ffd58a'),
+    }),
+    []
+  )
+  useFrame(() => {
+    const n = s.cur.night
+    mats.slab.color.copy(col.slabDay).lerp(col.slabNight, n)
+    mats.spandrel.color.copy(col.spDay).lerp(col.spNight, n)
+    mats.glass.color.copy(col.glassDay).lerp(col.glassNight, n)
+    mats.glass.emissiveIntensity = n * 0.9
+    mats.glass.opacity = THREE.MathUtils.lerp(0.22, 0.5, n)
+    mats.furniture.monitor.emissiveIntensity = THREE.MathUtils.lerp(0.25, 1.3, n)
+    mats.furniture.screen.emissiveIntensity = THREE.MathUtils.lerp(0.3, 1.2, n)
+    for (const k of Object.keys(mats.kinds) as Kind[]) mats.kinds[k].emissiveIntensity = n * 0.35
+  })
+  return mats
+}
+
+// ---------------------------------------------------------------------------
+// Furniture: one instanced mesh per item type per floor.
+
+const unitBox = new THREE.BoxGeometry(1, 1, 1)
+const unitCyl = new THREE.CylinderGeometry(0.5, 0.5, 1, 14)
+const unitSphere = new THREE.SphereGeometry(0.5, 12, 10)
+const unitCapsule = new THREE.CapsuleGeometry(0.5, 0.6, 4, 10)
+const GEOM: Record<ItemType, THREE.BufferGeometry> = {
+  desk: unitBox,
+  monitor: unitBox,
+  chair: unitBox,
+  sofa: unitBox,
+  table: unitCyl,
+  pot: unitCyl,
+  leaf: unitSphere,
+  shelf: unitBox,
+  book: unitBox,
+  screen: unitBox,
+  body: unitCapsule,
+  head: unitSphere,
+  partition: unitBox,
+  rail: unitBox,
+  counter: unitBox,
+}
+const NO_SHADOW: ItemType[] = ['partition', 'leaf', 'book']
+
+function Furniture({ items, mats }: { items: Item[]; mats: Mats }) {
+  const groups = useMemo(() => {
+    const by = new Map<ItemType, Item[]>()
+    for (const it of items) {
+      const list = by.get(it.type)
+      if (list) list.push(it)
+      else by.set(it.type, [it])
+    }
+    return [...by.entries()]
+  }, [items])
+  return (
+    <>
+      {groups.map(([type, list]) => (
+        <Instances
+          key={type}
+          limit={list.length}
+          range={list.length}
+          geometry={GEOM[type]}
+          material={mats.furniture[type]}
+          castShadow={!NO_SHADOW.includes(type)}
+          receiveShadow
+          frustumCulled={false}
+        >
+          {list.map((it, k) => (
+            <Instance
+              key={k}
+              position={[it.x, it.y, it.z]}
+              rotation={[0, it.ry, 0]}
+              scale={[it.sx, it.sy, it.sz]}
+              color={it.color}
+            />
+          ))}
+        </Instances>
+      ))}
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Zones and kiosks.
+
+function Kiosk({ room, mats }: { room: Room; mats: Mats }) {
+  const c = KIND_COLORS[room.kind]
+  return (
+    <group position={[0, PLATE, 0]}>
+      <RoundedBox args={[0.55, KIOSK_H - 0.1, 0.55]} radius={0.04} position={[0, (KIOSK_H - 0.1) / 2, 0]} castShadow receiveShadow>
+        <primitive object={mats.kinds[room.kind]} attach="material" />
+      </RoundedBox>
+      <mesh position={[0, KIOSK_H - 0.05, 0]}>
+        <boxGeometry args={[0.62, 0.1, 0.62]} />
+        <meshStandardMaterial color="#fbf8f2" emissive={c} emissiveIntensity={0.6} roughness={0.4} />
+      </mesh>
+      <mesh position={[0, KIOSK_H / 2, 0.29]}>
+        <planeGeometry args={[0.36, 0.5]} />
+        <meshStandardMaterial color="#fbf8f2" emissive="#ffffff" emissiveIntensity={0.35} roughness={0.3} />
+      </mesh>
+    </group>
+  )
+}
+
+function Zone({ room, mats }: { room: Room; mats: Mats }) {
+  const s = useShared()
+  const g = useRef<THREE.Group>(null)
+  const blocks = room.blocks ?? [{ x: room.x, z: room.z, w: room.w, d: room.d }]
+  const lift = room.base ? PLATE : 0
+  useFrame(() => {
+    if (!room.alt || !g.current) return
+    const t = smoothstep(s.healShift)
+    g.current.position.set((room.alt.x - room.x) * t, 0, (room.alt.z - room.z) * t)
+  })
+  return (
+    <group ref={g}>
+      {blocks.map((b, k) => (
+        <RoundedBox
+          key={k}
+          args={[b.w, PLATE, b.d]}
+          radius={0.03}
+          smoothness={2}
+          position={[b.x, lift + PLATE / 2, b.z]}
+          receiveShadow
+        >
+          <primitive object={mats.kinds[room.kind]} attach="material" />
+        </RoundedBox>
+      ))}
+      {room.kind === 'action' && (
+        <group position={[room.x, lift, room.z]}>
+          <Kiosk room={room} mats={mats} />
+        </group>
+      )}
+    </group>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Curtain walls on the two back sides: spandrel, glass, mullions, head beam.
+
+function CurtainWall({ mats, side }: { mats: Mats; side: 'x' | 'z' }) {
+  const len = side === 'x' ? FLOOR_D : FLOOR_W
+  const n = Math.round(len / 1.25)
+  const mullions = useMemo(() => Array.from({ length: n + 1 }, (_, k) => -len / 2 + (k * len) / n), [len, n])
+  const at = (u: number, y: number): [number, number, number] =>
+    side === 'x' ? [-FLOOR_W / 2 + WALL_T / 2, y, u] : [u, y, -FLOOR_D / 2 + WALL_T / 2]
+  const size = (u: number, y: number, t: number): [number, number, number] => (side === 'x' ? [t, y, u] : [u, y, t])
+  return (
+    <group>
+      <mesh position={at(0, 0.16)} castShadow receiveShadow>
+        <boxGeometry args={size(len, 0.32, WALL_T)} />
+        <primitive object={mats.spandrel} attach="material" />
+      </mesh>
+      <mesh position={at(0, 0.32 + (WALL_H - 0.42) / 2)}>
+        <boxGeometry args={size(len, WALL_H - 0.42, 0.02)} />
+        <primitive object={mats.glass} attach="material" />
+      </mesh>
+      <mesh position={at(0, WALL_H - 0.05)} castShadow>
+        <boxGeometry args={size(len, 0.1, WALL_T + 0.02)} />
+        <primitive object={mats.steel} attach="material" />
+      </mesh>
+      <Instances limit={mullions.length} range={mullions.length} geometry={unitBox} material={mats.steel} castShadow>
+        {mullions.map((u) => (
+          <Instance key={u} position={at(u, WALL_H / 2)} scale={size(0.07, WALL_H, WALL_T + 0.02)} />
+        ))}
+      </Instances>
+    </group>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+function FloorUnit({ index: i, mats, t0 }: { index: number; mats: Mats; t0: number }) {
+  const s = useShared()
+  const floor = FLOORS[i]
+  const g = useRef<THREE.Group>(null)
+  const sheet = useRef<THREE.Mesh>(null)
+  const sheetMat = useRef<THREE.MeshStandardMaterial>(null)
+  const lines = useRef<LineRef>(null)
+  const slab = useRef<THREE.Group>(null)
+  const rooms = useRef<THREE.Group>(null)
+  const walls = useRef<THREE.Group>(null)
+  const pts = useMemo(() => sheetLinePoints(i), [i])
+  const items = useMemo(() => floor.rooms.flatMap((r) => furnish(r)), [floor])
+  // LineSegments2 accumulates dash distance across every segment, so one
+  // growing dash draws the sheet in sequence: border, footprint, then rooms.
+  const total = useMemo(() => {
+    let l = 0
+    for (let k = 0; k < pts.length; k += 2) {
+      const a = pts[k]
+      const b = pts[k + 1]
+      l += Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2])
+    }
+    return l
+  }, [pts])
+  const pose = fan(i)
+
+  useFrame(() => {
+    const c = s.cur
+    const rise = stagger(c.rise, i)
+    const flat = 1 - rise
+    const y0 = 0.012 + i * 0.014
+    if (g.current) {
+      g.current.position.set(
+        pose.x * c.spread * flat,
+        THREE.MathUtils.lerp(y0, floorY(i), rise),
+        pose.z * c.spread * flat
+      )
+      g.current.rotation.y = pose.r * c.spread * flat
+    }
+    // The line work sketches itself in once, on load, then fades as the
+    // sheet becomes a slab.
+    const drawT = THREE.MathUtils.clamp((performance.now() - t0 - i * 260) / 3200, 0, 1)
+    const sheetA = 1 - smoothstep(rise * 1.7)
+    if (sheetMat.current) {
+      sheetMat.current.opacity = sheetA
+      sheetMat.current.color.set(c.night > 0.5 ? '#1d4a8f' : '#2a5fb3')
+    }
+    if (sheet.current) sheet.current.visible = sheetA > 0.01
+    if (lines.current) {
+      const m = lines.current.material as THREE.ShaderMaterial & { dashSize: number; gapSize: number; opacity: number }
+      m.dashSize = 0.001 + drawT * total
+      m.gapSize = 100000
+      const a = c.draw * (1 - smoothstep((rise - 0.3) / 0.45)) * 0.92
+      m.opacity = a
+      lines.current.visible = a > 0.01
+    }
+    if (slab.current) {
+      slab.current.visible = rise > 0.02
+      slab.current.scale.set(1, Math.max(rise, 0.001), 1)
+    }
+    if (rooms.current) {
+      const sy = smoothstep((rise - 0.35) / 0.65)
+      rooms.current.scale.y = Math.max(sy, 0.001)
+      rooms.current.visible = sy > 0.005
+    }
+    if (walls.current) {
+      const w = c.walls * smoothstep((rise - 0.55) / 0.45)
+      walls.current.scale.y = Math.max(w, 0.001)
+      walls.current.visible = w > 0.005
+    }
+  })
+
+  return (
+    <group ref={g}>
+      <mesh ref={sheet} rotation-x={-Math.PI / 2} receiveShadow>
+        <planeGeometry args={[SHEET.w, SHEET.d]} />
+        <meshStandardMaterial ref={sheetMat} color="#2a5fb3" roughness={1} transparent />
+      </mesh>
+      <Line
+        ref={lines}
+        points={pts}
+        segments
+        color="#ffffff"
+        lineWidth={1.4}
+        dashed
+        dashSize={0.001}
+        gapSize={100000}
+        transparent
+        opacity={0.9}
+        depthWrite={false}
+      />
+      {/* Slab: dark steel edge with a cream deck on top. */}
+      <group ref={slab}>
+        <mesh position={[0, SLAB_T / 2 - 0.02, 0]} castShadow receiveShadow>
+          <boxGeometry args={[FLOOR_W + 0.06, SLAB_T - 0.04, FLOOR_D + 0.06]} />
+          <primitive object={mats.steel} attach="material" />
+        </mesh>
+        <mesh position={[0, SLAB_T - 0.02, 0]} receiveShadow>
+          <boxGeometry args={[FLOOR_W, 0.04, FLOOR_D]} />
+          <primitive object={mats.slab} attach="material" />
+        </mesh>
+      </group>
+      <group ref={rooms} position={[0, SLAB_T, 0]}>
+        {floor.rooms.map((r) => (
+          <Zone key={r.name} room={r} mats={mats} />
+        ))}
+        <Furniture items={items} mats={mats} />
+      </group>
+      <group ref={walls} position={[0, SLAB_T, 0]}>
+        <CurtainWall mats={mats} side="x" />
+        <CurtainWall mats={mats} side="z" />
+      </group>
+    </group>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Roof: garden beds, deck, lounge, solar array, and the structural frame.
+
+function Roof({ mats }: { mats: Mats }) {
+  const s = useShared()
+  const g = useRef<THREE.Group>(null)
+  const beds = useMemo(
+    () => [
+      { x: -2.6, z: 1.6, w: 3.6, d: 1.3 },
+      { x: -3.8, z: -0.6, w: 1.4, d: 2.6 },
+      { x: 1.2, z: 2.6, w: 2.4, d: 0.9 },
+    ],
+    []
+  )
+  const bushes = useMemo(() => {
+    const out: { x: number; z: number; r: number; c: string }[] = []
+    const greens = ['#4f8a4c', '#67a05a', '#3d7a45', '#7bb06a', '#9ab86b']
+    let seed = 7
+    const rnd = () => ((seed = (seed * 16807) % 2147483647) / 2147483647)
+    for (const b of beds) {
+      const n = Math.floor((b.w * b.d) / 0.55)
+      for (let k = 0; k < n; k++) {
+        out.push({
+          x: b.x - b.w / 2 + 0.25 + rnd() * (b.w - 0.5),
+          z: b.z - b.d / 2 + 0.25 + rnd() * (b.d - 0.5),
+          r: 0.28 + rnd() * 0.3,
+          c: greens[Math.floor(rnd() * greens.length)],
+        })
+      }
+    }
+    return out
+  }, [beds])
+  const panels = useMemo(() => {
+    const out: [number, number][] = []
+    for (let i = 0; i < 3; i++) for (let j = 0; j < 2; j++) out.push([1.0 + i * 1.25, -2.6 + j * 1.0])
+    return out
+  }, [])
+  useFrame(() => {
+    if (!g.current) return
+    const rise = stagger(s.cur.rise, N) * s.cur.walls
+    g.current.visible = rise > 0.01
+    g.current.position.y = THREE.MathUtils.lerp(floorY(N) - 0.6, floorY(N), rise)
+    g.current.scale.setScalar(Math.max(rise, 0.001))
+  })
+  const top = SLAB_T
+  return (
+    <group ref={g}>
+      <mesh position={[0, SLAB_T / 2 - 0.02, 0]} castShadow receiveShadow>
+        <boxGeometry args={[FLOOR_W + 0.06, SLAB_T - 0.04, FLOOR_D + 0.06]} />
+        <primitive object={mats.steel} attach="material" />
+      </mesh>
+      <mesh position={[0, SLAB_T - 0.02, 0]} receiveShadow>
+        <boxGeometry args={[FLOOR_W, 0.04, FLOOR_D]} />
+        <primitive object={mats.slab} attach="material" />
+      </mesh>
+      {/* Parapet rail. */}
+      <Instances limit={4} range={4} geometry={unitBox} material={mats.steel} castShadow>
+        <Instance position={[FLOOR_W / 2 - 0.03, top + 0.45, 0]} scale={[0.06, 0.05, FLOOR_D]} />
+        <Instance position={[-FLOOR_W / 2 + 0.03, top + 0.45, 0]} scale={[0.06, 0.05, FLOOR_D]} />
+        <Instance position={[0, top + 0.45, FLOOR_D / 2 - 0.03]} scale={[FLOOR_W, 0.05, 0.06]} />
+        <Instance position={[0, top + 0.45, -FLOOR_D / 2 + 0.03]} scale={[FLOOR_W, 0.05, 0.06]} />
+      </Instances>
+      <Instances limit={24} range={24} geometry={unitBox} material={mats.steel} castShadow>
+        {Array.from({ length: 6 }, (_, k) => -FLOOR_D / 2 + 0.6 + k * 1.26).map((z) => (
+          <Instance key={`a${z}`} position={[FLOOR_W / 2 - 0.03, top + 0.23, z]} scale={[0.04, 0.46, 0.04]} />
+        ))}
+        {Array.from({ length: 8 }, (_, k) => -FLOOR_W / 2 + 0.6 + k * 1.26).map((x) => (
+          <Instance key={`b${x}`} position={[x, top + 0.23, FLOOR_D / 2 - 0.03]} scale={[0.04, 0.46, 0.04]} />
+        ))}
+      </Instances>
+      {/* Deck. */}
+      <mesh position={[0.6, top + 0.02, 0.4]} receiveShadow>
+        <boxGeometry args={[5.6, 0.04, 3.2]} />
+        <meshStandardMaterial color="#d9bf98" roughness={0.9} />
+      </mesh>
+      {/* Planters and bushes. */}
+      <Instances limit={beds.length} range={beds.length} geometry={unitBox} castShadow receiveShadow>
+        <meshStandardMaterial color="#8a7862" roughness={0.9} />
+        {beds.map((b, k) => (
+          <Instance key={k} position={[b.x, top + 0.2, b.z]} scale={[b.w, 0.4, b.d]} />
+        ))}
+      </Instances>
+      <Instances limit={bushes.length} range={bushes.length} geometry={unitSphere} castShadow>
+        <meshStandardMaterial color="#ffffff" roughness={1} />
+        {bushes.map((b, k) => (
+          <Instance key={k} position={[b.x, top + 0.4 + b.r * 0.45, b.z]} scale={[b.r * 2, b.r * 1.6, b.r * 2]} color={b.c} />
+        ))}
+      </Instances>
+      {/* Lounge. */}
+      <Instances limit={6} range={6} geometry={unitBox} castShadow receiveShadow>
+        <meshStandardMaterial color="#ffffff" roughness={0.85} />
+        <Instance position={[0.2, top + 0.22, 0.2]} scale={[1.5, 0.4, 0.62]} color="#e8e1d3" />
+        <Instance position={[0.2, top + 0.5, -0.05]} scale={[1.5, 0.28, 0.12]} color="#d9d0bf" />
+        <Instance position={[2.2, top + 0.22, 0.2]} scale={[0.62, 0.4, 0.62]} color="#e8e1d3" />
+        <Instance position={[2.2, top + 0.5, -0.05]} scale={[0.62, 0.28, 0.12]} color="#d9d0bf" />
+        <Instance position={[1.25, top + 0.18, 1.1]} scale={[0.9, 0.32, 0.5]} color="#d8bf9a" />
+        <Instance position={[3.8, top + 0.3, 1.2]} scale={[0.3, 0.6, 0.3]} color="#c7b299" />
+      </Instances>
+      <mesh position={[3.8, top + 0.95, 1.2]} castShadow>
+        <sphereGeometry args={[0.42, 12, 10]} />
+        <meshStandardMaterial color="#5e9a52" roughness={1} />
+      </mesh>
+      {/* Solar array. */}
+      <Instances limit={panels.length} range={panels.length} geometry={unitBox} castShadow receiveShadow>
+        <meshStandardMaterial color="#1f2f6b" roughness={0.25} metalness={0.4} />
+        {panels.map(([x, z], k) => (
+          <Instance key={k} position={[x, top + 0.3, z]} rotation={[-0.32, 0, 0]} scale={[1.1, 0.04, 0.85]} />
+        ))}
+      </Instances>
+      <Instances limit={panels.length} range={panels.length} geometry={unitBox} material={mats.steel}>
+        {panels.map(([x, z], k) => (
+          <Instance key={k} position={[x, top + 0.14, z + 0.25]} scale={[0.06, 0.28, 0.06]} />
+        ))}
+      </Instances>
+    </group>
+  )
+}
+
+function Frame({ mats }: { mats: Mats }) {
+  const s = useShared()
+  const g = useRef<THREE.Group>(null)
+  const H = floorY(N) + SLAB_T
+  useFrame(() => {
+    if (!g.current) return
+    const rise = smoothstep(THREE.MathUtils.clamp(s.cur.rise * 1.6 - 0.2, 0, 1)) * s.cur.walls
+    g.current.visible = rise > 0.01
+    g.current.scale.set(1, Math.max(rise, 0.001), 1)
+  })
+  const corners: [number, number][] = [
+    [FLOOR_W / 2 - 0.05, FLOOR_D / 2 - 0.05],
+    [FLOOR_W / 2 - 0.05, -FLOOR_D / 2 + 0.05],
+    [-FLOOR_W / 2 + 0.05, FLOOR_D / 2 - 0.05],
+    [-FLOOR_W / 2 + 0.05, -FLOOR_D / 2 + 0.05],
+  ]
+  return (
+    <group ref={g}>
+      <Instances limit={4} range={4} geometry={unitBox} material={mats.steel} castShadow>
+        {corners.map(([x, z], k) => (
+          <Instance key={k} position={[x, H / 2, z]} scale={[0.16, H, 0.16]} />
+        ))}
+      </Instances>
+      {/* Forecourt paving in front of the entrance. */}
+      <mesh position={[FLOOR_W / 2 + 1.4, 0.03, -0.6]} receiveShadow>
+        <boxGeometry args={[2.6, 0.06, 5.2]} />
+        <meshStandardMaterial color="#d3cdc2" roughness={0.95} />
+      </mesh>
+    </group>
+  )
+}
+
+export default function Tower() {
+  const mats = useMaterials()
+  const t0 = useMemo(() => performance.now() + 400, [])
+  return (
+    <group>
+      {FLOORS.map((_, i) => (
+        <FloorUnit key={i} index={i} mats={mats} t0={t0} />
+      ))}
+      <Roof mats={mats} />
+      <Frame mats={mats} />
+    </group>
+  )
+}

--- a/web/src/components/building/Trajectory.tsx
+++ b/web/src/components/building/Trajectory.tsx
@@ -1,0 +1,64 @@
+import { useFrame } from '@react-three/fiber'
+import { Html, Line } from '@react-three/drei'
+import { useMemo, useRef, type ComponentRef } from 'react'
+import { JOURNEYS, TRAVELLER_COLORS } from './model'
+import { buildPath } from './geometry'
+import { useShared } from './state'
+
+// Chapter 06. The BookFlight journey as a named route: a ribbon through the
+// building with a numbered pin at every stop.
+export default function Trajectory() {
+  const s = useShared()
+  const journey = JOURNEYS[0]
+  const path = useMemo(() => buildPath(journey, 0.16), [journey])
+  const line = useRef<ComponentRef<typeof Line>>(null)
+  const pins = useRef<(HTMLDivElement | null)[]>([])
+  const color = TRAVELLER_COLORS[journey.who]
+
+  useFrame(() => {
+    const o = s.cur.trajectory
+    if (line.current) {
+      const m = line.current.material as unknown as { opacity: number }
+      m.opacity = o * 0.95
+      line.current.visible = o > 0.02
+    }
+    pins.current.forEach((el, k) => {
+      if (!el) return
+      const po = Math.min(1, Math.max(0, o * 1.6 - k * 0.07))
+      el.style.opacity = po.toFixed(2)
+      el.style.visibility = po > 0.02 ? 'visible' : 'hidden'
+      el.style.transform = `scale(${(0.6 + 0.4 * po).toFixed(3)})`
+    })
+  })
+
+  return (
+    <>
+      <Line
+        ref={line}
+        points={path.points}
+        color={color}
+        lineWidth={3}
+        transparent
+        opacity={0}
+        depthWrite={false}
+      />
+      {journey.stops.map(([, name], k) => {
+        const p = path.points[path.stops[k]]
+        return (
+          <Html key={name + k} position={[p.x, p.y + 0.15, p.z]} center zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
+            <div
+              ref={(el) => {
+                pins.current[k] = el
+              }}
+              className="bld-pin"
+              style={{ opacity: 0, visibility: 'hidden' }}
+            >
+              <b>{k + 1}</b>
+              <span>{name}</span>
+            </div>
+          </Html>
+        )
+      })}
+    </>
+  )
+}

--- a/web/src/components/building/Wayfinding.tsx
+++ b/web/src/components/building/Wayfinding.tsx
@@ -1,0 +1,95 @@
+import { useFrame } from '@react-three/fiber'
+import { Html } from '@react-three/drei'
+import { useRef } from 'react'
+import { FLOORS, FLOOR_D, FLOOR_W, SLAB_T, floorY, roomTop } from './model'
+import { smoothstep } from './chapters'
+import { useShared } from './state'
+
+// The signage: a floor directory down the right-hand edge, tags over the
+// rooms that carry one, and yellow memory notes. Plain HTML anchored in 3D,
+// so it uses the site's fonts and stays crisp at any zoom.
+interface Anchor {
+  pos: [number, number, number]
+  kind: 'floor' | 'tag' | 'memory'
+  floor: number
+  node: React.ReactNode
+}
+
+const anchors: Anchor[] = []
+FLOORS.forEach((f, i) => {
+  anchors.push({
+    kind: 'floor',
+    floor: i,
+    pos: [FLOOR_W / 2 + 0.15, floorY(i) + 0.95, -FLOOR_D / 2 + 0.3],
+    node: (
+      <>
+        <b>{String(i).padStart(2, '0')}</b> {f.name} <span>{f.route}</span>
+      </>
+    ),
+  })
+  for (const r of f.rooms) {
+    if (r.tag) {
+      anchors.push({
+        kind: 'tag',
+        floor: i,
+        pos: [r.x, floorY(i) + SLAB_T + roomTop(r) + 0.15, r.z],
+        node: r.name,
+      })
+    }
+    if (r.memory) {
+      anchors.push({
+        kind: 'memory',
+        floor: i,
+        pos: [r.x - r.w / 2 - 0.4, floorY(i) + SLAB_T + roomTop(r) + 0.55, r.z + 1.0],
+        node: (
+          <>
+            <em>memory</em>
+            {r.memory}
+          </>
+        ),
+      })
+    }
+  }
+})
+
+export default function Wayfinding() {
+  const s = useShared()
+  const els = useRef<(HTMLDivElement | null)[]>([])
+  useFrame(() => {
+    const c = s.cur
+    const rise = smoothstep(Math.min(1, c.rise * 1.4 - 0.4))
+    anchors.forEach((a, k) => {
+      const el = els.current[k]
+      if (!el) return
+      const base = a.kind === 'floor' ? c.labels : c.tags
+      // Stagger by floor so the directory lights up bottom to top.
+      const o = smoothstep(base * 1.5 - a.floor * 0.08) * rise
+      el.style.opacity = o.toFixed(3)
+      el.style.visibility = o > 0.02 ? 'visible' : 'hidden'
+      el.style.transform = `translateY(${((1 - o) * 10).toFixed(1)}px)`
+    })
+  })
+  return (
+    <>
+      {anchors.map((a, k) => (
+        <Html
+          key={k}
+          position={a.pos}
+          center={a.kind === 'tag'}
+          zIndexRange={[6, 0]}
+          style={{ pointerEvents: 'none' }}
+        >
+          <div
+            ref={(el) => {
+              els.current[k] = el
+            }}
+            className={`bld-tag bld-tag--${a.kind}`}
+            style={{ opacity: 0, visibility: 'hidden' }}
+          >
+            {a.node}
+          </div>
+        </Html>
+      ))}
+    </>
+  )
+}

--- a/web/src/components/building/chapters.ts
+++ b/web/src/components/building/chapters.ts
@@ -1,0 +1,255 @@
+// The story, one chapter per scroll section, and the scene parameters each
+// chapter drives toward. Scene.tsx blends neighbouring chapters by scroll
+// position and damps toward the result, so every number here is a target, not
+// a keyframe. Copy uses `backticks` for inline code; the card renders them.
+import { COUNTS, JOURNEYS, RISERS, TOOLS } from './model'
+
+export interface SceneParams {
+  /** Blueprint sheets fanned across the table (1) vs stacked (0). */
+  spread: number
+  /** How much of the white line work is drawn. */
+  draw: number
+  /** Sheets lifted into floors and rooms extruded. */
+  rise: number
+  /** Back walls, windows and roof. */
+  walls: number
+  /** Floor directory labels. */
+  labels: number
+  /** Room tags and memory notes. */
+  tags: number
+  /** Crowd presence (scale of walkers). */
+  agents: number
+  /** Self-healing demo running. */
+  heal: number
+  /** Trajectory highlight. */
+  trajectory: number
+  /** Front desk with MCP tools. */
+  desk: number
+  /** Nightfall. */
+  night: number
+  /** Camera azimuth (deg), elevation (deg), zoom multiplier, look-at height. */
+  az: number
+  el: number
+  zoom: number
+  lookY: number
+}
+
+export interface Chapter {
+  id: string
+  eyebrow: string
+  /** Rail label. */
+  short: string
+  title: string
+  body: string
+  badge?: string
+  ctas?: { label: string; href: string; primary?: boolean; external?: boolean }[]
+  hud: { title: string; rows: [string, string][] }
+  /** Which journey the crowd is reduced to, if any. */
+  focus?: string
+  scene: SceneParams
+}
+
+const base: SceneParams = {
+  spread: 0,
+  draw: 1,
+  rise: 1,
+  walls: 1,
+  labels: 0,
+  tags: 0,
+  agents: 0,
+  heal: 0,
+  trajectory: 0,
+  desk: 0,
+  night: 0,
+  az: 42,
+  el: 27,
+  zoom: 1,
+  lookY: 6.2,
+}
+
+export const CHAPTERS: Chapter[] = [
+  {
+    id: 'arrival',
+    short: 'Arrival',
+    eyebrow: '00 · Arrival',
+    title: 'Every app is a building.',
+    body:
+      'The code is the blueprint. The running app is the building. The people inside are your users and your agents. Sightmap is the wayfinding that lets an agent find its way around without reading the blueprints first.',
+    hud: {
+      title: 'The model',
+      rows: [
+        ['Views', String(COUNTS.views)],
+        ['Components', String(COUNTS.components)],
+        ['Requests', String(COUNTS.requests)],
+      ],
+    },
+    scene: { ...base, spread: 1, draw: 1, rise: 0, walls: 0, az: 38, el: 46, zoom: 1.05, lookY: 0.4 },
+  },
+  {
+    id: 'blueprint',
+    short: 'Blueprint',
+    eyebrow: '01 · The blueprint',
+    title: 'Code describes every wall.',
+    body:
+      'Source files are the drawings the building was built from: components, routes, API handlers. They are complete and exact, and almost useless to someone standing in the lobby. Nothing on a blueprint says where the front desk is or which door sticks.',
+    hud: {
+      title: 'The drawing set',
+      rows: [
+        ['Sheets', String(COUNTS.views)],
+        ['Source files', '41'],
+        ['Says where the desk is', 'no'],
+      ],
+    },
+    scene: { ...base, spread: 0, draw: 1, rise: 0, walls: 0, az: 34, el: 54, zoom: 1.3, lookY: 0.3 },
+  },
+  {
+    id: 'building',
+    short: 'Building',
+    eyebrow: '02 · The building',
+    title: 'The running app is the building.',
+    body:
+      'Deploy the code and the drawings become floors. Each view is a floor with its own route. Components are the rooms on that floor. API requests are the service risers running up the core, carrying data between the floors and the basement.',
+    hud: {
+      title: 'The building',
+      rows: [
+        ['Floors', String(COUNTS.views)],
+        ['Rooms', String(COUNTS.components)],
+        ['Risers', String(RISERS.length)],
+      ],
+    },
+    scene: { ...base, rise: 1, walls: 1, az: 42, el: 27, zoom: 1.0, lookY: 6.2 },
+  },
+  {
+    id: 'wayfinding',
+    short: 'Wayfinding',
+    eyebrow: '03 · The wayfinding',
+    title: 'A sightmap is the signage.',
+    body:
+      'Real buildings do not hand visitors blueprints. They put a directory in the lobby, numbers on the doors, and a note on the door that sticks. A `.sightmap/` does the same for agents: names for every floor, room and riser, links back to the drawings, and memory for the quirks the drawings never recorded.',
+    hud: {
+      title: 'The map',
+      rows: [
+        ['Named', `${COUNTS.components}/${COUNTS.components}`],
+        ['Orphans', '0'],
+        ['Memory notes', String(COUNTS.memory)],
+      ],
+    },
+    scene: { ...base, labels: 1, tags: 1, az: 46, el: 24, zoom: 1.02, lookY: 6.6 },
+  },
+  {
+    id: 'people',
+    short: 'People',
+    eyebrow: '04 · The people',
+    title: 'Every day, people move through it.',
+    body:
+      'Users book a flight. Agents reproduce a bug, verify a fix, run a checkout. Each trip is a journey through rooms and floors, and Subtext records those journeys against the map, so a session reads as `FlightSearch → FareCard → PaymentForm` instead of a list of divs.',
+    hud: {
+      title: 'Today',
+      rows: [
+        ['Journeys', String(JOURNEYS.length)],
+        ['Steps named', '100%'],
+        ['Floors visited', String(COUNTS.views)],
+      ],
+    },
+    scene: { ...base, labels: 0.55, agents: 1, az: 40, el: 26, zoom: 1.02, lookY: 6.0 },
+  },
+  {
+    id: 'self-healing',
+    short: 'Self-healing',
+    eyebrow: '05 · Built on top',
+    badge: 'exploratory',
+    title: 'Tests that find the moved door.',
+    body:
+      'When a room moves, a test written against selectors walks into a wall. A test written against the map asks the building where the room went. The selector changes, the name does not, and the run finishes.',
+    hud: {
+      title: 'Self-healing run',
+      rows: [
+        ['Room moved', 'ContinueButton'],
+        ['Selectors updated', '1'],
+        ['Runs passed', '128 / 128'],
+      ],
+    },
+    focus: 'Regression',
+    scene: { ...base, labels: 0.4, agents: 0.35, heal: 1, az: 50, el: 22, zoom: 1.22, lookY: 8.2 },
+  },
+  {
+    id: 'trajectories',
+    short: 'Trajectories',
+    eyebrow: '06 · Built on top',
+    badge: 'exploratory',
+    title: 'Journeys you can name and rerun.',
+    body:
+      'Codify a journey on top of the primitives: the floors it visits, the rooms it touches, the requests it expects on the way. A trajectory is a route through the building any agent can follow, and any run can be checked against.',
+    hud: {
+      title: 'Trajectory',
+      rows: [
+        ['Route', 'BookFlight'],
+        ['Stops', String(JOURNEYS[0].stops.length)],
+        ['Requests expected', '3'],
+      ],
+    },
+    focus: 'BookFlight',
+    scene: { ...base, labels: 0.5, agents: 0.35, trajectory: 1, az: 44, el: 26, zoom: 1.05, lookY: 5.8 },
+  },
+  {
+    id: 'web-mcp',
+    short: 'Web MCP',
+    eyebrow: '07 · Built on top',
+    badge: 'exploratory',
+    title: 'A front desk for agents.',
+    body:
+      'Once the building knows its own rooms, it can offer services at the door. Generate MCP tools from the map: `search_flights`, `select_fare`, `create_booking`, each backed by a real view and a real request. An agent walks up to the counter instead of wandering the halls.',
+    hud: {
+      title: 'Front desk',
+      rows: [
+        ['Tools', String(TOOLS.length)],
+        ['Backed by views', '3'],
+        ['Backed by requests', '2'],
+      ],
+    },
+    scene: { ...base, labels: 0.3, agents: 0.5, desk: 1, az: 52, el: 21, zoom: 1.2, lookY: 3.4 },
+  },
+  {
+    id: 'nightfall',
+    short: 'Nightfall',
+    eyebrow: '08 · Nightfall',
+    title: 'Hand your agent the map.',
+    body:
+      'A sightmap is YAML in your repo. Install the CLI, let an agent walk the building, and commit the wayfinding alongside the code.',
+    ctas: [
+      { label: 'Get started', href: '/#start', primary: true },
+      { label: 'Read the docs →', href: 'https://docs.sightmap.org', external: true },
+      { label: 'View on GitHub', href: 'https://github.com/sightmap/sightmap', external: true },
+    ],
+    hud: {
+      title: 'Nightfall',
+      rows: [
+        ['Windows lit', String(COUNTS.components)],
+        ['Still walking', String(JOURNEYS.length)],
+        ['Map committed', 'yes'],
+      ],
+    },
+    scene: { ...base, labels: 0.5, agents: 1, night: 1, az: 36, el: 25, zoom: 0.98, lookY: 6.4 },
+  },
+]
+
+export const PARAM_KEYS = Object.keys(base) as (keyof SceneParams)[]
+
+export const smoothstep = (t: number): number => {
+  const x = Math.min(1, Math.max(0, t))
+  return x * x * (3 - 2 * x)
+}
+
+/** Scene target for a continuous chapter position (0 … CHAPTERS.length-1). */
+export function paramsAt(p: number, out: SceneParams): SceneParams {
+  const n = CHAPTERS.length
+  const c = Math.min(Math.max(p, 0), n - 1)
+  const i = Math.min(Math.floor(c), n - 2)
+  const t = smoothstep(c - i)
+  const a = CHAPTERS[i].scene
+  const b = CHAPTERS[i + 1].scene
+  for (const k of PARAM_KEYS) out[k] = a[k] + (b[k] - a[k]) * t
+  return out
+}
+
+export const defaultParams = (): SceneParams => ({ ...CHAPTERS[0].scene })

--- a/web/src/components/building/furnish.ts
+++ b/web/src/components/building/furnish.ts
@@ -1,0 +1,193 @@
+// Procedural furniture. Every component kind gets a recognisable interior —
+// workstations for forms, a counter for navigation, a library lounge for
+// content, a meeting room for data — laid out deterministically from the
+// room's footprint so the blueprint sheets and the built floors agree.
+// Items are cheap primitives (unit box / cylinder / sphere / capsule) with a
+// per-item scale and colour; Tower.tsx renders each type as one instanced
+// mesh per floor.
+import { PLATE, type Room } from './model'
+
+export type ItemType =
+  | 'desk'
+  | 'monitor'
+  | 'chair'
+  | 'sofa'
+  | 'table'
+  | 'pot'
+  | 'leaf'
+  | 'shelf'
+  | 'book'
+  | 'screen'
+  | 'body'
+  | 'head'
+  | 'partition'
+  | 'rail'
+  | 'counter'
+
+export interface Item {
+  type: ItemType
+  /** Centre, floor-local: x/z in floor coordinates, y above the slab top. */
+  x: number
+  y: number
+  z: number
+  ry: number
+  sx: number
+  sy: number
+  sz: number
+  color: string
+}
+
+/** Footprints worth drawing on the blueprint sheet. */
+export const DRAWN: ItemType[] = ['desk', 'table', 'sofa', 'shelf', 'counter']
+
+// mulberry32: tiny seeded RNG so a room always gets the same furniture.
+function rng(seed: string): () => number {
+  let a = 1779033703
+  for (let i = 0; i < seed.length; i++) a = Math.imul(a ^ seed.charCodeAt(i), 3432918353)
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const WOOD = '#d8bf9a'
+const DARK = '#2b2d33'
+const WHITE = '#f6f2ea'
+const SKIN = ['#e9c4a3', '#c9976f', '#8d5a3b', '#f0d5bd']
+const SHIRT = ['#6e7fa8', '#b8a58c', '#4f5d75', '#a86e7c', '#7c9a86', '#e0d6c8']
+const BOOKS = ['#c9456d', '#6b8aed', '#2d8a5e', '#b8860b', '#9b7ae8', '#e0d6c8', '#3d3929']
+const GREENS = ['#4f8a4c', '#67a05a', '#3d7a45', '#7bb06a']
+
+function item(type: ItemType, x: number, y: number, z: number, s: [number, number, number], color: string, ry = 0): Item {
+  return { type, x, y, z, ry, sx: s[0], sy: s[1], sz: s[2], color }
+}
+
+function plant(out: Item[], x: number, z: number, y: number, r: () => number, big = false): void {
+  const h = big ? 0.42 : 0.28
+  out.push(item('pot', x, y + h / 2, z, [big ? 0.34 : 0.26, h, big ? 0.34 : 0.26], '#c7b299'))
+  const g = GREENS[Math.floor(r() * GREENS.length)]
+  out.push(item('leaf', x, y + h + (big ? 0.34 : 0.24), z, big ? [0.75, 0.7, 0.75] : [0.5, 0.48, 0.5], g))
+  if (big) out.push(item('leaf', x + 0.12, y + h + 0.6, z - 0.08, [0.42, 0.4, 0.42], GREENS[(GREENS.indexOf(g) + 1) % GREENS.length]))
+}
+
+function person(out: Item[], x: number, z: number, y: number, ry: number, r: () => number): void {
+  const shirt = SHIRT[Math.floor(r() * SHIRT.length)]
+  const skin = SKIN[Math.floor(r() * SKIN.length)]
+  out.push(item('body', x, y + 0.24, z, [0.26, 0.34, 0.22], shirt, ry))
+  out.push(item('head', x, y + 0.52, z, [0.17, 0.17, 0.17], skin))
+}
+
+/** A desk facing +z (chair on the +z side). `ry` rotates the whole cluster. */
+function workstation(out: Item[], cx: number, cz: number, y: number, ry: number, r: () => number): void {
+  const c = Math.cos(ry)
+  const s = Math.sin(ry)
+  const at = (dx: number, dz: number): [number, number] => [cx + dx * c - dz * s, cz + dx * s + dz * c]
+  const [dx, dz] = at(0, 0)
+  out.push(item('desk', dx, y + 0.2, dz, [1.15, 0.4, 0.55], WOOD, ry))
+  const [mx, mz] = at(0, -0.12)
+  out.push(item('monitor', mx, y + 0.56, mz, [0.46, 0.28, 0.04], DARK, ry))
+  const [chx, chz] = at(0, 0.52)
+  out.push(item('chair', chx, y + 0.22, chz, [0.4, 0.44, 0.4], '#3b3f4a', ry))
+  if (r() < 0.6) person(out, chx, chz, y + 0.2, ry + Math.PI, r)
+}
+
+export function furnish(room: Room): Item[] {
+  const out: Item[] = []
+  const r = rng(room.name)
+  const y = (room.base ? PLATE : 0) + PLATE
+  const blocks = room.blocks ?? [{ x: room.x, z: room.z, w: room.w, d: room.d }]
+  // Glass partitions on the back two sides of any room big enough to be one.
+  if (!room.blocks && room.w >= 2.4 && room.d >= 1.4 && room.kind !== 'action') {
+    const h = 1.15
+    out.push(item('partition', room.x, y + h / 2, room.z - room.d / 2, [room.w, h, 0.04], '#cfe3f5'))
+    out.push(item('rail', room.x, y + h, room.z - room.d / 2, [room.w, 0.05, 0.06], DARK))
+    out.push(item('partition', room.x - room.w / 2, y + h / 2, room.z, [0.04, h, room.d], '#cfe3f5'))
+    out.push(item('rail', room.x - room.w / 2, y + h, room.z, [0.06, 0.05, room.d], DARK))
+  }
+  for (const b of blocks) {
+    const long = b.w >= b.d
+    switch (room.kind) {
+      case 'form': {
+        // Rows of workstations along the long axis.
+        const len = (long ? b.w : b.d) - 0.5
+        const dep = (long ? b.d : b.w) - 0.5
+        const cols = Math.max(1, Math.floor(len / 1.45))
+        const rows = Math.max(1, Math.floor(dep / 1.25))
+        for (let i = 0; i < cols; i++) {
+          for (let j = 0; j < rows; j++) {
+            const u = -len / 2 + (i + 0.5) * (len / cols)
+            const v = -dep / 2 + (j + 0.5) * (dep / rows) - 0.15
+            const x = long ? b.x + u : b.x + v
+            const z = long ? b.z + v : b.z + u
+            workstation(out, x, z, y, long ? 0 : Math.PI / 2, r)
+          }
+        }
+        if (b.w > 2 && b.d > 1.2) plant(out, b.x + b.w / 2 - 0.3, b.z - b.d / 2 + 0.3, y, r)
+        break
+      }
+      case 'nav': {
+        // A long counter with a sign, like a reception or a directory.
+        const len = (long ? b.w : b.d) - 0.6
+        out.push(item('counter', b.x, y + 0.26, b.z, long ? [len, 0.52, 0.42] : [0.42, 0.52, len], '#6b4a2f'))
+        out.push(item('counter', b.x, y + 0.545, b.z, long ? [len + 0.12, 0.05, 0.54] : [0.54, 0.05, len + 0.12], WHITE))
+        if (len > 2.5) out.push(item('screen', b.x, y + 0.82, b.z, long ? [0.9, 0.42, 0.04] : [0.04, 0.42, 0.9], DARK))
+        plant(out, long ? b.x - len / 2 - 0.05 : b.x, long ? b.z : b.z - len / 2 - 0.05, y, r)
+        if (b.w > 1.8 && b.d > 1.0 && r() < 0.8) person(out, b.x + (long ? 0.4 : 0.35), b.z + (long ? 0.35 : 0.4), y, Math.PI, r)
+        break
+      }
+      case 'content': {
+        // Library lounge: shelves along the back, a sofa and coffee table.
+        const len = b.w - 0.4
+        if (len > 1.2) {
+          out.push(item('shelf', b.x, y + 0.5, b.z - b.d / 2 + 0.17, [len, 1.0, 0.3], '#8b6a4a'))
+          const n = Math.floor(len / 0.16)
+          for (let i = 0; i < n; i++) {
+            if (r() < 0.2) continue
+            const bx = b.x - len / 2 + 0.1 + i * 0.16
+            const bh = 0.2 + r() * 0.12
+            const row = r() < 0.5 ? 0.18 : 0.62
+            out.push(item('book', bx, y + row + bh / 2, b.z - b.d / 2 + 0.16, [0.1, bh, 0.22], BOOKS[Math.floor(r() * BOOKS.length)]))
+          }
+        }
+        if (b.d > 1.3) {
+          const sz = b.z + b.d / 2 - 0.45
+          const sofaW = Math.min(1.5, b.w - 0.6)
+          out.push(item('sofa', b.x - 0.2, y + 0.22, sz, [sofaW, 0.44, 0.6], '#7f8fb8'))
+          out.push(item('sofa', b.x - 0.2, y + 0.55, sz - 0.24, [sofaW, 0.28, 0.12], '#6d7ca3'))
+          out.push(item('table', b.x - 0.2, y + 0.17, sz - 0.75, [0.5, 0.34, 0.5], WOOD))
+          if (r() < 0.7) person(out, b.x - 0.5, sz, y + 0.2, 0, r)
+        }
+        plant(out, b.x + b.w / 2 - 0.32, b.z + b.d / 2 - 0.32, y, r, b.w > 3)
+        break
+      }
+      case 'data': {
+        // Meeting room: table, chairs, a wall screen.
+        const tl = Math.min(2.6, (long ? b.w : b.d) - 1.1)
+        const tw = Math.min(1.0, (long ? b.d : b.w) - 1.0)
+        out.push(item('table', b.x, y + 0.2, b.z, [0.5, 0.4, 0.5], DARK))
+        out.push(item('desk', b.x, y + 0.42, b.z, long ? [tl, 0.06, tw] : [tw, 0.06, tl], WHITE))
+        const n = Math.max(2, Math.floor(tl / 0.7))
+        for (let i = 0; i < n; i++) {
+          const u = -tl / 2 + (i + 0.5) * (tl / n)
+          for (const side of [-1, 1]) {
+            const v = side * (tw / 2 + 0.32)
+            const x = long ? b.x + u : b.x + v
+            const z = long ? b.z + v : b.z + u
+            out.push(item('chair', x, y + 0.22, z, [0.38, 0.44, 0.38], '#3b3f4a'))
+            if (r() < 0.55) person(out, x, z, y + 0.2, long ? (side > 0 ? Math.PI : 0) : side > 0 ? -Math.PI / 2 : Math.PI / 2, r)
+          }
+        }
+        out.push(item('screen', b.x + (long ? 0 : -b.w / 2 + 0.12), y + 0.95, b.z + (long ? -b.d / 2 + 0.12 : 0), long ? [1.3, 0.72, 0.05] : [0.05, 0.72, 1.3], DARK))
+        plant(out, b.x + b.w / 2 - 0.3, b.z + b.d / 2 - 0.3, y, r)
+        break
+      }
+      case 'action':
+        // Kiosks are built by Tower.tsx so they can move (self-healing demo).
+        break
+    }
+  }
+  return out
+}

--- a/web/src/components/building/geometry.ts
+++ b/web/src/components/building/geometry.ts
@@ -1,0 +1,145 @@
+// Geometry derived from the model: the white line work drawn on each
+// blueprint sheet, and the walking paths a journey follows through the
+// building. Kept apart from the React components so the maths is testable
+// and so the same path feeds both the crowd and the trajectory highlight.
+import * as THREE from 'three'
+import {
+  CORE,
+  CORE_DOOR,
+  FLOORS,
+  FLOOR_D,
+  FLOOR_W,
+  SHEET,
+  SLAB_T,
+  findRoom,
+  floorY,
+  roomStand,
+  type Journey,
+} from './model'
+import { DRAWN, furnish } from './furnish'
+
+type P3 = [number, number, number]
+
+/** Pairs of points (LineSegments layout) drawing one floor plan on its sheet. */
+export function sheetLinePoints(floorIndex: number): P3[] {
+  const y = 0.012
+  const pts: P3[] = []
+  const rect = (x: number, z: number, w: number, d: number) => {
+    const a: P3 = [x - w / 2, y, z - d / 2]
+    const b: P3 = [x + w / 2, y, z - d / 2]
+    const c: P3 = [x + w / 2, y, z + d / 2]
+    const e: P3 = [x - w / 2, y, z + d / 2]
+    pts.push(a, b, b, c, c, e, e, a)
+  }
+  // Sheet border and the footprint of the floor.
+  rect(0, 0, SHEET.w - 0.3, SHEET.d - 0.3)
+  rect(0, 0, FLOOR_W, FLOOR_D)
+  // Title block in the sheet's front-right corner.
+  const tbx = SHEET.w / 2 - 0.15 - 1.4
+  const tbz = -SHEET.d / 2 + 0.15 + 0.32
+  rect(tbx, tbz, 2.8, 0.64)
+  pts.push([tbx - 1.4, y, tbz], [tbx + 1.4, y, tbz])
+  pts.push([tbx - 0.4, y, tbz - 0.32], [tbx - 0.4, y, tbz + 0.32])
+  // Core and its door.
+  rect(CORE.x, CORE.z, CORE.w, CORE.d)
+  pts.push([CORE.x + CORE.w / 2, y, CORE.z - 0.35], [CORE.x + CORE.w / 2 + 0.45, y, CORE.z - 0.35])
+  // Door swing on the core.
+  const arc = (cx: number, cz: number, rad: number, a0: number, a1: number) => {
+    const n = 6
+    for (let k = 0; k < n; k++) {
+      const t0 = a0 + ((a1 - a0) * k) / n
+      const t1 = a0 + ((a1 - a0) * (k + 1)) / n
+      pts.push([cx + Math.cos(t0) * rad, y, cz + Math.sin(t0) * rad], [cx + Math.cos(t1) * rad, y, cz + Math.sin(t1) * rad])
+    }
+  }
+  arc(CORE.x + CORE.w / 2, CORE.z - 0.35, 0.45, 0, Math.PI / 2)
+  // Rooms, with the footprints of their furniture drawn lighter in spirit:
+  // the same layout the built floor gets, so the drawing is the plan.
+  for (const r of FLOORS[floorIndex].rooms) {
+    const blocks = r.blocks ?? [{ x: r.x, z: r.z, w: r.w, d: r.d }]
+    for (const b of blocks) rect(b.x, b.z, b.w, b.d)
+    for (const it of furnish(r)) {
+      if (!DRAWN.includes(it.type)) continue
+      const c = Math.cos(it.ry)
+      const s = Math.sin(it.ry)
+      const hw = it.sx / 2
+      const hd = it.sz / 2
+      const corners: [number, number][] = [
+        [-hw, -hd],
+        [hw, -hd],
+        [hw, hd],
+        [-hw, hd],
+      ].map(([dx, dz]) => [it.x + dx * c - dz * s, it.z + dx * s + dz * c])
+      for (let k = 0; k < 4; k++) {
+        const a = corners[k]
+        const b2 = corners[(k + 1) % 4]
+        pts.push([a[0], y, a[1]], [b2[0], y, b2[1]])
+      }
+    }
+  }
+  // Dimension ticks along the front edge of the sheet.
+  for (let x = -FLOOR_W / 2; x <= FLOOR_W / 2 + 0.01; x += 1) {
+    pts.push([x, y, FLOOR_D / 2 + 0.25], [x, y, FLOOR_D / 2 + 0.45])
+  }
+  pts.push([-FLOOR_W / 2, y, FLOOR_D / 2 + 0.35], [FLOOR_W / 2, y, FLOOR_D / 2 + 0.35])
+  return pts
+}
+
+export interface Path {
+  points: THREE.Vector3[]
+  /** Cumulative length at each point. */
+  cum: number[]
+  /** Index into points for each stop of the journey. */
+  stops: number[]
+  length: number
+}
+
+/**
+ * The walk for a journey: room to room on the same floor, or room → core
+ * door → up the shaft → out the door → room when the floor changes.
+ * `lift` raises the whole path (the trajectory ribbon floats a little).
+ */
+export function buildPath(journey: Journey, lift = 0, healShift = 0): Path {
+  const points: THREE.Vector3[] = []
+  const stops: number[] = []
+  const push = (p: P3) => {
+    const v = new THREE.Vector3(p[0], p[1] + lift, p[2])
+    const last = points[points.length - 1]
+    if (!last || last.distanceToSquared(v) > 1e-6) points.push(v)
+    return points.length - 1
+  }
+  for (let k = 0; k < journey.stops.length; k++) {
+    const [f, name] = journey.stops[k]
+    const room = findRoom(f, name)
+    const stand = roomStand(f, room, room.alt ? healShift : 0)
+    if (k === 0) {
+      stops.push(push(stand))
+      continue
+    }
+    const [pf] = journey.stops[k - 1]
+    if (pf !== f) {
+      const yA = floorY(pf) + SLAB_T
+      const yB = floorY(f) + SLAB_T
+      push([CORE_DOOR.x, yA, CORE_DOOR.z])
+      push([CORE.x, yA, CORE.z])
+      push([CORE.x, yB, CORE.z])
+      push([CORE_DOOR.x, yB, CORE_DOOR.z])
+    }
+    stops.push(push(stand))
+  }
+  const cum = [0]
+  for (let i = 1; i < points.length; i++) cum.push(cum[i - 1] + points[i].distanceTo(points[i - 1]))
+  return { points, cum, stops, length: cum[cum.length - 1] }
+}
+
+/** Point at arc-length `d` along the path, written into `out`. */
+export function pointAt(path: Path, d: number, out: THREE.Vector3): THREE.Vector3 {
+  const { points, cum } = path
+  if (d <= 0) return out.copy(points[0])
+  if (d >= path.length) return out.copy(points[points.length - 1])
+  let i = 1
+  while (i < cum.length && cum[i] < d) i++
+  const seg = cum[i] - cum[i - 1]
+  const t = seg > 0 ? (d - cum[i - 1]) / seg : 0
+  return out.copy(points[i - 1]).lerp(points[i], t)
+}

--- a/web/src/components/building/model.ts
+++ b/web/src/components/building/model.ts
@@ -1,0 +1,355 @@
+// The fictional app the building is modelled on: a flight-booking site, the
+// same running example the homepage's spec section uses. Everything the scene
+// draws — floors, rooms, risers, journeys — derives from this one corpus so
+// the metaphor stays literal: a view is a floor, a component is a room, a
+// request is a riser in the service core, a journey is a walk through them.
+//
+// Units are metres-ish world units, +Y up. The camera sits at +X +Z looking
+// toward the origin, so the -X and -Z sides are the building's back walls and
+// the +X +Z faces are the open "dollhouse" cut. Screen-right is (+X, -Z).
+//
+// Pure data — no three.js import — so scripts/prerender.tsx can pull the
+// chapter copy that depends on these counts without loading WebGL code.
+
+export type Kind = 'nav' | 'form' | 'content' | 'action' | 'data'
+
+export interface Block {
+  x: number
+  z: number
+  w: number
+  d: number
+}
+
+export interface Room {
+  name: string
+  x: number
+  z: number
+  w: number
+  d: number
+  h: number
+  kind: Kind
+  /** Height of whatever this room sits on (a parent platform). */
+  base?: number
+  /** Several tiles that together are one component (a card list, a grid). */
+  blocks?: Block[]
+  /** Show a wayfinding tag over this room in the wayfinding chapter. */
+  tag?: boolean
+  /** A memory note pinned to the room in the wayfinding chapter. */
+  memory?: string
+  /** Where the room moves to in the self-healing chapter. */
+  alt?: { x: number; z: number }
+}
+
+export interface Floor {
+  name: string
+  route: string
+  source: string
+  rooms: Room[]
+}
+
+export interface Riser {
+  name: string
+  method: 'GET' | 'POST'
+  route: string
+  /** Floor indices this request is called from. */
+  floors: number[]
+  color: string
+}
+
+export type Traveller = 'user' | 'agent' | 'test'
+
+export interface Journey {
+  name: string
+  who: Traveller
+  /** [floor index, room name] pairs, in visit order. */
+  stops: [number, string][]
+  /** Seconds before the first departure, so the crowd is staggered. */
+  delay: number
+}
+
+export const FLOOR_W = 10
+export const FLOOR_D = 7.5
+export const FLOOR_H = 2.2
+export const SLAB_T = 0.18
+export const WALL_T = 0.12
+/** Thickness of a component's floor zone (its carpet). */
+export const PLATE = 0.07
+/** Height of the kiosk that stands for an action component. */
+export const KIOSK_H = 1.0
+
+/** Service core: elevator shaft + risers, in the back corner. */
+export const CORE = { x: -3.9, z: -2.9, w: 1.6, d: 1.5 }
+/** Where a walker steps out of the core onto a floor. */
+export const CORE_DOOR = { x: -2.65, z: -2.9 }
+
+export const TABLE = { w: 17.5, d: 14.5, t: 0.36 }
+export const SHEET = { w: 10.9, d: 8.4 }
+
+export const FLOORS: Floor[] = [
+  {
+    name: 'Home',
+    route: '/',
+    source: 'src/pages/Home.tsx',
+    rooms: [
+      { name: 'SiteHeader', x: 0.9, z: -3.15, w: 7.6, d: 0.7, h: 0.45, kind: 'nav' },
+      { name: 'HeroSearch', x: 0.4, z: -1.0, w: 4.8, d: 2.2, h: 0.75, kind: 'form', tag: true },
+      { name: 'PromoStrip', x: -3.6, z: -0.3, w: 1.8, d: 1.6, h: 0.5, kind: 'content' },
+      {
+        name: 'DealsGrid',
+        x: -0.9,
+        z: 2.1,
+        w: 5.7,
+        d: 1.7,
+        h: 0.5,
+        kind: 'content',
+        blocks: [
+          { x: -2.9, z: 2.1, w: 1.7, d: 1.7 },
+          { x: -0.9, z: 2.1, w: 1.7, d: 1.7 },
+          { x: 1.1, z: 2.1, w: 1.7, d: 1.7 },
+        ],
+      },
+      { name: 'FooterNav', x: 3.6, z: 2.3, w: 2.2, d: 1.5, h: 0.4, kind: 'nav' },
+    ],
+  },
+  {
+    name: 'FlightSearch',
+    route: '/search',
+    source: 'src/pages/FlightSearch.tsx',
+    rooms: [
+      { name: 'FlightSearchForm', x: 0.7, z: -1.6, w: 7.6, d: 2.7, h: 0.25, kind: 'form' },
+      {
+        name: 'DepartureDatePicker',
+        x: -1.5,
+        z: -1.6,
+        w: 1.9,
+        d: 1.5,
+        h: 0.9,
+        kind: 'form',
+        base: 0.25,
+        tag: true,
+        memory: 'Accepts typed YYYY-MM-DD, skips the calendar',
+      },
+      { name: 'PassengerPicker', x: 0.7, z: -1.6, w: 1.7, d: 1.5, h: 0.8, kind: 'form', base: 0.25 },
+      { name: 'SearchButton', x: 3.1, z: -1.6, w: 1.5, d: 1.1, h: 0.8, kind: 'action', base: 0.25, tag: true },
+      { name: 'RecentSearches', x: -2.6, z: 1.9, w: 3.8, d: 2.2, h: 0.55, kind: 'content', tag: true },
+      { name: 'PromoBanner', x: 2.2, z: 2.1, w: 4.6, d: 1.6, h: 0.45, kind: 'content' },
+    ],
+  },
+  {
+    name: 'Results',
+    route: '/results',
+    source: 'src/pages/Results.tsx',
+    rooms: [
+      { name: 'FilterRail', x: -3.9, z: 0.7, w: 1.6, d: 5.4, h: 0.85, kind: 'form' },
+      { name: 'SortMenu', x: 1.0, z: -3.0, w: 4.0, d: 0.8, h: 0.5, kind: 'nav' },
+      { name: 'ResultsList', x: 1.0, z: 0.4, w: 6.8, d: 5.2, h: 0.2, kind: 'content' },
+      {
+        name: 'FareCard',
+        x: 0.6,
+        z: 0.4,
+        w: 5.2,
+        d: 4.4,
+        h: 0.6,
+        kind: 'content',
+        base: 0.2,
+        blocks: [
+          { x: 0.6, z: -1.2, w: 5.2, d: 1.25 },
+          { x: 0.6, z: 0.4, w: 5.2, d: 1.25 },
+          { x: 0.6, z: 2.0, w: 5.2, d: 1.25 },
+        ],
+      },
+      { name: 'SelectFareButton', x: 3.7, z: 0.4, w: 1.0, d: 0.8, h: 0.85, kind: 'action', base: 0.2 },
+    ],
+  },
+  {
+    name: 'Checkout',
+    route: '/checkout',
+    source: 'src/pages/Checkout.tsx',
+    rooms: [
+      { name: 'PassengerForm', x: -2.2, z: -0.5, w: 4.6, d: 3.0, h: 0.75, kind: 'form' },
+      { name: 'PaymentForm', x: 2.4, z: -1.3, w: 4.4, d: 3.4, h: 0.8, kind: 'form', tag: true },
+      { name: 'CardFieldset', x: 2.4, z: -1.6, w: 3.4, d: 1.4, h: 0.9, kind: 'form', base: 0.8 },
+      { name: 'PromoCode', x: -2.6, z: 2.4, w: 3.6, d: 1.6, h: 0.55, kind: 'content' },
+      { name: 'OrderSummary', x: 1.1, z: 2.4, w: 3.4, d: 1.7, h: 0.65, kind: 'data' },
+      {
+        name: 'ContinueButton',
+        x: 3.9,
+        z: 2.5,
+        w: 1.4,
+        d: 1.0,
+        h: 0.95,
+        kind: 'action',
+        tag: true,
+        memory: 'Stays disabled until the CVC validates',
+        alt: { x: 3.9, z: 0.9 },
+      },
+    ],
+  },
+  {
+    name: 'BookingConfirmation',
+    route: '/bookings/*',
+    source: 'src/pages/Booking.tsx',
+    rooms: [
+      { name: 'ConfirmationCard', x: 0.6, z: -1.2, w: 6.6, d: 2.9, h: 0.85, kind: 'data' },
+      { name: 'HelpLink', x: -3.9, z: 0.4, w: 1.4, d: 1.6, h: 0.45, kind: 'nav' },
+      { name: 'Itinerary', x: -1.3, z: 2.2, w: 5.2, d: 2.0, h: 0.6, kind: 'content' },
+      { name: 'ShareButtons', x: 3.4, z: 2.3, w: 2.6, d: 1.5, h: 0.7, kind: 'action' },
+    ],
+  },
+  {
+    name: 'Account',
+    route: '/account',
+    source: 'src/pages/Account.tsx',
+    rooms: [
+      { name: 'ProfileCard', x: -2.2, z: -0.8, w: 4.4, d: 2.6, h: 0.75, kind: 'content' },
+      { name: 'TripsList', x: 2.4, z: -0.2, w: 4.4, d: 5.8, h: 0.55, kind: 'data' },
+      { name: 'Preferences', x: -2.2, z: 2.3, w: 4.4, d: 2.2, h: 0.65, kind: 'form' },
+    ],
+  },
+]
+
+export const RISERS: Riser[] = [
+  { name: 'SearchFlights', method: 'POST', route: '/api/flights/search', floors: [1, 2], color: '#6b8aed' },
+  { name: 'FareRules', method: 'GET', route: '/api/fares/:id/rules', floors: [2], color: '#9b7ae8' },
+  { name: 'CreateBooking', method: 'POST', route: '/api/bookings', floors: [3], color: '#e26a8d' },
+  { name: 'GetBooking', method: 'GET', route: '/api/bookings/:id', floors: [4], color: '#4aa87b' },
+  { name: 'GetTrips', method: 'GET', route: '/api/trips', floors: [5], color: '#d9a52a' },
+]
+
+export const JOURNEYS: Journey[] = [
+  {
+    name: 'BookFlight',
+    who: 'user',
+    delay: 0,
+    stops: [
+      [0, 'HeroSearch'],
+      [1, 'DepartureDatePicker'],
+      [1, 'SearchButton'],
+      [2, 'SelectFareButton'],
+      [3, 'PaymentForm'],
+      [3, 'ContinueButton'],
+      [4, 'ConfirmationCard'],
+    ],
+  },
+  {
+    name: 'BrowseDeals',
+    who: 'user',
+    delay: 3.5,
+    stops: [
+      [0, 'DealsGrid'],
+      [0, 'HeroSearch'],
+      [1, 'FlightSearchForm'],
+      [2, 'FilterRail'],
+      [2, 'FareCard'],
+    ],
+  },
+  {
+    name: 'ManageTrips',
+    who: 'user',
+    delay: 7,
+    stops: [
+      [0, 'SiteHeader'],
+      [5, 'TripsList'],
+      [4, 'Itinerary'],
+      [5, 'Preferences'],
+    ],
+  },
+  {
+    name: 'VerifyFix',
+    who: 'agent',
+    delay: 1.5,
+    stops: [
+      [1, 'DepartureDatePicker'],
+      [1, 'SearchButton'],
+      [2, 'ResultsList'],
+      [2, 'SortMenu'],
+    ],
+  },
+  {
+    name: 'ReproBug',
+    who: 'agent',
+    delay: 5,
+    stops: [
+      [3, 'PromoCode'],
+      [3, 'OrderSummary'],
+      [3, 'ContinueButton'],
+      [3, 'PaymentForm'],
+    ],
+  },
+  {
+    name: 'Regression',
+    who: 'test',
+    delay: 9,
+    stops: [
+      [0, 'HeroSearch'],
+      [1, 'SearchButton'],
+      [2, 'SelectFareButton'],
+      [3, 'ContinueButton'],
+      [4, 'ConfirmationCard'],
+    ],
+  },
+  {
+    name: 'Support',
+    who: 'user',
+    delay: 12,
+    stops: [
+      [0, 'FooterNav'],
+      [4, 'ShareButtons'],
+      [0, 'PromoStrip'],
+    ],
+  },
+]
+
+/** Tools the front desk offers in the Web MCP chapter, each backed by the map. */
+export const TOOLS = [
+  { name: 'search_flights', args: 'origin, destination, date', via: 'FlightSearch · POST /api/flights/search' },
+  { name: 'select_fare', args: 'fare_id', via: 'Results · FareCard' },
+  { name: 'create_booking', args: 'passenger, payment', via: 'Checkout · POST /api/bookings' },
+]
+
+export const KIND_COLORS: Record<Kind, string> = {
+  nav: '#a58ae8',
+  form: '#8ea4ee',
+  content: '#e0d3c0',
+  action: '#d4577c',
+  data: '#5cb08a',
+}
+
+export const TRAVELLER_COLORS: Record<Traveller, string> = {
+  user: '#d4577c',
+  agent: '#3fa477',
+  test: '#d9a52a',
+}
+
+export const floorY = (i: number): number => i * FLOOR_H
+
+export function findRoom(floor: number, name: string): Room {
+  const room = FLOORS[floor]?.rooms.find((r) => r.name === name)
+  if (!room) throw new Error(`model: no room ${name} on floor ${floor}`)
+  return room
+}
+
+/** Where a walker stands when visiting a room: on its floor zone, at the
+ *  front edge so it is not inside the furniture. */
+export function roomStand(floor: number, room: Room, shift = 0): [number, number, number] {
+  const x = room.alt ? room.x + (room.alt.x - room.x) * shift : room.x
+  const z = room.alt ? room.z + (room.alt.z - room.z) * shift : room.z
+  const front = room.kind === 'action' ? room.d / 2 + 0.35 : Math.max(0, room.d / 2 - 0.35)
+  return [x, floorY(floor) + SLAB_T + (room.base ? PLATE : 0) + PLATE, z + front]
+}
+
+/** Top of a room's tallest element, for hanging a label over it. */
+export function roomTop(room: Room): number {
+  const lift = (room.base ? PLATE : 0) + PLATE
+  if (room.kind === 'action') return lift + KIOSK_H
+  if (!room.blocks && room.w >= 2.4 && room.d >= 1.4) return lift + 1.15
+  return lift + 0.9
+}
+
+export const COUNTS = {
+  views: FLOORS.length,
+  components: FLOORS.reduce((n, f) => n + f.rooms.length, 0),
+  requests: RISERS.length,
+  memory: FLOORS.reduce((n, f) => n + f.rooms.filter((r) => r.memory).length, 0) + 5,
+  journeys: JOURNEYS.length,
+}

--- a/web/src/components/building/state.ts
+++ b/web/src/components/building/state.ts
@@ -1,0 +1,44 @@
+// Mutable, frame-rate state shared between the page (which owns scroll and
+// pointer) and the scene (which reads them every frame). Deliberately not
+// React state: scroll fires far more often than React should re-render, and
+// the scene only needs the latest value when it draws.
+import { createContext, useContext } from 'react'
+import { defaultParams, type SceneParams } from './chapters'
+
+export interface SharedState {
+  /** Continuous chapter position, 0 … CHAPTERS.length-1. */
+  progress: number
+  /** Pointer in [-1, 1] each axis, for parallax. */
+  pointer: { x: number; y: number }
+  /** Damped scene parameters, written by Scene's updater each frame. */
+  cur: SceneParams
+  /** Scratch target, refilled each frame. */
+  target: SceneParams
+  /** Self-healing demo: how far ContinueButton has slid to its new spot. */
+  healShift: number
+  /** Journey the crowd is reduced to (null = everyone). */
+  focus: string | null
+  mobile: boolean
+  reduced: boolean
+}
+
+export function createSharedState(): SharedState {
+  return {
+    progress: 0,
+    pointer: { x: 0, y: 0 },
+    cur: defaultParams(),
+    target: defaultParams(),
+    healShift: 0,
+    focus: null,
+    mobile: false,
+    reduced: false,
+  }
+}
+
+export const SharedStateContext = createContext<SharedState | null>(null)
+
+export function useShared(): SharedState {
+  const s = useContext(SharedStateContext)
+  if (!s) throw new Error('useShared: no SharedStateContext')
+  return s
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./building.css";
 
 :root {
   --bg: #faf8f6;

--- a/web/src/pages/Building.tsx
+++ b/web/src/pages/Building.tsx
@@ -1,0 +1,16 @@
+import Seo from '@/components/Seo'
+import BuildingExperience from '@/components/building/BuildingExperience'
+import { BUILDING_TITLE, BUILDING_DESCRIPTION } from '../../scripts/lib/site'
+
+// The immersive tour. Everything interesting lives in components/building/;
+// this page only sets metadata. The WebGL scene is client-only and lazy, so
+// the prerender of this route carries the SVG poster plus the full chapter
+// text and never loads three.js in Node.
+export default function Building() {
+  return (
+    <>
+      <Seo title={BUILDING_TITLE} description={BUILDING_DESCRIPTION} />
+      <BuildingExperience />
+    </>
+  )
+}


### PR DESCRIPTION
## What this changes

Adds a new route on the marketing site, `/building`: a scroll-driven 3D landing page that tells the Sightmap story as a building. Nine chapters: blueprint sheets on a drafting table (the code), the sheets extruding into a furnished, glass-walled building (the running app), a floor directory with room tags and memory notes (the sightmap as wayfinding), walkers looping through their journeys (users and agents), three chapters marked `exploratory` (self-healing tests, trajectories, Web MCP tools), and a nightfall CTA. The homepage and main nav are untouched; the tour is linked from the footer.

## Why

An explorable metaphor for how Sightmap works: code is the blueprint, the running app is the building, a `.sightmap/` is its signage, and journeys are the people moving through it. This PR ships it as its own page so it can get a Netlify deploy preview and be judged on real hardware before deciding how it relates to the homepage.

Implementation notes for reviewers:

- three.js via `@react-three/fiber` + `@react-three/drei` (new deps in `web/`). The scene chunk is lazy and client-only, about 260 KB gzipped, loaded only on this route.
- One fictional flight-booking corpus (`src/components/building/model.ts`) drives floors, rooms, risers, journeys, furniture, and the blueprint line work, so the drawings and the built floors agree.
- Scroll position blends per-chapter scene parameters and the scene damps toward them each frame; React only re-renders when the active chapter changes. Furniture is instanced per floor (about 400 draw calls total).
- The prerendered HTML carries an inline SVG poster plus all chapter text, so crawlers and no-JS or no-WebGL visitors still get the story. The route is in the sitemap and `llms.txt`, has a `building.md` twin, and is mapped in the dogfooded `web/.sightmap/app.yaml`.
- Mobile stacks the story card under the model, hides the desktop HUD, and honours `prefers-reduced-motion`.
- Verified with headless Chromium screenshots on desktop and mobile for every chapter (zero page errors), `pnpm build` (prerender + route coverage), and `pnpm test`.

## Area

- [ ] Spec (`spec/`)
- [ ] Go implementation / CLI (`go/`)
- [ ] Docs site (`docs/`)
- [x] Marketing site (`web/`)
- [ ] Maintainer / infrastructure

## Type of change

- [ ] Bug fix
- [ ] Docs / wording / typo
- [x] Feature
- [ ] Spec clarification (no semantic change)
- [ ] Spec change (requires an accepted SEP — link below)
- [ ] Example or conformance fixture added/updated

## Linked issues or SEPs

None.

## Checklist

- [x] I read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] Every commit on this branch is signed off (`git commit -s`) per [DCO](../CONTRIBUTING.md#developer-certificate-of-origin)
- [x] I kept this PR focused on a single concern
- [ ] If this changes the spec, there is an accepted SEP linked above (n/a)
- [ ] If this changes the JSON Schema, I updated the schema file, `spec/v1/schema.md`, and any affected examples (n/a)
- [x] Relevant checks pass locally (`go test ./...` in `go/`; `pnpm build` for a site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaLqX1swLnwsCmxEMoSxB8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaLqX1swLnwsCmxEMoSxB8)_