### PR TITLE
Add SplitFieldPath for escaped dot-path splitting

### DIFF
--- a/.changeset/split-field-path.md
+++ b/.changeset/split-field-path.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add `sightmap.SplitFieldPath`, an exported function that splits a `RequestPropertyDef.Field` body-source path into its dot-separated segments with backslash-escape support (`\.` for a literal dot in a JSON key, `\\` for a literal backslash). Previously `walkJSONPath` split on a plain `strings.Split(path, ".")`, so a JSON object key that itself contained a literal dot could never be addressed — there was no way to say "the key is literally `a.b`" versus "descend into `a` then `b`". `walkJSONPath` now uses `SplitFieldPath` internally, so existing unescaped paths behave identically and escaped ones now resolve correctly. External tools that need the same path-splitting semantics (for example, compiling a sightmap corpus into a target schema whose own path field documents the identical escaping) can call `SplitFieldPath` directly instead of re-deriving the parser.

--- a/go/sightmap/fieldpath.go
+++ b/go/sightmap/fieldpath.go
@@ -1,0 +1,57 @@
+package sightmap
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitFieldPath splits a RequestPropertyDef.Field body-source path into its
+// dot-separated segments, honoring backslash escapes: "\." is a literal dot
+// within a segment (for a JSON object key that itself contains a dot), "\\"
+// is a literal backslash, and an unescaped "." breaks a new segment. Any
+// other escape sequence is an error.
+//
+// This is purely mechanical — it does not validate segment content (an empty
+// segment from "a..b" splits into ["a", "", "b"] rather than erroring) or
+// resolve anything against a JSON document; walkJSONPath does that, and a
+// caller that needs its own validation (e.g. rejecting an empty segment) does
+// so over the returned slice. An empty field splits to nil (no segments), the
+// same "no path" case a header-source Field or a pattern-only body extraction
+// already treats specially at the call site.
+func SplitFieldPath(field string) ([]string, error) {
+	if field == "" {
+		return nil, nil
+	}
+
+	var segs []string
+	var cur strings.Builder
+	escaped := false
+
+	for i := 0; i < len(field); i++ {
+		c := field[i]
+		if escaped {
+			switch c {
+			case '.', '\\':
+				cur.WriteByte(c)
+			default:
+				return nil, fmt.Errorf("sightmap: invalid escape %q in field path %q at position %d", string(c), field, i)
+			}
+			escaped = false
+			continue
+		}
+		switch c {
+		case '\\':
+			escaped = true
+		case '.':
+			segs = append(segs, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if escaped {
+		return nil, fmt.Errorf("sightmap: field path %q ends with an unterminated escape", field)
+	}
+	segs = append(segs, cur.String())
+	return segs, nil
+}

--- a/go/sightmap/fieldpath_test.go
+++ b/go/sightmap/fieldpath_test.go
@@ -1,0 +1,77 @@
+package sightmap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitFieldPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", field: "", want: nil},
+		{name: "single segment", field: "status", want: []string{"status"}},
+		{name: "simple dotted path", field: "a.b.c", want: []string{"a", "b", "c"}},
+		{name: "array index segment", field: "items.0.name", want: []string{"items", "0", "name"}},
+		{name: "escaped literal dot", field: `a\.b.c`, want: []string{"a.b", "c"}},
+		{name: "escaped literal backslash", field: `a\\.b`, want: []string{`a\`, "b"}},
+		{name: "escaped dot at start of segment", field: `\.a.b`, want: []string{".a", "b"}},
+		{name: "escaped dot at end of field", field: `a.b\.`, want: []string{"a", "b."}},
+		{name: "malformed: empty segment", field: "a..b", want: []string{"a", "", "b"}},
+		{name: "malformed: leading dot", field: ".a.b", want: []string{"", "a", "b"}},
+		{name: "invalid escape", field: `a\xb`, wantErr: true},
+		{name: "trailing unterminated escape", field: `a\`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SplitFieldPath(tt.field)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SplitFieldPath(%q) = %v, nil; want an error", tt.field, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SplitFieldPath(%q) unexpected error: %v", tt.field, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitFieldPath(%q) = %#v, want %#v", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+// walkJSONPath must resolve an escaped-dot key correctly: a JSON object whose
+// key itself contains a literal "." can only be addressed via the escape.
+func TestWalkJSONPath_EscapedDotKey(t *testing.T) {
+	got, ok := walkJSONPath(`{"a.b":{"c":"value"}}`, `a\.b.c`)
+	if !ok {
+		t.Fatal("walkJSONPath: want ok=true")
+	}
+	if got != "value" {
+		t.Errorf("walkJSONPath = %q, want %q", got, "value")
+	}
+}
+
+// Before the escape existed, "a.b.c" against an object keyed "a.b" (nested
+// "c") was inherently unaddressable — plain splitting always read it as three
+// segments. Confirm the unescaped form still does NOT resolve the same
+// document (i.e. this is genuinely a new capability, not a silent behavior
+// change for existing unescaped paths).
+func TestWalkJSONPath_UnescapedDotStillSplitsNormally(t *testing.T) {
+	_, ok := walkJSONPath(`{"a.b":{"c":"value"}}`, `a.b.c`)
+	if ok {
+		t.Fatal("walkJSONPath: want ok=false — unescaped \"a.b.c\" must not resolve a key literally named \"a.b\"")
+	}
+}
+
+func TestWalkJSONPath_InvalidEscapeFailsResolution(t *testing.T) {
+	_, ok := walkJSONPath(`{"a":"value"}`, `a\xb`)
+	if ok {
+		t.Fatal("walkJSONPath: want ok=false for an invalid escape sequence")
+	}
+}

--- a/go/sightmap/request.go
+++ b/go/sightmap/request.go
@@ -50,8 +50,9 @@ type RequestPropertyDef struct {
 	Source string `json:"source"`
 	// Field selects a value within Source. For a body source it is a
 	// dot-separated object-key path (a numeric segment indexes an array when the
-	// value at that level is one). For a headers source it is a header name,
-	// matched case-insensitively, and is required.
+	// value at that level is one); a literal dot or backslash within a key is
+	// backslash-escaped ("\." / "\\") — see SplitFieldPath. For a headers source
+	// it is a header name, matched case-insensitively, and is required.
 	Field string `json:"field,omitempty"`
 	// Pattern is an RE2 regex (Go's regexp; no backreferences or lookaround)
 	// applied to what Field resolved, or to the raw source text when Field is

--- a/go/sightmap/request_extract.go
+++ b/go/sightmap/request_extract.go
@@ -149,20 +149,25 @@ func lookupHeader(headers []Header, name string) (string, bool) {
 	return strings.Join(vals, ", "), true
 }
 
-// walkJSONPath parses content as JSON and walks a dot-separated path, returning
-// the addressed value as a string. An object key indexes a map; a numeric
-// segment indexes an array when the value at that level is one. A scalar leaf is
-// stringified plainly (numbers without a trailing ".0", booleans as true/false);
-// a non-scalar leaf (object/array) is re-encoded as JSON so a pattern can still
-// scan it. Returns false when the content isn't JSON, a segment doesn't resolve,
-// or the leaf is JSON null.
+// walkJSONPath parses content as JSON and walks a dot-separated path (see
+// SplitFieldPath for the escaping rules), returning the addressed value as a
+// string. An object key indexes a map; a numeric segment indexes an array
+// when the value at that level is one. A scalar leaf is stringified plainly
+// (numbers without a trailing ".0", booleans as true/false); a non-scalar
+// leaf (object/array) is re-encoded as JSON so a pattern can still scan it.
+// Returns false when the content isn't JSON, path doesn't parse (e.g. a bad
+// escape), a segment doesn't resolve, or the leaf is JSON null.
 func walkJSONPath(content, path string) (string, bool) {
 	var root any
 	if err := json.Unmarshal([]byte(content), &root); err != nil {
 		return "", false
 	}
+	segs, err := SplitFieldPath(path)
+	if err != nil {
+		return "", false
+	}
 	cur := root
-	for _, seg := range strings.Split(path, ".") {
+	for _, seg := range segs {
 		switch node := cur.(type) {
 		case map[string]any:
 			v, ok := node[seg]


### PR DESCRIPTION
## Summary
- `RequestPropertyDef.Field`'s body-source path had no way to address a JSON key that itself contains a literal dot — `walkJSONPath` split on a plain `strings.Split(path, ".")`.
- Adds exported `sightmap.SplitFieldPath`, with backslash escaping (`\.` for a literal dot, `\\` for a literal backslash); `walkJSONPath` now uses it internally. Existing unescaped paths behave identically.
- Motivated by an external consumer (a Fullstory sightmap→org-config compiler) whose own target path field documents the identical escaping and needs the same segments without re-deriving the parser.

## Test plan
- [x] `go test ./sightmap/...` passes, including new `fieldpath_test.go` cases (escaping, malformed paths, an escaped-dot key resolving where the unescaped form does not)
- [x] `go vet ./sightmap/...` clean