### PR TITLE
docs(sep-0006): mark Accepted

### DIFF
--- a/spec/seps/0006-message-entity.md
+++ b/spec/seps/0006-message-entity.md
@@ -2,9 +2,9 @@
 sep: 0006
 title: A console/exception message entity (`messages[]`)
 author: Clint Ayres (@jurassix)
-status: Draft
+status: Accepted
 created: 2026-07-31
-updated: 2026-08-10
+updated: 2026-09-10
 spec-version-target: 1
 related-issues: [158]
 related-discussions: []


### PR DESCRIPTION
SEP-0006 (the console/exception messages[] entity) is already landed: it's in the JSON schema, has a full Go implementation (message.go, message_extract.go, validate_message.go, tests), and has even been amended by SEP-0010 — but its SEP status was still Draft.

This flips the status to Accepted and bumps the updated date. Docs-only; no code change.
