### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,20 @@
+{
+  "name": "Sightmap monorepo",
+  "install": "./.cursor/install.sh",
+  "ports": [
+    { "name": "web (sightmap.org)", "port": 5173 },
+    { "name": "docs (docs.sightmap.org)", "port": 3000 }
+  ],
+  "terminals": [
+    {
+      "name": "web (sightmap.org)",
+      "command": "cd web && pnpm dev",
+      "description": "Vite dev server for the marketing site on http://localhost:5173"
+    },
+    {
+      "name": "docs (docs.sightmap.org)",
+      "command": "cd docs && PATH=\"$HOME/.npm-global/bin:$PATH\" mint dev",
+      "description": "Mintlify docs preview on http://localhost:3000"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent setup for the Sightmap monorepo.
+# Installs the toolchains the repo needs beyond the base image (a modern Go and
+# the Mintlify CLI) and bootstraps dependencies for every area: root release
+# tooling, the web app, and the spec validators. Safe to run repeatedly.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Go toolchain -----------------------------------------------------------
+# go/go.mod requires go >= 1.23 (README asks for 1.25.2+); the base image ships
+# 1.22 and GOTOOLCHAIN auto-download is unavailable, so install a pinned Go.
+GO_VERSION="1.25.2"
+NEED_GO=1
+if command -v go >/dev/null 2>&1 && go version | grep -q "go${GO_VERSION}"; then
+  NEED_GO=0
+fi
+if [ "$NEED_GO" -eq 1 ]; then
+  echo "install: installing Go ${GO_VERSION}"
+  curl -fsSL -o /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+  sudo rm -rf /usr/local/go
+  sudo tar -C /usr/local -xzf /tmp/go.tgz
+  rm -f /tmp/go.tgz
+  # Base image resolves `go` from /usr/bin (older apt Go). /usr/local/bin wins
+  # in PATH, so point it at the freshly installed toolchain.
+  sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  sudo ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+fi
+hash -r
+go version
+
+# --- Node global prefix + Mintlify CLI --------------------------------------
+# The base image's npm prefix is `/`, which needs root for `-g` installs. Point
+# global installs at a user-writable prefix and put it on PATH for later shells.
+NPM_GLOBAL="$HOME/.npm-global"
+mkdir -p "$NPM_GLOBAL"
+npm config set prefix "$NPM_GLOBAL"
+if ! grep -q '.npm-global/bin' "$HOME/.bashrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.bashrc"
+fi
+export PATH="$NPM_GLOBAL/bin:$PATH"
+if ! command -v mint >/dev/null 2>&1; then
+  echo "install: installing Mintlify CLI"
+  npm install -g mint
+fi
+mint --version
+
+# --- Dependencies -----------------------------------------------------------
+echo "install: root npm ci (changesets/jest/prettier tooling)"
+npm ci
+
+echo "install: web deps (pnpm)"
+corepack enable >/dev/null 2>&1 || true
+cd web
+pnpm install --frozen-lockfile
+# pnpm does not run esbuild's install script by default; build its native
+# binary so tsx/vite work.
+pnpm rebuild esbuild
+cd "$REPO_ROOT"
+
+echo "install: spec validators (npm ci)"
+cd spec
+npm ci
+cd "$REPO_ROOT"
+
+echo "install: warming the Go module cache + building the CLI"
+cd go
+go build ./...
+cd "$REPO_ROOT"
+
+echo "install: done"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this changes

Adds `.cursor/environment.json` and an idempotent `.cursor/install.sh` so a Cloud Agent VM comes up fully provisioned for every area of the monorepo, with the two dev servers running as terminals.

## Why

The base image ships Go 1.22, but `go/go.mod` requires `>=1.23` (README asks for 1.25.2+) and `GOTOOLCHAIN` auto-download is unavailable in the sandbox, so `go build` fails out of the box. The image's npm global prefix is also `/`, which makes `npm i -g mint` (needed for the docs site) fail on permissions. This config captures the working setup so future agents don't have to rediscover it.

`.cursor/install.sh` (idempotent):
- Installs a pinned **Go 1.25.2** and points `/usr/local/bin/go` at it (base image `go` is 1.22 via apt).
- Installs the **Mintlify CLI** under a user-writable npm prefix (`~/.npm-global`) and adds it to `PATH`.
- Bootstraps dependencies: root (`npm ci`), `web/` (`pnpm install` + `pnpm rebuild esbuild`), and `spec/` validators (`npm ci`).
- Builds the `sightmap` CLI to warm the Go module cache.

`.cursor/environment.json` runs the **web** (Vite, `:5173`) and **docs** (Mintlify, `:3000`) dev servers as terminals and exposes both ports.

## Verification

All performed on this VM after running `install.sh`:

- `go/`: `go build ./...` ✓, `go test ./...` ✓ (all packages pass), CLI builds and runs (`sightmap version`, `validate`, `stats`).
- Root: `npm test` ✓ (67 jest tests), `npm run fmt:check` ✓ (prettier), `gofmt -l` clean, `go generate ./skills/...` produces no drift.
- `spec/`: `validate:examples` ✓, `validate:conformance` ✓.
- `docs/`: `mint validate` ✓, `mint broken-links` ✓, `sync-spec.mjs` produces no drift; site serves HTTP 200.
- `web/`: dev server serves HTTP 200; content build scripts (`build:blog`, `build:atlas`) succeed.

## Area

- [x] Maintainer / infrastructure

## Type of change

- [x] Feature (development environment tooling)

## Checklist

- [x] Every commit on this branch is signed off (`git commit -s`) per DCO
- [x] I kept this PR focused on a single concern
- [x] Relevant checks pass locally (`go test ./...` in `go/`; dev servers/build for the sites)

## Demo

Both dev servers running on the provisioned VM:

![Marketing landing page hero (Vite, :5173)](https://cursor.com/artifacts/c/art-04d86c6d-bc77-4fde-a4ca-f3b43ab85b8d)
![Marketing landing page scrolled (Vite, :5173)](https://cursor.com/artifacts/c/art-5377fa31-4357-44b7-94e4-4dd232385f83)
![Docs home (Mintlify, :3000)](https://cursor.com/artifacts/c/art-7a30d813-5331-4ac5-9ebe-ae1bbfb62b9f)
![Docs quickstart page (Mintlify, :3000)](https://cursor.com/artifacts/c/art-b56eccd4-2244-4382-ab12-c66f44cd5346)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad0514fd-ce7c-4730-b08a-a077c0c55cc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad0514fd-ce7c-4730-b08a-a077c0c55cc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

