### PR TITLE
web: publish the sightkick blog post

### DIFF
--- a/web/content/blog/sightkick.md
+++ b/web/content/blog/sightkick.md
@@ -5,7 +5,6 @@ topic: 'research'
 date: '2026-09-08'
 author: 'Clint Ayres'
 slug: 'sightkick'
-draft: true
 image: '/blog/og/sightkick.png'
 ---
 


### PR DESCRIPTION
The post shipped with `draft: true` in its front matter. The blog index filters drafts out, and the production prerender skips them entirely, so the post never appeared after the last deploy.

This removes the flag. `pnpm build:blog` now lists `sightkick` in the manifest with no draft marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8chiprYM9bwtqgajkzKmh