### PR TITLE
web: homepage billboard for the /building tour

### DIFF
--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -35,6 +35,25 @@ views:
           - name: hero-diff
             selector: ".hero-diff"
 
+      - name: BuildingBillboard
+        selector: '[data-component="BuildingBillboard"]'
+        source: src/components/BuildingBillboard.tsx
+        dependencies:
+          - src/components/building/BillboardScene.tsx
+        description: Billboard for the /building tour — headline, subcopy, CTA, and a live slice of the 3D building that orbits slowly through a day/night cycle
+        memory:
+          - Rendered inside the Hero section, between the hero copy and the date-picker diff, so it sits inside `[data-component="Hero"]` in the DOM
+          - The WebGL slice mounts only once the frame has scrolled near the viewport and pauses while off-screen; the SVG poster covers the frame before that and for no-WebGL visitors
+          - The whole frame is one link to /building and carries `data-night` on the section while the slice is in its night phase; there are no interactive nodes inside the frame
+        children:
+          - name: billboard-copy
+            selector: '.billboard__copy'
+          - name: billboard-ctas
+            selector: '.billboard__ctas'
+          - name: BillboardFrame
+            selector: '.billboard__frame'
+            description: The live slice, linked to the tour
+
       - name: PitchSection
         selector: '[data-component="PitchSection"]'
         source: src/components/PitchSection.tsx

--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -43,6 +43,7 @@ views:
         description: Billboard for the /building tour — headline, subcopy, CTA, and a live slice of the 3D building that orbits slowly through a day/night cycle
         memory:
           - Rendered inside the Hero section, between the hero copy and the date-picker diff, so it sits inside `[data-component="Hero"]` in the DOM
+          - A full-bleed dark band (always dark, unlike /building which only darkens at nightfall); text inside uses light colours regardless of the slice's day/night phase
           - The WebGL slice mounts only once the frame has scrolled near the viewport and pauses while off-screen; the SVG poster covers the frame before that and for no-WebGL visitors
           - The whole frame is one link to /building and carries `data-night` on the section while the slice is in its night phase; there are no interactive nodes inside the frame
         children:

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -675,13 +675,38 @@
 /* ---- Homepage billboard for the tour ----------------------------------- */
 
 .billboard {
-  --bb-frame-bg: #eef1f8;
   --bb-chip-bg: rgba(250, 248, 246, 0.86);
   --bb-chip-fg: var(--text);
-  max-width: 1180px;
-  margin: 0.5rem auto 4.5rem;
-  padding: 0 2rem;
+  position: relative;
+  margin: 5rem 0 4.5rem;
+  padding: 5.5rem 2rem 6rem;
   text-align: left;
+  color: #b9c2d6;
+  background:
+    radial-gradient(90% 70% at 80% 0%, rgba(107, 138, 237, 0.22) 0%, rgba(12, 21, 49, 0) 60%),
+    linear-gradient(180deg, #0f1a3d 0%, #0a1230 60%, #070d22 100%);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* A faint drafting grid, so the band reads as the same table the tour sits on. */
+.billboard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(80% 90% at 50% 40%, #000 30%, transparent 100%);
+  -webkit-mask-image: radial-gradient(80% 90% at 50% 40%, #000 30%, transparent 100%);
+}
+
+.billboard__inner {
+  position: relative;
+  max-width: 1180px;
+  margin: 0 auto;
 }
 
 .billboard__grid {
@@ -698,7 +723,7 @@
   line-height: 1.1;
   letter-spacing: -0.03em;
   font-weight: 700;
-  color: var(--text-bright);
+  color: #f5f1ea;
   margin: 0 0 1rem;
   text-wrap: balance;
 }
@@ -706,7 +731,7 @@
 .billboard__body {
   font-size: 1.02rem;
   line-height: 1.62;
-  color: var(--text-dim);
+  color: #b9c2d6;
   margin: 0 0 1.5rem;
   max-width: 34rem;
 }
@@ -722,7 +747,12 @@
   font-family: var(--mono);
   font-size: 0.72rem;
   letter-spacing: 0.04em;
-  color: var(--text-dim);
+  color: #8f9ab8;
+}
+
+.billboard .billboard__ctas .btn-primary {
+  background: #f5f1ea;
+  color: #0c1531;
 }
 
 .billboard__frame {
@@ -732,8 +762,8 @@
   border-radius: 20px;
   overflow: hidden;
   isolation: isolate;
-  border: 1px solid var(--border);
-  box-shadow: 0 30px 80px rgba(24, 44, 92, 0.16), 0 2px 6px rgba(24, 44, 92, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(0, 0, 0, 0.3);
   text-decoration: none;
   color: inherit;
   transition: transform 0.4s ease, box-shadow 0.4s ease;
@@ -741,7 +771,7 @@
 
 .billboard__frame:hover {
   transform: translateY(-3px);
-  box-shadow: 0 40px 90px rgba(24, 44, 92, 0.22), 0 2px 6px rgba(24, 44, 92, 0.06);
+  box-shadow: 0 40px 90px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .billboard__frame::before,
@@ -826,8 +856,8 @@
   z-index: 2;
   padding: 0.5rem 0.9rem;
   border-radius: 8px;
-  background: var(--text-bright);
-  color: var(--bg);
+  background: #f5f1ea;
+  color: #0c1531;
   font-family: var(--mono);
   font-size: 0.78rem;
   font-weight: 600;
@@ -843,7 +873,7 @@
 }
 
 @media (max-width: 900px) {
-  .billboard { margin-bottom: 3.5rem; padding: 0 1.25rem; }
+  .billboard { margin: 3.5rem 0 3rem; padding: 3.5rem 1.25rem 4rem; }
   .billboard__grid { grid-template-columns: 1fr; gap: 1.75rem; }
   .billboard__frame { aspect-ratio: 5 / 4; border-radius: 16px; }
   .billboard__enter { opacity: 1; transform: none; }

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -671,3 +671,187 @@
   .bld-hint span,
   .bld-hud__live::before { animation: none; }
 }
+
+/* ---- Homepage billboard for the tour ----------------------------------- */
+
+.billboard {
+  --bb-frame-bg: #eef1f8;
+  --bb-chip-bg: rgba(250, 248, 246, 0.86);
+  --bb-chip-fg: var(--text);
+  max-width: 1180px;
+  margin: 0.5rem auto 4.5rem;
+  padding: 0 2rem;
+  text-align: left;
+}
+
+.billboard__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  gap: 2.5rem 3rem;
+  align-items: center;
+}
+
+.billboard__copy .section-label { margin-bottom: 0.9rem; }
+
+.billboard .billboard__title {
+  font-size: clamp(1.75rem, 2.7vw, 2.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  font-weight: 700;
+  color: var(--text-bright);
+  margin: 0 0 1rem;
+  text-wrap: balance;
+}
+
+.billboard__body {
+  font-size: 1.02rem;
+  line-height: 1.62;
+  color: var(--text-dim);
+  margin: 0 0 1.5rem;
+  max-width: 34rem;
+}
+
+.billboard__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.1rem;
+}
+
+.billboard__meta {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.billboard__frame {
+  position: relative;
+  display: block;
+  aspect-ratio: 4 / 3;
+  border-radius: 20px;
+  overflow: hidden;
+  isolation: isolate;
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(24, 44, 92, 0.16), 0 2px 6px rgba(24, 44, 92, 0.06);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.billboard__frame:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 40px 90px rgba(24, 44, 92, 0.22), 0 2px 6px rgba(24, 44, 92, 0.06);
+}
+
+.billboard__frame::before,
+.billboard__frame::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  transition: opacity 1.6s ease;
+}
+
+.billboard__frame::before {
+  background:
+    radial-gradient(120% 90% at 70% 6%, #e6ecfb 0%, rgba(250, 248, 246, 0) 55%),
+    linear-gradient(180deg, #f6f3ee 0%, #ede7de 100%);
+  opacity: 1;
+}
+
+.billboard__frame::after {
+  background:
+    radial-gradient(120% 90% at 70% 6%, #22346b 0%, rgba(9, 16, 38, 0) 60%),
+    linear-gradient(180deg, #0c1531 0%, #070d22 100%);
+  opacity: 0;
+}
+
+.billboard[data-night='true'] .billboard__frame::after { opacity: 1; }
+.billboard[data-night='true'] .billboard__frame::before { opacity: 0; }
+.billboard[data-night='true'] {
+  --bb-chip-bg: rgba(12, 22, 50, 0.7);
+  --bb-chip-fg: #e7ebf5;
+}
+
+.billboard__frame > div,
+.billboard__frame canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.billboard__frame .bld-poster {
+  padding: 6% 10% 8%;
+  filter: drop-shadow(0 20px 30px rgba(20, 40, 90, 0.22));
+}
+
+.billboard__frame .bld-titleblock { display: none; }
+.billboard__frame .bld-tag--floor span { display: none; }
+
+.billboard__chip {
+  position: absolute;
+  top: 0.9rem;
+  left: 0.9rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 100px;
+  background: var(--bb-chip-bg);
+  color: var(--bb-chip-fg);
+  border: 1px solid rgba(61, 57, 41, 0.12);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: background 0.8s ease, color 0.8s ease;
+}
+
+.billboard__chip .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 8px rgba(45, 138, 94, 0.6);
+  animation: bld-pulse 1.6s ease-in-out infinite;
+}
+
+.billboard__enter {
+  position: absolute;
+  right: 0.9rem;
+  bottom: 0.9rem;
+  z-index: 2;
+  padding: 0.5rem 0.9rem;
+  border-radius: 8px;
+  background: var(--text-bright);
+  color: var(--bg);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.billboard__frame:hover .billboard__enter,
+.billboard__frame:focus-visible .billboard__enter {
+  opacity: 1;
+  transform: none;
+}
+
+@media (max-width: 900px) {
+  .billboard { margin-bottom: 3.5rem; padding: 0 1.25rem; }
+  .billboard__grid { grid-template-columns: 1fr; gap: 1.75rem; }
+  .billboard__frame { aspect-ratio: 5 / 4; border-radius: 16px; }
+  .billboard__enter { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .billboard__frame,
+  .billboard__frame::before,
+  .billboard__frame::after { transition: none; }
+  .billboard__chip .dot { animation: none; }
+}

--- a/web/src/components/BuildingBillboard.tsx
+++ b/web/src/components/BuildingBillboard.tsx
@@ -1,0 +1,90 @@
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import Poster from './building/Poster'
+import { createSharedState } from './building/state'
+import { webglAvailable } from './building/webgl'
+import { JOURNEYS } from './building/model'
+
+// Homepage billboard for the /building tour: headline, subcopy, CTA, and a
+// live slice of the model. The WebGL chunk loads only once the frame has
+// scrolled near the viewport and the frame loop pauses while it is off-screen,
+// so the homepage's own bundle and idle cost are unchanged. The SVG poster
+// covers the frame until the scene renders, and stays for no-WebGL visitors.
+const BillboardScene = lazy(() => import('./building/BillboardScene'))
+
+export default function BuildingBillboard() {
+  const shared = useMemo(() => {
+    const s = createSharedState()
+    s.frame = 'billboard'
+    return s
+  }, [])
+  const frame = useRef<HTMLAnchorElement>(null)
+  const [mounted, setMounted] = useState(false)
+  const [webgl, setWebgl] = useState(false)
+  const [near, setNear] = useState(false)
+  const [seen, setSeen] = useState(false)
+  const [ready, setReady] = useState(false)
+  const [night, setNight] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    setWebgl(webglAvailable())
+    shared.reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const el = frame.current
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setNear(true)
+      setSeen(true)
+      return
+    }
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        setNear(entry.isIntersecting)
+        if (entry.isIntersecting) setSeen(true)
+      },
+      { rootMargin: '240px 0px' }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [shared])
+
+  return (
+    <section className="billboard" data-component="BuildingBillboard" data-night={night ? 'true' : 'false'}>
+      <div className="billboard__grid">
+        <div className="billboard__copy">
+          <div className="section-label">The Building · interactive tour</div>
+          <h2 className="billboard__title">
+            Every app is a building.
+            <br />
+            Take the tour.
+          </h2>
+          <p className="billboard__body">
+            Code is the blueprint. The running app is the building. A sightmap is the wayfinding that lets
+            an agent find its way around. Scroll through a living model of how it all fits together, from
+            the first drawing to the lights coming on.
+          </p>
+          <div className="billboard__ctas">
+            <a href="/building" className="btn-primary">
+              Enter the building →
+            </a>
+            <span className="billboard__meta">Nine chapters · scroll-driven · works on mobile</span>
+          </div>
+        </div>
+
+        <a ref={frame} href="/building" className="billboard__frame" aria-label="Enter the building tour">
+          <Poster hidden={ready} />
+          {mounted && webgl && seen && (
+            <Suspense fallback={null}>
+              <BillboardScene shared={shared} active={near} onReady={() => setReady(true)} onNight={setNight} />
+            </Suspense>
+          )}
+          <span className="billboard__chip" aria-hidden="true">
+            <span className="dot" />
+            live · {JOURNEYS.length} journeys walking
+          </span>
+          <span className="billboard__enter" aria-hidden="true">
+            Enter the building →
+          </span>
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/BuildingBillboard.tsx
+++ b/web/src/components/BuildingBillboard.tsx
@@ -48,6 +48,7 @@ export default function BuildingBillboard() {
 
   return (
     <section className="billboard" data-component="BuildingBillboard" data-night={night ? 'true' : 'false'}>
+      <div className="billboard__inner">
       <div className="billboard__grid">
         <div className="billboard__copy">
           <div className="section-label">The Building · interactive tour</div>
@@ -84,6 +85,7 @@ export default function BuildingBillboard() {
             Enter the building →
           </span>
         </a>
+      </div>
       </div>
     </section>
   )

--- a/web/src/components/Hero.tsx
+++ b/web/src/components/Hero.tsx
@@ -1,3 +1,5 @@
+import BuildingBillboard from './BuildingBillboard'
+
 export default function Hero() {
   return (
     <section className="hero" data-component="Hero">
@@ -26,6 +28,8 @@ export default function Hero() {
           A sightmap is YAML checked into your repo. It maps views, components, and API routes to source files, so every agent gets the same context. Agents check it against the running app to keep it current.
         </p>
       </div>
+
+      <BuildingBillboard />
 
       <div className="hero-diff-wrap">
         <div className="hero-diff-caption">

--- a/web/src/components/building/BillboardScene.tsx
+++ b/web/src/components/building/BillboardScene.tsx
@@ -1,0 +1,61 @@
+// The homepage slice of the building: the same model as /building, driven by
+// a clock instead of scroll. The camera orbits gently and the light runs a
+// slow day-to-night cycle so the lit windows get their moment. Loaded lazily
+// by BuildingBillboard once the frame nears the viewport; the parent pauses
+// the frame loop while it is off-screen.
+import { Canvas, useFrame } from '@react-three/fiber'
+import { useRef } from 'react'
+import { CHAPTERS, smoothstep } from './chapters'
+import { SharedStateContext, useShared, type SharedState } from './state'
+import { CANVAS_PROPS, Ready, Rig, SceneContent } from './Scene'
+
+const CYCLE = 44 // seconds per day
+
+function Driver({ onNight }: { onNight: (night: boolean) => void }) {
+  const s = useShared()
+  const wasNight = useRef(false)
+  useFrame(({ clock }) => {
+    const t = s.reduced ? 0 : clock.getElapsedTime()
+    const c = s.cur
+    Object.assign(c, CHAPTERS[4].scene) // "The people": built, labelled, populated
+    c.labels = 0.75
+    c.agents = 1
+    c.az = 42 + Math.sin(t * 0.085) * 9
+    c.el = 25 + Math.sin(t * 0.05) * 1.5
+    c.zoom = 1
+    c.lookY = 5.4
+    const phase = (Math.sin((t * 2 * Math.PI) / CYCLE - Math.PI / 2) + 1) / 2
+    c.night = smoothstep((phase - 0.4) / 0.25)
+    const night = c.night > 0.5
+    if (night !== wasNight.current) {
+      wasNight.current = night
+      onNight(night)
+    }
+  }, -100)
+  return null
+}
+
+export interface BillboardSceneProps {
+  shared: SharedState
+  active: boolean
+  onReady: () => void
+  onNight: (night: boolean) => void
+}
+
+export default function BillboardScene({ shared, active, onReady, onNight }: BillboardSceneProps) {
+  return (
+    <Canvas
+      {...CANVAS_PROPS}
+      dpr={[1, 1.5]}
+      frameloop={active ? 'always' : 'never'}
+      onCreated={({ gl }) => gl.setClearColor(0x000000, 0)}
+    >
+      <SharedStateContext.Provider value={shared}>
+        <Driver onNight={onNight} />
+        <Ready onReady={onReady} />
+        <Rig />
+        <SceneContent />
+      </SharedStateContext.Provider>
+    </Canvas>
+  )
+}

--- a/web/src/components/building/BuildingExperience.tsx
+++ b/web/src/components/building/BuildingExperience.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { CHAPTERS } from './chapters'
 import { createSharedState, SharedStateContext } from './state'
+import { webglAvailable } from './webgl'
 import Poster from './Poster'
 import BuildingNav from './BuildingNav'
 
@@ -13,15 +14,6 @@ import BuildingNav from './BuildingNav'
 // text is real markup and the poster is inline SVG. The scene is decoration
 // on top — aria-hidden, lazy, and skipped entirely when WebGL is missing.
 const Scene = lazy(() => import('./Scene'))
-
-function webglAvailable(): boolean {
-  try {
-    const c = document.createElement('canvas')
-    return !!(c.getContext('webgl2') || c.getContext('webgl'))
-  } catch {
-    return false
-  }
-}
 
 /** Renders `code` spans in chapter copy. */
 function inline(text: string): ReactNode[] {

--- a/web/src/components/building/Scene.tsx
+++ b/web/src/components/building/Scene.tsx
@@ -22,9 +22,21 @@ import FrontDesk from './FrontDesk'
 
 const CAMERA_DISTANCE = 42
 
-function Updater({ onReady }: { onReady: () => void }) {
-  const s = useShared()
+/** Calls `onReady` after the first rendered frame, so the poster can fade. */
+export function Ready({ onReady }: { onReady: () => void }) {
   const fired = useRef(false)
+  useFrame(() => {
+    if (!fired.current) {
+      fired.current = true
+      onReady()
+    }
+  }, -99)
+  return null
+}
+
+/** The tour's driver: scroll position → chapter blend → damped parameters. */
+function Updater() {
+  const s = useShared()
   useEffect(() => {
     // Start on the chapter the page loaded at, not on a morph from chapter 0.
     paramsAt(s.progress, s.cur)
@@ -34,15 +46,11 @@ function Updater({ onReady }: { onReady: () => void }) {
     const d = Math.min(dt, 0.25)
     const lambda = s.reduced ? 16 : 4.5
     for (const k of PARAM_KEYS) s.cur[k] = THREE.MathUtils.damp(s.cur[k], s.target[k], lambda, d)
-    if (!fired.current) {
-      fired.current = true
-      onReady()
-    }
   }, -100)
   return null
 }
 
-function Stats() {
+export function Stats() {
   // Exposes draw calls / triangles / fps for the headless verification loop.
   const { gl } = useThree()
   const frames = useRef(0)
@@ -67,7 +75,7 @@ function Stats() {
   return null
 }
 
-function Rig() {
+export function Rig() {
   const s = useShared()
   const { camera, size } = useThree()
   const az = useRef(s.cur.az)
@@ -94,8 +102,10 @@ function Rig() {
 
     // Frame the model: the table's isometric footprint is ~27 world units
     // wide and, with the tower on it, ~18 tall, whatever the viewport.
-    const fit = Math.min(size.width / 27, size.height / 22)
-    const zoom = fit * c.zoom * (s.mobile ? 1.3 : 1)
+    // The billboard crops in tight on the tower instead.
+    const billboard = s.frame === 'billboard'
+    const fit = billboard ? Math.min(size.width / 15, size.height / 12.5) : Math.min(size.width / 27, size.height / 22)
+    const zoom = fit * c.zoom * (s.mobile && !billboard ? 1.3 : 1)
 
     v.dir.set(Math.cos(e) * Math.sin(a), Math.sin(e), Math.cos(e) * Math.cos(a))
     v.right.set(Math.cos(a), 0, -Math.sin(a))
@@ -103,8 +113,9 @@ function Rig() {
 
     // Desktop: the story card sits on the left, so push the model right.
     // Mobile: the card sits at the bottom, so push the model up.
-    const shiftRight = s.mobile ? (-size.width * 0.12) / zoom : (size.width * 0.13) / zoom
-    const shiftUp = s.mobile ? (size.height * 0.11) / zoom : 0
+    // Billboard: nudge the tower left so the floor directory fits in the frame.
+    const shiftRight = billboard ? (-size.width * 0.07) / zoom : s.mobile ? (-size.width * 0.12) / zoom : (size.width * 0.13) / zoom
+    const shiftUp = billboard || !s.mobile ? 0 : (size.height * 0.11) / zoom
     v.target.set(0, c.lookY, 0).addScaledVector(v.right, -shiftRight).addScaledVector(v.up, -shiftUp)
 
     camera.position.copy(v.target).addScaledVector(v.dir, CAMERA_DISTANCE)
@@ -119,6 +130,32 @@ function Rig() {
   return null
 }
 
+/** Everything on the table. Reads the shared state; needs a driver and a Rig. */
+export function SceneContent() {
+  return (
+    <>
+      <Lights />
+      <Table />
+      <Tower />
+      <Core />
+      <Wayfinding />
+      <Agents />
+      <HealDemo />
+      <Trajectory />
+      <FrontDesk />
+    </>
+  )
+}
+
+export const CANVAS_PROPS = {
+  orthographic: true,
+  shadows: 'percentage',
+  flat: true,
+  gl: { antialias: true, alpha: true, powerPreference: 'high-performance' },
+  camera: { position: [24, 24, 24], zoom: 50, near: 0.1, far: 140 },
+  style: { position: 'absolute', inset: 0 },
+} satisfies Partial<React.ComponentProps<typeof Canvas>>
+
 export interface SceneProps {
   shared: SharedState
   onReady: () => void
@@ -127,28 +164,16 @@ export interface SceneProps {
 export default function Scene({ shared, onReady }: SceneProps) {
   return (
     <Canvas
-      orthographic
-      shadows="percentage"
-      flat
+      {...CANVAS_PROPS}
       dpr={shared.mobile ? [1, 1.5] : [1, 1.75]}
-      gl={{ antialias: true, alpha: true, powerPreference: 'high-performance' }}
-      camera={{ position: [24, 24, 24], zoom: 50, near: 0.1, far: 140 }}
-      style={{ position: 'absolute', inset: 0 }}
       onCreated={({ gl }) => gl.setClearColor(0x000000, 0)}
     >
       <SharedStateContext.Provider value={shared}>
-        <Updater onReady={onReady} />
+        <Updater />
+        <Ready onReady={onReady} />
         <Stats />
         <Rig />
-        <Lights />
-        <Table />
-        <Tower />
-        <Core />
-        <Wayfinding />
-        <Agents />
-        <HealDemo />
-        <Trajectory />
-        <FrontDesk />
+        <SceneContent />
       </SharedStateContext.Provider>
     </Canvas>
   )

--- a/web/src/components/building/state.ts
+++ b/web/src/components/building/state.ts
@@ -20,6 +20,9 @@ export interface SharedState {
   focus: string | null
   mobile: boolean
   reduced: boolean
+  /** 'tour' frames the whole table for the /building page; 'billboard' is
+   *  the tight, centred crop used by the homepage slice. */
+  frame: 'tour' | 'billboard'
 }
 
 export function createSharedState(): SharedState {
@@ -32,6 +35,7 @@ export function createSharedState(): SharedState {
     focus: null,
     mobile: false,
     reduced: false,
+    frame: 'tour',
   }
 }
 

--- a/web/src/components/building/webgl.ts
+++ b/web/src/components/building/webgl.ts
@@ -1,0 +1,8 @@
+export function webglAvailable(): boolean {
+  try {
+    const c = document.createElement('canvas')
+    return !!(c.getContext('webgl2') || c.getContext('webgl'))
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## What this changes

Adds a billboard section for the `/building` tour to the homepage, inside the hero between the hero copy and the date-picker diff: a headline, subcopy, a CTA, and a live slice of the 3D building. The slice is the same model as `/building`, driven by a clock instead of scroll, with a gentle camera orbit and a 44-second day-to-night cycle. The whole frame links to `/building`.

## Why

Give the tour a bigger stage on the homepage before deciding whether it becomes the homepage itself. Follows up #304.

Notes for reviewers:

- `Scene.tsx` now exports its pieces (`SceneContent`, `Rig`, `Ready`, `Stats`, `CANVAS_PROPS`) so `BillboardScene.tsx` can compose them with its own driver; the tour's behaviour is unchanged. Shared state gained a `frame` mode so the rig crops tight on the tower for the billboard instead of framing the whole table.
- The WebGL chunk loads only once the frame scrolls near the viewport (IntersectionObserver) and the frame loop pauses while off-screen, so the homepage bundle and idle cost are unchanged. The SVG poster covers the frame until the scene renders and stays for no-WebGL visitors. Reduced motion freezes the orbit and cycle.
- Prerender and hydration are unaffected: the section renders static copy plus the poster on the server and mounts the canvas client-side.
- The `HomePage` view in `web/.sightmap/app.yaml` gains a `BuildingBillboard` component.
- Verified with headless Chromium screenshots (desktop and mobile, day and night phase, zero page errors), a re-check of `/building`, `pnpm build`, and `pnpm test` (159 passing).

## Area

- [ ] Spec (`spec/`)
- [ ] Go implementation / CLI (`go/`)
- [ ] Docs site (`docs/`)
- [x] Marketing site (`web/`)
- [ ] Maintainer / infrastructure

## Type of change

- [ ] Bug fix
- [ ] Docs / wording / typo
- [x] Feature
- [ ] Spec clarification (no semantic change)
- [ ] Spec change (requires an accepted SEP — link below)
- [ ] Example or conformance fixture added/updated

## Linked issues or SEPs

Follows #304.

## Checklist

- [x] I read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] Every commit on this branch is signed off (`git commit -s`) per [DCO](../CONTRIBUTING.md#developer-certificate-of-origin)
- [x] I kept this PR focused on a single concern
- [ ] If this changes the spec, there is an accepted SEP linked above (n/a)
- [ ] If this changes the JSON Schema, I updated the schema file, `spec/v1/schema.md`, and any affected examples (n/a)
- [x] Relevant checks pass locally (`go test ./...` in `go/`; `pnpm build` for a site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaLqX1swLnwsCmxEMoSxB8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaLqX1swLnwsCmxEMoSxB8)_