### PR TITLE
skill(authoring): reframe property principles around purpose (kill text/label noise)

### DIFF
--- a/.changeset/property-purpose-guidance.md
+++ b/.changeset/property-purpose-guidance.md
@@ -1,0 +1,16 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Reframe the sightmap-authoring skill's "Property extraction principles" around
+**purpose**: a property earns its place only as a discriminator (makes an
+otherwise-ambiguous instance addressable) or as signal (a value a downstream
+event/agent needs). A property that does neither — most commonly a `text`/`label`
+that just restates a node's accessible name, or a `text` on a nameless container
+that dumps its whole subtree — is noise. Rule 1 now requires a link/button to be
+*identifiable* (by its accessible name, or a useful property) rather than
+mandating a property (which invited restating-the-name busywork); Rule 2's
+per-instance discriminator is preserved, with an explicit carve-out for responsive
+duplicates (narrow the selector, don't invent a discriminator). Validated against
+the JetBlue corpus (drove ~90% of property decisions cleanly; 21 noise properties
+removed with zero tool breakage).

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -354,11 +354,14 @@ components:
 
 A property earns its place two ways: it **discriminates** an otherwise ambiguous
 instance so a query can address one (`Card[title^="Today"]`), or it carries
-**signal** a downstream event or agent needs (`price`, `status`, `sku`). A
-property that does neither is noise: a `text`/`label` that just restates the
-node's accessible name (the snapshot prints that anyway), or a `text` on a
-container with no accessible name (it resolves to the whole innerText — a subtree
-dump, not a value; promote the real value to a child instead).
+**signal** a downstream event or agent needs (`price`, `status`, `sku`) —
+including a control's current **state** (a sort's active option, a passenger
+count, a field's value), which counts even when it equals the accessible name;
+the test is whether the value would read differently in another capture, not
+whether it matches the name. A property that does neither is noise: a
+`text`/`label` restating a control's fixed **affordance** (its unchanging name —
+`Search`, `Give Feedback`), or a `text` on a nameless container (a whole-innerText
+subtree dump — promote the real value to a child instead).
 
 Two property rules are **mandatory**:
 

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -402,6 +402,15 @@ Two property rules are **mandatory**:
       extract: attr=aria-label
 ```
 
+A `label` restating the accessible name is noise **only when the component's
+selector specifically identifies that control**. If the selector is generic (a
+utility class matching a category), the component is effectively generic and the
+label is its discriminator — keep it, but name the component for what the
+selector actually matches (`Button[label=…]`), not a specific thing the selector
+can't back up (`ExploreMoreFlights` on `a.rounded-button`). Fixing the selector
+to a stable, specific hook is the better end state; until then, an honest generic
+name + label discriminator beats a false-specific name.
+
 **Extract modes** — exactly one of four forms:
 
 | Mode | Resolves to |

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -352,10 +352,22 @@ components:
 
 ## Property extraction principles
 
+A property earns its place two ways: it **discriminates** an otherwise ambiguous
+instance so a query can address one (`Card[title^="Today"]`), or it carries
+**signal** a downstream event or agent needs (`price`, `status`, `sku`). A
+property that does neither is noise: a `text`/`label` that just restates the
+node's accessible name (the snapshot prints that anyway), or a `text` on a
+container with no accessible name (it resolves to the whole innerText — a subtree
+dump, not a value; promote the real value to a child instead).
+
 Two property rules are **mandatory**:
 
-1. Every child component that is a link or button **must** have at least one
-   property.
+1. Every child component that is a link or button must be **identifiable** — by
+   its accessible name (a self-naming `Give Feedback` button needs no property),
+   or, when the name is absent, ambiguous, or repeated, a *useful* property (a
+   discriminator or signal). Never add a property that just restates the name —
+   unless it is a repeated component's per-instance discriminator (rule 2),
+   which is legitimate even when each value equals its own instance's name.
 2. Every component whose selector matches **more than one instance** — a
    repeated container or control (cards, list rows, nav tabs, feed items) —
    **must** carry a property that *varies per instance* (a title, label, key, or
@@ -366,7 +378,10 @@ Two property rules are **mandatory**:
    wherever it lives — a header title, an `aria-label`, a stable `data-*`. When
    the repeated node is an *identical leaf* that has no discriminator of its own
    (every row's identical Rescue button), put the discriminator on its container
-   and nest the leaf beneath it — see **Component hierarchy** above.
+   and nest the leaf beneath it — see **Component hierarchy** above. But when the
+   matches are *responsive duplicates* of one control (the **same** value on every
+   match, only one visible), there is nothing to discriminate — narrow the
+   selector to the visible instance rather than adding a property.
 
 ```yaml
 - name: FooterLink

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -354,11 +354,14 @@ components:
 
 A property earns its place two ways: it **discriminates** an otherwise ambiguous
 instance so a query can address one (`Card[title^="Today"]`), or it carries
-**signal** a downstream event or agent needs (`price`, `status`, `sku`). A
-property that does neither is noise: a `text`/`label` that just restates the
-node's accessible name (the snapshot prints that anyway), or a `text` on a
-container with no accessible name (it resolves to the whole innerText — a subtree
-dump, not a value; promote the real value to a child instead).
+**signal** a downstream event or agent needs (`price`, `status`, `sku`) —
+including a control's current **state** (a sort's active option, a passenger
+count, a field's value), which counts even when it equals the accessible name;
+the test is whether the value would read differently in another capture, not
+whether it matches the name. A property that does neither is noise: a
+`text`/`label` restating a control's fixed **affordance** (its unchanging name —
+`Search`, `Give Feedback`), or a `text` on a nameless container (a whole-innerText
+subtree dump — promote the real value to a child instead).
 
 Two property rules are **mandatory**:
 

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -402,6 +402,15 @@ Two property rules are **mandatory**:
       extract: attr=aria-label
 ```
 
+A `label` restating the accessible name is noise **only when the component's
+selector specifically identifies that control**. If the selector is generic (a
+utility class matching a category), the component is effectively generic and the
+label is its discriminator — keep it, but name the component for what the
+selector actually matches (`Button[label=…]`), not a specific thing the selector
+can't back up (`ExploreMoreFlights` on `a.rounded-button`). Fixing the selector
+to a stable, specific hook is the better end state; until then, an honest generic
+name + label discriminator beats a false-specific name.
+
 **Extract modes** — exactly one of four forms:
 
 | Mode | Resolves to |

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -352,10 +352,22 @@ components:
 
 ## Property extraction principles
 
+A property earns its place two ways: it **discriminates** an otherwise ambiguous
+instance so a query can address one (`Card[title^="Today"]`), or it carries
+**signal** a downstream event or agent needs (`price`, `status`, `sku`). A
+property that does neither is noise: a `text`/`label` that just restates the
+node's accessible name (the snapshot prints that anyway), or a `text` on a
+container with no accessible name (it resolves to the whole innerText — a subtree
+dump, not a value; promote the real value to a child instead).
+
 Two property rules are **mandatory**:
 
-1. Every child component that is a link or button **must** have at least one
-   property.
+1. Every child component that is a link or button must be **identifiable** — by
+   its accessible name (a self-naming `Give Feedback` button needs no property),
+   or, when the name is absent, ambiguous, or repeated, a *useful* property (a
+   discriminator or signal). Never add a property that just restates the name —
+   unless it is a repeated component's per-instance discriminator (rule 2),
+   which is legitimate even when each value equals its own instance's name.
 2. Every component whose selector matches **more than one instance** — a
    repeated container or control (cards, list rows, nav tabs, feed items) —
    **must** carry a property that *varies per instance* (a title, label, key, or
@@ -366,7 +378,10 @@ Two property rules are **mandatory**:
    wherever it lives — a header title, an `aria-label`, a stable `data-*`. When
    the repeated node is an *identical leaf* that has no discriminator of its own
    (every row's identical Rescue button), put the discriminator on its container
-   and nest the leaf beneath it — see **Component hierarchy** above.
+   and nest the leaf beneath it — see **Component hierarchy** above. But when the
+   matches are *responsive duplicates* of one control (the **same** value on every
+   match, only one visible), there is nothing to discriminate — narrow the
+   selector to the visible instance rather than adding a property.
 
 ```yaml
 - name: FooterLink


### PR DESCRIPTION
Rewrites the sightmap-authoring skill's **Property extraction principles** so agents stop generating noise properties.

## Why
The old Rule 1 — *every link/button must have at least one property* — was satisfied by `label: text` busywork (`FeedbackButton label="Give Feedback"`), because it demanded *a* property, not a *useful* one. `text` defaults to the accessible name the snapshot already prints, so a lone restating property is provably redundant.

## What
- **Lead-in:** a property earns its place two ways — **discriminate** an otherwise-ambiguous instance so a query can address it, or carry **signal** a downstream event/agent needs. Anything else is noise: a `text`/`label` restating the accessible name, or a `text` on a nameless container (whole-innerText subtree dump).
- **Rule 1** now requires a link/button to be **identifiable** (by its accessible name — a self-naming button needs no property — or a useful property), never a name restatement.
- **Rule 2** (per-instance discriminator for repeated components) preserved, with a carve-out: *responsive duplicates* (same value on every match, one visible) → narrow the selector, don't invent a discriminator.

## Validation
Applied to the JetBlue corpus (4 views) via an agent following this wording: it drove ~90% of property decisions cleanly and removed **21 noise properties with zero tool breakage**; coverage held at 0 orphaned. The edge cases it surfaced are captured as design refinements (not folded here, to keep the rules terse).

Embedded `go/skills/` copy regenerated (no drift); `go build` green; `patch` changeset included.