### PR TITLE
fix(browser): treat multi-match component query as present in wait-for

### DIFF
--- a/.changeset/wait-for-component-multi-match.md
+++ b/.changeset/wait-for-component-multi-match.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `browser wait-for --component 'X'` timing out whenever the query matched more than one node on the page. The wait polled with the strict single-node resolver (the one `click`/`fill`/`hover` need), so a "several match" result was reported as an ambiguity error and mistaken for "not present yet" — even though `snapshot` listed every instance and `wait-for --selector` with the same multi-match CSS returned immediately. `wait-for --component` now treats presence of ≥1 match as satisfied (multiple matches are proof the component is on the page, which is exactly what the caller is waiting for), via a new `compquery.Present` presence predicate. The interaction commands are unchanged: they still resolve to a single target through the strict `compquery.Resolve`. Narrowed queries keep working — a property predicate (`X[status="Published"]`) or an occurrence index (`X#0`) still matches, and `X#N` waits until occurrence N exists.

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -407,13 +407,17 @@ func waitForView(ctx context.Context, conn *browser.CDPConn, sightmapDir, viewNa
 	}
 }
 
-// waitForComponent polls until the component query matches at least one node on
-// the live page, or ctx expires. The query syntax is validated up front so a
-// typo fails immediately instead of silently timing out. Each poll re-extracts
-// the live tree (so property-filtered queries like `Row[state="Done"]` are
-// honored), which is the same resolve path a `click 'Query'` uses.
+// waitForComponent polls until the component query is present on the live page
+// (matches at least one node), or ctx expires. The query syntax is validated up
+// front so a typo fails immediately instead of silently timing out. Each poll
+// re-extracts the live tree (so property-filtered queries like `Row[state="Done"]`
+// are honored). Presence — not single-node resolution — is the right predicate
+// here: a query matching several nodes proves the component is on the page, so
+// it counts as satisfied, whereas `click 'Query'` still needs the strict
+// single-target Resolve.
 func waitForComponent(ctx context.Context, conn *browser.CDPConn, sightmapDir, query string) error {
-	if _, err := compquery.ParseQuery(query); err != nil {
+	q, err := compquery.ParseQuery(query)
+	if err != nil {
 		return err
 	}
 	for {
@@ -422,7 +426,7 @@ func waitForComponent(ctx context.Context, conn *browser.CDPConn, sightmapDir, q
 			return ctx.Err()
 		default:
 		}
-		if node, err := resolveComponentQuery(ctx, conn, sightmapDir, query); err == nil && node != nil {
+		if present, err := componentPresent(ctx, conn, sightmapDir, q); err == nil && present {
 			return nil
 		}
 		time.Sleep(300 * time.Millisecond)

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -48,32 +48,64 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, err
 	}
+	root, matches, props, err := extractMatchedComponents(ctx, conn, sightmapDir)
+	if err != nil {
+		return nil, err
+	}
+	return compquery.Resolve(root, matches, props, q)
+}
 
+// componentPresent reports whether queryStr matches at least one node on the
+// live page. It shares resolveComponentQuery's extract→match→project pipeline
+// but decides presence with compquery.Present instead of the single-node
+// Resolve, so a query that matches several nodes counts as present rather than
+// failing with an ambiguity error. This is what `wait-for --component` needs
+// (presence, not a single target); the interaction commands keep the strict
+// Resolve via resolveComponentQuery.
+func componentPresent(ctx context.Context, conn *browser.CDPConn, sightmapDir string, q *compquery.Query) (bool, error) {
+	root, matches, props, err := extractMatchedComponents(ctx, conn, sightmapDir)
+	if err != nil {
+		return false, err
+	}
+	return compquery.Present(root, matches, props, q), nil
+}
+
+// extractMatchedComponents pulls the live component tree, applies the corpus at
+// sightmapDir, and projects the matches' resolved properties — the shared front
+// half of every component-query resolution (the interaction commands' strict
+// resolve and wait-for's presence check). It returns everything the compquery
+// engine consumes: the tree root, the node→match map, and the id-keyed property
+// values.
+func extractMatchedComponents(ctx context.Context, conn *browser.CDPConn, sightmapDir string) (
+	*sightmap.ComponentNode,
+	map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	map[string]map[string]string,
+	error,
+) {
 	page, err := conn.DefaultPage()
 	if err != nil {
-		return nil, fmt.Errorf("resolve query: %w", err)
+		return nil, nil, nil, fmt.Errorf("resolve query: %w", err)
 	}
 	root, err := browser.ExtractComponents(ctx, page)
 	if err != nil {
-		return nil, fmt.Errorf("resolve query: extract: %w", err)
+		return nil, nil, nil, fmt.Errorf("resolve query: extract: %w", err)
 	}
 	pageURL, err := browser.GetURL(ctx, conn)
 	if err != nil {
-		return nil, fmt.Errorf("resolve query: get URL: %w", err)
+		return nil, nil, nil, fmt.Errorf("resolve query: get URL: %w", err)
 	}
 
 	corpus, err := sightmap.Load(sightmapDir)
 	if err != nil {
-		return nil, fmt.Errorf("resolve query: load corpus: %w", err)
+		return nil, nil, nil, fmt.Errorf("resolve query: load corpus: %w", err)
 	}
 	matcher := match.NewMatcher(corpus)
 	matches := matcher.Match(root, pageURL)
 	if len(matches) == 0 {
-		return nil, fmt.Errorf(
+		return nil, nil, nil, fmt.Errorf(
 			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
 	}
-
-	return compquery.Resolve(root, matches, queryPropertyValues(matches), q)
+	return root, matches, queryPropertyValues(matches), nil
 }
 
 // queryPropertyValues projects each match's resolved properties (populated

--- a/go/compquery/compquery.go
+++ b/go/compquery/compquery.go
@@ -129,6 +129,27 @@ func Resolve(
 	return nil, ambiguityError(q, cands, matches, props)
 }
 
+// Present reports whether q matches at least one node in the tree — the
+// existence predicate behind `wait-for --component`. Unlike Resolve, several
+// matches count as present rather than an ambiguity error: multiple matches are
+// proof the component is on the page, which is exactly what a caller waiting for
+// it wants. When q carries an occurrence index (#N), Present holds only once
+// that occurrence exists (N in range), mirroring Resolve's bounds check without
+// treating an as-yet-unreached occurrence as an error. Resolve stays strict for
+// the interaction commands (click/fill/hover), which need a single target.
+func Present(
+	root *sightmap.ComponentNode,
+	matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch,
+	props map[string]map[string]string,
+	q *Query,
+) bool {
+	cands := FindCandidates(root, matches, props, q)
+	if q.Index >= 0 {
+		return q.Index < len(cands)
+	}
+	return len(cands) > 0
+}
+
 // FindCandidates returns every node satisfying q's target part whose matched
 // ancestors satisfy the preceding chain parts as an ordered subsequence
 // (descendant semantics). Results are in document (pre-order) order.

--- a/go/compquery/compquery_test.go
+++ b/go/compquery/compquery_test.go
@@ -1,9 +1,10 @@
 package compquery
 
 import (
-	"github.com/sightmap/sightmap/go/sightmap"
 	"strings"
 	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // ── Parser ────────────────────────────────────────────────────────────────────
@@ -240,6 +241,60 @@ func TestResolve_AmbiguityError(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("ambiguity error missing %q; got:\n%s", want, msg)
 		}
+	}
+}
+
+// TestPresent is the wait-for --component predicate: presence, not single-node
+// resolution. A query matching several nodes must count as PRESENT (the whole
+// point of waiting for a component is that it has appeared), even though the
+// very same query is an ambiguity ERROR for Resolve, which the interaction
+// commands use because they need one target. This is the regression guard for
+// issue #387, where multi-match was mistaken for "not matched yet" and polled to
+// a timeout.
+func TestPresent(t *testing.T) {
+	root, matches, props := buildFixture()
+
+	// Multi-match: Resolve errors (ambiguous), but Present is true.
+	multi, _ := ParseQuery("FulfillmentTileButton")
+	if _, err := Resolve(root, matches, props, multi); err == nil {
+		t.Fatal("precondition: expected FulfillmentTileButton to be ambiguous for Resolve")
+	}
+	if !Present(root, matches, props, multi) {
+		t.Error("Present(FulfillmentTileButton) = false; multiple matches must count as present")
+	}
+
+	// Single match and predicate-narrowed queries are present too.
+	for _, qs := range []string{
+		"UserNameInput",
+		`FulfillmentTileButton[label=Delivery]`,
+		"LoginForm UserNameInput",
+	} {
+		q, _ := ParseQuery(qs)
+		if !Present(root, matches, props, q) {
+			t.Errorf("Present(%q) = false, want true", qs)
+		}
+	}
+
+	// Absent queries are not present (so wait-for keeps polling / times out).
+	for _, qs := range []string{
+		"NoSuchComponent",
+		`FulfillmentTileButton[label=Nope]`,
+	} {
+		q, _ := ParseQuery(qs)
+		if Present(root, matches, props, q) {
+			t.Errorf("Present(%q) = true, want false", qs)
+		}
+	}
+
+	// An occurrence index is present only when that occurrence exists (mirrors
+	// Resolve's bounds check, without erroring on an as-yet-unreached index).
+	in0, _ := ParseQuery("FulfillmentTileButton#0")
+	if !Present(root, matches, props, in0) {
+		t.Error("Present(FulfillmentTileButton#0) = false, want true")
+	}
+	oob, _ := ParseQuery("FulfillmentTileButton#5")
+	if Present(root, matches, props, oob) {
+		t.Error("Present(FulfillmentTileButton#5) = true, want false (occurrence out of range)")
 	}
 }
 


### PR DESCRIPTION
Fixes #387

## The bug

`sightmap browser wait-for --component 'X'` times out whenever `X` matches **more than one** node on the page — even though `snapshot` lists every instance from the same corpus, `wait-for --selector` with the same multi-match raw CSS returns immediately, and narrowing `X` to a single node (`X[status="Published"]` or `X#0`) matches instantly. Deterministic on a fully settled page (reported on `@sightmap/sightmap@0.31.1`, Chrome for Testing 151).

## Cause

`waitForComponent` polled with `resolveComponentQuery` → `compquery.Resolve`, the **strict single-node resolver** that `click`/`fill`/`hover` rely on. For >1 match with no occurrence index, `Resolve` returns an **ambiguity error** (distinct from "no such component"). The wait loop only treated `err == nil && node != nil` as success, so it mistook that ambiguity for "not present yet" and polled until timeout. The `--selector` path worked because its predicate is pure presence.

## Fix

Treat presence of ≥1 match as **matched** — multiple matches are proof the component is on the page, which is exactly what the caller is waiting for.

- Add `compquery.Present(root, matches, props, q)`: an existence predicate built on the existing multi-match `FindCandidates` (the same function `browser bounds` uses for its multi-instance semantics). Returns `len(candidates) > 0`, and for an `#N` occurrence query holds only once occurrence N is in range — mirroring `Resolve`'s bounds check without erroring on an as-yet-unreached occurrence.
- `waitForComponent` now uses a new `componentPresent` helper that shares the extract→match→project pipeline with `resolveComponentQuery` (factored into `extractMatchedComponents`) but decides via `Present` instead of `Resolve`.

### Why it's safe for the interaction commands

`compquery.Resolve` is **unchanged**. `click`/`fill`/`hover`/`scroll`/`drag` still resolve to a single target through `resolveComponentQuery` → `Resolve` and keep their strict ambiguity error. Only the wait-for predicate was loosened, and only to presence — exactly the semantic a wait wants. Narrowed queries (`X[prop=...]`, `X#0`) keep working.

## Test

`compquery.TestPresent` (unit test at the resolver layer — no live browser needed) proves the exact contrast the fix relies on: the ambiguous query `FulfillmentTileButton` is an **error** for `Resolve` but **present** for `Present`, single/predicate/chain queries are present, absent queries are not, and `#N` honors occurrence bounds.

## Validation

```
cd go && go build ./... && go test ./...   # all packages green; gofmt clean
```

Includes a `patch` changeset for `@sightmap/sightmap`.