### PR TITLE
web: polish building tour overlays, lighting, and walker paths

### DIFF
--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -46,6 +46,7 @@ views:
           - A full-bleed dark band (always dark, unlike /building which only darkens at nightfall); text inside uses light colours regardless of the slice's day/night phase
           - The WebGL slice mounts only once the frame has scrolled near the viewport and pauses while off-screen; the SVG poster covers the frame before that and for no-WebGL visitors
           - The whole frame is one link to /building and carries `data-night` on the section while the slice is in its night phase; there are no interactive nodes inside the frame
+          - Floor-directory labels (and other in-scene Html tags) are not mounted in this slice so they cannot cover the "Enter the building" chip; the tour at /building still shows them
         children:
           - name: billboard-copy
             selector: '.billboard__copy'

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -368,7 +368,7 @@
   z-index: 15;
   transform: translateX(-50%);
   width: min(880px, calc(100vw - 2.5rem));
-  padding: 0.8rem 2.4rem 1.7rem;
+  padding: 0.8rem 2.8rem 1.7rem;
   border-radius: 100px;
   background: var(--bld-chrome-bg);
   border: 1px solid var(--bld-chrome-border);
@@ -395,8 +395,8 @@
 
 .bld-rail__dots {
   position: absolute;
-  left: 2.4rem;
-  right: 2.4rem;
+  left: 2.8rem;
+  right: 2.8rem;
   top: calc(0.8rem + 0.4rem + 1px);
   display: flex;
   justify-content: space-between;
@@ -821,7 +821,7 @@
   position: absolute;
   top: 0.9rem;
   left: 0.9rem;
-  z-index: 2;
+  z-index: 3;
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
@@ -852,7 +852,7 @@
   position: absolute;
   right: 0.9rem;
   bottom: 0.9rem;
-  z-index: 2;
+  z-index: 4;
   padding: 0.5rem 0.9rem;
   border-radius: 8px;
   background: #f5f1ea;

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -601,21 +601,6 @@
 .bld-tool b span { color: var(--text-dim); font-weight: 400; }
 .bld-tool small { font-size: 0.58rem; color: var(--text-dim); }
 
-.bld-titleblock {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  font-family: var(--mono);
-  font-size: 0.6rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  padding: 0.35rem 0.6rem;
-  white-space: nowrap;
-  transform: translate(0, 8px);
-}
-
 /* Mobile ----------------------------------------------------------------- */
 
 @media (max-width: 899px) {
@@ -655,8 +640,7 @@
 
   .bld-tag { font-size: 0.6rem; }
   .bld-tag--tag,
-  .bld-tag--floor span,
-  .bld-titleblock { display: none; }
+  .bld-tag--floor span { display: none; }
   .bld-tag--memory { width: 118px; font-size: 0.56rem; padding: 0.35rem 0.45rem; }
   .bld-tag--floor { font-size: 0.56rem; margin-left: 16px; }
   .bld-tag--floor::before { left: -16px; width: 12px; }
@@ -814,7 +798,6 @@
   filter: drop-shadow(0 20px 30px rgba(20, 40, 90, 0.22));
 }
 
-.billboard__frame .bld-titleblock { display: none; }
 /* Belt-and-suspenders: drei Html writes its own z-index, so hide every
  * in-scene tag in this crop even if a portal still mounts. */
 .billboard__frame .bld-tag { display: none; }

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -368,7 +368,7 @@
   z-index: 15;
   transform: translateX(-50%);
   width: min(880px, calc(100vw - 2.5rem));
-  padding: 0.8rem 1.4rem 1.7rem;
+  padding: 0.8rem 2.4rem 1.7rem;
   border-radius: 100px;
   background: var(--bld-chrome-bg);
   border: 1px solid var(--bld-chrome-border);
@@ -395,8 +395,8 @@
 
 .bld-rail__dots {
   position: absolute;
-  left: 1.4rem;
-  right: 1.4rem;
+  left: 2.4rem;
+  right: 2.4rem;
   top: calc(0.8rem + 0.4rem + 1px);
   display: flex;
   justify-content: space-between;
@@ -523,8 +523,6 @@
   background: #ffe27a;
   color: #3d3929;
   border-radius: 3px;
-  transform-origin: top left;
-  rotate: -3deg;
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
   font-size: 0.64rem;
   line-height: 1.35;
@@ -615,7 +613,7 @@
   border: 1px solid rgba(255, 255, 255, 0.28);
   padding: 0.35rem 0.6rem;
   white-space: nowrap;
-  transform: translate(-50%, 8px);
+  transform: translate(0, 8px);
 }
 
 /* Mobile ----------------------------------------------------------------- */
@@ -647,10 +645,10 @@
   .bld-rail {
     bottom: 0.7rem;
     width: calc(100vw - 1.8rem);
-    padding: 0.7rem 1rem 1.5rem;
+    padding: 0.7rem 1.4rem 1.5rem;
   }
 
-  .bld-rail__dots { left: 1rem; right: 1rem; top: calc(0.7rem + 0.4rem + 1px); }
+  .bld-rail__dots { left: 1.4rem; right: 1.4rem; top: calc(0.7rem + 0.4rem + 1px); }
   .bld-rail__dot { width: 12px; height: 12px; }
   .bld-rail__label { display: none; }
   .bld-rail__dot[aria-pressed='true'] .bld-rail__label { display: block; }
@@ -808,6 +806,7 @@
 .billboard__frame canvas {
   position: absolute;
   inset: 0;
+  z-index: 0;
 }
 
 .billboard__frame .bld-poster {

--- a/web/src/building.css
+++ b/web/src/building.css
@@ -815,7 +815,12 @@
 }
 
 .billboard__frame .bld-titleblock { display: none; }
-.billboard__frame .bld-tag--floor span { display: none; }
+/* Belt-and-suspenders: drei Html writes its own z-index, so hide every
+ * in-scene tag in this crop even if a portal still mounts. */
+.billboard__frame .bld-tag { display: none; }
+.billboard__enter {
+  isolation: isolate;
+}
 
 .billboard__chip {
   position: absolute;
@@ -852,7 +857,7 @@
   position: absolute;
   right: 0.9rem;
   bottom: 0.9rem;
-  z-index: 4;
+  z-index: 20;
   padding: 0.5rem 0.9rem;
   border-radius: 8px;
   background: #f5f1ea;

--- a/web/src/components/building/Agents.tsx
+++ b/web/src/components/building/Agents.tsx
@@ -118,7 +118,10 @@ function Agent({ journey, path }: { journey: Journey; path: Path }) {
     const focusTarget = s.focus && s.focus !== journey.name ? 0.55 : 1
     r.focus = THREE.MathUtils.damp(r.focus, focusTarget, 5, d)
     const rise = smoothstep(Math.min(1, c.rise * 1.3 - 0.3))
-    const sc = c.agents * r.focus * smoothstep(r.fade) * rise
+    // Neighbouring chapters still leak a little `agents` while the heal
+    // vignette is up; hide the crowd for the whole self-healing beat.
+    const crowd = c.agents * (1 - smoothstep((c.heal - 0.2) / 0.4))
+    const sc = crowd * r.focus * smoothstep(r.fade) * rise
     g.current.scale.setScalar(Math.max(sc, 0.001))
     g.current.visible = sc > 0.02
     if (tg.current) tg.current.visible = sc > 0.4 && r.fade > 0.5 && r.dwell <= 0

--- a/web/src/components/building/Agents.tsx
+++ b/web/src/components/building/Agents.tsx
@@ -9,7 +9,7 @@ import { useShared } from './state'
 
 // The people: one walker per journey, looping through its stops, riding the
 // core between floors. Users are pink, coding agents green, tests gold.
-const WALK = 1.75
+const WALK = 2.0
 const DWELL = 0.9
 const RESET = 1.4
 
@@ -19,6 +19,7 @@ interface Runner {
   next: number
   wait: number
   fade: number
+  focus: number
 }
 
 export function Walker({
@@ -50,8 +51,8 @@ export function Walker({
           <sphereGeometry args={[0.12, 14, 14]} />
           <meshStandardMaterial color="#fbf8f2" roughness={0.6} />
         </mesh>
-        <mesh position={[0, 0.012, 0]} rotation-x={-Math.PI / 2}>
-          <ringGeometry args={[0.18, 0.28, 24]} />
+        <mesh position={[0, 0.03, 0]} rotation-x={-Math.PI / 2}>
+          <ringGeometry args={[0.15, 0.22, 24]} />
           <meshBasicMaterial color={color} transparent opacity={0.55} depthWrite={false} />
         </mesh>
         </group>
@@ -76,7 +77,7 @@ function Agent({ journey, path }: { journey: Journey; path: Path }) {
   const s = useShared()
   const g = useRef<THREE.Group>(null)
   const tg = useRef<THREE.Mesh>(null)
-  const run = useRef<Runner>({ d: 0, dwell: DWELL, next: 1, wait: journey.delay, fade: 0 })
+  const run = useRef<Runner>({ d: 0, dwell: DWELL, next: 1, wait: journey.delay, fade: 0, focus: 1 })
   const tmp = useMemo(() => new THREE.Vector3(), [])
   const color = TRAVELLER_COLORS[journey.who]
 
@@ -114,9 +115,10 @@ function Agent({ journey, path }: { journey: Journey; path: Path }) {
     if (!g.current) return
     pointAt(path, r.d, tmp)
     g.current.position.copy(tmp)
-    const focus = s.focus && s.focus !== journey.name ? 0.3 : 1
+    const focusTarget = s.focus && s.focus !== journey.name ? 0.55 : 1
+    r.focus = THREE.MathUtils.damp(r.focus, focusTarget, 5, d)
     const rise = smoothstep(Math.min(1, c.rise * 1.3 - 0.3))
-    const sc = c.agents * focus * smoothstep(r.fade) * rise
+    const sc = c.agents * r.focus * smoothstep(r.fade) * rise
     g.current.scale.setScalar(Math.max(sc, 0.001))
     g.current.visible = sc > 0.02
     if (tg.current) tg.current.visible = sc > 0.4 && r.fade > 0.5 && r.dwell <= 0

--- a/web/src/components/building/BillboardScene.tsx
+++ b/web/src/components/building/BillboardScene.tsx
@@ -17,8 +17,9 @@ function Driver({ onNight }: { onNight: (night: boolean) => void }) {
   useFrame(({ clock }) => {
     const t = s.reduced ? 0 : clock.getElapsedTime()
     const c = s.cur
-    Object.assign(c, CHAPTERS[4].scene) // "The people": built, labelled, populated
-    c.labels = 0.75
+    Object.assign(c, CHAPTERS[4].scene) // "The people": built, populated
+    // Floor directory labels collide with the enter chip on this tight crop.
+    c.labels = 0
     c.agents = 1
     c.az = 42 + Math.sin(t * 0.085) * 9
     c.el = 25 + Math.sin(t * 0.05) * 1.5

--- a/web/src/components/building/FrontDesk.tsx
+++ b/web/src/components/building/FrontDesk.tsx
@@ -74,7 +74,7 @@ export default function FrontDesk() {
           <meshStandardMaterial color="#8a8272" roughness={0.6} />
         </mesh>
         {TOOLS.map((tool, k) => (
-          <Html key={tool.name} position={[1.0, 0.9 + k * 1.05, -1.4]} center zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
+          <Html key={tool.name} position={[1.0 + k * 0.08, 0.85 + k * 1.25, -1.4]} center zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
             <div
               ref={(el) => {
                 cards.current[k] = el

--- a/web/src/components/building/FrontDesk.tsx
+++ b/web/src/components/building/FrontDesk.tsx
@@ -30,7 +30,7 @@ export default function FrontDesk() {
     }
     if (visitor.current) {
       const t = clock.getElapsedTime()
-      visitor.current.position.set(6.1 + (s.reduced ? 0 : Math.sin(t * 0.8) * 0.05), 0, -1.2)
+      visitor.current.position.set(6.1 + (s.reduced ? 0 : Math.sin(t * 0.8) * 0.05), 0.06, -1.2)
       visitor.current.scale.setScalar(Math.max(o, 0.001))
       visitor.current.visible = o > 0.01
     }
@@ -69,12 +69,12 @@ export default function FrontDesk() {
         </mesh>
       </group>
       <group ref={g} position={DESK}>
-        <mesh position={[0, 1.45, 0]}>
-          <cylinderGeometry args={[0.03, 0.03, 1.2, 8]} />
+        <mesh position={[0, 2.05, 0]}>
+          <cylinderGeometry args={[0.03, 0.03, 2.4, 8]} />
           <meshStandardMaterial color="#8a8272" roughness={0.6} />
         </mesh>
         {TOOLS.map((tool, k) => (
-          <Html key={tool.name} position={[1.0, 0.9 + k * 0.7, -1.4]} center zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
+          <Html key={tool.name} position={[1.0, 0.9 + k * 1.05, -1.4]} center zIndexRange={[7, 0]} style={{ pointerEvents: 'none' }}>
             <div
               ref={(el) => {
                 cards.current[k] = el

--- a/web/src/components/building/HealDemo.tsx
+++ b/web/src/components/building/HealDemo.tsx
@@ -2,10 +2,19 @@ import { useFrame } from '@react-three/fiber'
 import { Html } from '@react-three/drei'
 import { useMemo, useRef } from 'react'
 import * as THREE from 'three'
-import { KIOSK_H, PLATE, SLAB_T, TRAVELLER_COLORS, findRoom, floorY, roomStand } from './model'
+import { KIOSK_H, PLATE, SLAB_T, TRAVELLER_COLORS, findRoom, floorY, roomStand, surfaceAt } from './model'
+import { pointAt, routeOnFloor, type Path } from './geometry'
 import { smoothstep } from './chapters'
 import { useShared } from './state'
 import { Walker } from './Agents'
+
+function pathFromStands(floor: number, a: THREE.Vector3, b: THREE.Vector3): Path {
+  const route = routeOnFloor(floor, a.x, a.z, b.x, b.z)
+  const points = route.map((p) => new THREE.Vector3(p.x, surfaceAt(floor, p.x, p.z), p.z))
+  const cum = [0]
+  for (let i = 1; i < points.length; i++) cum.push(cum[i - 1] + points[i].distanceTo(points[i - 1]))
+  return { points, cum, stops: [0, points.length - 1], length: cum[cum.length - 1] }
+}
 
 // Chapter 05. A looping vignette on the Checkout floor: the ContinueButton
 // room slides to a new position (a redesign), a test walks to where the room
@@ -54,6 +63,8 @@ export default function HealDemo() {
   const from = useMemo(() => new THREE.Vector3(...roomStand(FLOOR, findRoom(FLOOR, 'PaymentForm'))), [])
   const oldPos = useMemo(() => new THREE.Vector3(...roomStand(FLOOR, room, 0)), [room])
   const newPos = useMemo(() => new THREE.Vector3(...roomStand(FLOOR, room, 1)), [room])
+  const walk1 = useMemo(() => pathFromStands(FLOOR, from, oldPos), [from, oldPos])
+  const walk2 = useMemo(() => pathFromStands(FLOOR, oldPos, newPos), [oldPos, newPos])
   const tmp = useMemo(() => new THREE.Vector3(), [])
   const start = useRef<number | null>(null)
   const lastPhase = useRef<Phase>('reset')
@@ -78,11 +89,11 @@ export default function HealDemo() {
     if (walker.current) {
       let p = from
       if (phase === 'walk') {
-        p = tmp.copy(from).lerp(oldPos, smoothstep((t - T.slideStart) / (T.walkEnd - T.slideStart)))
+        p = pointAt(walk1, walk1.length * smoothstep((t - T.slideStart) / (T.walkEnd - T.slideStart)), tmp)
       } else if (phase === 'fail' || phase === 'update') {
         p = oldPos
       } else if (phase === 'walk2') {
-        p = tmp.copy(oldPos).lerp(newPos, smoothstep((t - T.updateEnd) / (T.walk2End - T.updateEnd)))
+        p = pointAt(walk2, walk2.length * smoothstep((t - T.updateEnd) / (T.walk2End - T.updateEnd)), tmp)
       } else if (phase === 'pass') {
         p = newPos
       }

--- a/web/src/components/building/Lights.tsx
+++ b/web/src/components/building/Lights.tsx
@@ -4,12 +4,14 @@ import * as THREE from 'three'
 import { useShared } from './state'
 
 // Daylight from the front-right, softening to moonlight at nightfall. One
-// shadow-casting directional light covers the whole table.
+// shadow-casting directional light covers the whole table. A warm unshadowed
+// point light comes up at night so the interiors stay readable.
 export default function Lights() {
   const s = useShared()
   const dir = useRef<THREE.DirectionalLight>(null)
   const amb = useRef<THREE.AmbientLight>(null)
   const hemi = useRef<THREE.HemisphereLight>(null)
+  const fill = useRef<THREE.PointLight>(null)
   const col = useMemo(
     () => ({
       day: new THREE.Color('#fff2dc'),
@@ -22,31 +24,34 @@ export default function Lights() {
   useFrame(() => {
     const n = s.cur.night
     if (dir.current) {
-      dir.current.intensity = THREE.MathUtils.lerp(1.85, 0.45, n)
+      dir.current.intensity = THREE.MathUtils.lerp(1.7, 0.45, n)
       dir.current.color.copy(col.day).lerp(col.night, n)
     }
     if (amb.current) {
-      amb.current.intensity = THREE.MathUtils.lerp(0.72, 0.32, n)
+      amb.current.intensity = THREE.MathUtils.lerp(0.78, 0.36, n)
       amb.current.color.copy(col.ambDay).lerp(col.ambNight, n)
     }
-    if (hemi.current) hemi.current.intensity = THREE.MathUtils.lerp(0.7, 0.28, n)
+    if (hemi.current) hemi.current.intensity = THREE.MathUtils.lerp(0.7, 0.32, n)
+    if (fill.current) fill.current.intensity = s.mobile ? 0 : 35 * n
   })
   const mapSize = s.mobile ? 1024 : 2048
   return (
     <>
-      <ambientLight ref={amb} intensity={0.72} />
+      <ambientLight ref={amb} intensity={0.78} />
       <hemisphereLight ref={hemi} args={['#ffffff', '#5a7ac9', 0.7]} />
       <directionalLight
         ref={dir}
         position={[13, 15, -7]}
-        intensity={1.85}
+        intensity={1.7}
         castShadow
+        shadow-intensity={0.7}
         shadow-mapSize={[mapSize, mapSize]}
         shadow-bias={-0.0004}
         shadow-normalBias={0.03}
       >
         <orthographicCamera attach="shadow-camera" args={[-15, 15, 15, -15, 1, 50]} />
       </directionalLight>
+      <pointLight ref={fill} position={[1.2, 4.5, 0.4]} color="#ffd7a0" intensity={0} distance={8} decay={2} />
     </>
   )
 }

--- a/web/src/components/building/Scene.tsx
+++ b/web/src/components/building/Scene.tsx
@@ -113,7 +113,7 @@ export function Rig() {
 
     // Desktop: the story card sits on the left, so push the model right.
     // Mobile: the card sits at the bottom, so push the model up.
-    // Billboard: nudge the tower left so the floor directory fits in the frame.
+    // Billboard: nudge the tower slightly left in the tight crop.
     const shiftRight = billboard ? (-size.width * 0.07) / zoom : s.mobile ? (-size.width * 0.12) / zoom : (size.width * 0.13) / zoom
     const shiftUp = billboard || !s.mobile ? 0 : (size.height * 0.11) / zoom
     v.target.set(0, c.lookY, 0).addScaledVector(v.right, -shiftRight).addScaledVector(v.up, -shiftUp)
@@ -132,13 +132,17 @@ export function Rig() {
 
 /** Everything on the table. Reads the shared state; needs a driver and a Rig. */
 export function SceneContent() {
+  const s = useShared()
+  // The homepage crop is too tight for the floor directory — those Html
+  // portals stack above the "Enter the building" chip. The tour still shows them.
+  const wayfinding = s.frame !== 'billboard'
   return (
     <>
       <Lights />
       <Table />
       <Tower />
       <Core />
-      <Wayfinding />
+      {wayfinding && <Wayfinding />}
       <Agents />
       <HealDemo />
       <Trajectory />

--- a/web/src/components/building/Table.tsx
+++ b/web/src/components/building/Table.tsx
@@ -35,7 +35,7 @@ export default function Table() {
       </RoundedBox>
       <Line points={grid} segments color="#2f62b8" lineWidth={1} transparent opacity={0.5} depthWrite={false} />
       <Html
-        position={[-TABLE.w / 2 + 0.6, 0.02, TABLE.d / 2 - 0.6]}
+        position={[-TABLE.w / 2 + 2.8, 0.02, TABLE.d / 2 - 2.3]}
         zIndexRange={[4, 0]}
         style={{ pointerEvents: 'none' }}
       >

--- a/web/src/components/building/Table.tsx
+++ b/web/src/components/building/Table.tsx
@@ -1,5 +1,5 @@
 import { useFrame } from '@react-three/fiber'
-import { Html, Line, RoundedBox } from '@react-three/drei'
+import { Line, RoundedBox } from '@react-three/drei'
 import { useMemo, useRef } from 'react'
 import * as THREE from 'three'
 import { TABLE } from './model'
@@ -34,16 +34,6 @@ export default function Table() {
         <meshStandardMaterial ref={mat} color="#12315f" roughness={0.96} />
       </RoundedBox>
       <Line points={grid} segments color="#2f62b8" lineWidth={1} transparent opacity={0.5} depthWrite={false} />
-      <Html
-        position={[-TABLE.w / 2 + 2.8, 0.02, TABLE.d / 2 - 2.3]}
-        zIndexRange={[4, 0]}
-        style={{ pointerEvents: 'none' }}
-      >
-        <div className="bld-titleblock">
-          <span>Drawing set A-101</span>
-          <span>northwind-air · .sightmap/ · v1</span>
-        </div>
-      </Html>
     </group>
   )
 }

--- a/web/src/components/building/Tower.tsx
+++ b/web/src/components/building/Tower.tsx
@@ -86,7 +86,12 @@ function useMaterials(): Mats {
     }
     return {
       kinds,
-      slab: new THREE.MeshStandardMaterial({ color: '#f2ece3', roughness: 0.92 }),
+      slab: new THREE.MeshStandardMaterial({
+        color: '#f2ece3',
+        roughness: 0.92,
+        emissive: new THREE.Color('#ffc36a'),
+        emissiveIntensity: 0,
+      }),
       steel: new THREE.MeshStandardMaterial({ color: STEEL, roughness: 0.55, metalness: 0.2 }),
       glass: new THREE.MeshStandardMaterial({
         color: '#cfe3f5',
@@ -120,10 +125,11 @@ function useMaterials(): Mats {
     mats.spandrel.color.copy(col.spDay).lerp(col.spNight, n)
     mats.glass.color.copy(col.glassDay).lerp(col.glassNight, n)
     mats.glass.emissiveIntensity = n * 0.9
-    mats.glass.opacity = THREE.MathUtils.lerp(0.22, 0.5, n)
-    mats.furniture.monitor.emissiveIntensity = THREE.MathUtils.lerp(0.25, 1.3, n)
-    mats.furniture.screen.emissiveIntensity = THREE.MathUtils.lerp(0.3, 1.2, n)
-    for (const k of Object.keys(mats.kinds) as Kind[]) mats.kinds[k].emissiveIntensity = n * 0.35
+    mats.glass.opacity = THREE.MathUtils.lerp(0.22, 0.42, n)
+    mats.slab.emissiveIntensity = n * 0.14
+    mats.furniture.monitor.emissiveIntensity = THREE.MathUtils.lerp(0.25, 1.55, n)
+    mats.furniture.screen.emissiveIntensity = THREE.MathUtils.lerp(0.3, 1.45, n)
+    for (const k of Object.keys(mats.kinds) as Kind[]) mats.kinds[k].emissiveIntensity = n * 0.5
   })
   return mats
 }

--- a/web/src/components/building/Wayfinding.tsx
+++ b/web/src/components/building/Wayfinding.tsx
@@ -76,6 +76,7 @@ export default function Wayfinding() {
           key={k}
           position={a.pos}
           center={a.kind === 'tag'}
+          transform={false}
           zIndexRange={[6, 0]}
           style={{ pointerEvents: 'none' }}
         >

--- a/web/src/components/building/chapters.ts
+++ b/web/src/components/building/chapters.ts
@@ -169,8 +169,7 @@ export const CHAPTERS: Chapter[] = [
         ['Runs passed', '128 / 128'],
       ],
     },
-    focus: 'Regression',
-    scene: { ...base, labels: 0.4, agents: 0.35, heal: 1, az: 50, el: 22, zoom: 1.22, lookY: 8.2 },
+    scene: { ...base, labels: 0.4, agents: 0, heal: 1, az: 50, el: 22, zoom: 1.22, lookY: 8.2 },
   },
   {
     id: 'trajectories',
@@ -189,7 +188,7 @@ export const CHAPTERS: Chapter[] = [
       ],
     },
     focus: 'BookFlight',
-    scene: { ...base, labels: 0.5, agents: 0.35, trajectory: 1, az: 44, el: 26, zoom: 1.05, lookY: 5.8 },
+    scene: { ...base, labels: 0.5, agents: 0.6, trajectory: 1, az: 44, el: 26, zoom: 1.05, lookY: 5.8 },
   },
   {
     id: 'web-mcp',

--- a/web/src/components/building/geometry.test.ts
+++ b/web/src/components/building/geometry.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+import { furnish } from './furnish'
+import { buildPath, routeOnFloor } from './geometry'
+import {
+  CORE,
+  FLOOR_H,
+  FLOORS,
+  JOURNEYS,
+  LANES,
+  SLAB_T,
+  findRoom,
+  roomStand,
+} from './model'
+
+const RADIUS = 0.13
+const SKIP_TYPES = new Set(['partition', 'rail'])
+
+interface Obstacle {
+  x: number
+  z: number
+  sx: number
+  sz: number
+  ry: number
+  label: string
+}
+
+function obstaclesOn(floor: number, skipKiosk?: string): Obstacle[] {
+  const out: Obstacle[] = []
+  for (const room of FLOORS[floor].rooms) {
+    for (const it of furnish(room)) {
+      if (SKIP_TYPES.has(it.type)) continue
+      if (it.y - it.sy / 2 > 0.75) continue
+      out.push({ x: it.x, z: it.z, sx: it.sx, sz: it.sz, ry: it.ry, label: `${room.name}:${it.type}` })
+    }
+    if (room.kind === 'action' && room.name !== skipKiosk) {
+      out.push({ x: room.x, z: room.z, sx: 0.55, sz: 0.55, ry: 0, label: `${room.name}:kiosk` })
+    }
+  }
+  return out
+}
+
+function inside(x: number, z: number, minx: number, minz: number, maxx: number, maxz: number): boolean {
+  return x >= minx && x <= maxx && z >= minz && z <= maxz
+}
+
+function segmentHitsAabb(
+  x0: number,
+  z0: number,
+  x1: number,
+  z1: number,
+  minx: number,
+  minz: number,
+  maxx: number,
+  maxz: number
+): boolean {
+  if (inside(x0, z0, minx, minz, maxx, maxz) || inside(x1, z1, minx, minz, maxx, maxz)) return true
+  const dx = x1 - x0
+  const dz = z1 - z0
+  let t0 = 0
+  let t1 = 1
+  const clip = (p: number, q: number): boolean => {
+    if (Math.abs(p) < 1e-9) return q >= 0
+    const r = q / p
+    if (p < 0) {
+      if (r > t1) return false
+      if (r > t0) t0 = r
+    } else {
+      if (r < t0) return false
+      if (r < t1) t1 = r
+    }
+    return true
+  }
+  return clip(-dx, x0 - minx) && clip(dx, maxx - x0) && clip(-dz, z0 - minz) && clip(dz, maxz - z0)
+}
+
+function hits(ax: number, az: number, bx: number, bz: number, it: Obstacle): boolean {
+  const c = Math.cos(-it.ry)
+  const s = Math.sin(-it.ry)
+  const loc = (x: number, z: number): [number, number] => {
+    const dx = x - it.x
+    const dz = z - it.z
+    return [dx * c - dz * s, dx * s + dz * c]
+  }
+  const [axl, azl] = loc(ax, az)
+  const [bxl, bzl] = loc(bx, bz)
+  const hw = it.sx / 2 + RADIUS
+  const hd = it.sz / 2 + RADIUS
+  return segmentHitsAabb(axl, azl, bxl, bzl, -hw, -hd, hw, hd)
+}
+
+function collisions(ax: number, az: number, bx: number, bz: number, obs: Obstacle[]): string[] {
+  return obs.filter((it) => hits(ax, az, bx, bz, it)).map((it) => it.label)
+}
+
+describe('lane graph', () => {
+  it('keeps every lane segment clear of low furniture', () => {
+    const hitsAll: string[] = []
+    LANES.forEach((lanes, floor) => {
+      const obs = obstaclesOn(floor)
+      for (const lane of lanes) {
+        for (let i = 0; i < lane.length - 1; i++) {
+          const [ax, az] = lane[i]
+          const [bx, bz] = lane[i + 1]
+          for (const label of collisions(ax, az, bx, bz, obs)) {
+            hitsAll.push(`F${floor} ${ax},${az}→${bx},${bz} ${label}`)
+          }
+        }
+      }
+    })
+    expect(hitsAll).toEqual([])
+  })
+})
+
+describe('buildPath', () => {
+  it('does not emit consecutive duplicate points', () => {
+    for (const j of JOURNEYS) {
+      const path = buildPath(j)
+      for (let i = 1; i < path.points.length; i++) {
+        expect(path.points[i].distanceToSquared(path.points[i - 1]), `${j.name} dup at ${i}`).toBeGreaterThan(1e-6)
+      }
+    }
+  })
+
+  it('routes floor changes through the core at both floor heights', () => {
+    for (const j of JOURNEYS) {
+      const path = buildPath(j)
+      for (let k = 1; k < j.stops.length; k++) {
+        const [pf] = j.stops[k - 1]
+        const [f] = j.stops[k]
+        if (pf === f) continue
+        const ys = path.points.filter((p) => Math.hypot(p.x - CORE.x, p.z - CORE.z) < 1e-3).map((p) => p.y)
+        expect(ys.some((y) => Math.abs(y - (pf * FLOOR_H + SLAB_T)) < 0.2), `${j.name} missing core at F${pf}`).toBe(true)
+        expect(ys.some((y) => Math.abs(y - (f * FLOOR_H + SLAB_T)) < 0.2), `${j.name} missing core at F${f}`).toBe(true)
+      }
+    }
+  })
+
+  it('keeps every journey leg clear of low furniture', () => {
+    const hitsAll: string[] = []
+    for (const j of JOURNEYS) {
+      const path = buildPath(j)
+      for (let k = 1; k < j.stops.length; k++) {
+        const [pf, fromName] = j.stops[k - 1]
+        const [f, toName] = j.stops[k]
+        const a = path.stops[k - 1]
+        const b = path.stops[k]
+        for (let i = a; i < b; i++) {
+          const p = path.points[i]
+          const q = path.points[i + 1]
+          if (Math.abs(p.y - q.y) > 0.3) continue
+          const useFloor = Math.abs(p.y - (pf * FLOOR_H + SLAB_T)) < Math.abs(p.y - (f * FLOOR_H + SLAB_T)) ? pf : f
+          const obs = obstaclesOn(useFloor, toName)
+          for (const label of collisions(p.x, p.z, q.x, q.z, obs)) {
+            hitsAll.push(`${j.name} ${fromName}→${toName} ${p.x.toFixed(2)},${p.z.toFixed(2)}→${q.x.toFixed(2)},${q.z.toFixed(2)} ${label}`)
+          }
+        }
+      }
+    }
+    expect(hitsAll).toEqual([])
+  })
+})
+
+describe('HealDemo legs', () => {
+  it('routes PaymentForm to both ContinueButton stands without clipping', () => {
+    const hitsAll: string[] = []
+    const from = roomStand(3, findRoom(3, 'PaymentForm'))
+    const room = findRoom(3, 'ContinueButton')
+    const oldPos = roomStand(3, room, 0)
+    const newPos = roomStand(3, room, 1)
+    const legs: [string, [number, number, number], [number, number, number]][] = [
+      ['pay→old', from, oldPos],
+      ['old→new', oldPos, newPos],
+    ]
+    for (const [label, a, b] of legs) {
+      const route = routeOnFloor(3, a[0], a[2], b[0], b[2])
+      const obs = obstaclesOn(3, 'ContinueButton')
+      for (let i = 0; i < route.length - 1; i++) {
+        const p = route[i]
+        const q = route[i + 1]
+        for (const hit of collisions(p.x, p.z, q.x, q.z, obs)) {
+          hitsAll.push(`${label} ${p.x.toFixed(2)},${p.z.toFixed(2)}→${q.x.toFixed(2)},${q.z.toFixed(2)} ${hit}`)
+        }
+      }
+    }
+    expect(hitsAll).toEqual([])
+  })
+})
+
+describe('roomStand', () => {
+  it('places walkers on the slab, not below it', () => {
+    for (const j of JOURNEYS) {
+      for (const [f, name] of j.stops) {
+        const stand = roomStand(f, findRoom(f, name))
+        expect(stand[1], `${name} F${f}`).toBeGreaterThanOrEqual(f * FLOOR_H + SLAB_T - 1e-6)
+      }
+    }
+  })
+})

--- a/web/src/components/building/geometry.ts
+++ b/web/src/components/building/geometry.ts
@@ -9,11 +9,11 @@ import {
   FLOORS,
   FLOOR_D,
   FLOOR_W,
+  LANES,
   SHEET,
-  SLAB_T,
   findRoom,
-  floorY,
   roomStand,
+  surfaceAt,
   type Journey,
 } from './model'
 import { DRAWN, furnish } from './furnish'
@@ -42,7 +42,7 @@ export function sheetLinePoints(floorIndex: number): P3[] {
   pts.push([tbx - 0.4, y, tbz - 0.32], [tbx - 0.4, y, tbz + 0.32])
   // Core and its door.
   rect(CORE.x, CORE.z, CORE.w, CORE.d)
-  pts.push([CORE.x + CORE.w / 2, y, CORE.z - 0.35], [CORE.x + CORE.w / 2 + 0.45, y, CORE.z - 0.35])
+  pts.push([CORE.x + CORE.w / 2, y, CORE_DOOR.z], [CORE_DOOR.x, y, CORE_DOOR.z])
   // Door swing on the core.
   const arc = (cx: number, cz: number, rad: number, a0: number, a1: number) => {
     const n = 6
@@ -52,7 +52,7 @@ export function sheetLinePoints(floorIndex: number): P3[] {
       pts.push([cx + Math.cos(t0) * rad, y, cz + Math.sin(t0) * rad], [cx + Math.cos(t1) * rad, y, cz + Math.sin(t1) * rad])
     }
   }
-  arc(CORE.x + CORE.w / 2, CORE.z - 0.35, 0.45, 0, Math.PI / 2)
+  arc(CORE.x + CORE.w / 2, CORE_DOOR.z, 0.45, 0, Math.PI / 2)
   // Rooms, with the footprints of their furniture drawn lighter in spirit:
   // the same layout the built floor gets, so the drawing is the plan.
   for (const r of FLOORS[floorIndex].rooms) {
@@ -94,9 +94,192 @@ export interface Path {
   length: number
 }
 
+type P2 = { x: number; z: number }
+
+const EPS = 1e-4
+
+interface Graph {
+  nodes: Map<string, P2>
+  adj: Map<string, { to: string; w: number }[]>
+}
+
+const quant = (n: number): number => Math.round(n * 1000) / 1000
+const nid = (x: number, z: number): string => `${quant(x)},${quant(z)}`
+
+function addNode(g: Graph, x: number, z: number): string {
+  const k = nid(x, z)
+  if (!g.nodes.has(k)) {
+    g.nodes.set(k, { x: quant(x), z: quant(z) })
+    g.adj.set(k, [])
+  }
+  return k
+}
+
+function addEdge(g: Graph, a: string, b: string): void {
+  if (a === b) return
+  const pa = g.nodes.get(a)!
+  const pb = g.nodes.get(b)!
+  const w = Math.hypot(pa.x - pb.x, pa.z - pb.z)
+  const ea = g.adj.get(a)!
+  if (!ea.some((e) => e.to === b)) ea.push({ to: b, w })
+  const eb = g.adj.get(b)!
+  if (!eb.some((e) => e.to === a)) eb.push({ to: a, w })
+}
+
+function between(t: number, a: number, b: number): boolean {
+  return t >= Math.min(a, b) - EPS && t <= Math.max(a, b) + EPS
+}
+
+function laneSegments(floor: number): { a: P2; b: P2 }[] {
+  const segs: { a: P2; b: P2 }[] = []
+  for (const lane of LANES[floor]) {
+    for (let i = 0; i < lane.length - 1; i++) {
+      segs.push({ a: { x: lane[i][0], z: lane[i][1] }, b: { x: lane[i + 1][0], z: lane[i + 1][1] } })
+    }
+  }
+  return segs
+}
+
+function isH(s: { a: P2; b: P2 }): boolean {
+  return Math.abs(s.a.z - s.b.z) < EPS
+}
+
+function isV(s: { a: P2; b: P2 }): boolean {
+  return Math.abs(s.a.x - s.b.x) < EPS
+}
+
+function splitPoints(s: { a: P2; b: P2 }, others: { a: P2; b: P2 }[]): P2[] {
+  const pts: P2[] = [{ ...s.a }, { ...s.b }]
+  for (const o of others) {
+    if (isH(s) && isV(o)) {
+      const z = s.a.z
+      const x = o.a.x
+      if (between(x, s.a.x, s.b.x) && between(z, o.a.z, o.b.z)) pts.push({ x, z })
+    } else if (isV(s) && isH(o)) {
+      const x = s.a.x
+      const z = o.a.z
+      if (between(z, s.a.z, s.b.z) && between(x, o.a.x, o.b.x)) pts.push({ x, z })
+    }
+    if (isH(s) && isH(o) && Math.abs(s.a.z - o.a.z) < EPS) {
+      if (between(o.a.x, s.a.x, s.b.x)) pts.push({ x: o.a.x, z: s.a.z })
+      if (between(o.b.x, s.a.x, s.b.x)) pts.push({ x: o.b.x, z: s.a.z })
+    }
+    if (isV(s) && isV(o) && Math.abs(s.a.x - o.a.x) < EPS) {
+      if (between(o.a.z, s.a.z, s.b.z)) pts.push({ x: s.a.x, z: o.a.z })
+      if (between(o.b.z, s.a.z, s.b.z)) pts.push({ x: s.a.x, z: o.b.z })
+    }
+  }
+  return pts
+}
+
+const graphs: Graph[] = []
+
+function graphFor(floor: number): Graph {
+  const cached = graphs[floor]
+  if (cached) return cached
+  const g: Graph = { nodes: new Map(), adj: new Map() }
+  const raw = laneSegments(floor)
+  for (const s of raw) {
+    const pts = splitPoints(s, raw)
+    if (isH(s)) pts.sort((a, b) => a.x - b.x)
+    else pts.sort((a, b) => a.z - b.z)
+    const uniq: P2[] = []
+    for (const p of pts) {
+      const last = uniq[uniq.length - 1]
+      if (!last || Math.hypot(p.x - last.x, p.z - last.z) > EPS) uniq.push(p)
+    }
+    for (let i = 0; i < uniq.length - 1; i++) {
+      addEdge(g, addNode(g, uniq[i].x, uniq[i].z), addNode(g, uniq[i + 1].x, uniq[i + 1].z))
+    }
+  }
+  graphs[floor] = g
+  return g
+}
+
+function cloneGraph(src: Graph): Graph {
+  const g: Graph = { nodes: new Map(), adj: new Map() }
+  for (const [k, p] of src.nodes) g.nodes.set(k, { ...p })
+  for (const [k, edges] of src.adj) g.adj.set(k, edges.map((e) => ({ ...e })))
+  return g
+}
+
+function projectToGraph(g: Graph, x: number, z: number): { x: number; z: number; a: string; b: string } {
+  let best = { d: Infinity, x, z, a: '', b: '' }
+  for (const [ak, nbrs] of g.adj) {
+    const A = g.nodes.get(ak)!
+    for (const e of nbrs) {
+      if (e.to <= ak) continue
+      const B = g.nodes.get(e.to)!
+      const vx = B.x - A.x
+      const vz = B.z - A.z
+      const len2 = vx * vx + vz * vz
+      const t = len2 < EPS ? 0 : Math.max(0, Math.min(1, ((x - A.x) * vx + (z - A.z) * vz) / len2))
+      const px = A.x + vx * t
+      const pz = A.z + vz * t
+      const d = Math.hypot(x - px, z - pz)
+      if (d < best.d) best = { d, x: px, z: pz, a: ak, b: e.to }
+    }
+  }
+  return best
+}
+
+function dijkstra(g: Graph, start: string, end: string): string[] {
+  const dist = new Map<string, number>([[start, 0]])
+  const prev = new Map<string, string>()
+  const pq: { k: string; d: number }[] = [{ k: start, d: 0 }]
+  while (pq.length) {
+    let best = 0
+    for (let i = 1; i < pq.length; i++) if (pq[i].d < pq[best].d) best = i
+    const { k, d } = pq.splice(best, 1)[0]
+    if (d !== dist.get(k)) continue
+    if (k === end) break
+    for (const e of g.adj.get(k) ?? []) {
+      const nd = d + e.w
+      if (nd < (dist.get(e.to) ?? Infinity)) {
+        dist.set(e.to, nd)
+        prev.set(e.to, k)
+        pq.push({ k: e.to, d: nd })
+      }
+    }
+  }
+  const path = [end]
+  while (path[0] !== start) {
+    const p = prev.get(path[0])
+    if (!p) break
+    path.unshift(p)
+  }
+  return path
+}
+
+/** Axis-aligned lane route on one floor, including the start and end stands. */
+export function routeOnFloor(floor: number, ax: number, az: number, bx: number, bz: number): P2[] {
+  if (Math.hypot(ax - bx, az - bz) < EPS) return [{ x: ax, z: az }]
+  const g = cloneGraph(graphFor(floor))
+  const pa = projectToGraph(g, ax, az)
+  const pb = projectToGraph(g, bx, bz)
+  const sa = addNode(g, pa.x, pa.z)
+  const sb = addNode(g, pb.x, pb.z)
+  addEdge(g, sa, pa.a)
+  addEdge(g, sa, pa.b)
+  addEdge(g, sb, pb.a)
+  addEdge(g, sb, pb.b)
+  const ids = dijkstra(g, sa, sb)
+  const out: P2[] = []
+  const push = (p: P2) => {
+    const last = out[out.length - 1]
+    if (!last || Math.hypot(p.x - last.x, p.z - last.z) > EPS) out.push(p)
+  }
+  push({ x: ax, z: az })
+  if (Math.hypot(ax - pa.x, az - pa.z) > EPS) push({ x: pa.x, z: pa.z })
+  for (const k of ids) push(g.nodes.get(k)!)
+  if (Math.hypot(bx - pb.x, bz - pb.z) > EPS) push({ x: pb.x, z: pb.z })
+  push({ x: bx, z: bz })
+  return out
+}
+
 /**
- * The walk for a journey: room to room on the same floor, or room → core
- * door → up the shaft → out the door → room when the floor changes.
+ * The walk for a journey: room to room along that floor's lanes, or
+ * room → door → up the shaft → out the door → room when the floor changes.
  * `lift` raises the whole path (the trajectory ribbon floats a little).
  */
 export function buildPath(journey: Journey, lift = 0, healShift = 0): Path {
@@ -108,24 +291,32 @@ export function buildPath(journey: Journey, lift = 0, healShift = 0): Path {
     if (!last || last.distanceToSquared(v) > 1e-6) points.push(v)
     return points.length - 1
   }
+  const follow = (floor: number, route: { x: number; z: number }[], skipFirst: boolean) => {
+    for (const p of skipFirst ? route.slice(1) : route) {
+      push([p.x, surfaceAt(floor, p.x, p.z), p.z])
+    }
+  }
+  let last: P3 | null = null
   for (let k = 0; k < journey.stops.length; k++) {
     const [f, name] = journey.stops[k]
     const room = findRoom(f, name)
     const stand = roomStand(f, room, room.alt ? healShift : 0)
-    if (k === 0) {
+    if (!last) {
       stops.push(push(stand))
+      last = stand
       continue
     }
     const [pf] = journey.stops[k - 1]
     if (pf !== f) {
-      const yA = floorY(pf) + SLAB_T
-      const yB = floorY(f) + SLAB_T
-      push([CORE_DOOR.x, yA, CORE_DOOR.z])
-      push([CORE.x, yA, CORE.z])
-      push([CORE.x, yB, CORE.z])
-      push([CORE_DOOR.x, yB, CORE_DOOR.z])
+      follow(pf, routeOnFloor(pf, last[0], last[2], CORE_DOOR.x, CORE_DOOR.z), true)
+      push([CORE.x, surfaceAt(pf, CORE.x, CORE.z), CORE.z])
+      push([CORE.x, surfaceAt(f, CORE.x, CORE.z), CORE.z])
+      follow(f, routeOnFloor(f, CORE_DOOR.x, CORE_DOOR.z, stand[0], stand[2]), false)
+    } else {
+      follow(f, routeOnFloor(f, last[0], last[2], stand[0], stand[2]), true)
     }
-    stops.push(push(stand))
+    stops.push(points.length - 1)
+    last = stand
   }
   const cum = [0]
   for (let i = 1; i < points.length; i++) cum.push(cum[i - 1] + points[i].distanceTo(points[i - 1]))

--- a/web/src/components/building/model.ts
+++ b/web/src/components/building/model.ts
@@ -38,6 +38,8 @@ export interface Room {
   memory?: string
   /** Where the room moves to in the self-healing chapter. */
   alt?: { x: number; z: number }
+  /** Override the walker's stand [x, z] when the geometric front is blocked. */
+  stand?: [number, number]
 }
 
 export interface Floor {
@@ -80,7 +82,48 @@ export const KIOSK_H = 1.0
 /** Service core: elevator shaft + risers, in the back corner. */
 export const CORE = { x: -3.9, z: -2.9, w: 1.6, d: 1.5 }
 /** Where a walker steps out of the core onto a floor. */
-export const CORE_DOOR = { x: -2.65, z: -2.9 }
+export const CORE_DOOR = { x: -2.65, z: -2.5 }
+/** Open +Z dollhouse face — the shared front aisle on every floor. */
+export const AISLE_Z = FLOOR_D / 2 - 0.3
+
+/**
+ * Per-floor circulation: axis-aligned polylines. Walkers project onto the
+ * nearest lane and route along the graph rather than cutting through rooms.
+ * First vertex of the trunk is CORE_DOOR so elevator hops connect cleanly.
+ */
+export const LANES: [number, number][][][] = [
+  [
+    [[-2.65, -2.5], [-1.9, -2.5], [-1.9, 0.85], [-1.9, 3.45]],
+    [[-4.4, 0.85], [4.4, 0.85]],
+    [[-4.4, 3.45], [4.4, 3.45]],
+  ],
+  [
+    [[-2.65, -2.5], [-2.85, -2.5], [-2.85, 0.3], [-0.4, 0.3], [-0.4, 3.45]],
+    [[-4.4, 0.3], [4.4, 0.3]],
+    [[-4.4, 3.45], [4.4, 3.45]],
+  ],
+  [
+    [[-2.65, -2.5], [-2.75, -2.5], [-2.75, 3.45]],
+    [[-2.75, -2.5], [3.0, -2.5]],
+    [[-2.75, 1.24], [4.4, 1.24]],
+    [[-4.4, 3.45], [4.4, 3.45]],
+  ],
+  [
+    [[-2.65, -2.5], [-2.2, -2.5], [-2.2, 1.35], [3.0, 1.35], [3.0, 3.45]],
+    [[-4.4, 1.35], [4.4, 1.35]],
+    [[-4.4, 3.45], [4.4, 3.45]],
+  ],
+  [
+    [[-2.65, -2.5], [-2.3, -2.5], [-2.3, 0.75], [1.7, 0.75], [1.7, 3.45]],
+    [[-3.0, 0.75], [4.4, 0.75]],
+    [[-4.4, 3.45], [4.4, 3.45]],
+  ],
+  [
+    [[-2.65, -2.5], [3.7, -2.5], [3.7, 3.45]],
+    [[-4.4, 0.85], [0.12, 0.85], [0.12, 3.45]],
+    [[-4.4, 3.45], [4.4, 3.45]],
+  ],
+]
 
 export const TABLE = { w: 17.5, d: 14.5, t: 0.36 }
 export const SHEET = { w: 10.9, d: 8.4 }
@@ -152,6 +195,7 @@ export const FLOORS: Floor[] = [
         h: 0.6,
         kind: 'content',
         base: 0.2,
+        stand: [0.6, 1.24],
         blocks: [
           { x: 0.6, z: -1.2, w: 5.2, d: 1.25 },
           { x: 0.6, z: 0.4, w: 5.2, d: 1.25 },
@@ -329,13 +373,26 @@ export function findRoom(floor: number, name: string): Room {
   return room
 }
 
-/** Where a walker stands when visiting a room: on its floor zone, at the
- *  front edge so it is not inside the furniture. */
+/** Deck height at a point: slab plus the tallest zone carpet covering it. */
+export function surfaceAt(floor: number, x: number, z: number): number {
+  let lift = 0
+  for (const room of FLOORS[floor].rooms) {
+    const blocks = room.blocks ?? [{ x: room.x, z: room.z, w: room.w, d: room.d }]
+    if (!blocks.some((b) => Math.abs(x - b.x) <= b.w / 2 && Math.abs(z - b.z) <= b.d / 2)) continue
+    const top = (room.base ? PLATE : 0) + PLATE
+    if (top > lift) lift = top
+  }
+  return floorY(floor) + SLAB_T + lift
+}
+
+/** Where a walker stands when visiting a room: just outside the front of
+ *  its zone, on whatever carpet is actually underfoot. */
 export function roomStand(floor: number, room: Room, shift = 0): [number, number, number] {
-  const x = room.alt ? room.x + (room.alt.x - room.x) * shift : room.x
-  const z = room.alt ? room.z + (room.alt.z - room.z) * shift : room.z
-  const front = room.kind === 'action' ? room.d / 2 + 0.35 : Math.max(0, room.d / 2 - 0.35)
-  return [x, floorY(floor) + SLAB_T + (room.base ? PLATE : 0) + PLATE, z + front]
+  const rx = room.alt ? room.x + (room.alt.x - room.x) * shift : room.x
+  const rz = room.alt ? room.z + (room.alt.z - room.z) * shift : room.z
+  const x = room.stand ? room.stand[0] : rx
+  const z = room.stand ? room.stand[1] : Math.min(rz + room.d / 2 + (room.kind === 'action' ? 0.35 : 0.25), AISLE_Z)
+  return [x, surfaceAt(floor, x, z), z]
 }
 
 /** Top of a room's tallest element, for hanging a label over it. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homepage and `/building` visual polish from the landing-page audit. Fixes overlay stacking, chapter-rail padding, harsh shadows, tilted memory notes, walker-ring z-fighting, furniture-cutting paths, the tiny self-healing crowd, overlapping MCP cards, and nightfall interiors. Drops the DRAWING SET title block — it only belonged on Arrival/Blueprint and was hard to read even there.

## What changed

**Overlays**
- Homepage billboard no longer mounts Wayfinding Html, forces `labels = 0`, and hides leftover in-scene tags so “Enter the building →” is never covered by `00 Home`
- Chapter rail padding increased so Arrival / Nightfall have breathing room
- DRAWING SET title block removed (Html + CSS)
- Memory stickies are screen-aligned (`transform={false}`; the leftover `-3deg` tilt is gone)

**People**
- Walker rings sit at `y = 0.03` so they no longer z-fight the floor
- Walkers follow per-floor aisle graphs instead of cutting through furniture
- Self-healing beat hides the crowd (and fades them during chapter blend) so only the gold tester remains
- MCP tool cards are spaced so they no longer overlap

**Rendering (cheap)**
- Softer shadows (`shadow-intensity` 0.7)
- Nightfall: warm unshadowed point fill + warmer slab emissive so interiors stay readable
- No extra shadow-casting lights, no larger shadow maps, no textures

## Test plan
- [x] Homepage: hover the live slice — “Enter the building →” is fully readable, no floor tags on top
- [x] `/building` rail: Arrival / Nightfall have left/right padding
- [x] Wayfinding: memory notes sit square to the viewport
- [x] People: rings sit above the floor; walkers stay in aisles
- [x] Self-healing: only the gold tester + box; no tiny crowd walking through slabs
- [x] Web MCP: tool cards do not overlap
- [x] Nightfall: interiors glow enough to read furniture
- [x] `pnpm test src/components/building/geometry.test.ts` from `web/`
- [ ] Arrival/Blueprint: DRAWING SET overlay is gone (removed after the walkthrough)

Web-only. No changeset — this does not affect `@sightmap/sightmap`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2cd08a7-d105-4cfe-a4b4-13bde59830c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2cd08a7-d105-4cfe-a4b4-13bde59830c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

