### PR TITLE
fix(browser): name the real Chrome flag for native WebMCP

### DIFF
--- a/.changeset/webmcp-flag-hint.md
+++ b/.changeset/webmcp-flag-hint.md
@@ -1,0 +1,11 @@
+---
+"@sightmap/sightmap": patch
+---
+
+`browser mcp` no longer points at Chrome flags that do not exist. The "no WebMCP
+tools here" error used to suggest `--enable-blink-features=ModelContext,ModelContextTesting`
+and `--enable-features=DevToolsWebMCPSupport`; Chrome silently ignores those
+names, so following them left `document.modelContext` undefined on Google Chrome
+and made the native path look unshipped. The message and the `browser mcp` docs
+now name the real switch, `--enable-features=WebMCPTesting` (the same feature as
+`chrome://flags/#enable-webmcp-testing`). Fixes #413.

--- a/docs/cli/browser.mdx
+++ b/docs/cli/browser.mdx
@@ -202,14 +202,12 @@ sightmap browser inject --remove inj-1
 
 Enumerate and call the [WebMCP](https://webmachinelearning.github.io/webmcp/) tools a page exposes. A page can declare callable actions to an in-browser agent through `document.modelContext` (`getTools()` / `executeTool()`); `mcp list` reads them and `mcp call` invokes one — so you can call a named action instead of driving the UI blind.
 
-`mcp list` distinguishes three states: **native** WebMCP (a browser-provided `document.modelContext`), a **polyfilled** one (provided by a page script), and **absent**. When absent it fails loudly with the Chrome flags that enable native WebMCP. One tool runs at a single point in time; WebMCP has no cross-navigation tool responses, so if a tool triggers a client-side navigation, re-run `mcp list` on the new view. Any guidance the tool returns (e.g. a hint toward the next tool) is part of its result.
+`mcp list` distinguishes three states: **native** WebMCP (a browser-provided `document.modelContext`), a **polyfilled** one (provided by a page script), and **absent**. When absent it fails loudly with the Chrome flag that enables native WebMCP. One tool runs at a single point in time; WebMCP has no cross-navigation tool responses, so if a tool triggers a client-side navigation, re-run `mcp list` on the new view. Any guidance the tool returns (e.g. a hint toward the next tool) is part of its result.
 
-Native WebMCP is behind Chrome flags; start the session with them:
+Google Chrome ships native WebMCP off, behind `chrome://flags/#enable-webmcp-testing`. Start the session with the equivalent switch (the managed Chrome for Testing from `browser install` has it on by default):
 
 ```bash
-sightmap browser start \
-  --chrome-flag=--enable-blink-features=ModelContext,ModelContextTesting \
-  --chrome-flag=--enable-features=DevToolsWebMCPSupport
+sightmap browser start --chrome-flag=--enable-features=WebMCPTesting
 ```
 
 | Command | Flags | Description |

--- a/go/cmd/sightmap/cmd_browser_mcp.go
+++ b/go/cmd/sightmap/cmd_browser_mcp.go
@@ -55,15 +55,16 @@ type mcpCallResult struct {
 }
 
 // mcpAbsentError is the loud, actionable message for a page with no WebMCP
-// surface — the "absent" arm of the native/polyfilled/absent detection. Native
-// WebMCP is behind Chrome flags, so it names them; a page can also register
-// tools via its own script.
+// surface — the "absent" arm of the native/polyfilled/absent detection. Google
+// Chrome ships native WebMCP off, behind chrome://flags/#enable-webmcp-testing
+// (the WebMCPTesting feature), so the message names that flag; Chrome for
+// Testing has it on by default via the field-trial testing config. A page can
+// also register tools via its own script.
 func mcpAbsentError() error {
 	return fmt.Errorf("no WebMCP tools here: document.modelContext is not available on this page.\n" +
-		"  Native WebMCP needs Chrome flags — start the session with:\n" +
-		"    sightmap browser start \\\n" +
-		"      --chrome-flag=--enable-blink-features=ModelContext,ModelContextTesting \\\n" +
-		"      --chrome-flag=--enable-features=DevToolsWebMCPSupport\n" +
+		"  Google Chrome ships native WebMCP off — start the session with:\n" +
+		"    sightmap browser start --chrome-flag=--enable-features=WebMCPTesting\n" +
+		"  (the same switch as chrome://flags/#enable-webmcp-testing).\n" +
 		"  A page can also register tools via its own script; if you expect tools here, confirm it ran.")
 }
 

--- a/go/cmd/sightmap/cmd_browser_mcp_test.go
+++ b/go/cmd/sightmap/cmd_browser_mcp_test.go
@@ -147,3 +147,26 @@ func TestRenderCallResult(t *testing.T) {
 		}
 	})
 }
+
+// The absent-arm error names the Chrome flag that turns on native WebMCP.
+// Google Chrome stable ships it off; `WebMCPTesting` is the feature behind
+// chrome://flags/#enable-webmcp-testing (webmachinelearning/webmcp,
+// implementation-status.md). The names it used to suggest — ModelContext,
+// ModelContextTesting, DevToolsWebMCPSupport — are not Chromium features and
+// were silently ignored (sightmap/sightmap#413).
+func TestMCPAbsentErrorNamesRealChromeFlag(t *testing.T) {
+	msg := mcpAbsentError().Error()
+	for _, want := range []string{
+		"--chrome-flag=--enable-features=WebMCPTesting",
+		"chrome://flags/#enable-webmcp-testing",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("mcpAbsentError missing %q in:\n%s", want, msg)
+		}
+	}
+	for _, stale := range []string{"ModelContext,ModelContextTesting", "DevToolsWebMCPSupport"} {
+		if strings.Contains(msg, stale) {
+			t.Errorf("mcpAbsentError still suggests non-existent feature %q in:\n%s", stale, msg)
+		}
+	}
+}


### PR DESCRIPTION
The "no WebMCP tools here" error told users to start Chrome with `--enable-blink-features=ModelContext,ModelContextTesting` and `--enable-features=DevToolsWebMCPSupport`. None of those are Chromium features. Chrome ignores unknown names without a warning, so on Google Chrome `document.modelContext` stayed undefined after following the message, and the native path looked unshipped.

The native surface is behind the `WebMCP` runtime feature. `--enable-features=WebMCPTesting` turns it on and is the command-line form of `chrome://flags/#enable-webmcp-testing`. The error text and the `browser mcp` docs now name that flag.

The wrong flags went unnoticed because the managed Chrome for Testing has WebMCP on by default through Chromium's field-trial testing config, so they appeared to work there.

Verified on Google Chrome 152.0.7977.83 with a fresh profile on example.com:

| Flags | `document.modelContext` |
|---|---|
| none | undefined |
| old flags from the error | undefined |
| `--enable-features=WebMCPTesting` | native `ModelContext` |

Fixes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nj6NtC6kV551kYqJXgaev
