### PR TITLE
fix(web): migrate web/.sightmap property extractions to the tree-closed model

### DIFF
--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -5,7 +5,7 @@ memory:
   - All homepage sections live in src/components/ and compose into src/pages/Home.tsx
   - Posts are markdown in content/blog/; scripts/build-blog.ts generates the manifest and per-post HTML modules
   - Pages are statically prerendered by scripts/prerender.tsx; the client hydrates rather than mounting fresh
-  - The negotiate edge function (netlify/edge-functions/negotiate.ts) serves markdown twins for Accept: text/markdown and JSON errors for /api/* and for 404s that asked for JSON; it always sets Vary: Accept
+  - "The negotiate edge function (netlify/edge-functions/negotiate.ts) serves markdown twins for Accept: text/markdown and JSON errors for /api/* and for 404s that asked for JSON; it always sets Vary: Accept"
   - "The offline matcher has no pseudo-class support: a selector like `.foo:first-child` probes 1 live and 0 offline, so keep selectors to attributes, classes and descendant combinators"
 
 views:

--- a/web/.sightmap/app.yaml
+++ b/web/.sightmap/app.yaml
@@ -126,12 +126,20 @@ views:
         description: One post summary — topic, date, title, excerpt
         properties:
           - name: title
-            extract: '.blog-card__title'
+            extract: blog-card-title.text
           - name: topic
-            extract: '.blog-card__meta span'
+            extract: blog-card-topic.text
         children:
           - name: blog-card-title
             selector: '.blog-card__title'
+            properties:
+              - name: text
+                extract: text
+          - name: blog-card-topic
+            selector: '.blog-card__meta span'
+            properties:
+              - name: text
+                extract: text
           - name: blog-card-excerpt
             selector: '.blog-card__excerpt'
 
@@ -201,9 +209,9 @@ views:
         description: One entry summary — screenshot, mark, name, method pill, stats, author, updated
         properties:
           - name: site
-            extract: '.atlas-card__name'
+            extract: atlas-card-name.text
           - name: method
-            extract: '.atlas-card__method'
+            extract: atlas-card-method.text
         memory:
           - The whole card is the link to /atlas/<slug>; there is no inner call to action
           - An entry with no screenshots renders a typographic fallback panel in place of the image
@@ -211,6 +219,14 @@ views:
         children:
           - name: atlas-card-name
             selector: '.atlas-card__name'
+            properties:
+              - name: text
+                extract: text
+          - name: atlas-card-method
+            selector: '.atlas-card__method'
+            properties:
+              - name: text
+                extract: text
           - name: atlas-card-stats
             selector: '.atlas-card__stats'
 
@@ -243,12 +259,15 @@ views:
         description: The `sightmap atlas add <slug>` command with a copy button
         properties:
           - name: command
-            extract: '.atlas-install__cmd'
+            extract: atlas-install-cmd.text
         memory:
           - The button label toggles to "Copied" for 2s and only on a copy that actually succeeded
         children:
           - name: atlas-install-cmd
             selector: '.atlas-install__cmd'
+            properties:
+              - name: text
+                extract: text
           - name: atlas-install-copy
             selector: '.atlas-install__copy'
 
@@ -258,12 +277,22 @@ views:
         description: Provenance rail for the entry — how and when it was captured, by whom, against which CLI and spec version
         properties:
           - name: lastVerified
-            extract: 'time'
+            extract: atlas-meta-verified.text
           - name: commit
-            extract: 'code'
+            extract: atlas-meta-commit.text
         memory:
           - A row is omitted entirely rather than left blank when its value is absent, so the rail's row count varies by entry
         children:
+          - name: atlas-meta-verified
+            selector: 'time'
+            properties:
+              - name: text
+                extract: text
+          - name: atlas-meta-commit
+            selector: 'code'
+            properties:
+              - name: text
+                extract: text
           - name: AtlasMetaMachine
             selector: '.atlas-meta__machine'
             description: Links to the machine-readable twins of this entry


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this changes

Re-authors the 7 component-property `extract` directives in `web/.sightmap/app.yaml` that used the pre-SEP-0010 extraction model, so `sightmap validate` reports no errors.

> Stacked on #390 (the parse fix). Base is that branch so this diff shows only the property re-authoring; it retargets to `main` automatically once #390 merges.

## Why

These properties passed a bare CSS selector (or a tag name) as the `extract` value:

| Component | Property | Was | Now |
|---|---|---|---|
| `BlogCard` | `title` | `.blog-card__title` | `blog-card-title.text` |
| `BlogCard` | `topic` | `.blog-card__meta span` | `blog-card-topic.text` |
| `AtlasCard` | `site` | `.atlas-card__name` | `atlas-card-name.text` |
| `AtlasCard` | `method` | `.atlas-card__method` | `atlas-card-method.text` |
| `AtlasInstall` | `command` | `.atlas-install__cmd` | `atlas-install-cmd.text` |
| `AtlasMeta` | `lastVerified` | `time` | `atlas-meta-verified.text` |
| `AtlasMeta` | `commit` | `code` | `atlas-meta-commit.text` |

The v1 `extract` grammar (`spec/v1/schema.md`) only accepts `text`, `attr=NAME`, `PATH.prop`, or `exists:PATH` — the tree-closed component-property model from [SEP-0010](../spec/seps/0010-tree-closed-component-properties.md). The old selector-as-extract form was rejected by validation; the errors had been masked because the file previously failed to parse at all (fixed in #390).

## How

Following the canonical pattern (`spec/conformance/014-component-properties.fixture`): each target sub-element is promoted to a declared child component that exposes a `text` property (`extract: text`), and the parent references it via `PATH.prop`. New child names use the same kebab-case convention their siblings already use (e.g. `blog-card-title`).

## Verification

`sightmap validate` on `web/.sightmap`: **7 errors → 0**. Each property was also confirmed to resolve against the running site (`pnpm dev` on :5173) with `sightmap snapshot` in a headless Chrome session:

```
[BlogCard title="Sightmap: the runtime map of your app" topic="RESEARCH"]
  [blog-card-title text="Sightmap: the runtime map of your app"]
  [blog-card-topic text="RESEARCH"]
[AtlasCard method="BROWSER" site="Instacart"]
[AtlasInstall command="$ sightmap atlas add github"]
[AtlasMeta commit="18315720bf34" lastVerified="August 8, 2026"]
```

`method="BROWSER"` (CSS-uppercased) matches the existing memory note on `AtlasCard`. `AtlasInstall.command` includes the rendered `$` prompt, which is the text content of `.atlas-install__cmd` — faithful to the original selector's intent. Full before/after log attached below.

Note: `sightmap lint` still emits pre-existing `name-case` warnings for kebab-case leaf components across the whole corpus; the new children match that existing style and `lint` is advisory (not run in CI).

## Area

- [x] Marketing site (`web/`)

## Type of change

- [x] Bug fix

## Checklist

- [x] Every commit on this branch is signed off (`git commit -s`) per DCO
- [x] I kept this PR focused on a single concern

## Evidence log

[sightmap_validate_and_extract_evidence.log](https://cursor.com/artifacts/c/art-1a120b99-a1fa-4ac7-a9e5-89dda944d643)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad0514fd-ce7c-4730-b08a-a077c0c55cc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad0514fd-ce7c-4730-b08a-a077c0c55cc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

