### PR TITLE
browser: fix inject --persist not firing across navigations

### DIFF
--- a/.changeset/fix-inject-persist-page-enable.md
+++ b/.changeset/fix-inject-persist-page-enable.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `browser inject --persist` not re-injecting across navigations. The persisted script was registered with `Page.addScriptToEvaluateOnNewDocument` on the daemon's collector connection, but that connection never enabled the Page domain — so the command returned an identifier (and `inject --list` showed the entry) while the script was never actually evaluated on new documents. Only the initial one-shot run fired. The collector now enables Page before registering, so a persisted script runs at document start on every subsequent navigation and new tab, as documented.

--- a/go/browser/collector.go
+++ b/go/browser/collector.go
@@ -630,9 +630,19 @@ func (c *Collector) tabConns() map[string]*CDPConn {
 }
 
 // addScriptOnNewDocument registers source to run at the start of every future
-// document on conn's target, returning CDP's identifier for later removal. It
-// does not require Page.enable.
+// document on conn's target, returning CDP's identifier for later removal.
+//
+// The Page domain MUST be enabled first: without it,
+// Page.addScriptToEvaluateOnNewDocument still returns an identifier (so the
+// script looks registered) but is never actually evaluated on new documents —
+// the persist-across-navigation bug. Enabling Page is idempotent, so calling it
+// per registration is safe; the collector connection subscribes to Runtime and
+// Network only, so the Page lifecycle events it turns on are dispatched to no
+// subscribers and dropped.
 func addScriptOnNewDocument(ctx context.Context, conn *CDPConn, source string) (string, error) {
+	if err := conn.EnableDomain(ctx, "Page"); err != nil {
+		return "", fmt.Errorf("addScriptToEvaluateOnNewDocument: enable Page: %w", err)
+	}
 	raw, err := conn.call(ctx, "Page.addScriptToEvaluateOnNewDocument", map[string]interface{}{
 		"source": source,
 	})

--- a/go/browser/collector_test.go
+++ b/go/browser/collector_test.go
@@ -239,6 +239,16 @@ func TestCollector_PersistentScripts(t *testing.T) {
 		t.Errorf("add: source = %q, want %q", adds[0].Source, src)
 	}
 
+	// Regression guard: Page must be enabled before the add, or the script is
+	// registered but never fires on new documents (persist-across-navigation bug).
+	enableIdx := rec.firstIndexOf("Page.enable")
+	addIdx := rec.firstIndexOf("Page.addScriptToEvaluateOnNewDocument")
+	if enableIdx < 0 {
+		t.Error("Page.enable was never sent; persisted scripts won't fire on navigation")
+	} else if enableIdx > addIdx {
+		t.Errorf("Page.enable (idx %d) sent AFTER addScriptToEvaluateOnNewDocument (idx %d); must precede it", enableIdx, addIdx)
+	}
+
 	if got := c.PersistentScripts(); len(got) != 1 || got[0].ID != id || got[0].Tabs != 1 || got[0].Bytes != len(src) {
 		t.Fatalf("PersistentScripts() = %+v, want one {ID:%s Tabs:1 Bytes:%d}", got, id, len(src))
 	}
@@ -295,6 +305,18 @@ func (r *cdpRecorder) withMethod(method string) []recordedCall {
 	return out
 }
 
+// firstIndexOf returns the position of the first recorded call for method, or -1.
+func (r *cdpRecorder) firstIndexOf(method string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, c := range r.calls {
+		if c.Method == method {
+			return i
+		}
+	}
+	return -1
+}
+
 // newRecordingBrowser is newFakeBrowser plus command recording: it records the
 // injection commands into rec and replies to addScriptToEvaluateOnNewDocument
 // with a stable identifier so removal has something to target.
@@ -348,6 +370,10 @@ func newRecordingBrowser(t *testing.T, rec *cdpRecorder) string {
 					rec.add(recordedCall{Method: req.Method, Source: req.Params.Source, Identifier: ident})
 				case "Page.removeScriptToEvaluateOnNewDocument":
 					rec.add(recordedCall{Method: req.Method, Identifier: req.Params.Identifier})
+				default:
+					// Record every other command (e.g. Page.enable) so ordering
+					// assertions can see the domain was enabled before the add.
+					rec.add(recordedCall{Method: req.Method})
 				}
 				reply, _ := json.Marshal(map[string]any{"id": req.ID, "result": result})
 				wsMu.Lock()


### PR DESCRIPTION
### Problem

`browser inject --persist` claims to "re-inject on every new document/tab" but the re-injection never fires — only the initial one-shot run works. After a navigation the persisted script is gone, even though `inject --list` still shows the entry.

### Root cause

The persisted script is registered with CDP `Page.addScriptToEvaluateOnNewDocument` on the daemon's collector connection — the one session-lifetime CDP client — but that connection only enables the **Runtime** and **Network** domains, never **Page**. `addScriptToEvaluateOnNewDocument` returns an identifier regardless of whether Page is enabled (so the registration *looks* successful and `--list` shows it), but the script is only actually evaluated on new documents when the Page domain is enabled on that session. So the registration was inert: the initial "also ran once in the current document" worked (that's a separate `Runtime.evaluate` path), while every subsequent navigation silently dropped the script.

This matches the report exactly: `--list` shows the entry, a manual `inject --file` on the post-nav document works (payload/CSP fine), but the persisted script never re-fires.

### Fix

Enable the Page domain before `Page.addScriptToEvaluateOnNewDocument`. It's idempotent, and the collector subscribes only to Runtime/Network events, so the Page lifecycle events it now turns on are dispatched to no subscribers and dropped — no effect on console/network capture.

### Tests

Extended the collector's persistent-script test with a regression guard asserting `Page.enable` is sent **before** the script registration (without the fix, `Page.enable` is never sent). `go test ./browser/... ./cmd/...` green under `-race`; gofmt clean.

**Not yet live-verified** in this environment (needs a real browser session). The unit test locks in the CDP call ordering that was missing; a live repro — `inject --persist`, navigate, confirm the marker re-fires — is the remaining check.

### Note

Page is enabled only on the collector connection and only when a persistent script is actually registered, so sessions that never use `inject --persist` are unchanged. One thing to watch during the live pass: with the Page domain enabled, JS dialogs on a page that uses `inject --persist` may need `browser dialog` handling.
