### PR TITLE
fix(web): quote memory entry so web/.sightmap parses

### DIFF
--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -5,7 +5,7 @@ memory:
   - All homepage sections live in src/components/ and compose into src/pages/Home.tsx
   - Posts are markdown in content/blog/; scripts/build-blog.ts generates the manifest and per-post HTML modules
   - Pages are statically prerendered by scripts/prerender.tsx; the client hydrates rather than mounting fresh
-  - The negotiate edge function (netlify/edge-functions/negotiate.ts) serves markdown twins for Accept: text/markdown and JSON errors for /api/* and for 404s that asked for JSON; it always sets Vary: Accept
+  - "The negotiate edge function (netlify/edge-functions/negotiate.ts) serves markdown twins for Accept: text/markdown and JSON errors for /api/* and for 404s that asked for JSON; it always sets Vary: Accept"
   - "The offline matcher has no pseudo-class support: a selector like `.foo:first-child` probes 1 live and 0 offline, so keep selectors to attributes, classes and descendant combinators"
 
 views:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this changes

Quotes a single `memory:` entry in `web/.sightmap/app.yaml` so the corpus parses.

## Why

The HomePage-level memory note about the negotiate edge function was an unquoted YAML scalar containing `Accept: text/markdown` and `Vary: Accept`. Those embedded `": "` sequences made the YAML parser treat the list item as a mapping, so `sightmap validate` couldn't load the corpus at all:

```
sightmap validate: load corpus: sightmap: parse "web/.sightmap/app.yaml":
  yaml: line 8: mapping values are not allowed in this context
```

Wrapping the entry in double quotes (matching the already-quoted sibling entry just below it, which has the same `": "` hazard) makes the file parse. The string contains no double quotes, so the quoting is unambiguous.

### Verification

Before this change `sightmap validate` in `web/` failed at the parse step (line 8). After it, the file parses and validation proceeds to semantic checks. Confirmed with a locally-built `sightmap` CLI.

## Note: pre-existing errors this un-masks (not fixed here)

Because the parse failure previously aborted loading before any semantic validation ran, fixing it surfaces 7 pre-existing `extract`-mode errors that were hidden underneath it — property definitions that use a bare CSS selector (or `time` / `code`) as the `extract` value:

```
BlogCard.title    extract ".blog-card__title"
BlogCard.topic    extract ".blog-card__meta span"
AtlasCard.site    extract ".atlas-card__name"
AtlasCard.method  extract ".atlas-card__method"
AtlasInstall.command  extract ".atlas-install__cmd"
AtlasMeta.lastVerified  extract "time"
AtlasMeta.commit  extract "code"
```

The v1 `extract` grammar (`spec/v1/schema.md`) only permits `text`, `attr=NAME`, `PATH.prop`, or `exists:PATH` — the tree-closed property model from SEP-0010. These entries predate that model and need to be re-authored (promoting the target sub-elements to child components and referencing them via `PATH.prop`), which is best verified against the live DOM. That's a separate, more substantive concern, so it's intentionally out of scope for this focused parse fix and left for a follow-up PR.

## Area

- [x] Marketing site (`web/`)

## Type of change

- [x] Bug fix

## Checklist

- [x] Every commit on this branch is signed off (`git commit -s`) per DCO
- [x] I kept this PR focused on a single concern

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad0514fd-ce7c-4730-b08a-a077c0c55cc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad0514fd-ce7c-4730-b08a-a077c0c55cc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

