### PR TITLE
docs(sightkick): name the real WebMCP flag in the --webmcp description

### DIFF
--- a/docs/sightkick/cli.mdx
+++ b/docs/sightkick/cli.mdx
@@ -45,7 +45,7 @@ sightkick browser <app-dir> [--url URL] [--webmcp] [--no-inspector]
 | Flag | Description |
 |------|-------------|
 | `--url` | Page to open. Defaults to the corpus's home view URL. |
-| `--webmcp` | Enable the blink flags that expose the native `document.modelContext`, and load the bundled WebMCP inspector for driving tools with Gemini from Chrome's side panel. |
+| `--webmcp` | Enable the Chrome flag (`--enable-features=WebMCPTesting`) that exposes the native `document.modelContext`, and load the bundled WebMCP inspector for driving tools with Gemini from Chrome's side panel. |
 | `--no-inspector` | With `--webmcp`, use the native surface without the inspector. |
 | `--extensions` | Load extra unpacked extensions, merged with the defaults. |
 | `--profile`, `--cdp-port`, `--chrome-flag` | Passed through to `sightmap browser start`. |


### PR DESCRIPTION
Small follow-on stacked atop #430. That PR fixes the `browser mcp` error string and the `browser` CLI docs, but the sightkick CLI reference (`docs/sightkick/cli.mdx`) still describes `--webmcp` as enabling "the blink flags" — the same non-existent names #430 removes everywhere else.

Names the real switch, `--enable-features=WebMCPTesting`, so the sightkick docs match #430.

Docs-only, no changeset. Stacked on `fix/webmcp-flag-hint` (#430). See #413.