### PR TITLE
Guide agents through verified selector repair

### DIFF
--- a/.changeset/verified-selector-repair.md
+++ b/.changeset/verified-selector-repair.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Guide missing component queries through evidence-based recovery and document a verified, reviewable selector repair workflow for agents.

--- a/go/cmd/sightmap/cmd_browser_query.go
+++ b/go/cmd/sightmap/cmd_browser_query.go
@@ -52,7 +52,22 @@ func resolveComponentQuery(ctx context.Context, conn *browser.CDPConn, sightmapD
 	if err != nil {
 		return nil, err
 	}
-	return compquery.Resolve(root, matches, props, q)
+	return resolveMatchedQuery(root, matches, props, q)
+}
+
+// queryRecoveryHint directs the calling agent to inspect evidence before editing
+// the corpus. Missing query results can reflect page state or predicates, not
+// selector drift; resolution must never guess a target or retry an action.
+const queryRecoveryHint = "Recovery: take a fresh sightmap snapshot in the same tab and corpus; check the URL/view, loading or hidden UI state, query properties and ancestor scope, and conflicts. If the intended element is present but unannotated, use sightmap explain and sel-probe to verify a selector repair (see sightmap-authoring)."
+
+// resolveMatchedQuery adds recovery guidance only for an empty candidate set.
+// Ambiguity and occurrence errors retain the query engine's diagnostics.
+func resolveMatchedQuery(root *sightmap.ComponentNode, matches map[*sightmap.ComponentNode]*sightmap.ComponentMatch, props map[string]map[string]string, q *compquery.Query) (*sightmap.ComponentNode, error) {
+	node, err := compquery.Resolve(root, matches, props, q)
+	if err != nil && len(compquery.FindCandidates(root, matches, props, q)) == 0 {
+		return nil, fmt.Errorf("%w\n%s", err, queryRecoveryHint)
+	}
+	return node, err
 }
 
 // componentPresent reports whether queryStr matches at least one node on the
@@ -103,7 +118,7 @@ func extractMatchedComponents(ctx context.Context, conn *browser.CDPConn, sightm
 	matches := matcher.Match(root, pageURL)
 	if len(matches) == 0 {
 		return nil, nil, nil, fmt.Errorf(
-			"resolve query: no sightmap components matched the page (need a corpus in %s)", sightmapDir)
+			"resolve query: no sightmap components matched the page (check the corpus in %s)\n%s", sightmapDir, queryRecoveryHint)
 	}
 	return root, matches, queryPropertyValues(matches), nil
 }

--- a/go/cmd/sightmap/cmd_browser_query_test.go
+++ b/go/cmd/sightmap/cmd_browser_query_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/sightmap/sightmap/go/compquery"
+	"github.com/sightmap/sightmap/go/match"
 	"github.com/sightmap/sightmap/go/sightmap"
 )
 
@@ -46,5 +49,54 @@ func TestQueryPropertyValues(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// A replacement selector must restore the same semantic query, rather than
+// bypassing the corpus with a guessed ID. The root remains matched so this also
+// exercises the common case of one stale selector in an otherwise useful map.
+func TestVerifiedSelectorRepair(t *testing.T) {
+	button := &sightmap.ComponentNode{Id: "2", Element: &sightmap.Element{Tag: "button", Attrs: map[string]string{"data-testid": "save-new"}}}
+	root := &sightmap.ComponentNode{Id: "1", Element: &sightmap.Element{Tag: "main"}, Children: []*sightmap.ComponentNode{button}}
+	q, err := compquery.ParseQuery("Editor Save")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		selector string
+		repaired bool
+	}{{"[data-testid=save-old]", false}, {"[data-testid=save-new]", true}} {
+		corpus := &sightmap.Corpus{GlobalComponents: []sightmap.ComponentDef{{Name: "Editor", Selectors: []string{"main"}}, {Name: "Save", Selectors: []string{"main " + tc.selector}, ParentChain: []string{"Editor"}}}}
+		matches := match.NewMatcher(corpus).Match(root, "https://example.test/editor")
+		got, err := resolveMatchedQuery(root, matches, queryPropertyValues(matches), q)
+		if tc.repaired {
+			if err != nil || got != button {
+				t.Fatalf("repaired query got %v, %v", got, err)
+			}
+		} else if got != nil || err == nil || !strings.Contains(err.Error(), "Recovery:") {
+			t.Fatalf("stale selector got %v, %v; want failure with recovery", got, err)
+		}
+	}
+}
+
+func TestQueryRecoveryPreservesResolutionErrors(t *testing.T) {
+	a, b := &sightmap.ComponentNode{Id: "1"}, &sightmap.ComponentNode{Id: "2"}
+	root := &sightmap.ComponentNode{Children: []*sightmap.ComponentNode{a, b}}
+	matches := map[*sightmap.ComponentNode]*sightmap.ComponentMatch{a: {Name: "Save"}, b: {Name: "Save"}}
+	for _, query := range []string{"Save", "Save#2"} {
+		q, err := compquery.ParseQuery(query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, want := compquery.Resolve(root, matches, nil, q)
+		_, got := resolveMatchedQuery(root, matches, nil, q)
+		if got == nil || want == nil || got.Error() != want.Error() {
+			t.Fatalf("%s: got %v, want %v", query, got, want)
+		}
+	}
+	q, _ := compquery.ParseQuery("Save")
+	_, err := resolveMatchedQuery(root, nil, nil, q)
+	if err == nil || !strings.Contains(err.Error(), "Recovery:") {
+		t.Fatalf("empty map: %v", err)
 	}
 }

--- a/go/skills/sightmap-authoring/SKILL.md
+++ b/go/skills/sightmap-authoring/SKILL.md
@@ -818,6 +818,56 @@ sightmap lint --warn-only   # deep-nesting warnings (see Component hierarchy: pr
 
 ---
 
+## Verified selector repair
+
+Use this workflow when a previously useful component query fails and the intended
+element is visibly present but no longer has its expected annotation. The calling
+agent supplies semantic judgment; the CLI supplies observations and verification.
+A zero-match warning alone does not authorize guessing a replacement.
+
+1. **Establish the failure.** Preserve the failed query, URL/view, and relevant UI
+   state. Use the same corpus throughout and pass the same `--tab` on live commands. Take a fresh
+   snapshot, check loading/hidden states, query predicates and ancestor scope,
+   and `[Conflicts]`. Compare relevant captures: absence in one state is normal.
+2. **Find the definition.** Use `sightmap search --field name 'ComponentName'` and
+   read the YAML, descriptions, properties, and memory. Trace `children:` and
+   `$ref` to the owning definition. The `source:` field points to application
+   code, not the YAML destination. Preserve names and semantic intent.
+3. **Find the intended node.** Read the fresh annotated tree, then use
+   `sightmap explain --grep 'Accessible name'` or `--id N` to inspect facts,
+   stable selector candidates, and ancestor hooks. Probe IDs are temporary
+   inspection handles; never persist them as selectors. If intent remains
+   ambiguous, stop the repair and record the uncertainty.
+4. **Verify before editing.** Run `sightmap sel-probe -- 'old-effective-selector'`
+   and `sightmap sel-probe -- 'proposed-effective-selector'`. For nested children,
+   include the ancestor selectors: a child selector matching elsewhere on the
+   page proves nothing about its intended scope. Inspect node identity, expected
+   cardinality, and both live and offline counts. A successful exit status is
+   insufficient: zero matches exits successfully, and the offline check is best
+   effort. Resolve divergence or an unavailable offline check before treating
+   the repair as verified. Do not broaden a selector merely to get a match.
+5. **Make and verify the smallest edit.** Change the owning YAML definition,
+   preserving unrelated selectors, properties, and notes. Run `sightmap validate`
+   and `sightmap lint --warn-only`, re-snapshot the affected state, and inspect
+   annotations, conflicts, and extracted properties. Check the original query with the read-only command
+   `sightmap browser bounds --include-offscreen 'OriginalQuery'`; inspect the
+   returned count and target identity (zero matches can exit successfully). Do
+   not replay a side-effecting action as a test. For global or referenced components, check other affected views and
+   their saved captures; do not sacrifice existing matches to fix one state.
+6. **Prepare a reviewable repair.** When corpus maintenance is in scope, put the
+   focused YAML change in a branch/draft PR according to the repository's
+   conventions. Describe the failed query and UI state, old and new effective
+   selectors, why the node preserves the component's meaning, verification
+   counts, and affected-view checks. Include only necessary, sanitized evidence;
+   raw captured trees may contain page/user data. If PR publication is not
+   authorized, leave the local diff and verification summary for review.
+
+A verified corpus repair can support continuing the already authorized browser
+task with a freshly resolved component query. It does not grant permission for
+new actions or justify automatic retries of actions whose outcome is uncertain.
+
+---
+
 ## Known limitations
 
 **Async-rendered pages** (React/Next.js): use `--wait 1` or `--wait 2` for pages

--- a/go/skills/sightmap-browser/SKILL.md
+++ b/go/skills/sightmap-browser/SKILL.md
@@ -143,6 +143,31 @@ so nothing goes stale. Prefer queries on dynamic pages.
   addressable (see the `sightmap-authoring` skill).
 - `--sightmap-dir` (default `.sightmap`) controls which corpus resolves a query.
 
+## Recovering a missing component
+
+A zero-match query is a failed observation, not proof of a broken selector. Do
+not guess another target or replay the action automatically.
+
+1. Keep the same `--tab` and `--sightmap-dir` on live/browser commands. Check the current
+   URL/view and take a fresh `sightmap snapshot`. If the page is still loading,
+   wait for a known readiness condition; if the control lives in a menu or modal,
+   reveal that state before inspecting it again.
+2. Read the query and relevant YAML. A component may exist but fail a property
+   predicate, ancestor chain, or occurrence selection. Check the snapshot's
+   extracted values and `[Conflicts]` before changing any selector. Ambiguous
+   results need disambiguation, not repair.
+3. If the intended element is present in the fresh tree but lacks its expected
+   component annotation, follow **Verified selector repair** in the
+   `sightmap-authoring` skill. Use `explain` to inspect candidate facts and
+   `sel-probe` to verify the effective selector before editing YAML.
+4. After a verified repair, take another snapshot and confirm the original
+   component query identifies the intended target. Continue the authorized task
+   using that query; do not reuse a probe ID from an earlier extraction.
+
+If the intended element is absent, preserve the corpus and report the observed
+state. Optional components and intermittent page content can correctly match zero
+nodes; a single missing capture is insufficient evidence for a repair.
+
 ## Console & network — the runtime view of the corpus
 
 The `browser start` daemon owns the session and runs a **collector** that buffers

--- a/skills/sightmap-authoring/SKILL.md
+++ b/skills/sightmap-authoring/SKILL.md
@@ -818,6 +818,56 @@ sightmap lint --warn-only   # deep-nesting warnings (see Component hierarchy: pr
 
 ---
 
+## Verified selector repair
+
+Use this workflow when a previously useful component query fails and the intended
+element is visibly present but no longer has its expected annotation. The calling
+agent supplies semantic judgment; the CLI supplies observations and verification.
+A zero-match warning alone does not authorize guessing a replacement.
+
+1. **Establish the failure.** Preserve the failed query, URL/view, and relevant UI
+   state. Use the same corpus throughout and pass the same `--tab` on live commands. Take a fresh
+   snapshot, check loading/hidden states, query predicates and ancestor scope,
+   and `[Conflicts]`. Compare relevant captures: absence in one state is normal.
+2. **Find the definition.** Use `sightmap search --field name 'ComponentName'` and
+   read the YAML, descriptions, properties, and memory. Trace `children:` and
+   `$ref` to the owning definition. The `source:` field points to application
+   code, not the YAML destination. Preserve names and semantic intent.
+3. **Find the intended node.** Read the fresh annotated tree, then use
+   `sightmap explain --grep 'Accessible name'` or `--id N` to inspect facts,
+   stable selector candidates, and ancestor hooks. Probe IDs are temporary
+   inspection handles; never persist them as selectors. If intent remains
+   ambiguous, stop the repair and record the uncertainty.
+4. **Verify before editing.** Run `sightmap sel-probe -- 'old-effective-selector'`
+   and `sightmap sel-probe -- 'proposed-effective-selector'`. For nested children,
+   include the ancestor selectors: a child selector matching elsewhere on the
+   page proves nothing about its intended scope. Inspect node identity, expected
+   cardinality, and both live and offline counts. A successful exit status is
+   insufficient: zero matches exits successfully, and the offline check is best
+   effort. Resolve divergence or an unavailable offline check before treating
+   the repair as verified. Do not broaden a selector merely to get a match.
+5. **Make and verify the smallest edit.** Change the owning YAML definition,
+   preserving unrelated selectors, properties, and notes. Run `sightmap validate`
+   and `sightmap lint --warn-only`, re-snapshot the affected state, and inspect
+   annotations, conflicts, and extracted properties. Check the original query with the read-only command
+   `sightmap browser bounds --include-offscreen 'OriginalQuery'`; inspect the
+   returned count and target identity (zero matches can exit successfully). Do
+   not replay a side-effecting action as a test. For global or referenced components, check other affected views and
+   their saved captures; do not sacrifice existing matches to fix one state.
+6. **Prepare a reviewable repair.** When corpus maintenance is in scope, put the
+   focused YAML change in a branch/draft PR according to the repository's
+   conventions. Describe the failed query and UI state, old and new effective
+   selectors, why the node preserves the component's meaning, verification
+   counts, and affected-view checks. Include only necessary, sanitized evidence;
+   raw captured trees may contain page/user data. If PR publication is not
+   authorized, leave the local diff and verification summary for review.
+
+A verified corpus repair can support continuing the already authorized browser
+task with a freshly resolved component query. It does not grant permission for
+new actions or justify automatic retries of actions whose outcome is uncertain.
+
+---
+
 ## Known limitations
 
 **Async-rendered pages** (React/Next.js): use `--wait 1` or `--wait 2` for pages

--- a/skills/sightmap-browser/SKILL.md
+++ b/skills/sightmap-browser/SKILL.md
@@ -143,6 +143,31 @@ so nothing goes stale. Prefer queries on dynamic pages.
   addressable (see the `sightmap-authoring` skill).
 - `--sightmap-dir` (default `.sightmap`) controls which corpus resolves a query.
 
+## Recovering a missing component
+
+A zero-match query is a failed observation, not proof of a broken selector. Do
+not guess another target or replay the action automatically.
+
+1. Keep the same `--tab` and `--sightmap-dir` on live/browser commands. Check the current
+   URL/view and take a fresh `sightmap snapshot`. If the page is still loading,
+   wait for a known readiness condition; if the control lives in a menu or modal,
+   reveal that state before inspecting it again.
+2. Read the query and relevant YAML. A component may exist but fail a property
+   predicate, ancestor chain, or occurrence selection. Check the snapshot's
+   extracted values and `[Conflicts]` before changing any selector. Ambiguous
+   results need disambiguation, not repair.
+3. If the intended element is present in the fresh tree but lacks its expected
+   component annotation, follow **Verified selector repair** in the
+   `sightmap-authoring` skill. Use `explain` to inspect candidate facts and
+   `sel-probe` to verify the effective selector before editing YAML.
+4. After a verified repair, take another snapshot and confirm the original
+   component query identifies the intended target. Continue the authorized task
+   using that query; do not reuse a probe ID from an earlier extraction.
+
+If the intended element is absent, preserve the corpus and report the observed
+state. Optional components and intermittent page content can correctly match zero
+nodes; a single missing capture is insufficient evidence for a repair.
+
 ## Console & network — the runtime view of the corpus
 
 The `browser start` daemon owns the session and runs a **collector** that buffers


### PR DESCRIPTION
## Summary

When a component query stops matching, the CLI now points the agent to a verified repair workflow. The browser and authoring skills distinguish selector drift from page state, predicates, ancestor scope, and matching conflicts, then guide a focused corpus edit backed by live/offline selector probes and read-only query checks.

The calling agent identifies the intended element and verifies the repair before editing the corpus. Query resolution remains strict, and failed actions are not retried automatically. Includes a patch changeset for the CLI diagnostics and shipped skills.

## Validation

- `go test ./...` and `go build ./...` passed.
- A stale-selector fixture verifies that a repaired effective selector restores the same component query.
- Ambiguity and out-of-range occurrence diagnostics remain unchanged.
- Canonical and embedded skills are synchronized; gofmt and `git diff --check` passed.
