### PR TITLE
browser start: make --port 0 / --cdp-port 0 actually auto-allocate

### DIFF
--- a/.changeset/browser-start-port-zero.md
+++ b/.changeset/browser-start-port-zero.md
@@ -1,0 +1,11 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Fix `sightmap browser start --port 0` / `--cdp-port 0` (documented as
+"auto-allocate"): port 0 now asks the OS for a free port and records the port
+actually bound in `.sightmap/.session`. Previously 0 resolved to 0, the daemon
+bound an OS-chosen port but wrote `serverPort: 0`, CDP landed on port 1, and
+`start --detach` exited 0 while every client command then refused the session
+with "no running session". `start --detach` also no longer reports a session
+ready until its file records a reachable server port.

--- a/go/browser/launcher.go
+++ b/go/browser/launcher.go
@@ -70,6 +70,12 @@ func ReadSessionInfo(sightmapDir string) (SessionInfo, error) {
 
 // FindFreePort finds the first available TCP port starting from start.
 // It tries up to 100 consecutive ports before giving up.
+//
+// A start of 0 means "auto-allocate": the OS is asked for a free ephemeral
+// port and the port it actually handed out is returned, so callers can bind
+// it, pass it to Chrome, and record it in the session file. (Scanning upward
+// from 0 would "succeed" on port 0 itself — net.Listen treats 0 as a wildcard —
+// and hand back a number nothing can be reached on.)
 func FindFreePort(start int) (int, error) {
 	return FindFreePortExcluding(start)
 }
@@ -87,6 +93,9 @@ func FindFreePortExcluding(start int, exclude ...int) (int, error) {
 	for _, p := range exclude {
 		excluded[p] = true
 	}
+	if start <= 0 {
+		return ephemeralPortExcluding(excluded)
+	}
 	for port := start; port < start+100; port++ {
 		if excluded[port] {
 			continue
@@ -103,6 +112,28 @@ func FindFreePortExcluding(start int, exclude ...int) (int, error) {
 		}
 	}
 	return 0, fmt.Errorf("no free port found in range %d–%d", start, start+99)
+}
+
+// ephemeralPortExcluding asks the OS for a free port on the IPv4 loopback and
+// returns the concrete port number it bound. Like the scanning path it only
+// probes (the listener is closed before returning), so the caller is expected
+// to bind the port promptly. The OS is asked again if it hands back an excluded
+// port; ephemeral allocation cycles through a large range, so a handful of
+// tries is plenty.
+func ephemeralPortExcluding(excluded map[int]bool) (int, error) {
+	const attempts = 16
+	for range attempts {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return 0, fmt.Errorf("auto-allocate port: %w", err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+		ln.Close()
+		if port > 0 && !excluded[port] {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("auto-allocate port: no free port after %d tries", attempts)
 }
 
 // RemoveSessionFile deletes the session file for the corpus at sightmapDir, if present.

--- a/go/browser/launcher_test.go
+++ b/go/browser/launcher_test.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -136,5 +137,35 @@ func TestFindFreePortExcluding_SkipsExcluded(t *testing.T) {
 	}
 	if cdpPort == busy {
 		t.Fatalf("FindFreePortExcluding returned the busy port %d", busy)
+	}
+}
+
+// TestFindFreePort_ZeroAsksOS covers the documented "0 = auto-allocate" case:
+// the result must be a concrete, bindable port chosen by the OS — never 0 (the
+// old upward scan from 0 "succeeded" on port 0 itself, because net.Listen treats
+// 0 as a wildcard, and the daemon then recorded serverPort=0 and a CDP port of 1).
+func TestFindFreePort_ZeroAsksOS(t *testing.T) {
+	port, err := FindFreePort(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port <= 0 || port > 65535 {
+		t.Fatalf("FindFreePort(0) = %d, want a concrete port in 1..65535", port)
+	}
+	// The port the OS handed out must actually be bindable by the caller.
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("FindFreePort(0) returned %d but it cannot be bound: %v", port, err)
+	}
+	ln.Close()
+
+	// A second auto-allocation that excludes the first must come back distinct —
+	// this is how `start --port 0 --cdp-port 0` keeps the server and CDP apart.
+	cdp, err := FindFreePortExcluding(0, port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cdp <= 0 || cdp == port {
+		t.Fatalf("FindFreePortExcluding(0, %d) = %d, want a different concrete port", port, cdp)
 	}
 }

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -124,7 +124,9 @@ func runBrowserStart(args []string) error {
 
 	// ── New Chrome launch ─────────────────────────────────────────────────────
 
-	// Resolve ports: 0 means auto-allocate starting from default.
+	// Resolve ports: a concrete port is probed and slid upward if busy; 0 means
+	// auto-allocate (the OS picks, and the port it actually chose is what gets
+	// bound, handed to Chrome, and written to the session file).
 	resolvedServerPort, err := browser.FindFreePort(*portFlag)
 	if err != nil {
 		return fmt.Errorf("start: sightmap server: %w", err)
@@ -461,8 +463,12 @@ func startDetached(args []string, sightmapDir, logFile string) error {
 			"  log: %s\n%s", exitErr, logPath, tailFile(logPath, 4000))
 	}
 	if !ready {
+		hint := ""
+		if info.Port > 0 && info.ServerPort == 0 {
+			hint = "  the daemon's session file records no server port (serverPort=0), so client commands could not reach it\n"
+		}
 		return fmt.Errorf("start --detach: daemon did not become ready in time\n"+
-			"  log: %s\n%s", logPath, tailFile(logPath, 4000))
+			"%s  log: %s\n%s", hint, logPath, tailFile(logPath, 4000))
 	}
 
 	fmt.Fprintf(os.Stderr, "● detached  cdp=%d  server=%d  daemon-pid=%d\n", info.Port, info.ServerPort, daemonPID)
@@ -486,11 +492,19 @@ func defaultDaemonLog(sightmapDir string) string {
 }
 
 // waitDetachedReady polls until the daemon for sightmapDir is serving — session
-// file written, CDP answering, and (when its port is known) the HTTP server up —
-// or it returns early if the child process exits first (childDone) or the
-// timeout elapses.
+// file written with both ports, CDP answering, and the HTTP server up — or it
+// returns early if the child process exits first (childDone) or the timeout
+// elapses. On timeout the last session info observed (if any) is returned with
+// ready=false so the caller can say what was missing.
+//
+// A session file without a server port (serverPort=0) is never ready: the
+// daemon we just spawned always records the port it bound, and client commands
+// (inject, devtools queries) refuse a session whose server port is unknown. A
+// legacy plain-port file can only be a stale leftover here, so it is treated
+// the same way — we wait for the daemon to write the real thing.
 func waitDetachedReady(sightmapDir string, childDone <-chan error, timeout time.Duration) (browser.SessionInfo, bool, error) {
 	deadline := time.Now().Add(timeout)
+	var last browser.SessionInfo
 	for time.Now().Before(deadline) {
 		select {
 		case err := <-childDone:
@@ -501,13 +515,15 @@ func waitDetachedReady(sightmapDir string, childDone <-chan error, timeout time.
 		default:
 		}
 		info, err := browser.ReadSessionInfo(sightmapDir)
-		if err == nil && info.Port > 0 && isPortAlive(info.Port) &&
-			(info.ServerPort == 0 || serverAlive(info.ServerPort)) {
-			return info, true, nil
+		if err == nil {
+			last = info
+			if info.Port > 0 && info.ServerPort > 0 && isPortAlive(info.Port) && serverAlive(info.ServerPort) {
+				return info, true, nil
+			}
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
-	return browser.SessionInfo{}, false, nil
+	return last, false, nil
 }
 
 // stripStartFlags removes the named flags (and their `=value` / separate-value

--- a/go/cmd/sightmap/cmd_browser_start_test.go
+++ b/go/cmd/sightmap/cmd_browser_start_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"slices"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/sightmap/sightmap/go/browser"
 )
 
 func TestSandboxHint(t *testing.T) {
@@ -90,5 +97,87 @@ func TestStripStartFlags(t *testing.T) {
 				t.Errorf("stripStartFlags(%v, %v) = %v, want %v", tc.args, tc.strip, got, tc.want)
 			}
 		})
+	}
+}
+
+// fakeCDP serves a minimal Chrome /json/version so isPortAlive treats the port
+// as a live CDP endpoint.
+func fakeCDP(t *testing.T) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/version" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"Browser":"fake/1","webSocketDebuggerUrl":"ws://127.0.0.1/devtools/browser/x"}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().(*net.TCPAddr).Port
+}
+
+// fakeServer serves a minimal /sightmap/version so serverAlive treats the port
+// as a live sightmap HTTP server.
+func fakeServer(t *testing.T) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sightmap/version" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"1"}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().(*net.TCPAddr).Port
+}
+
+// TestWaitDetachedReady_RejectsZeroServerPort guards the `start --detach --port 0`
+// regression: a daemon that wrote serverPort=0 into the session file used to be
+// reported ready (0 was read as "legacy/unknown"), so `start` exited 0 while every
+// client command then refused the session as "no running session". A session
+// whose server port is unknown must never count as ready, even with CDP alive.
+func TestWaitDetachedReady_RejectsZeroServerPort(t *testing.T) {
+	dir := t.TempDir()
+	cdp := fakeCDP(t)
+	if err := browser.WriteSessionInfo(dir, browser.SessionInfo{Port: cdp, PID: 1}); err != nil {
+		t.Fatal(err)
+	}
+	childDone := make(chan error) // never fires: the daemon is "still running"
+
+	info, ready, err := waitDetachedReady(dir, childDone, 600*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected child-exit error: %v", err)
+	}
+	if ready {
+		t.Fatalf("session with serverPort=0 reported ready: %+v", info)
+	}
+	// The last observed session is handed back so the caller can explain the
+	// missing server port in its timeout error.
+	if info.Port != cdp || info.ServerPort != 0 {
+		t.Fatalf("expected last-seen session info on timeout, got %+v", info)
+	}
+}
+
+// TestWaitDetachedReady_ReadyWithBothPorts is the happy path: CDP and the
+// sightmap server both answering on the recorded (concrete) ports.
+func TestWaitDetachedReady_ReadyWithBothPorts(t *testing.T) {
+	dir := t.TempDir()
+	cdp := fakeCDP(t)
+	server := fakeServer(t)
+	if err := browser.WriteSessionInfo(dir, browser.SessionInfo{Port: cdp, PID: 1, ServerPort: server}); err != nil {
+		t.Fatal(err)
+	}
+	childDone := make(chan error)
+
+	info, ready, err := waitDetachedReady(dir, childDone, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected child-exit error: %v", err)
+	}
+	if !ready {
+		t.Fatalf("expected ready with cdp=%d server=%d, got %+v", cdp, server, info)
+	}
+	if info.Port != cdp || info.ServerPort != server {
+		t.Fatalf("ready info = %+v, want port=%d serverPort=%d", info, cdp, server)
 	}
 }


### PR DESCRIPTION
**Stack: part 1 of 8.** Base: `main`. Next: `atlas/01-directory-contract-and-scanner`. Review in order; each part builds and tests on its own.

## What this changes

`sightmap browser start --port 0 --cdp-port 0` now asks the OS for free ports and records the ports actually bound in `.sightmap/.session`; `start --detach` no longer reports a session ready while its file records a zero server port. Includes a patch changeset.

## Why

The flags were documented as auto-allocate but resolved to a literal 0: the daemon bound an OS-chosen port, wrote `serverPort: 0`, CDP landed on port 1, and every daemon-backed command (`inject --persist`, `status`) then refused the session with "no running session" even though `start` had exited 0. The Atlas scanner (part 2) hit this on its first run.

## Area

- [ ] Spec (`spec/`)
- [x] Go implementation / CLI (`go/`)
- [ ] Docs site (`docs/`)
- [ ] Marketing site (`web/`)
- [ ] Maintainer / infrastructure

## Type of change

- [x] Bug fix
- [ ] Docs / wording / typo
- [ ] Feature
- [ ] Spec clarification (no semantic change)
- [ ] Spec change (requires an accepted SEP — link below)
- [ ] Example or conformance fixture added/updated

## Linked issues or SEPs

Part of the Atlas WebMCP directory stack (this PR and the ones above/below it).

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] Every commit on this branch is signed off (`git commit -s`) per DCO
- [x] I kept this PR focused on a single concern
- [ ] If this changes the spec, there is an accepted SEP linked above (n/a)
- [ ] If this changes the JSON Schema, I updated the schema file, `spec/v1/schema.md`, and any affected examples (n/a)
- [x] Relevant checks pass locally (`go test ./...` in `go/`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpEUDK1MADpEDitJ3Px7D4