### PR TITLE
docs(skills): sync authoring + browser skills to offline-extraction / eval changes

### DIFF
--- a/.changeset/skills-offline-extraction-sync.md
+++ b/.changeset/skills-offline-extraction-sync.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Docs: sync the authoring and browser agent skills to recent offline-extraction and `eval` changes. The authoring skill now states that every attribute (not just `class`/`id`) matches offline and that `text` falls back to a node's rendered `innerText` when it has no accessible name; the browser skill notes that `browser eval` awaits a returned promise.

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -137,8 +137,11 @@ that `snapshot`/`coverage`/`capture` actually use — it prints both counts and 
 `⚠ offline/live divergence` warning when they disagree. Trust the **offline**
 count: that is what the corpus will see. Wrong match count = corrupt coverage.
 
-**Attribute selectors on `class` and `id` match offline**, the same as live
-(`[class*=…]`, `[class^=…]`, `[class~=…]`, `[id^=…]`, `[id$=…]`, …). `class` and
+**Every attribute matches offline**, the same as live: the offline element model
+captures the full attribute set the DOM carries — minus injected sightmap ids and
+framework `_ng*`-style scoping attrs — so `[class*=…]`, `[id^=…]`, `[value=…]`,
+`[data-*=…]` and `extract: attr=NAME` all resolve offline for standard **and**
+non-standard attributes (e.g. `value` on a `role="option"` `<li>`). `class` and
 `id` are captured for every element (SVG included) and resolve to the same fields
 `.classname` / `#id` use. Prefer `.classname` / `#id` when a full class or id is
 stable — they're the shortest forms — but reach for the attribute forms when only
@@ -385,7 +388,7 @@ Two property rules are **mandatory**:
 
 | Mode | Resolves to |
 |------|-------------|
-| `text` | the matched node's accessible text (the default) |
+| `text` | the matched node's accessible name (the default), falling back to its rendered `innerText` when it has no accessible name — so role-less `<span>`s / custom elements resolve their visible value offline, not empty |
 | `attr=NAME` | the value of attribute `NAME` on the matched node |
 | `Child.prop` | the extracted `prop` of a descendant *component* `Child` |
 | `exists:Child` | `"true"` if descendant component `Child` matched, else omitted (a boolean flag) |

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -62,7 +62,7 @@ daemon and returns immediately.
 | `sightmap browser status` | Check session health, tabs, and current URL. Reports `⚠ degraded` when Chrome's CDP is up but the daemon's HTTP server was reaped. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
-| `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |
+| `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. A returned promise is awaited, so `async` evals resolve to their value. |
 | `sightmap browser screenshot --out FILE.png` | Screenshot the page. Clip to a component with `--component NAME` (or `--selector CSS`), optionally `--expand-pct N` for context. |
 
 ## Reading the page: annotated snapshots

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -137,8 +137,11 @@ that `snapshot`/`coverage`/`capture` actually use — it prints both counts and 
 `⚠ offline/live divergence` warning when they disagree. Trust the **offline**
 count: that is what the corpus will see. Wrong match count = corrupt coverage.
 
-**Attribute selectors on `class` and `id` match offline**, the same as live
-(`[class*=…]`, `[class^=…]`, `[class~=…]`, `[id^=…]`, `[id$=…]`, …). `class` and
+**Every attribute matches offline**, the same as live: the offline element model
+captures the full attribute set the DOM carries — minus injected sightmap ids and
+framework `_ng*`-style scoping attrs — so `[class*=…]`, `[id^=…]`, `[value=…]`,
+`[data-*=…]` and `extract: attr=NAME` all resolve offline for standard **and**
+non-standard attributes (e.g. `value` on a `role="option"` `<li>`). `class` and
 `id` are captured for every element (SVG included) and resolve to the same fields
 `.classname` / `#id` use. Prefer `.classname` / `#id` when a full class or id is
 stable — they're the shortest forms — but reach for the attribute forms when only
@@ -385,7 +388,7 @@ Two property rules are **mandatory**:
 
 | Mode | Resolves to |
 |------|-------------|
-| `text` | the matched node's accessible text (the default) |
+| `text` | the matched node's accessible name (the default), falling back to its rendered `innerText` when it has no accessible name — so role-less `<span>`s / custom elements resolve their visible value offline, not empty |
 | `attr=NAME` | the value of attribute `NAME` on the matched node |
 | `Child.prop` | the extracted `prop` of a descendant *component* `Child` |
 | `exists:Child` | `"true"` if descendant component `Child` matched, else omitted (a boolean flag) |

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -62,7 +62,7 @@ daemon and returns immediately.
 | `sightmap browser status` | Check session health, tabs, and current URL. Reports `⚠ degraded` when Chrome's CDP is up but the daemon's HTTP server was reaped. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
-| `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |
+| `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. A returned promise is awaited, so `async` evals resolve to their value. |
 | `sightmap browser screenshot --out FILE.png` | Screenshot the page. Clip to a component with `--component NAME` (or `--selector CSS`), optionally `--expand-pct N` for context. |
 
 ## Reading the page: annotated snapshots


### PR DESCRIPTION
Fixes #307.

Three merged, released changes altered observable extraction / `eval` behavior but left the agent skills stale (and corpora authored before them carry now-false caveats). This syncs the skills; the embedded `go/skills/` copies are regenerated via `go generate ./skills/...`.

### Edits
- **#301 `extract: capture the full attribute set for offline matching`** — `skills/sightmap-authoring/SKILL.md` said *"Attribute selectors on `class` and `id` match offline"* (scoped to class/id). Broadened to "**every attribute matches offline**" (minus injected sightmap ids + framework `_ng*` scoping attrs), covering `[value=…]`, `[data-*=…]` and `extract: attr=NAME`.
- **#299 `extract: capture rendered node text as the offline text fallback`** — documents the rendered-`innerText` fallback for the `text` extract mode, so role-less `<span>`s / custom elements resolve their visible value offline instead of empty.
- **#302 `browser: eval awaits a returned promise`** — `skills/sightmap-browser/SKILL.md`'s `eval` entry now notes a returned promise is awaited.

### Notes
- Changeset added (`patch`) — the skills ship inside `@sightmap/sightmap`, so this is user-facing (downstream vendors re-vendor on the next pin).
- Docs-only; `go build ./...` clean and `go generate ./skills/...` leaves no drift.
