### PR TITLE
browser: make start fail loudly instead of running sessionless

### DIFF
--- a/.changeset/browser-start-loud-session.md
+++ b/.changeset/browser-start-loud-session.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `browser start` silently running sessionless when it couldn't persist the session file. `start` now creates the corpus dir if absent (so the session lives at the per-corpus `.sightmap/.session` rather than a shared `$TMPDIR` fallback) and fails loudly if it still can't write it, instead of continuing without a session. Client commands that find no session file now warn before falling back to the default CDP port — where a session may belong to a different corpus or agent — rather than silently attaching to a foreign tab. Applies to both the launched and `--attach` start paths.

--- a/docs/cli/browser.mdx
+++ b/docs/cli/browser.mdx
@@ -40,7 +40,7 @@ The final line is the binary path on stdout, so scripts can capture it; progress
 
 The `start` daemon owns the session: it is the only way to launch Chrome for sightmap, and every live command attaches to it. It also runs the console/network **collector** that buffers browser activity for the [`console` and `network`](/cli/devtools) commands, so those need a running `start` session.
 
-Run it from the site directory (the one containing `.sightmap/`), typically in a second terminal or as a background job.
+Run it from the site directory (the one containing `.sightmap/`), typically in a second terminal or as a background job. `start` creates `.sightmap/` if it is absent and records the session at `.sightmap/.session`; if it cannot persist that file it fails loudly rather than running sessionless. Every other command finds the session through this file, keyed by `--sightmap-dir` — so with no session file a command falls back to the default CDP port and **warns**, since a session answering there may belong to a different corpus or agent. Pass `--addr` to target a specific session explicitly.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/go/cmd/sightmap/cli.go
+++ b/go/cmd/sightmap/cli.go
@@ -63,10 +63,31 @@ func (lf *liveFlags) connect(ctx context.Context) (*browser.CDPConn, func(), err
 // corpora from finding each other's daemon. Commands pass "" for explicitAddr
 // when --addr was left at its empty default.
 func resolveCDPAddr(explicitAddr, sightmapDir string) string {
-	if explicitAddr != "" {
-		return explicitAddr
+	addr, warn := cdpAddrForDir(explicitAddr, sightmapDir)
+	if warn != "" {
+		fmt.Fprintln(os.Stderr, "warning: "+warn)
 	}
-	return browser.DefaultAddr(sightmapDir)
+	return addr
+}
+
+// cdpAddrForDir resolves the CDP address for a client command. When it has to
+// fall back to the default CDP port because no usable session file exists for
+// sightmapDir, it also returns a warning (empty otherwise): a session answering
+// on the default port may belong to a different corpus/agent, and silently
+// attaching to it returns a foreign tab's DOM with no signal why. Kept pure so
+// the fallback decision is unit-testable; resolveCDPAddr prints the warning.
+func cdpAddrForDir(explicitAddr, sightmapDir string) (addr, warn string) {
+	if explicitAddr != "" {
+		return explicitAddr, ""
+	}
+	if info, err := browser.ReadSessionInfo(sightmapDir); err == nil && info.Port > 0 && info.Port <= 65535 {
+		return fmt.Sprintf("localhost:%d", info.Port), ""
+	}
+	return fmt.Sprintf("localhost:%d", browser.DefaultCDPPort),
+		fmt.Sprintf("no session file at %s — falling back to the default CDP port %d; "+
+			"a session answering there may belong to a different corpus/agent. Run "+
+			"'sightmap browser start' or pass --addr to target a specific session.",
+			browser.SessionFilePath(sightmapDir), browser.DefaultCDPPort)
 }
 
 // navOpts tunes how navigate waits for the page to settle.

--- a/go/cmd/sightmap/cli_test.go
+++ b/go/cmd/sightmap/cli_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sightmap/sightmap/go/browser"
+)
+
+// TestCDPAddrForDir covers the client-side session resolution: an explicit --addr
+// wins, a present session file is honored silently, and the absence of one falls
+// back to the default CDP port WITH a warning — the fix for a command silently
+// attaching to another agent's session on the default port.
+//
+// Each subtest creates the corpus dir first, so SessionFilePath keys on the
+// per-corpus <dir>/.session rather than the shared $TMPDIR fallback — keeping the
+// assertions hermetic.
+func TestCDPAddrForDir(t *testing.T) {
+	t.Run("explicit addr wins, no warning", func(t *testing.T) {
+		addr, warn := cdpAddrForDir("host:1234", mkCorpusDir(t))
+		if addr != "host:1234" || warn != "" {
+			t.Fatalf("cdpAddrForDir(explicit) = (%q, %q), want (host:1234, \"\")", addr, warn)
+		}
+	})
+
+	t.Run("present session file is honored silently", func(t *testing.T) {
+		dir := mkCorpusDir(t)
+		if err := browser.WriteSessionInfo(dir, browser.SessionInfo{Port: 9999, ServerPort: 8888}); err != nil {
+			t.Fatalf("seed session file: %v", err)
+		}
+		addr, warn := cdpAddrForDir("", dir)
+		if addr != "localhost:9999" || warn != "" {
+			t.Fatalf("cdpAddrForDir(session) = (%q, %q), want (localhost:9999, \"\")", addr, warn)
+		}
+	})
+
+	t.Run("missing session file falls back loudly", func(t *testing.T) {
+		dir := mkCorpusDir(t) // exists, but no .session written
+		addr, warn := cdpAddrForDir("", dir)
+		want := fmt.Sprintf("localhost:%d", browser.DefaultCDPPort)
+		if addr != want {
+			t.Errorf("cdpAddrForDir(no session) addr = %q, want %q", addr, want)
+		}
+		if warn == "" {
+			t.Error("cdpAddrForDir(no session) returned no warning; want a foreign-session warning")
+		}
+	})
+}
+
+// mkCorpusDir makes a fresh <tmp>/.sightmap directory and returns its path.
+func mkCorpusDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".sightmap")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir corpus dir: %v", err)
+	}
+	return dir
+}

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -83,6 +83,17 @@ func runBrowserStart(args []string) error {
 	}
 	_ = os.MkdirAll(resolvedProfile, 0o700)
 
+	// Ensure the corpus dir exists BEFORE any session-file access. The session
+	// file lives at <sightmap-dir>/.session and is the per-corpus rendezvous that
+	// keeps concurrent sessions from finding each other. When the dir is absent,
+	// SessionFilePath falls back to a single shared $TMPDIR file, so two corpus-
+	// less starts clobber each other's session and a later client command can
+	// silently drive a foreign tab. Creating it up front keeps the session
+	// per-corpus; failing here is loud rather than degrading to sessionless.
+	if err := os.MkdirAll(*sightmapDir, 0o755); err != nil {
+		return fmt.Errorf("start: cannot create %s (needed to persist the session): %w", *sightmapDir, err)
+	}
+
 	// ── Detect existing Chrome for this corpus ────────────────────────────────
 	// The session file is keyed to --sightmap-dir, so this only ever matches a
 	// prior session for THIS corpus — never another agent's browser.
@@ -217,10 +228,19 @@ func runBrowserStart(args []string) error {
 	if cmd.Process != nil {
 		pid = cmd.Process.Pid
 	}
-	_ = browser.WriteSessionInfo(*sightmapDir, browser.SessionInfo{
+	if err := browser.WriteSessionInfo(*sightmapDir, browser.SessionInfo{
 		Port: resolvedCDPPort, PID: pid, Pgid: pid, Profile: resolvedProfile,
 		ServerPort: resolvedServerPort,
-	})
+	}); err != nil {
+		// Refuse to run sessionless: without the session file, client commands fall
+		// back to the default CDP port and could attach to another session's tab.
+		// Tear down the Chrome we just launched rather than leaving it orphaned.
+		cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("start: cannot persist the session file at %s — refusing to run "+
+			"sessionless (clients would fall back to the default CDP port and could drive "+
+			"another session's tab): %w", browser.SessionFilePath(*sightmapDir), err)
+	}
 
 	var initialTabID string
 	ctx := context.Background()
@@ -583,6 +603,13 @@ func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlF
 	}
 	cdpAddr := net.JoinHostPort(host, port)
 
+	// Keep the session per-corpus (see the launch path): create the corpus dir so
+	// the session file isn't the shared $TMPDIR fallback, and fail loudly if it
+	// can't be created rather than advertising a session we can't persist.
+	if err := os.MkdirAll(sightmapDir, 0o755); err != nil {
+		return fmt.Errorf("start --attach: cannot create %s (needed to persist the session): %w", sightmapDir, err)
+	}
+
 	// Verify the endpoint is actually reachable before we advertise a session.
 	if !cdpVersionAlive(context.Background(), cdpAddr) {
 		return fmt.Errorf("start --attach: no Chrome CDP endpoint answering at %s\n"+
@@ -607,9 +634,13 @@ func runAttachedSession(attachAddr, sightmapDir string, serverPortFlag int, urlF
 
 	// Record the session. PID is the DAEMON's pid (there is no owned Chrome), and
 	// Attached tells stop to detach rather than kill. Profile is empty.
-	_ = browser.WriteSessionInfo(sightmapDir, browser.SessionInfo{
+	if err := browser.WriteSessionInfo(sightmapDir, browser.SessionInfo{
 		Port: cdpPort, PID: os.Getpid(), ServerPort: resolvedServerPort, Attached: true,
-	})
+	}); err != nil {
+		return fmt.Errorf("start --attach: cannot persist the session file at %s — refusing to run "+
+			"sessionless (clients would fall back to the default CDP port and could drive "+
+			"another session's tab): %w", browser.SessionFilePath(sightmapDir), err)
+	}
 
 	// Install signal handling and liveness polling up front, so the daemon is
 	// always interruptible even while the best-effort setup below is still running.

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -58,7 +58,7 @@ daemon and returns immediately.
 
 | Command | What it does |
 |---------|-------------|
-| `sightmap browser start` | Launch Chrome + the overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Writes `.sightmap/.session`. |
+| `sightmap browser start` | Launch Chrome + the overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Creates `.sightmap/` if absent and writes `.sightmap/.session` (fails loudly if it can't). Every other command finds the session via this file, so with no session file a command warns and falls back to the default CDP port — which may be a **different agent's** Chrome; pass `--addr` to be explicit. |
 | `sightmap browser status` | Check session health, tabs, and current URL. Reports `⚠ degraded` when Chrome's CDP is up but the daemon's HTTP server was reaped. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -58,7 +58,7 @@ daemon and returns immediately.
 
 | Command | What it does |
 |---------|-------------|
-| `sightmap browser start` | Launch Chrome + the overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Writes `.sightmap/.session`. |
+| `sightmap browser start` | Launch Chrome + the overlay server. **Foreground daemon — holds the shell; pass `--detach` in scripts/agents.** Creates `.sightmap/` if absent and writes `.sightmap/.session` (fails loudly if it can't). Every other command finds the session via this file, so with no session file a command warns and falls back to the default CDP port — which may be a **different agent's** Chrome; pass `--addr` to be explicit. |
 | `sightmap browser status` | Check session health, tabs, and current URL. Reports `⚠ degraded` when Chrome's CDP is up but the daemon's HTTP server was reaped. |
 | `sightmap browser navigate 'URL'` | Navigate to URL (positional arg — no `--url` flag). |
 | `sightmap browser stop` | Stop Chrome session. |


### PR DESCRIPTION
### Problem

Running `sightmap browser start` in a directory where `.sightmap/` does not exist yet leaves the daemon unable to write `.sightmap/.session`, but it stays alive **sessionless**. Subsequent commands (`eval`, `sel-probe`, `tabs`, …) then silently fall back to the default CDP port (`7892`) — and if another sightmap session is already running there, the client drives a **different** session's tab and returns a foreign page's DOM with no error. With parallel agents/sessions on one host this is an easy, silent detour.

### Fix

- `browser start` now creates the corpus dir up front, so the session file lives at the per-corpus `.sightmap/.session` (the rendezvous that keeps concurrent sessions apart) rather than the shared `$TMPDIR` fallback used when the dir is absent.
- If it still cannot persist the session file, `start` **fails loudly** and tears down the Chrome it launched, instead of continuing sessionless. Applies to both the launched and `--attach` paths.
- Client commands that find no session file now **warn** before falling back to the default CDP port, noting that a session answering there may belong to a different corpus/agent, and to pass `--addr` to be explicit.

### Tests

New unit test (`TestCDPAddrForDir`) covering the client-side resolution: explicit `--addr` wins, a present session file is honored silently, and a missing one falls back to the default port with a warning. `go build ./...`, `go test ./cmd/... ./browser/...`, gofmt, and the embedded-skills drift check are green.

### Docs

`browser start` reference and the `sightmap-browser` skill both note the create/loud-fail behavior and the fallback warning; changeset included (patch).
