### PR TITLE
browser: pass mcp call args as a JSON string to native WebMCP

### DIFF
--- a/.changeset/mcp-call-native-args.md
+++ b/.changeset/mcp-call-native-args.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `browser mcp call` failing against native Chrome WebMCP. `executeTool` on a native `document.modelContext` requires the arguments as a JSON string (and returns the result as a JSON string), whereas a JS polyfill takes and returns objects. `mcp call` passed arguments as an object unconditionally, so it worked against a polyfill but failed on native with "Failed to parse input arguments". It now detects the native surface (the built-in `executeTool` reads as `[native code]`) and serializes the arguments accordingly; the native JSON-string result was already normalized.

--- a/go/cmd/sightmap/cmd_browser_mcp.go
+++ b/go/cmd/sightmap/cmd_browser_mcp.go
@@ -158,11 +158,15 @@ func mcpCallScript(name, argsJSON string) string {
   const name = %s;
   const tool = tools.find(t => t && t.name === name);
   if (!tool) return { present: true, found: false, names: tools.map(t => t && t.name).filter(Boolean) };
+  const args = %s;
+  // Native document.modelContext wants arguments as a JSON string and hands the
+  // CallToolResult back as a JSON string; a JS polyfill takes/returns objects. A
+  // built-in method reads as "[native code]", so shape the payload to the surface
+  // (native rejects a bare object with "Failed to parse input arguments").
+  const nativeSurface = /\[native code\]/.test(Function.prototype.toString.call(mc.executeTool));
   try {
-    let result = await mc.executeTool(tool, %s);
-    // Native document.modelContext returns the CallToolResult as a JSON string;
-    // the polyfill returns an object. Normalize to an object so the CLI sees one
-    // shape (mirrors what an in-page WebMCP client does).
+    let result = await mc.executeTool(tool, nativeSurface ? JSON.stringify(args) : args);
+    // Normalize the native JSON-string result to an object so the CLI sees one shape.
     if (typeof result === 'string') { try { result = JSON.parse(result); } catch (_) {} }
     return { present: true, found: true, result: result };
   } catch (e) {

--- a/go/cmd/sightmap/cmd_browser_mcp_test.go
+++ b/go/cmd/sightmap/cmd_browser_mcp_test.go
@@ -54,7 +54,11 @@ func TestBuildMCPArgs(t *testing.T) {
 
 func TestMCPCallScript(t *testing.T) {
 	s := mcpCallScript("search", `{"query":"ATL to LHR"}`)
-	for _, want := range []string{"getTools", "executeTool", `const name = "search"`, `{"query":"ATL to LHR"}`} {
+	for _, want := range []string{
+		"getTools", "executeTool", `const name = "search"`, `const args = {"query":"ATL to LHR"}`,
+		// Native surfaces need args as a JSON string; the script must branch on it.
+		"nativeSurface", "JSON.stringify(args)",
+	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("mcpCallScript missing %q in:\n%s", want, s)
 		}


### PR DESCRIPTION
### Problem

`browser mcp call` (shipped in 0.31.0) fails against **native** Chrome WebMCP. `executeTool` on a native `document.modelContext` requires the arguments as a **JSON string** (and returns the `CallToolResult` as a JSON string), whereas a JS polyfill takes and returns objects. `mcp call` passed arguments as an object unconditionally, so it worked against a polyfill but failed on native with `Failed to parse input arguments`.

### Fix

Detect the native surface — the built-in `executeTool` reads as `[native code]`, the same heuristic `mcp list` already uses to label native vs polyfilled — and `JSON.stringify` the arguments when native:

```js
const nativeSurface = /\[native code\]/.test(Function.prototype.toString.call(mc.executeTool));
let result = await mc.executeTool(tool, nativeSurface ? JSON.stringify(args) : args);
```

The native string-*result* direction was already normalized when `mcp call` first landed; this closes the argument direction. The detection stays generic (no producer-specific marker).

### Tests

`TestMCPCallScript` now asserts the script branches on the native surface and stringifies args. `go build ./...` and `go test ./cmd/sightmap/...` green; gofmt clean.

**Not yet live-verified** against a native session in this environment — folds into the existing `mcp` live-verify pass. The behavior mirrors what an in-page WebMCP client does for the same surface split.
