### PR TITLE
browser: add inject command for persistent script injection

### DIFF
--- a/.changeset/browser-inject-persist.md
+++ b/.changeset/browser-inject-persist.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add `browser inject` for persistent script injection. Unlike `eval` (which runs once in the current document), `inject --persist` registers a script with the running session daemon, which re-applies it at the start of every new document in every tab via CDP `Page.addScriptToEvaluateOnNewDocument` — so it survives navigations and new tabs for the life of the session. `--file` loads the source from disk, and `--list` / `--remove ID` manage the persisted set. Useful for polyfills, overlays, and debugging/experimentation bundles that must outlive a multi-page flow.

--- a/docs/cli/browser.mdx
+++ b/docs/cli/browser.mdx
@@ -170,6 +170,34 @@ sightmap browser eval '({url: location.href, title: document.title})'
 
 ---
 
+### `browser inject`
+
+Injects a script into the page. Where `eval` runs once in the current document, `inject --persist` registers the script with the session daemon so it re-runs at the start of **every new document, in every tab, for the life of the session** — surviving navigations. It is backed by CDP `Page.addScriptToEvaluateOnNewDocument`, held on the daemon's session-lifetime connection (a script added over a per-command connection would be dropped the moment that command exits). Handy for polyfills, overlays, and instrumentation or experimentation bundles that must outlive a multi-page flow.
+
+Provide the source as an inline positional argument or with `--file`. `--persist` also runs the script once in the currently-loaded document (best-effort), since `addScriptToEvaluateOnNewDocument` only affects future documents.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--file` | — | Read the script source from this file instead of an inline arg |
+| `--persist` | `false` | Re-inject on every new document and new tab for the whole session |
+| `--remove` | — | Remove a previously-persisted script by its id |
+| `--list` | `false` | List the scripts currently persisted for this session |
+| `--addr` | `localhost:7892` | CDP address (one-shot run) |
+| `--tab` | the lone content tab | Target tab ID (one-shot run) |
+
+`--persist`, `--remove`, and `--list` require a running `browser start` session, since the registry lives in its daemon.
+
+```bash
+# Register a bundle that re-applies on every navigation, and print its id.
+sightmap browser inject --file ./runtime.js --persist
+# inject: persisted as inj-1 — re-injected on every new document; remove with 'browser inject --remove inj-1'
+
+sightmap browser inject --list
+sightmap browser inject --remove inj-1
+```
+
+---
+
 ### `browser clear-storage`
 
 Clears all cookies, including `httpOnly` cookies, and clears storage for one origin. Origin storage includes localStorage, IndexedDB, service workers, and caches.

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -68,6 +68,34 @@ type Collector struct {
 	cancel context.CancelFunc
 
 	wg sync.WaitGroup
+
+	// scriptsMu guards the persistent-script registry: sources registered via
+	// AddPersistentScript that the collector re-applies to every attached tab
+	// (current and future) so they survive navigations and new tabs. It is held
+	// across the CDP (un)register calls so a tab attaching concurrently with an
+	// Add can neither double-apply a script nor miss one (the per-tab guard in
+	// applyScriptsToTab / AddPersistentScript keys off ps.cdpIDs).
+	scriptsMu sync.Mutex
+	scripts   []*persistentScript
+	scriptSeq int
+}
+
+// persistentScript is one source registered for auto-injection at the start of
+// every new document. id is the logical handle handed to callers; cdpIDs maps a
+// tabID to the identifier CDP returned on that tab, which removal needs (and
+// whose presence marks the script as already applied to that tab).
+type persistentScript struct {
+	id     string
+	source string
+	cdpIDs map[string]string
+}
+
+// PersistentScriptInfo is a public, source-free snapshot of one registered
+// script for the daemon's list surface.
+type PersistentScriptInfo struct {
+	ID    string `json:"id"`
+	Bytes int    `json:"bytes"`
+	Tabs  int    `json:"tabs"`
 }
 
 type tabColl struct {
@@ -200,6 +228,11 @@ func (c *Collector) attachTab(tabID string) {
 	c.tabsMu.Unlock()
 
 	go c.drain(ctx, tabID, conn, consoleCh, excCh, reqCh, respCh, finishedCh)
+
+	// A newly-attached tab (a fresh tab, or the initial one) must carry every
+	// persistent script so injection survives new tabs, not just navigations
+	// within one tab. No-op when nothing is registered.
+	c.applyScriptsToTab(ctx, tabID, conn)
 }
 
 // drain funnels one tab's CDP events into the shared buffers until ctx is
@@ -484,6 +517,143 @@ func (c *Collector) lookupRequest(index int) (string, *CDPConn, bool) {
 		}
 	}
 	return "", nil, false
+}
+
+// ── persistent script injection ─────────────────────────────────────────────
+//
+// Scripts registered with Page.addScriptToEvaluateOnNewDocument live only as
+// long as the CDP session that added them, so a transient per-command connection
+// cannot persist one. The collector is the session-lifetime CDP owner, so it
+// holds the registry and re-applies each script to every tab it attaches. Because
+// addScriptToEvaluateOnNewDocument re-runs the script at the start of every new
+// document, a script registered here survives navigations, and re-applying on
+// attach extends that to new tabs.
+
+// AddPersistentScript registers source to auto-run at the start of every new
+// document, in every tab of the session (now and future), returning a logical id
+// for RemovePersistentScript. It applies the script to every attached tab
+// immediately; because CDP only injects into FUTURE documents, a caller that also
+// wants it in the currently-loaded document must eval it once separately (the
+// `inject` command does).
+func (c *Collector) AddPersistentScript(ctx context.Context, source string) (string, error) {
+	c.scriptsMu.Lock()
+	defer c.scriptsMu.Unlock()
+
+	c.scriptSeq++
+	ps := &persistentScript{
+		id:     fmt.Sprintf("inj-%d", c.scriptSeq),
+		source: source,
+		cdpIDs: make(map[string]string),
+	}
+	// Apply to every currently-attached tab. A tab attaching concurrently is
+	// covered by attachTab's own apply pass (also under scriptsMu); the cdpIDs
+	// guard there makes the two idempotent so neither double-applies.
+	for tabID, conn := range c.tabConns() {
+		cdpID, err := addScriptOnNewDocument(ctx, conn, source)
+		if err != nil {
+			continue // tab may be navigating/closing; a later attach re-applies
+		}
+		ps.cdpIDs[tabID] = cdpID
+	}
+	c.scripts = append(c.scripts, ps)
+	return ps.id, nil
+}
+
+// RemovePersistentScript unregisters the script with the given id and best-effort
+// removes it from every tab it was applied to. It reports whether such an id
+// existed.
+func (c *Collector) RemovePersistentScript(ctx context.Context, id string) (bool, error) {
+	c.scriptsMu.Lock()
+	defer c.scriptsMu.Unlock()
+
+	idx := -1
+	for i, ps := range c.scripts {
+		if ps.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return false, nil
+	}
+	ps := c.scripts[idx]
+	conns := c.tabConns()
+	for tabID, cdpID := range ps.cdpIDs {
+		if conn, ok := conns[tabID]; ok {
+			_ = removeScriptOnNewDocument(ctx, conn, cdpID) // best-effort; tab may be gone
+		}
+	}
+	c.scripts = append(c.scripts[:idx], c.scripts[idx+1:]...)
+	return true, nil
+}
+
+// PersistentScripts returns a source-free snapshot of the registry.
+func (c *Collector) PersistentScripts() []PersistentScriptInfo {
+	c.scriptsMu.Lock()
+	defer c.scriptsMu.Unlock()
+	out := make([]PersistentScriptInfo, 0, len(c.scripts))
+	for _, ps := range c.scripts {
+		out = append(out, PersistentScriptInfo{ID: ps.id, Bytes: len(ps.source), Tabs: len(ps.cdpIDs)})
+	}
+	return out
+}
+
+// applyScriptsToTab registers every not-yet-applied persistent script on conn.
+// Called from attachTab for each new tab; the ps.cdpIDs guard skips a script a
+// concurrent AddPersistentScript already put on this tab, keeping the two paths
+// idempotent.
+func (c *Collector) applyScriptsToTab(ctx context.Context, tabID string, conn *CDPConn) {
+	c.scriptsMu.Lock()
+	defer c.scriptsMu.Unlock()
+	for _, ps := range c.scripts {
+		if _, done := ps.cdpIDs[tabID]; done {
+			continue
+		}
+		cdpID, err := addScriptOnNewDocument(ctx, conn, ps.source)
+		if err != nil {
+			continue
+		}
+		ps.cdpIDs[tabID] = cdpID
+	}
+}
+
+// tabConns snapshots the attached tabs' connections. Taken under tabsMu only;
+// callers already hold scriptsMu, so the lock order is always scriptsMu→tabsMu.
+func (c *Collector) tabConns() map[string]*CDPConn {
+	c.tabsMu.Lock()
+	defer c.tabsMu.Unlock()
+	out := make(map[string]*CDPConn, len(c.tabs))
+	for id, tc := range c.tabs {
+		out[id] = tc.conn
+	}
+	return out
+}
+
+// addScriptOnNewDocument registers source to run at the start of every future
+// document on conn's target, returning CDP's identifier for later removal. It
+// does not require Page.enable.
+func addScriptOnNewDocument(ctx context.Context, conn *CDPConn, source string) (string, error) {
+	raw, err := conn.call(ctx, "Page.addScriptToEvaluateOnNewDocument", map[string]interface{}{
+		"source": source,
+	})
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Identifier string `json:"identifier"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", fmt.Errorf("addScriptToEvaluateOnNewDocument: unmarshal: %w", err)
+	}
+	return resp.Identifier, nil
+}
+
+// removeScriptOnNewDocument unregisters a script previously added on conn.
+func removeScriptOnNewDocument(ctx context.Context, conn *CDPConn, identifier string) error {
+	_, err := conn.call(ctx, "Page.removeScriptToEvaluateOnNewDocument", map[string]interface{}{
+		"identifier": identifier,
+	})
+	return err
 }
 
 // tailLimit keeps only the most recent n entries when n > 0.

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -3,6 +3,7 @@ package browser
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -208,6 +209,160 @@ func TestCollectorStop_NoDeadlockWhileConnected(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Collector.Stop deadlocked with a healthy (uncancelled) drain")
 	}
+}
+
+// TestCollector_PersistentScripts drives the real attach path against a fake
+// browser that records the CDP commands it receives, then exercises the
+// persistent-script registry: adding a script must send
+// Page.addScriptToEvaluateOnNewDocument with the source to the attached tab, and
+// removing it must send Page.removeScriptToEvaluateOnNewDocument with the
+// identifier CDP handed back.
+func TestCollector_PersistentScripts(t *testing.T) {
+	rec := &cdpRecorder{}
+	c := NewCollector(newRecordingBrowser(t, rec))
+	c.Start()
+	t.Cleanup(c.Stop)
+	waitForTabs(t, c, 1, "collector never attached the fake tab")
+
+	ctx := context.Background()
+	const src = "window.__x = 1;"
+	id, err := c.AddPersistentScript(ctx, src)
+	if err != nil || id == "" {
+		t.Fatalf("AddPersistentScript: id=%q err=%v", id, err)
+	}
+
+	adds := rec.withMethod("Page.addScriptToEvaluateOnNewDocument")
+	if len(adds) != 1 {
+		t.Fatalf("add: sent %d addScriptToEvaluateOnNewDocument, want 1", len(adds))
+	}
+	if adds[0].Source != src {
+		t.Errorf("add: source = %q, want %q", adds[0].Source, src)
+	}
+
+	if got := c.PersistentScripts(); len(got) != 1 || got[0].ID != id || got[0].Tabs != 1 || got[0].Bytes != len(src) {
+		t.Fatalf("PersistentScripts() = %+v, want one {ID:%s Tabs:1 Bytes:%d}", got, id, len(src))
+	}
+
+	removed, err := c.RemovePersistentScript(ctx, id)
+	if err != nil || !removed {
+		t.Fatalf("RemovePersistentScript: removed=%v err=%v", removed, err)
+	}
+	rems := rec.withMethod("Page.removeScriptToEvaluateOnNewDocument")
+	if len(rems) != 1 {
+		t.Fatalf("remove: sent %d removeScriptToEvaluateOnNewDocument, want 1", len(rems))
+	}
+	// The identifier removed must be the one the fake returned for the add.
+	if rems[0].Identifier != "cdp-script-1" {
+		t.Errorf("remove: identifier = %q, want cdp-script-1", rems[0].Identifier)
+	}
+	if got := c.PersistentScripts(); len(got) != 0 {
+		t.Errorf("after remove: PersistentScripts() = %+v, want empty", got)
+	}
+
+	// Unknown id is a clean no-op.
+	if removed, err := c.RemovePersistentScript(ctx, "inj-999"); removed || err != nil {
+		t.Errorf("RemovePersistentScript(absent) = removed=%v err=%v, want false, nil", removed, err)
+	}
+}
+
+// cdpRecorder captures the injection-related CDP commands a fake browser saw.
+type cdpRecorder struct {
+	mu    sync.Mutex
+	calls []recordedCall
+}
+
+type recordedCall struct {
+	Method     string
+	Source     string
+	Identifier string
+}
+
+func (r *cdpRecorder) add(call recordedCall) {
+	r.mu.Lock()
+	r.calls = append(r.calls, call)
+	r.mu.Unlock()
+}
+
+func (r *cdpRecorder) withMethod(method string) []recordedCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []recordedCall
+	for _, c := range r.calls {
+		if c.Method == method {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// newRecordingBrowser is newFakeBrowser plus command recording: it records the
+// injection commands into rec and replies to addScriptToEvaluateOnNewDocument
+// with a stable identifier so removal has something to target.
+func newRecordingBrowser(t *testing.T, rec *cdpRecorder) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewUnstartedServer(mux)
+
+	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
+		targets := []map[string]string{{
+			"id": "tab-1", "type": "page", "url": "http://fake.test/",
+			"webSocketDebuggerUrl": "ws://" + r.Host + "/ws",
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(targets); err != nil {
+			t.Logf("newRecordingBrowser: encode targets: %v", err)
+		}
+	})
+
+	var scriptSeq int
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		wsConn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("newRecordingBrowser: ws upgrade: %v", err)
+			return
+		}
+		var wsMu sync.Mutex
+		go func() {
+			for {
+				_, raw, readErr := wsConn.ReadMessage()
+				if readErr != nil {
+					return
+				}
+				var req struct {
+					ID     int64  `json:"id"`
+					Method string `json:"method"`
+					Params struct {
+						Source     string `json:"source"`
+						Identifier string `json:"identifier"`
+					} `json:"params"`
+				}
+				if json.Unmarshal(raw, &req) != nil {
+					continue
+				}
+				result := map[string]any{}
+				switch req.Method {
+				case "Page.addScriptToEvaluateOnNewDocument":
+					scriptSeq++
+					ident := fmt.Sprintf("cdp-script-%d", scriptSeq)
+					result["identifier"] = ident
+					rec.add(recordedCall{Method: req.Method, Source: req.Params.Source, Identifier: ident})
+				case "Page.removeScriptToEvaluateOnNewDocument":
+					rec.add(recordedCall{Method: req.Method, Identifier: req.Params.Identifier})
+				}
+				reply, _ := json.Marshal(map[string]any{"id": req.ID, "result": result})
+				wsMu.Lock()
+				err := wsConn.WriteMessage(websocket.TextMessage, reply)
+				wsMu.Unlock()
+				if err != nil {
+					return
+				}
+			}
+		}()
+	})
+
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
 }
 
 // newFakeBrowser starts a fake Chrome CDP endpoint exposing a single page target

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -32,6 +32,8 @@ func runBrowser(args []string) error {
 		return runNavigate(args[1:])
 	case "eval":
 		return runEval(args[1:])
+	case "inject", "add-script":
+		return runInject(args[1:])
 	case "click":
 		return runClick(args[1:])
 	case "fill":
@@ -75,6 +77,8 @@ Session:
   status
   navigate <url>
   eval <script>
+  inject [--file PATH | <script>] [--persist]   run a script now; --persist re-injects it on every new document/tab (whole session)
+  inject --list | --remove ID                   list or remove persisted scripts
 
 Interaction (IDs from sightmap snapshot output):
   click    COMPONENT-ID | --x N --y N

--- a/go/cmd/sightmap/cmd_browser_inject.go
+++ b/go/cmd/sightmap/cmd_browser_inject.go
@@ -1,0 +1,217 @@
+// Persistent script injection: `browser inject`. Where `eval` runs a script once
+// in the current document, `inject --persist` registers it with the session
+// daemon's collector, which re-applies it to every tab at the start of every new
+// document (CDP Page.addScriptToEvaluateOnNewDocument) — so it survives
+// navigations and new tabs for the life of the session. Useful for polyfills,
+// overlays, and injecting an instrumentation/experimentation bundle that must
+// outlive a multi-page flow instead of being re-evaled after each navigation.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sightmap/sightmap/go/browser"
+)
+
+func runInject(args []string) error {
+	fs := flag.NewFlagSet("inject", flag.ContinueOnError)
+	addrFlag := fs.String("addr", "", "CDP address (default: the session for --sightmap-dir)")
+	tabFlag := fs.String("tab", "", "Target tab ID for the immediate one-shot run (from 'browser start' output)")
+	sightmapDirFlag := fs.String("sightmap-dir", ".sightmap", "Path to .sightmap/ dir (keys session lookup)")
+	fileFlag := fs.String("file", "", "Read the script source from this file (instead of an inline arg)")
+	persistFlag := fs.Bool("persist", false, "Re-inject on every new document + new tab for the whole session (survives navigations)")
+	removeFlag := fs.String("remove", "", "Remove a previously-persisted script by its id")
+	listFlag := fs.Bool("list", false, "List the scripts currently persisted for this session")
+	if err := parseFlagsInterspersed(fs, args); err != nil {
+		return err
+	}
+
+	// Management modes talk only to the daemon.
+	if *listFlag {
+		return injectList(*sightmapDirFlag)
+	}
+	if *removeFlag != "" {
+		return injectRemove(*sightmapDirFlag, *removeFlag)
+	}
+
+	// Otherwise we need a script source: exactly one of --file or an inline arg.
+	source, err := injectSource(*fileFlag, fs.Args())
+	if err != nil {
+		return err
+	}
+
+	if *persistFlag {
+		// Register with the daemon so the script outlives this command's transient
+		// connection and rides every future navigation.
+		id, err := injectPersist(*sightmapDirFlag, source)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "inject: persisted as %s — re-injected on every new document; remove with 'browser inject --remove %s'\n", id, id)
+		// addScriptToEvaluateOnNewDocument only affects FUTURE documents, so also
+		// run it once now (best-effort) to cover the already-loaded page.
+		if err := injectOnce(*addrFlag, *tabFlag, *sightmapDirFlag, source); err != nil {
+			fmt.Fprintf(os.Stderr, "inject: note: could not run in the current document (%v) — it will apply on the next navigation\n", err)
+		} else {
+			fmt.Fprintln(os.Stderr, "inject: also ran once in the current document")
+		}
+		return nil
+	}
+
+	// One-shot: behaves like `eval` but adds --file support.
+	if err := injectOnce(*addrFlag, *tabFlag, *sightmapDirFlag, source); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "inject: ran once in the current document (use --persist to re-inject on every navigation)")
+	return nil
+}
+
+// injectSource returns the script from --file or a single inline positional arg,
+// requiring exactly one of the two.
+func injectSource(file string, positionals []string) (string, error) {
+	switch {
+	case file != "" && len(positionals) > 0:
+		return "", fmt.Errorf("inject: pass either --file or an inline <script>, not both")
+	case file != "":
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("inject: read %s: %w", file, err)
+		}
+		if len(b) == 0 {
+			return "", fmt.Errorf("inject: %s is empty", file)
+		}
+		return string(b), nil
+	case len(positionals) == 1:
+		return positionals[0], nil
+	case len(positionals) == 0:
+		return "", fmt.Errorf("usage: browser inject [--file PATH | <script>] [--persist]")
+	default:
+		return "", fmt.Errorf("inject: too many arguments — pass one inline <script> or --file PATH")
+	}
+}
+
+// injectOnce evaluates source a single time in the current document over a
+// transient CDP connection (the same path as `eval`).
+func injectOnce(addr, tab, sightmapDir, source string) error {
+	conn, err := browser.Connect(resolveCDPAddr(addr, sightmapDir), tab)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), evalTimeout)
+	defer cancel()
+	_, err = browser.EvalJSON(ctx, conn, source)
+	return err
+}
+
+// daemonBaseURL resolves the session daemon's HTTP base URL from the session
+// file, matching devtoolsGet's resolution.
+func daemonBaseURL(sightmapDir string) (string, error) {
+	info, err := browser.ReadSessionInfo(sightmapDir)
+	if err != nil || info.ServerPort == 0 {
+		return "", fmt.Errorf("no running session — start one with 'sightmap browser start'")
+	}
+	return fmt.Sprintf("http://localhost:%d", info.ServerPort), nil
+}
+
+func injectPersist(sightmapDir, source string) (string, error) {
+	base, err := daemonBaseURL(sightmapDir)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Post(base+"/inject", "application/javascript", bytes.NewReader([]byte(source)))
+	if err != nil {
+		return "", fmt.Errorf("reach daemon: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", daemonError(resp.StatusCode, body)
+	}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("parse daemon response: %w", err)
+	}
+	return out.ID, nil
+}
+
+func injectRemove(sightmapDir, id string) error {
+	base, err := daemonBaseURL(sightmapDir)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodDelete, base+"/inject?"+url.Values{"id": {id}}.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("reach daemon: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("no persisted script with id %q (see 'browser inject --list')", id)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return daemonError(resp.StatusCode, body)
+	}
+	fmt.Fprintf(os.Stderr, "inject: removed %s\n", id)
+	return nil
+}
+
+func injectList(sightmapDir string) error {
+	base, err := daemonBaseURL(sightmapDir)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(base + "/inject")
+	if err != nil {
+		return fmt.Errorf("reach daemon: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return daemonError(resp.StatusCode, body)
+	}
+	var out struct {
+		Scripts []browser.PersistentScriptInfo `json:"scripts"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("parse daemon response: %w", err)
+	}
+	if len(out.Scripts) == 0 {
+		fmt.Println("No persisted scripts.")
+		return nil
+	}
+	for _, s := range out.Scripts {
+		fmt.Printf("%s  (%d bytes, %d tab(s))\n", s.ID, s.Bytes, s.Tabs)
+	}
+	return nil
+}
+
+func daemonError(status int, body []byte) error {
+	if status == http.StatusServiceUnavailable {
+		return fmt.Errorf("session is still starting (collector not ready) — retry shortly")
+	}
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		msg = http.StatusText(status)
+	}
+	return fmt.Errorf("daemon returned %d: %s", status, msg)
+}

--- a/go/cmd/sightmap/cmd_devtools_server.go
+++ b/go/cmd/sightmap/cmd_devtools_server.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"sync/atomic"
@@ -16,6 +17,10 @@ import (
 	"github.com/sightmap/sightmap/go/browser"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
+
+// maxInjectBytes caps a persisted script's size. Generous enough for a bundled
+// runtime while refusing a pathological upload.
+const maxInjectBytes = 16 << 20 // 16 MiB
 
 // registerDevtoolsHandlers wires the /devtools/* endpoints onto mux. The
 // collector is supplied via ptr because it is created only after Chrome is
@@ -74,6 +79,59 @@ func registerDevtoolsHandlers(mux *http.ServeMux, ptr *atomic.Pointer[browser.Co
 			Limit:        atoiDefault(q.Get("limit"), 0),
 		})
 		writeJSON(w, map[string]any{"entries": annotateNetwork(corpusNow(), entries), "dropped": dropped})
+	})
+
+	// Persistent script injection. POST registers a script (raw body) and returns
+	// its id; DELETE?id= removes one; GET lists them. The collector holds the
+	// registry because it is the session-lifetime CDP client — a script must
+	// outlive any single per-command connection.
+	mux.HandleFunc("/inject", func(w http.ResponseWriter, r *http.Request) {
+		c, ok := load(w)
+		if !ok {
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"scripts": c.PersistentScripts()})
+		case http.MethodPost:
+			src, err := io.ReadAll(io.LimitReader(r.Body, maxInjectBytes))
+			if err != nil {
+				http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			if len(src) == 0 {
+				http.Error(w, "empty script", http.StatusBadRequest)
+				return
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+			defer cancel()
+			id, err := c.AddPersistentScript(ctx, string(src))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			writeJSON(w, map[string]any{"id": id, "bytes": len(src)})
+		case http.MethodDelete:
+			id := r.URL.Query().Get("id")
+			if id == "" {
+				http.Error(w, "id required", http.StatusBadRequest)
+				return
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+			defer cancel()
+			removed, err := c.RemovePersistentScript(ctx, id)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if !removed {
+				http.Error(w, "no such script id", http.StatusNotFound)
+				return
+			}
+			writeJSON(w, map[string]any{"removed": id})
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
 	})
 
 	mux.HandleFunc("/devtools/network/body", func(w http.ResponseWriter, r *http.Request) {

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -63,6 +63,7 @@ daemon and returns immediately.
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
 | `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |
+| `sightmap browser inject --file X --persist` | Inject a script that re-runs on **every** new document/tab for the whole session (survives navigations), vs `eval`'s one-shot. `--list` / `--remove ID` manage them. Needs a running session (the daemon holds the registry). |
 | `sightmap browser screenshot --out FILE.png` | Screenshot the page. Clip to a component with `--component NAME` (or `--selector CSS`), optionally `--expand-pct N` for context. |
 
 ## Reading the page: annotated snapshots

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -63,6 +63,7 @@ daemon and returns immediately.
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |
 | `sightmap browser eval 'js'` | Evaluate JS in page context. Returns JSON-serializable values only — DOM element references return an error. |
+| `sightmap browser inject --file X --persist` | Inject a script that re-runs on **every** new document/tab for the whole session (survives navigations), vs `eval`'s one-shot. `--list` / `--remove ID` manage them. Needs a running session (the daemon holds the registry). |
 | `sightmap browser screenshot --out FILE.png` | Screenshot the page. Clip to a component with `--component NAME` (or `--selector CSS`), optionally `--expand-pct N` for context. |
 
 ## Reading the page: annotated snapshots


### PR DESCRIPTION
Closes #309.

### Summary

`sightmap browser eval` runs a script once in the current document. This adds `browser inject`, whose `--persist` mode registers a script that re-runs at the start of **every new document, in every tab, for the life of the session** — surviving navigations.

```
sightmap browser inject [--file PATH | <script>] [--persist]
sightmap browser inject --list
sightmap browser inject --remove <id>
```

- Without `--persist`, behaves like `eval` but adds `--file`.
- `--persist` registers the script and also runs it once in the current document (CDP only injects into future ones).

### How it works

Backed by CDP `Page.addScriptToEvaluateOnNewDocument`. Those registrations are scoped to the CDP session that added them and are dropped when that client disconnects, so a per-command connection can't persist one. The registry therefore lives on the session daemon's `Collector` — the one session-lifetime CDP owner — which re-applies each script as it attaches to tabs. That makes scripts survive both navigations (the script re-fires per document) and new tabs (re-applied on attach). The CLI reaches the registry over the daemon HTTP server (`POST` / `GET` / `DELETE /inject`).

### Testing

- New collector unit test (`TestCollector_PersistentScripts`) drives the real attach path against a recording CDP fake and asserts add/remove wiring; passes under `-race`.
- `go build ./...` and `go test ./browser/... ./cmd/...` green; gofmt clean; embedded-skills copy regenerated (no drift).

### Docs

CLI reference (`docs/cli/browser.mdx`) and the `sightmap-browser` skill both document the command; changeset included (minor).
