### PR TITLE
fix: live/offline selector-matcher parity (:not(:has()) + form named-property collision)

### DIFF
--- a/.changeset/quiet-forms-deepquery.md
+++ b/.changeset/quiet-forms-deepquery.md
@@ -1,0 +1,9 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Live shadow-piercing query (`sel-probe`, `click`/`fill`, property extraction) no longer under-reports on pages with a form.
+
+`__smDeepQueryAll` walked the DOM via instance properties (`node.children`, `el.matches`, `el.shadowRoot`). On an `HTMLFormElement`, a control whose `name`/`id` is `children` makes the form's named getter return that control instead of the element `HTMLCollection` (`[LegacyOverrideBuiltIns]`), so `for (const c of node.children)` threw "children is not iterable" on that form. The blanket `catch` then returned a **truncated** result — silently `0` matches for any element after the form in document order (observed on jetblue.com: `[data-fs-element="submit"]`, `a.rounded-button`, `[data-fs-element="points-toggle"]`, and others reported 0 live while `querySelectorAll` and the offline matcher saw them).
+
+The traversal now goes through cached `Node.prototype`/`Element.prototype` accessors, which bypass any named-property shadowing, so form-heavy pages resolve correctly. Affects every live lookup: `sel-probe`, component-query `click`/`fill`/`hover`, and live property extraction.

--- a/.changeset/spicy-selectors-not-has.md
+++ b/.changeset/spicy-selectors-not-has.md
@@ -1,0 +1,14 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Offline matcher: support `:not(:has(...))` and a combinator inside `:not(...)`, for parity with the live DOM.
+
+The offline component-tree matcher (used by `snapshot`, `coverage`, `validate`, `sel-check`, and the overlay) now honors two standard-CSS relational selectors it previously mishandled:
+
+- **`:not(:has(...))`** and **`:is(...:has(...))`** — a relational pseudo nested inside `:not()`/`:is()` is now evaluated with the subject's subtree instead of being silently dropped. This unblocks the leaf-scoping pattern `X:not(:has(X))` (e.g. `jb-form-field-container:not(:has(jb-form-field-container))`), which previously matched **zero** nodes offline while resolving live.
+- **A descendant/child combinator inside `:not()`** (e.g. `button:not(nav button)`) now parses and is evaluated against the subject's ancestor chain. Such selectors previously threw a parse error, so a corpus using valid CSS failed to `validate` even though it resolved live.
+
+`:not()` now accepts a complex-selector list, matching CSS Selectors Level 4. Sibling combinators (`+`, `~`) remain unsupported and are still rejected loudly at parse time.
+
+Note: `SelectorPart.Not` changes from `*SelectorPart` to `[]ParsedSelector` to represent the complex-selector-list argument.

--- a/go/browser/deepquery.js
+++ b/go/browser/deepquery.js
@@ -4,19 +4,51 @@
 // own light-DOM subtree, fully, before that node's shadow-DOM subtree). See
 // deepquery.go for why this exists and schema.md's "Selector model & shadow
 // DOM" for the flattening rule this mirrors.
-
+//
+// DOM access goes through cached prototype accessors, NOT instance properties
+// (node.children / el.matches / el.shadowRoot). An <input name="children"> makes
+// HTMLFormElement's named getter return that control for form.children instead
+// of the HTMLCollection, so a naive `for (const c of node.children)` throws
+// "children is not iterable" on that form and the blanket catch below then
+// returns a TRUNCATED result — silently 0 for any match after the form. (JetBlue's
+// booker form has a "children" passenger-count control; that one collision made
+// sel-probe and click/fill under-report.) The cached prototype accessors bypass
+// any such named-property shadowing entirely.
+//
+// The accessors are cached INSIDE the function (not at top level): this file is
+// prepended to CDP evals that run repeatedly in one tab context, so it must
+// declare no top-level lexical bindings (a second eval of a top-level `const`
+// throws "already declared"). Function declarations are re-eval-safe; keep it
+// that way. See deepquery.go.
 function __smDeepQueryAll(root, sel) {
+  const childNodesOf = Object.getOwnPropertyDescriptor(
+    Node.prototype,
+    "childNodes",
+  ).get;
+  const matchesFn = Element.prototype.matches;
+  const shadowRootGetter = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "shadowRoot",
+  ).get;
+  // shadowRoot's getter lives on Element.prototype, so it is only valid for
+  // element nodes (a Document/ShadowRoot root has none).
+  const shadowOf = (node) =>
+    node.nodeType === 1 ? shadowRootGetter.call(node) : null;
+
   const out = [];
   function visit(node) {
-    for (const child of node.children) {
-      if (child.matches(sel)) out.push(child);
+    for (const child of childNodesOf.call(node)) {
+      if (child.nodeType !== 1) continue; // ELEMENT_NODE only
+      if (matchesFn.call(child, sel)) out.push(child);
       visit(child);
-      if (child.shadowRoot) visit(child.shadowRoot);
+      const sr = shadowOf(child);
+      if (sr) visit(sr);
     }
   }
   try {
     visit(root);
-    if (root.shadowRoot) visit(root.shadowRoot);
+    const rootShadow = shadowOf(root);
+    if (rootShadow) visit(rootShadow);
   } catch (e) {
     return out;
   }

--- a/go/browser/deepquery.test.js
+++ b/go/browser/deepquery.test.js
@@ -69,6 +69,30 @@ describe("__smDeepQueryAll", () => {
     expect(__smDeepQueryAll(document, "[")).toEqual([]);
   });
 
+  // A <form> with a control named "children" makes HTMLFormElement's named
+  // getter (which [LegacyOverrideBuiltIns] lets shadow built-ins) return that
+  // control for form.children instead of the HTMLCollection. A naive
+  // `for (const c of node.children)` then throws "children is not iterable" on
+  // that form, aborting the whole walk — so any match AFTER the form silently
+  // vanished (the JetBlue booker-form bug). We simulate the collision directly
+  // so the guard holds regardless of the test DOM's form named-property
+  // fidelity: the cached childNodes getter must bypass the instance override.
+  test("survives a node whose `children` property is shadowed by a non-iterable value", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const decoy = document.createElement("input"); // non-iterable, like form[name=children]
+    const target = document.createElement("span");
+    target.className = "x";
+    container.appendChild(target);
+    // Shadow the built-in `children` accessor on this instance.
+    Object.defineProperty(container, "children", {
+      value: decoy,
+      configurable: true,
+    });
+    expect(container.children).toBe(decoy); // collision is in effect
+    expect(__smDeepQueryAll(document, ".x")).toEqual([target]);
+  });
+
   test("root itself carrying a shadow root is searched too", () => {
     const host = document.createElement("div");
     host.attachShadow({ mode: "open" }).innerHTML =

--- a/go/conformance/fixtures/013-not-has-leaf-scoping/README.md
+++ b/go/conformance/fixtures/013-not-has-leaf-scoping/README.md
@@ -1,0 +1,22 @@
+# 013-not-has-leaf-scoping
+
+Exercises a `:not(:has())` argument — the relational pseudo-class **nested inside
+`:not()`** — which requires the subject's subtree to evaluate. This is the
+leaf-scoping pattern `X:not(:has(X))`: match only the innermost `X`, the one that
+does not itself contain another `X`. (Drawn from the JetBlue checkout form, where
+a couple of fields are wrapped in an outer `jb-form-field-container` that shares
+the inner field's label; scoping to leaves gives one container per field.)
+
+A `div` root contains `fieldA` (a `jb-form-field-container` whose only descendant
+is an `input`) and `wrapper` (a `jb-form-field-container` that contains a nested
+`jb-form-field-container`, `fieldB`, which in turn holds an `input`). The sightmap
+uses `jb-form-field-container:not(:has(jb-form-field-container))`.
+
+`fieldA` and `fieldB` match `FormField`: neither contains a nested
+`jb-form-field-container`. `wrapper` does not match: its subtree contains
+`fieldB`, so its `:has(jb-form-field-container)` argument is satisfied and
+`:not()` excludes it.
+
+A matcher that ignores the `:has()` nested inside `:not()` (evaluating the `:not`
+argument by tag alone) excludes **every** `jb-form-field-container`, yielding zero
+matches — the offline-vs-live divergence this fixture guards against.

--- a/go/conformance/fixtures/013-not-has-leaf-scoping/component-tree.json
+++ b/go/conformance/fixtures/013-not-has-leaf-scoping/component-tree.json
@@ -1,0 +1,80 @@
+{
+  "id": "root",
+  "role": "generic",
+  "name": "",
+  "value": "",
+  "isVisible": true,
+  "isInteractive": false,
+  "inViewport": true,
+  "isIgnored": false,
+  "nthChild": 1,
+  "element": { "tag": "div" },
+  "children": [
+    {
+      "id": "fieldA",
+      "role": "generic",
+      "name": "",
+      "value": "",
+      "isVisible": true,
+      "isInteractive": false,
+      "inViewport": true,
+      "isIgnored": false,
+      "nthChild": 1,
+      "element": { "tag": "jb-form-field-container" },
+      "children": [
+        {
+          "id": "inputA",
+          "role": "textbox",
+          "name": "",
+          "value": "",
+          "isVisible": true,
+          "isInteractive": true,
+          "inViewport": true,
+          "isIgnored": false,
+          "nthChild": 1,
+          "element": { "tag": "input" }
+        }
+      ]
+    },
+    {
+      "id": "wrapper",
+      "role": "generic",
+      "name": "",
+      "value": "",
+      "isVisible": true,
+      "isInteractive": false,
+      "inViewport": true,
+      "isIgnored": false,
+      "nthChild": 2,
+      "element": { "tag": "jb-form-field-container" },
+      "children": [
+        {
+          "id": "fieldB",
+          "role": "generic",
+          "name": "",
+          "value": "",
+          "isVisible": true,
+          "isInteractive": false,
+          "inViewport": true,
+          "isIgnored": false,
+          "nthChild": 1,
+          "element": { "tag": "jb-form-field-container" },
+          "children": [
+            {
+              "id": "inputB",
+              "role": "textbox",
+              "name": "",
+              "value": "",
+              "isVisible": true,
+              "isInteractive": true,
+              "inViewport": true,
+              "isIgnored": false,
+              "nthChild": 1,
+              "element": { "tag": "input" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/go/conformance/fixtures/013-not-has-leaf-scoping/expected-matches.json
+++ b/go/conformance/fixtures/013-not-has-leaf-scoping/expected-matches.json
@@ -1,0 +1,1 @@
+{"FormField": ["fieldA", "fieldB"]}

--- a/go/conformance/fixtures/013-not-has-leaf-scoping/sightmap.yaml
+++ b/go/conformance/fixtures/013-not-has-leaf-scoping/sightmap.yaml
@@ -1,0 +1,3 @@
+- name: FormField
+  selectors:
+    - 'jb-form-field-container:not(:has(jb-form-field-container))'

--- a/go/conformance/fixtures/014-not-complex-descendant/README.md
+++ b/go/conformance/fixtures/014-not-complex-descendant/README.md
@@ -1,0 +1,20 @@
+# 014-not-complex-descendant
+
+Exercises a **descendant combinator inside `:not()`** — a complex selector as the
+`:not()` argument (CSS Selectors Level 4), which expresses an ancestor constraint
+on the subject and so requires the subject's ancestor chain to evaluate. (Drawn
+from the JetBlue checkout step CTA, which must exclude the `jb-sign-in` log-in
+button that is also a `jb-button-primary` within `jb-checkout`.)
+
+A `jb-checkout` contains a `jb-sign-in` wrapping `loginBtn` (a
+`button.jb-button-primary`) and a sibling `stepBtn` (also
+`button.jb-button-primary`, but not under `jb-sign-in`). The sightmap uses
+`jb-checkout button.jb-button-primary:not(jb-sign-in button)`.
+
+Only `stepBtn` matches `CheckoutNextButton`. `loginBtn` is excluded because it
+matches the `:not()` argument `jb-sign-in button` — it is a `button` with a
+`jb-sign-in` ancestor.
+
+A matcher that cannot parse a combinator inside `:not()` rejects this valid CSS
+selector outright (a corpus that fails to validate); one that parses it but drops
+the ancestor part silently includes `loginBtn`. This fixture guards both.

--- a/go/conformance/fixtures/014-not-complex-descendant/component-tree.json
+++ b/go/conformance/fixtures/014-not-complex-descendant/component-tree.json
@@ -1,0 +1,66 @@
+{
+  "id": "root",
+  "role": "generic",
+  "name": "",
+  "value": "",
+  "isVisible": true,
+  "isInteractive": false,
+  "inViewport": true,
+  "isIgnored": false,
+  "nthChild": 1,
+  "element": { "tag": "div" },
+  "children": [
+    {
+      "id": "checkout",
+      "role": "generic",
+      "name": "",
+      "value": "",
+      "isVisible": true,
+      "isInteractive": false,
+      "inViewport": true,
+      "isIgnored": false,
+      "nthChild": 1,
+      "element": { "tag": "jb-checkout" },
+      "children": [
+        {
+          "id": "signin",
+          "role": "generic",
+          "name": "",
+          "value": "",
+          "isVisible": true,
+          "isInteractive": false,
+          "inViewport": true,
+          "isIgnored": false,
+          "nthChild": 1,
+          "element": { "tag": "jb-sign-in" },
+          "children": [
+            {
+              "id": "loginBtn",
+              "role": "button",
+              "name": "Log in",
+              "value": "",
+              "isVisible": true,
+              "isInteractive": true,
+              "inViewport": true,
+              "isIgnored": false,
+              "nthChild": 1,
+              "element": { "tag": "button", "classes": ["jb-button-primary"] }
+            }
+          ]
+        },
+        {
+          "id": "stepBtn",
+          "role": "button",
+          "name": "Next: Seats & Extras",
+          "value": "",
+          "isVisible": true,
+          "isInteractive": true,
+          "inViewport": true,
+          "isIgnored": false,
+          "nthChild": 2,
+          "element": { "tag": "button", "classes": ["jb-button-primary"] }
+        }
+      ]
+    }
+  ]
+}

--- a/go/conformance/fixtures/014-not-complex-descendant/expected-matches.json
+++ b/go/conformance/fixtures/014-not-complex-descendant/expected-matches.json
@@ -1,0 +1,1 @@
+{"CheckoutNextButton": ["stepBtn"]}

--- a/go/conformance/fixtures/014-not-complex-descendant/sightmap.yaml
+++ b/go/conformance/fixtures/014-not-complex-descendant/sightmap.yaml
@@ -1,0 +1,3 @@
+- name: CheckoutNextButton
+  selectors:
+    - 'jb-checkout button.jb-button-primary:not(jb-sign-in button)'

--- a/go/match/matcher.go
+++ b/go/match/matcher.go
@@ -34,7 +34,7 @@ func FindAllMatches(
 	if root == nil || len(queries) == 0 {
 		return
 	}
-	findAllMatchesNFA(root, nil, nil, queries, onMatch)
+	findAllMatchesNFA([]*sightmap.ComponentNode{root}, nil, nil, queries, onMatch)
 }
 
 // ---- NFA internals ----------------------------------------------------------
@@ -52,11 +52,15 @@ type selectorState struct {
 //	direct     – states that must be checked at this node ONLY (direct-child
 //	             combinator consumed one level).
 func findAllMatchesNFA(
-	node *sightmap.ComponentNode,
+	chain []*sightmap.ComponentNode,
 	descendant, direct []selectorState,
 	queries []MatchQuery,
 	onMatch func(*sightmap.ComponentNode, *MatchQuery),
 ) {
+	// chain is root-first, including node as its last element; chain[:len-1] is
+	// node's ancestor path, which MatchesNodeChain needs to evaluate a :not()
+	// argument that carries a combinator (an ancestor constraint on the subject).
+	node := chain[len(chain)-1]
 	// Build de-duplicated set of states to evaluate at this node.
 	// Fresh starts ({q, 0}) are added for every query at every node — this is
 	// what makes "descendant" semantics work without explicit propagation of
@@ -104,9 +108,9 @@ func findAllMatchesNFA(
 
 	for _, state := range toCheck {
 		rule := state.q.Parts[state.idx]
-		// MatchesNode honors :has() (needs node's subtree); falls back to the
-		// flat checks for everything else.
-		if !sightmap.MatchesNode(node, rule) {
+		// MatchesNodeChain honors :has() (node's subtree) and a combinator-bearing
+		// :not() (node's ancestor chain); falls back to the flat checks otherwise.
+		if !sightmap.MatchesNodeChain(chain, rule) {
 			continue
 		}
 
@@ -136,7 +140,10 @@ func findAllMatchesNFA(
 	// is consumed after one hop because those children won't re-include it in
 	// their own nextDescendant when recursing further).
 	for _, child := range node.Children {
-		findAllMatchesNFA(child, nextDescendant, nextDirect, queries, onMatch)
+		// Full-slice expression caps capacity so each child's append allocates a
+		// fresh backing array — siblings never clobber one another's chain.
+		childChain := append(chain[:len(chain):len(chain)], child)
+		findAllMatchesNFA(childChain, nextDescendant, nextDirect, queries, onMatch)
 	}
 }
 

--- a/go/match/not_test.go
+++ b/go/match/not_test.go
@@ -1,0 +1,73 @@
+package match_test
+
+import (
+	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
+)
+
+// TestNot_HasLeafScoping is the load-bearing X:not(:has(Y)) leaf-scoping pattern
+// (JB FormField: 'jb-form-field-container:not(:has(jb-form-field-container))').
+// Only the leaf container — the one with no nested container of its own — should
+// match. Regresses the bug where :not(:has()) was evaluated by the flat matcher,
+// which ignored the inner :has() and so excluded EVERY container (0 offline).
+func TestNot_HasLeafScoping(t *testing.T) {
+	inner := node("inner", "jb-form-field-container", nil, node("lbl", "label", nil))
+	outer := node("outer", "jb-form-field-container", nil, inner)
+	root := node("root", "div", nil, outer)
+
+	defs := []sightmap.ComponentDef{{
+		Name:      "FormField",
+		Selectors: []string{`jb-form-field-container:not(:has(jb-form-field-container))`},
+	}}
+	assertIDs(t, applyDefs(t, root, defs), "FormField", "inner")
+}
+
+// TestNot_DescendantCombinator covers a descendant combinator inside :not() (an
+// ancestor constraint on the subject), the JB CheckoutNextButton case
+// 'jb-checkout button.jb-button-primary:not(jb-sign-in button)'. The primary
+// button nested under jb-sign-in must be excluded; the sibling step CTA (same
+// class, not under jb-sign-in) must match. Regresses both a parse error and the
+// need for ancestor context to evaluate it.
+func TestNot_DescendantCombinator(t *testing.T) {
+	login := node("login", "button", []string{"jb-button-primary"})
+	signIn := node("signin", "jb-sign-in", nil, login)
+	step := node("step", "button", []string{"jb-button-primary"})
+	root := node("root", "div", nil, node("co", "jb-checkout", nil, signIn, step))
+
+	defs := []sightmap.ComponentDef{{
+		Name:      "CheckoutNextButton",
+		Selectors: []string{`jb-checkout button.jb-button-primary:not(jb-sign-in button)`},
+	}}
+	assertIDs(t, applyDefs(t, root, defs), "CheckoutNextButton", "step")
+}
+
+// TestNot_DirectChildCombinator checks the > combinator inside :not(): only a
+// button that is a DIRECT child of a toolbar is excluded; a more deeply nested
+// one is not.
+func TestNot_DirectChildCombinator(t *testing.T) {
+	directChild := node("direct", "button", nil)
+	nested := node("nested", "button", nil)
+	root := node("root", "div", nil,
+		node("tb", "toolbar", nil, directChild, node("wrap", "span", nil, nested)),
+	)
+	defs := []sightmap.ComponentDef{{
+		Name:      "FreeButton",
+		Selectors: []string{`button:not(toolbar > button)`},
+	}}
+	// directChild is a direct toolbar child → excluded; nested is a grandchild → kept.
+	assertIDs(t, applyDefs(t, root, defs), "FreeButton", "nested")
+}
+
+// TestIs_HasNodeAware verifies an alternative inside :is() carrying a :has() is
+// evaluated with tree context (same class of bug as :not(:has())).
+func TestIs_HasNodeAware(t *testing.T) {
+	withChild := node("withkid", "section", []string{"card"}, node("k", "img", nil))
+	without := node("nokid", "section", []string{"card"})
+	root := node("root", "div", nil, withChild, without)
+	defs := []sightmap.ComponentDef{{
+		Name:      "MediaCard",
+		Selectors: []string{`section:is(.card:has(img))`},
+	}}
+	assertIDs(t, applyDefs(t, root, defs), "MediaCard", "withkid")
+}

--- a/go/sightmap/comps_component.go
+++ b/go/sightmap/comps_component.go
@@ -20,9 +20,15 @@ type SelectorPart struct {
 	// operator is not exact equality. Omitted entries default to "=".
 	// Valid operators: "=" (default), "^=", "$=", "*=", "~=", "|=", "[]" (presence-only).
 	AttrOps map[string]string `json:"attrOps,omitempty"`
-	// Not, if non-nil, is a selector that the element must NOT match.
-	// Represents the :not() pseudo-class.
-	Not *SelectorPart `json:"not,omitempty"`
+	// Not, if non-empty, holds the argument(s) of the :not() pseudo-class(es) on
+	// this compound selector as a flat selector list: the element matches only if
+	// it matches NONE of the entries. Each entry is a full complex selector whose
+	// SUBJECT (the element under test) is its last Part; any earlier Part is an
+	// ancestor constraint, evaluated only when ancestor context is available (see
+	// MatchesNodeChain). Multiple :not() on one compound and a comma-separated
+	// list inside one :not() both flatten here (both mean "exclude if ANY match").
+	// A plain :not(.foo) is a single entry whose Parts has length 1.
+	Not []ParsedSelector `json:"not,omitempty"`
 	// Is, if non-empty, contains the alternatives from a :is() or :where()
 	// pseudo-class. The element must match at least one alternative.
 	Is []*SelectorPart `json:"is,omitempty"`

--- a/go/sightmap/lint.go
+++ b/go/sightmap/lint.go
@@ -346,7 +346,7 @@ func lintComponentWithCounts(comp ComponentDef, global bool, counts map[string]i
 		if global {
 			if ps, err := ParseSightmapSelector(selStr); err == nil && len(ps.Parts) == 1 {
 				p := ps.Parts[0]
-				if p.Tag != "" && p.Id == "" && len(p.Classes) == 0 && len(p.Attrs) == 0 && p.Not == nil {
+				if p.Tag != "" && p.Id == "" && len(p.Classes) == 0 && len(p.Attrs) == 0 && len(p.Not) == 0 {
 					warnings = append(warnings, LintWarning{
 						Component: name,
 						Selector:  selStr,

--- a/go/sightmap/sel_match.go
+++ b/go/sightmap/sel_match.go
@@ -5,20 +5,72 @@ import (
 )
 
 // MatchesNode reports whether a tree node satisfies rule, including the
-// relational :has() pseudo-class (which needs the node's subtree). It first
-// applies the flat checks via Matches, then verifies every :has() entry against
-// node's descendants. Tree-walking callers (the rule matcher, sel-check, lint)
-// should use this instead of Matches so :has() is honored.
+// relational pseudo-classes that need the node's subtree (:has()) or its
+// ancestors (a :not() whose argument carries a combinator). It is the
+// single-node entry point: the node is treated as the root of its own chain, so
+// an ancestor-constrained :not() argument finds no ancestor and therefore does
+// not exclude. Callers that hold the node's ancestor chain (the NFA matcher)
+// should use MatchesNodeChain so those :not() arguments are evaluated fully.
+// Tree-walking callers (sel-check, lint, coverage) use this.
 func MatchesNode(node *ComponentNode, rule *SelectorPart) bool {
+	return MatchesNodeChain([]*ComponentNode{node}, rule)
+}
+
+// MatchesNodeChain reports whether the LAST node of chain (the subject) satisfies
+// rule. chain is root-first (chain[0] is the outermost ancestor, chain[len-1] is
+// the subject); chain[:len-1] is the subject's ancestor path, used to evaluate a
+// :not() argument that carries a combinator (an ancestor constraint on the
+// subject). :has() is evaluated against the subject's own subtree. A nil rule
+// matches everything.
+func MatchesNodeChain(chain []*ComponentNode, rule *SelectorPart) bool {
 	if rule == nil {
 		return true
 	}
+	if len(chain) == 0 {
+		return matchesNodeChain([]*ComponentNode{{}}, 0, rule)
+	}
+	return matchesNodeChain(chain, len(chain)-1, rule)
+}
+
+// matchesNodeChain reports whether chain[i] satisfies rule, using chain[:i] as
+// its ancestors (for combinator-bearing :not() arguments) and chain[i]'s subtree
+// (for :has()). It is the recursion core shared by MatchesNodeChain, :is()
+// alternatives, and :not() argument subjects, so every nested relational pseudo
+// is honored with the correct tree context.
+func matchesNodeChain(chain []*ComponentNode, i int, rule *SelectorPart) bool {
+	if rule == nil {
+		return true
+	}
+	node := chain[i]
 	el := node.Element
 	if el == nil {
 		el = &Element{}
 	}
-	if !Matches(el, rule) {
+	// Flat identity: tag, id, classes, attributes.
+	if !matchesIdentity(el, rule) {
 		return false
+	}
+	// :is() / :where() — the subject must match at least one alternative.
+	// Evaluated node-aware so an alternative may itself carry :has()/:not().
+	if len(rule.Is) > 0 {
+		anyMatch := false
+		for _, alt := range rule.Is {
+			if matchesNodeChain(chain, i, alt) {
+				anyMatch = true
+				break
+			}
+		}
+		if !anyMatch {
+			return false
+		}
+	}
+	// :not() — exclude if the subject matches ANY argument (as that argument's
+	// subject). Multiple :not() and comma-lists both flatten into rule.Not.
+	for n := range rule.Not {
+		arg := rule.Not[n]
+		if complexSubjectMatch(chain, i, arg.Parts, arg.Combinators, len(arg.Parts)-1) {
+			return false
+		}
 	}
 	// :has() — each entry is AND-ed; within an entry, alternatives are OR-ed.
 	for _, h := range rule.Has {
@@ -27,6 +79,33 @@ func MatchesNode(node *ComponentNode, rule *SelectorPart) bool {
 		}
 	}
 	return true
+}
+
+// complexSubjectMatch reports whether chain[i] matches the complex selector
+// parts[:pi+1] (root-first, combinators[k] precedes parts[k], combinators[0]=="")
+// with parts[pi] as the subject. parts[pi] is tested against chain[i]; each
+// earlier part is matched against an ancestor per its combinator (">" = direct
+// parent, " " = any ancestor). Used to evaluate a :not() argument.
+func complexSubjectMatch(chain []*ComponentNode, i int, parts []*SelectorPart, combs []string, pi int) bool {
+	if pi < 0 || pi >= len(parts) {
+		return false
+	}
+	if !matchesNodeChain(chain, i, parts[pi]) {
+		return false
+	}
+	if pi == 0 {
+		return true
+	}
+	// combs[pi] links parts[pi-1] (ancestor) to parts[pi] (this subject).
+	if combs[pi] == ">" {
+		return i > 0 && complexSubjectMatch(chain, i-1, parts, combs, pi-1)
+	}
+	for a := i - 1; a >= 0; a-- {
+		if complexSubjectMatch(chain, a, parts, combs, pi-1) {
+			return true
+		}
+	}
+	return false
 }
 
 // hasMatches reports whether node's subtree satisfies the :has() selector h
@@ -66,15 +145,53 @@ func relMatches(anchor *ComponentNode, parts []*SelectorPart, combs []string, id
 	return search(anchor)
 }
 
-// Matches reports whether node satisfies rule. It checks tag, id, classes,
-// attribute operators, :not(), and :is()/:where(). It does NOT evaluate :has()
-// (which needs tree context — use MatchesNode for that). A nil rule matches
-// everything. el is the observed element's identity (the subject).
+// Matches reports whether el satisfies rule using only the element's own
+// identity (no tree). It checks tag, id, classes, attribute operators, :is()/
+// :where(), and the tree-free part of :not(). It CANNOT evaluate :has() (needs a
+// subtree), a :not() argument carrying a combinator (needs ancestors), or a
+// :not(:has()) (needs a subtree): those are skipped here, so this is a best-
+// effort element-only check — use MatchesNode / MatchesNodeChain for full,
+// tree-aware matching. A nil rule matches everything. el is the observed
+// element's identity (the subject).
 func Matches(el *Element, rule *SelectorPart) bool {
 	if rule == nil {
 		return true
 	}
+	if !matchesIdentity(el, rule) {
+		return false
+	}
 
+	// :is() / :where() — node must match at least one alternative.
+	if len(rule.Is) > 0 {
+		anyMatch := false
+		for _, alt := range rule.Is {
+			if Matches(el, alt) {
+				anyMatch = true
+				break
+			}
+		}
+		if !anyMatch {
+			return false
+		}
+	}
+
+	// :not() — element-only: an argument that is a single compound with no :has()
+	// can be evaluated against el alone. Complex (ancestor-constrained) or
+	// :has()-bearing arguments need tree context and are skipped here.
+	for n := range rule.Not {
+		arg := rule.Not[n]
+		if len(arg.Parts) == 1 && len(arg.Parts[0].Has) == 0 && Matches(el, arg.Parts[0]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchesIdentity checks the tree-free identity of el against rule: tag, id,
+// classes, and attribute operators. It ignores the logical/relational pseudos
+// (:is/:not/:has), which the callers layer on with the appropriate context.
+func matchesIdentity(el *Element, rule *SelectorPart) bool {
 	// Tag match (case-insensitive for HTML; case-sensitive for synthetic mobile).
 	if rule.Tag != "" && !strings.EqualFold(el.Tag, rule.Tag) {
 		return false
@@ -112,25 +229,6 @@ func Matches(el *Element, rule *SelectorPart) bool {
 		}
 
 		if !attrMatches(op, nodeVal, ruleVal) {
-			return false
-		}
-	}
-
-	// :not() check.
-	if rule.Not != nil && Matches(el, rule.Not) {
-		return false
-	}
-
-	// :is() / :where() — node must match at least one alternative.
-	if len(rule.Is) > 0 {
-		anyMatch := false
-		for _, alt := range rule.Is {
-			if Matches(el, alt) {
-				anyMatch = true
-				break
-			}
-		}
-		if !anyMatch {
 			return false
 		}
 	}

--- a/go/sightmap/sel_match_test.go
+++ b/go/sightmap/sel_match_test.go
@@ -1,8 +1,9 @@
 package sightmap_test
 
 import (
-	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 func TestMatches_NilRule(t *testing.T) {
@@ -248,7 +249,10 @@ func TestMatches_Not(t *testing.T) {
 
 	rule := &sightmap.SelectorPart{
 		Tag: "button",
-		Not: &sightmap.SelectorPart{Classes: []string{"disabled"}},
+		Not: []sightmap.ParsedSelector{{
+			Parts:       []*sightmap.SelectorPart{{Classes: []string{"disabled"}}},
+			Combinators: []string{""},
+		}},
 	}
 
 	if !sightmap.Matches(enabled, rule) {

--- a/go/sightmap/sel_parse.go
+++ b/go/sightmap/sel_parse.go
@@ -22,8 +22,9 @@ type ParsedSelector struct {
 // ParsedSelector. Supports the sightmap subset: tag, #id, .class,
 // [attr], [attr=val], [attr^=val], [attr$=val], [attr*=val], [attr~=val],
 // [attr|=val], :not(), :is(), :where(), :has(), and descendant /
-// direct-child (>) combinators. Sibling combinators (+, ~) are not supported,
-// including inside :has().
+// direct-child (>) combinators. :not() and :has() accept a complex-selector
+// list (combinators and nested :has()/:not() allowed). Sibling combinators
+// (+, ~) are not supported, including inside :not() and :has().
 func ParseSightmapSelector(s string) (ParsedSelector, error) {
 	p := &parser{s: s}
 	result, err := p.parseSelector()
@@ -400,7 +401,37 @@ func (p *parser) parsePseudo(part *SelectorPart) error {
 
 	switch name {
 	case "not":
-		// handled below
+		// :not() takes a complex-selector list (CSS Selectors L4). Each item is a
+		// full complex selector whose subject is the element under test; an earlier
+		// part is an ancestor constraint. parseSelector handles combinators and any
+		// nested :has()/:not(), and stops at ',' or ')'.
+		if p.i >= len(p.s) || p.s[p.i] != '(' {
+			return fmt.Errorf("expected '(' after :not")
+		}
+		p.i++ // consume '('
+		for {
+			inner, innerErr := p.parseSelector()
+			if innerErr != nil {
+				return fmt.Errorf(":not() argument: %w", innerErr)
+			}
+			if len(inner.Parts) == 0 {
+				return fmt.Errorf(":not() argument is empty")
+			}
+			part.Not = append(part.Not, inner)
+			p.skipWhitespace()
+			if p.i >= len(p.s) {
+				return fmt.Errorf("expected ')' or ',' in :not()")
+			}
+			if p.s[p.i] == ')' {
+				p.i++
+				break
+			}
+			if p.s[p.i] != ',' {
+				return fmt.Errorf("expected ')' or ',' in :not(), got %q", p.s[p.i])
+			}
+			p.i++ // consume ','
+		}
+		return nil
 
 	case "has":
 		if p.i >= len(p.s) || p.s[p.i] != '(' {
@@ -464,29 +495,6 @@ func (p *parser) parsePseudo(part *SelectorPart) error {
 			" — to distinguish identical siblings, merge them into one component"+
 			" (e.g. one CardActionButton) or add a distinguishing data-* attribute to the source element", name)
 	}
-
-	// :not() logic
-	// Consume '('
-	if p.i >= len(p.s) || p.s[p.i] != '(' {
-		return fmt.Errorf("expected '(' after :not")
-	}
-	p.i++
-	p.skipWhitespace()
-
-	// Parse the inner simple selector.
-	inner, err := p.parseSimpleSelectors()
-	if err != nil {
-		return fmt.Errorf(":not() argument: %w", err)
-	}
-
-	p.skipWhitespace()
-	if p.i >= len(p.s) || p.s[p.i] != ')' {
-		return fmt.Errorf("expected ')' to close :not()")
-	}
-	p.i++ // consume ')'
-
-	part.Not = inner
-	return nil
 }
 
 // parseRelativeSelector parses one relative selector inside :has(). It allows an

--- a/go/sightmap/sel_parse_test.go
+++ b/go/sightmap/sel_parse_test.go
@@ -1,8 +1,9 @@
 package sightmap_test
 
 import (
-	"github.com/sightmap/sightmap/go/sightmap"
 	"testing"
+
+	"github.com/sightmap/sightmap/go/sightmap"
 )
 
 // parseOK parses s and fails t if there's an error.
@@ -157,22 +158,69 @@ func TestParse_NotPseudo(t *testing.T) {
 	if part.Tag != "button" {
 		t.Errorf("tag: got %q, want button", part.Tag)
 	}
-	if part.Not == nil {
-		t.Fatal("Not is nil")
+	if len(part.Not) != 1 || len(part.Not[0].Parts) != 1 {
+		t.Fatalf("Not: got %d entries, want 1 single-part", len(part.Not))
 	}
-	if len(part.Not.Classes) != 1 || part.Not.Classes[0] != "disabled" {
-		t.Errorf("Not.Classes: got %v, want [disabled]", part.Not.Classes)
+	notArg := part.Not[0].Parts[0]
+	if len(notArg.Classes) != 1 || notArg.Classes[0] != "disabled" {
+		t.Errorf("Not.Classes: got %v, want [disabled]", notArg.Classes)
 	}
 }
 
 func TestParse_NotWithAttr(t *testing.T) {
 	ps := parseOK(t, `div:not([hidden])`)
-	if ps.Parts[0].Not == nil {
-		t.Fatal("Not is nil")
+	if len(ps.Parts[0].Not) != 1 || len(ps.Parts[0].Not[0].Parts) != 1 {
+		t.Fatalf("Not: got %d entries, want 1 single-part", len(ps.Parts[0].Not))
 	}
-	if ps.Parts[0].Not.AttrOps["hidden"] != "[]" {
-		t.Errorf("Not attr presence: got %q", ps.Parts[0].Not.AttrOps["hidden"])
+	if ps.Parts[0].Not[0].Parts[0].AttrOps["hidden"] != "[]" {
+		t.Errorf("Not attr presence: got %q", ps.Parts[0].Not[0].Parts[0].AttrOps["hidden"])
 	}
+}
+
+func TestParse_NotComplexDescendant(t *testing.T) {
+	// A descendant combinator inside :not() (CSS L4 complex-selector argument):
+	// the argument parses into a 2-part complex selector, subject last.
+	ps := parseOK(t, `button.jb-button-primary:not(jb-sign-in button)`)
+	if len(ps.Parts) != 1 {
+		t.Fatalf("outer parts: got %d, want 1", len(ps.Parts))
+	}
+	not := ps.Parts[0].Not
+	if len(not) != 1 {
+		t.Fatalf("Not entries: got %d, want 1", len(not))
+	}
+	if len(not[0].Parts) != 2 {
+		t.Fatalf(":not() arg parts: got %d, want 2", len(not[0].Parts))
+	}
+	if not[0].Parts[0].Tag != "jb-sign-in" || not[0].Parts[1].Tag != "button" {
+		t.Errorf(":not() arg tags: got [%q %q], want [jb-sign-in button]", not[0].Parts[0].Tag, not[0].Parts[1].Tag)
+	}
+	if not[0].Combinators[1] != " " {
+		t.Errorf(":not() arg combinator[1]: got %q, want descendant", not[0].Combinators[1])
+	}
+}
+
+func TestParse_NotList(t *testing.T) {
+	// A comma-separated list inside one :not() flattens into two entries.
+	ps := parseOK(t, `div:not(.a, .b)`)
+	if got := len(ps.Parts[0].Not); got != 2 {
+		t.Fatalf("Not entries: got %d, want 2", got)
+	}
+}
+
+func TestParse_NotDirectChild(t *testing.T) {
+	ps := parseOK(t, `button:not(toolbar > button)`)
+	not := ps.Parts[0].Not
+	if len(not) != 1 || len(not[0].Parts) != 2 {
+		t.Fatalf(":not() arg: got %d entries", len(not))
+	}
+	if not[0].Combinators[1] != ">" {
+		t.Errorf(":not() arg combinator[1]: got %q, want >", not[0].Combinators[1])
+	}
+}
+
+func TestParse_NotSiblingRejected(t *testing.T) {
+	// Sibling combinators remain unsupported, including inside :not() — reject loudly.
+	parseErr(t, `button:not(span + button)`)
 }
 
 func TestParse_DescendantCombinator(t *testing.T) {


### PR DESCRIPTION
Closes #410.

Brings both selector matchers back into parity with the browser on real, form-heavy pages. Two independent parity bugs, one per commit; both are pure standard-CSS / DOM fixes (no spec change).

## 1. `fix(match)` — offline `:not(:has())` + combinator inside `:not()`

- `:not(:has(...))` / `:is(...:has(...))` evaluated their argument via the flat element matcher (ignores `:has()`), so `X:not(:has(X))` leaf-scoping matched **0** offline (`jb-form-field-container:not(:has(jb-form-field-container))` was 18 live / 0 offline).
- A descendant/child combinator inside `:not()` (`button:not(nav button)`) failed to **parse**, so valid CSS wouldn't `validate`.

Generalizes `SelectorPart.Not` to a complex-selector list and makes node matching ancestor-chain aware (`MatchesNodeChain`; the NFA threads the root→node chain) so a combinator-`:not` evaluates its ancestor constraint and `:is`/`:not` arguments are evaluated node-aware. Sibling combinators stay rejected loudly at parse.

Tests: `match/not_test.go`, `sel_parse` tests, and conformance fixtures `013-not-has-leaf-scoping` / `014-not-complex-descendant` (the cross-implementation contract).

## 2. `fix(browser)` — live deep query under-reports on forms

`__smDeepQueryAll` walked via `node.children`. On a `<form>` with a control named `children`, the form's named getter returns that control instead of the `HTMLCollection` (`[LegacyOverrideBuiltIns]`), so `for (const c of node.children)` throws and the blanket `catch` returns a **truncated** result — silently 0 for any match after the form. Now traverses via cached `Node.prototype`/`Element.prototype` accessors (cached inside the function, since the file is re-eval'd in one tab context). Fixes `sel-probe` and component-query `click`/`fill`/`hover`.

Test: `browser/deepquery.test.js` (named-property-collision regression).

## Verification

- Full Go suite + `deepquery` jest green; gofmt clean; embedded-skills drift check clean.
- `sightmap validate` now passes on the JetBlue corpus (previously errored on the combinator-`:not`).
- Live on jetblue.com: `sel-probe` now equals native `querySelectorAll` for every previously-flagged selector (submit 1/1, input-search a 1/1, rounded-button 1/1, points-toggle 2/2, dy-container a 3/3, dy_cta 1/1).

Changesets: `minor` (offline matcher; `SelectorPart.Not` type change) + `patch` (live deep query).
