### PR TITLE
feat(extract): add raw_text extract mode (SEP-0013)

### DIFF
--- a/.changeset/raw-text-extract.md
+++ b/.changeset/raw-text-extract.md
@@ -1,0 +1,11 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add the `raw_text` extract mode (SEP-0013, first half).
+
+`extract: raw_text` returns a node's **own literal text** — the concatenation of its direct text-node children, whitespace-normalized — never its accessibility name. It is pinned to `textContent`-style data, **not** the layout-dependent `innerText`, and it excludes both descendant element text (no `<style>`/`<script>` bleed, no subtree concatenation) and CSS pseudo content (`::before`/`::after`).
+
+It is the deterministic escape for when the accessible name welds in extra text: a heading whose AX name appends a CSS `::after` badge resolves `text` to "Main Most popular" but `raw_text` to "Main", so an exact property match (`SubFare[tier="Main"]`) works. `text` stays the default (and the right choice when the accessible name *is* the value); an empty `raw_text` omits the property, like the other extract forms.
+
+(The other half of SEP-0013 — pinning `text` to a faithful, cross-consumer accessible-name computation, and carrying interactive-state attributes — is deferred.)

--- a/go/extract/build.go
+++ b/go/extract/build.go
@@ -111,6 +111,7 @@ func walkDOMNode(
 		Role:          role,
 		Name:          name,
 		Text:          normalizeText(pc.Text),
+		RawText:       normalizeText(pc.RawText),
 		Value:         value,
 		Properties:    props,
 		Element:       el,

--- a/go/extract/types.go
+++ b/go/extract/types.go
@@ -16,9 +16,10 @@ type ProbeResult struct {
 // the string using sightmap.ParseSightmapSelector.
 type ProbeComponent struct {
 	Id            string            `json:"id"`
-	Role          string            `json:"role"`  // empty pre-merge
-	Text          string            `json:"text"`  // raw textContent
-	Value         string            `json:"value"` // empty pre-merge
+	Role          string            `json:"role"`    // empty pre-merge
+	Text          string            `json:"text"`    // rendered innerText
+	RawText       string            `json:"rawText"` // own direct-text-node content (SEP-0013 raw_text)
+	Value         string            `json:"value"`   // empty pre-merge
 	Properties    map[string]string `json:"properties"`
 	Bounds        *sightmap.Bounds  `json:"bounds"`
 	Selector      string            `json:"selector"`   // CSS selector string

--- a/go/match/component_props.go
+++ b/go/match/component_props.go
@@ -52,6 +52,14 @@ func resolveExtract(
 		}
 		return node.Text, node.Text != ""
 
+	case extract == "raw_text":
+		// The node's own literal text (direct text nodes, normalized) — never the
+		// accessibility name, and pinned to textContent-style data rather than the
+		// layout-dependent innerText (SEP-0013). The deterministic escape when the
+		// accessible name welds in extra text (e.g. a heading whose AX name appends
+		// a CSS ::after badge: `text` -> "Main Most popular" but `raw_text` -> "Main").
+		return node.RawText, node.RawText != ""
+
 	case strings.HasPrefix(extract, "attr="):
 		name := extract[len("attr="):]
 		if name == "" || node.Element == nil {

--- a/go/match/component_props_test.go
+++ b/go/match/component_props_test.go
@@ -42,6 +42,49 @@ func productCardDefs() []sightmap.ComponentDef {
 	}
 }
 
+// TestResolveRawText covers the SEP-0013 raw_text extractor: it always returns
+// the node's raw rendered Text, never the accessibility Name — the deterministic
+// escape when the AX name welds in extra text. Mirrors the JetBlue sub-fare tile,
+// whose heading AX name is "Main Most popular" but whose raw text is "Main", so
+// SubFare[tier="Main"] can only match via raw_text.
+func TestResolveRawText(t *testing.T) {
+	defs := []sightmap.ComponentDef{{
+		Name:      "SubFare",
+		Selectors: []string{"[data-testid=tile]"},
+		Properties: []sightmap.ComponentPropertyDef{
+			{Name: "welded", Extract: "text"},   // AX name (welded)
+			{Name: "tier", Extract: "raw_text"}, // raw text (clean)
+		},
+	}}
+	tile := &sightmap.ComponentNode{
+		Id:      "tile",
+		Name:    "Main Most popular", // welded accessibility name (Name)
+		RawText: "Main",              // clean own text (RawText)
+		Element: &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "tile"}},
+	}
+	// A node with no own text at all: raw_text omits (per SEP-0013). Name is
+	// non-empty to prove raw_text never falls back to the accessibility name.
+	noText := &sightmap.ComponentNode{
+		Id:      "tile",
+		Name:    "Only a name",
+		RawText: "",
+		Element: &sightmap.Element{Tag: "div", Attrs: map[string]string{"data-testid": "tile"}},
+	}
+
+	res := match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs}).Match(tile, "")
+	if v, ok := propVal(res[tile], "welded"); !ok || v != "Main Most popular" {
+		t.Errorf("welded (text) = %q, %v; want \"Main Most popular\", true", v, ok)
+	}
+	if v, ok := propVal(res[tile], "tier"); !ok || v != "Main" {
+		t.Errorf("tier (raw_text) = %q, %v; want \"Main\", true", v, ok)
+	}
+
+	res2 := match.NewMatcher(&sightmap.Corpus{GlobalComponents: defs}).Match(noText, "")
+	if v, ok := propVal(res2[noText], "tier"); ok {
+		t.Errorf("tier (raw_text) on empty Text = %q, %v; want omitted", v, ok)
+	}
+}
+
 func propVal(cm *sightmap.ComponentMatch, name string) (string, bool) {
 	if cm == nil {
 		return "", false

--- a/go/probe/probe.js
+++ b/go/probe/probe.js
@@ -374,6 +374,21 @@ function computeCompProps(isLogicalRoot, useScrollOffset) {
             // returns its <style> text). Go-side normalizeText collapses any
             // residual whitespace.
             text: (noTextTags.has(tag) || !isVisible) ? '' : ((element.innerText || '').substring(0, 100)),
+            // Raw own text: the element's OWN direct text-node children, verbatim.
+            // Unlike `text` (innerText) it is layout-independent and deterministic,
+            // and unlike textContent it excludes descendant element text (no
+            // <style>/<script> bleed, no subtree concatenation) and CSS pseudo
+            // content (::before/::after are not child nodes). This is the pinned
+            // source for `extract: raw_text` (SEP-0013) — the literal author text
+            // of the node, distinct from its (possibly welded) accessible name.
+            rawText: noTextTags.has(tag) ? '' : (function () {
+                var s = '';
+                var kids = element.childNodes;
+                for (var i = 0; i < kids.length; i++) {
+                    if (kids[i].nodeType === 3) s += kids[i].data;
+                }
+                return s.substring(0, 100);
+            })(),
             value: '',                                                 // Will be filled by accessibility data
             properties: {},                                            // Will be filled by accessibility data
             bounds: bounds,

--- a/go/sightmap/comps_component.go
+++ b/go/sightmap/comps_component.go
@@ -123,6 +123,15 @@ type ComponentNode struct {
 	// Unlike Name, it is present for role-less leaves/containers. (post-merge)
 	Text string `json:"text,omitempty"`
 
+	// RawText is the node's OWN literal text: the concatenation of its direct
+	// text-node children, whitespace-normalized. Unlike Text (innerText) it is
+	// layout-independent and deterministic, and unlike a subtree textContent it
+	// excludes descendant element text and CSS pseudo content (::before/::after).
+	// It is the source for `extract: raw_text` (SEP-0013): the literal author text,
+	// distinct from Name (the accessibility name, which may weld in pseudo/aria
+	// text). Empty when the node has no direct text of its own. (post-merge)
+	RawText string `json:"rawText,omitempty"`
+
 	// Value is the current value for form controls (inputs, selects, etc.). (post-merge)
 	Value string `json:"value"`
 

--- a/go/sightmap/validate_component.go
+++ b/go/sightmap/validate_component.go
@@ -15,10 +15,11 @@ var (
 	pathSegmentRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 )
 
-// checkComponentProperties validates every component's properties[] (SEP-0010):
-// names must be unique within a component, and each extract directive must be one
-// of the four forms text | attr=NAME | PATH.prop | exists:PATH. Anything else —
-// the removed DOM modes (inner_text, text_only, inner_html), a bare CSS
+// checkComponentProperties validates every component's properties[] (SEP-0010,
+// extended by SEP-0013): names must be unique within a component, and each
+// extract directive must be one of the forms
+// text | raw_text | attr=NAME | PATH.prop | exists:PATH. Anything else — the
+// removed DOM modes (inner_text, text_only, inner_html), a bare CSS
 // sub-selector, or a mistyped attr/exists prefix — is an error.
 func checkComponentProperties(c *Corpus) []ValidationError {
 	var errs []ValidationError
@@ -55,6 +56,8 @@ func checkExtractMode(extract string) string {
 	switch {
 	case extract == "text":
 		return ""
+	case extract == "raw_text":
+		return ""
 	case strings.HasPrefix(extract, "attr="):
 		if extract == "attr=" {
 			return "attr= requires an attribute name"
@@ -65,7 +68,7 @@ func checkExtractMode(extract string) string {
 	default: // PATH.prop
 		dot := strings.LastIndex(extract, ".")
 		if dot <= 0 || dot == len(extract)-1 {
-			return fmt.Sprintf("unrecognized extract mode %q (expected text, attr=NAME, PATH.prop, or exists:PATH)", extract)
+			return fmt.Sprintf("unrecognized extract mode %q (expected text, raw_text, attr=NAME, PATH.prop, or exists:PATH)", extract)
 		}
 		if msg := checkComponentPath(extract[:dot]); msg != "" {
 			return msg

--- a/go/sightmap/validate_component_test.go
+++ b/go/sightmap/validate_component_test.go
@@ -28,6 +28,7 @@ func TestCheckComponentProperties(t *testing.T) {
 			name: "valid forms",
 			props: []ComponentPropertyDef{
 				{Name: "label", Extract: "text"},
+				{Name: "tier", Extract: "raw_text"},
 				{Name: "href", Extract: "attr=href"},
 				{Name: "price", Extract: "Price.text"},
 				{Name: "sold_out", Extract: "exists:SoldOutBadge"},

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -190,7 +190,7 @@
         "extract": {
           "type": "string",
           "minLength": 1,
-          "description": "Extraction directive, one of: text | attr=NAME | PATH.prop | exists:PATH. The grammar is validated by the SDK. See SEP-0010 Extract grammar."
+          "description": "Extraction directive, one of: text | raw_text | attr=NAME | PATH.prop | exists:PATH. The grammar is validated by the SDK. See SEP-0010 Extract grammar (raw_text added by SEP-0013)."
         }
       }
     },


### PR DESCRIPTION
Adds the `raw_text` extract mode (SEP-0013, first half).

> **Stacked on #411** — base is `fix/live-offline-matcher-parity`. Review/merge #411 first; this then rebases onto `main`. The diff below is only the `raw_text` commit.

## Changes
- New `extract: raw_text` — a node's **own literal text** (concatenation of its direct text-node children, whitespace-normalized), never the accessibility name and never `innerText`. The deterministic escape when the accessible name welds in CSS/aria text (a heading whose AX name appends a `::after` badge: `text` → "Main Most popular", `raw_text` → "Main").
- Sourced from a new probe-captured `node.RawText` (own direct text nodes) carried through the extract pipeline; resolver (`match/component_props.go`), validator (`validate_component.go`), `probe.js`, `ComponentNode.RawText`, JSON Schema description.
- Changeset: `@sightmap/sightmap` minor.

## Verification
- Unit tests (`TestResolveRawText`; validator accepts `raw_text`); full suite green; gofmt clean.
- Live on jetblue.com: `SubFare.tier` via `raw_text` extracts "Main" (not the AX name "Main Most popular"), so `select_fare`'s `SubFare[tier="Main"]` resolves and commits the leg (previously a silent timeout).

SEP: #406. Runtime counterpart: sightmap/sightkick#26.
