### PR TITLE
lint: auto-reconcile multi-instance-no-property against snapshots

### DIFF
--- a/.changeset/lint-auto-reconcile-snapshots.md
+++ b/.changeset/lint-auto-reconcile-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`sightmap lint` now auto-reconciles the `multi-instance-no-property` rule against captured snapshots by default. The static heuristic guesses from selector shape alone and false-positived on container-ish selectors that in fact match a single node; when captures exist under `.sightmap/snapshots/`, lint now uses their real match counts (a count of 1 suppresses the warning) without needing an explicit `--all-snapshots`. With no captures present it runs the static heuristics unchanged, and `--snapshot`/`--all-snapshots` still control the set explicitly. A missing `snapshots/` directory is no longer an error.

--- a/docs/cli/corpus.mdx
+++ b/docs/cli/corpus.mdx
@@ -66,6 +66,8 @@ By default, `lint` exits 1 when it finds a warning. Pass `--warn-only` to print 
 
 Snapshot data refines `multi-instance-no-property`. `--snapshot FILE` counts selector matches in one capture; `--all-snapshots` reads `.sightmap/snapshots/**/*.snap.tree.json`. A count of 1 suppresses the warning. A count of 0 adds `(0 matches in snapshot — selector may be broken)`, while a higher count adds `(matched N times in snapshot)`.
 
+When you pass no snapshot flag, `lint` **auto-reconciles** against any captures under `.sightmap/snapshots/` — so a container-ish selector that actually matches a single node is not falsely flagged. With no captures present it runs the static heuristics unchanged. Pass `--snapshot`/`--all-snapshots` to control the set explicitly.
+
 **Flags:**
 
 | Flag | Default | Description |

--- a/go/cmd/sightmap/cmd_lint.go
+++ b/go/cmd/sightmap/cmd_lint.go
@@ -26,21 +26,12 @@ func runLint(args []string) error {
 		return fmt.Errorf("load corpus: %w", err)
 	}
 
-	// Collect tree JSON paths from flags.
-	var treeFiles []string
-	if *snapshotFlag != "" {
-		tf := *snapshotFlag
-		if !strings.HasSuffix(tf, ".tree.json") {
-			tf = tf + ".tree.json"
-		}
-		treeFiles = append(treeFiles, tf)
+	treeFiles, autoUsed, err := resolveLintTreeFiles(*sightmapDir, *snapshotFlag, *allSnapshotsFlag)
+	if err != nil {
+		return fmt.Errorf("find snapshots: %w", err)
 	}
-	if *allSnapshotsFlag {
-		found, findErr := findLintSnapshotTreeFiles(*sightmapDir)
-		if findErr != nil {
-			return fmt.Errorf("find snapshots: %w", findErr)
-		}
-		treeFiles = append(treeFiles, found...)
+	if autoUsed && len(treeFiles) > 0 {
+		fmt.Fprintf(os.Stderr, "lint: reconciling against %d captured snapshot(s); pass --snapshot/--all-snapshots to control this, or capture with 'sightmap capture'\n", len(treeFiles))
 	}
 
 	var warnings []sightmap.LintWarning
@@ -67,10 +58,48 @@ func runLint(args []string) error {
 	return fmt.Errorf("%d lint warning(s)", len(warnings))
 }
 
+// resolveLintTreeFiles decides which snapshot tree files lint uses for
+// match-count reconciliation. Explicit --snapshot / --all-snapshots win;
+// otherwise it auto-discovers captured snapshots (auto=true) so the default run
+// reconciles the static [multi-instance-no-property] heuristic against real
+// counts — a container-ish selector that matches a single node then isn't
+// flagged. A missing snapshots/ dir yields no files, so lint falls back to the
+// static heuristic unchanged.
+func resolveLintTreeFiles(sightmapDir, snapshotFlag string, allSnapshots bool) (files []string, auto bool, err error) {
+	if snapshotFlag != "" {
+		tf := snapshotFlag
+		if !strings.HasSuffix(tf, ".tree.json") {
+			tf += ".tree.json"
+		}
+		files = append(files, tf)
+	}
+	if allSnapshots {
+		found, findErr := findLintSnapshotTreeFiles(sightmapDir)
+		if findErr != nil {
+			return nil, false, findErr
+		}
+		files = append(files, found...)
+	}
+	if snapshotFlag == "" && !allSnapshots {
+		found, findErr := findLintSnapshotTreeFiles(sightmapDir)
+		if findErr != nil {
+			return nil, false, findErr
+		}
+		files = append(files, found...)
+		auto = true
+	}
+	return files, auto, nil
+}
+
 // findLintSnapshotTreeFiles walks sightmapDir/snapshots/ and returns all
-// .snap.tree.json files found.
+// .snap.tree.json files found. A missing snapshots/ dir is not an error — it
+// yields no files, so callers (including the default auto-reconcile) degrade to
+// the static heuristic instead of failing.
 func findLintSnapshotTreeFiles(sightmapDir string) ([]string, error) {
 	snapshotsDir := filepath.Join(sightmapDir, "snapshots")
+	if _, err := os.Stat(snapshotsDir); os.IsNotExist(err) {
+		return nil, nil
+	}
 	var treeFiles []string
 	err := filepath.Walk(snapshotsDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/go/cmd/sightmap/cmd_lint_test.go
+++ b/go/cmd/sightmap/cmd_lint_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveLintTreeFiles covers how lint decides which snapshot tree files to
+// reconcile against — in particular the default auto-discovery that fixes the
+// [multi-instance-no-property] false positive on single-match components.
+func TestResolveLintTreeFiles(t *testing.T) {
+	t.Run("explicit --snapshot normalizes extension, not auto", func(t *testing.T) {
+		files, auto, err := resolveLintTreeFiles(t.TempDir(), "shots/home.snap", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if auto {
+			t.Error("explicit --snapshot should not be an auto run")
+		}
+		if len(files) != 1 || files[0] != "shots/home.snap.tree.json" {
+			t.Errorf("files = %v, want [shots/home.snap.tree.json]", files)
+		}
+	})
+
+	t.Run("default with no snapshots dir: empty, auto, no error", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), ".sightmap") // exists, but no snapshots/ subdir
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		files, auto, err := resolveLintTreeFiles(dir, "", false)
+		if err != nil {
+			t.Fatalf("missing snapshots/ dir must not error: %v", err)
+		}
+		if !auto {
+			t.Error("no snapshot flags should be an auto run")
+		}
+		if len(files) != 0 {
+			t.Errorf("files = %v, want none", files)
+		}
+	})
+
+	t.Run("default auto-discovers a captured snapshot", func(t *testing.T) {
+		dir := seedSnapshot(t)
+		files, auto, err := resolveLintTreeFiles(dir, "", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !auto {
+			t.Error("no snapshot flags should be an auto run")
+		}
+		if len(files) != 1 {
+			t.Fatalf("files = %v, want the one seeded snapshot", files)
+		}
+	})
+
+	t.Run("--all-snapshots discovers snapshots, not auto", func(t *testing.T) {
+		dir := seedSnapshot(t)
+		files, auto, err := resolveLintTreeFiles(dir, "", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if auto {
+			t.Error("explicit --all-snapshots should not be flagged auto")
+		}
+		if len(files) != 1 {
+			t.Fatalf("files = %v, want the one seeded snapshot", files)
+		}
+	})
+}
+
+// seedSnapshot makes a <tmp>/.sightmap dir with one snapshots/*.snap.tree.json.
+func seedSnapshot(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".sightmap")
+	snaps := filepath.Join(dir, "snapshots")
+	if err := os.MkdirAll(snaps, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(snaps, "home.snap.tree.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}


### PR DESCRIPTION
> Stacked on #312 (`fix/browser-start-loud-session`) — review/merge that first; this PR's base is that branch, so its own diff is just the lint change.

### Problem

`sightmap lint` flags components with `[multi-instance-no-property]` purely from selector shape (a container-ish selector with no `properties:`), even when the component matches **exactly one** node. Harmless under `--warn-only` but noisy and misleading.

The library already suppresses the warning when given a real match count (`LintWithCounts`, count of 1 → suppressed), and the CLI can feed counts via `--snapshot`/`--all-snapshots` — but the **default** run uses the static heuristic only, so the false positive stands unless you remember the flag.

### Fix

`lint` now **auto-reconciles** against captured snapshots by default: with no snapshot flag it discovers `.sightmap/snapshots/**/*.snap.tree.json` and uses their match counts, so a single-match selector isn't flagged. With no captures present it runs the static heuristics unchanged, and `--snapshot`/`--all-snapshots` still control the set explicitly. A missing `snapshots/` directory is no longer an error.

The tree-file resolution is extracted into `resolveLintTreeFiles` (explicit-vs-auto) with a unit test.

### Tests

`TestResolveLintTreeFiles` covers explicit `--snapshot` normalization, the no-snapshots-dir default (empty + no error), default auto-discovery, and explicit `--all-snapshots`. `go build ./...` and `go test ./cmd/... ./sightmap/...` are green; gofmt clean.

### Docs

`lint` reference (`docs/cli/corpus.mdx`) documents the auto-reconcile default; changeset included (patch).
