### PR TITLE
feat(signals): SEP-0007 Component/View state-signal subset

### DIFF
--- a/.changeset/sep-0007-state-signals.md
+++ b/.changeset/sep-0007-state-signals.md
@@ -1,0 +1,5 @@
+---
+"@sightmap/sightmap": minor
+---
+
+Add the SEP-0007 Component/View **state-signal** subset. A corpus-root `signals:` block names a component (present) or a view (route-active) as a named boolean predicate (`{name, ref, tags?}`) — the dependency-free core of SEP-0007. Resolve one with `Corpus.ResolveSignal` / `SignalByName`; validation reports `signal-ref-unresolved` and `signal-ref-ambiguous`. Request/message refs and the temporal/window machinery are intentionally out of scope.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -388,6 +388,30 @@ Two entries that can match the same record are reported as `message-conflict` (a
 
 A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](https://github.com/sightmap/sightmap/blob/main/spec/seps/0006-message-entity.md).
 
+## Signal
+
+A named, reference-based **state predicate**: a signal names an existing component or view (`ref:`) and denotes the boolean of that entity's *current* state — a component being present, or a view's route being active. It is the smallest, dependency-free slice of [SEP-0007](https://github.com/sightmap/sightmap/blob/main/spec/seps/0007-signals.md): the point-signal shape restricted to `Component` and `View` refs (a component ref leans only on the existing [component properties](#component-properties); a view ref needs nothing). Request and message refs — and the temporal/window machinery of the fuller signals proposal — are intentionally out of scope in this subset.
+
+Its purpose is to give the rest of the tooling a named boolean to point at: a completion predicate ("done once `checkout.reached` holds"), an availability predicate ("offer the dismiss affordance while `upsell.present` holds"), or a session classification. Because a component ref evaluates exactly like a component match and a view ref like a route match, a signal is the *named* form of a predicate the matcher already computes.
+
+```yaml
+signals:
+  - name: checkout.reached
+    ref: Checkout           # a view -> its route is active
+
+  - name: upsell.present
+    ref: UpsellModal        # a component -> it currently matches (is present)
+    tags: [interstitial]
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Semantic identity of the signal — a named boolean predicate, addressable by other tooling. |
+| `ref` | string | yes | Name of an existing component or view this signal is about. Must resolve to exactly one. |
+| `tags` | string[] | no | Open-vocabulary classification labels carried onto the signal. |
+
+`ref` must resolve to exactly one entity. A name that matches nothing is reported as `signal-ref-unresolved`; a name that matches **both** a component and a view is `signal-ref-ambiguous` (there is no adjacency rule to prefer one, so it is rejected rather than silently resolved). Signal names must be unique across the corpus. `signals:` is corpus-root only — there is no view-scoped form. See [SEP-0007](https://github.com/sightmap/sightmap/blob/main/spec/seps/0007-signals.md).
+
 ## Regular expressions
 
 Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)), a message's `message` ([Message](#message)), and a message property's `pattern` ([Message properties](#message-properties)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.

--- a/go/sightmap/corpus.go
+++ b/go/sightmap/corpus.go
@@ -37,6 +37,11 @@ type Corpus struct {
 	// file-root `messages:` list). There is no view-scoped form.
 	Messages []MessageDef `json:"messages,omitempty"`
 
+	// Signals is the flat list of named state predicates (from a file-root
+	// `signals:` list) — the Component/View subset of SEP-0007. Resolve one with
+	// ResolveSignal / SignalByName. Corpus-root only; no view-scoped form.
+	Signals []SignalDef `json:"signals,omitempty"`
+
 	// loadDiagnostics holds structural problems detected while loading that are
 	// no longer visible in the flattened data (e.g. a circular $ref chain, which
 	// is expanded away). Validate surfaces these alongside its own checks.

--- a/go/sightmap/loader.go
+++ b/go/sightmap/loader.go
@@ -44,8 +44,15 @@ type rawFile struct {
 	Views      []rawView      `yaml:"views"`
 	Requests   []rawRequest   `yaml:"requests"`
 	Messages   []rawMessage   `yaml:"messages"`
+	Signals    []rawSignal    `yaml:"signals"`
 	URL        string         `yaml:"url"`
 	Snapshots  []rawSnapshot  `yaml:"snapshots"`
+}
+
+type rawSignal struct {
+	Name string   `yaml:"name"`
+	Ref  string   `yaml:"ref"`
+	Tags []string `yaml:"tags"`
 }
 
 type rawMessage struct {
@@ -188,6 +195,7 @@ func loadDir(path string) (*Corpus, error) {
 	var globalRaws []rawComponent
 	var globalRequestRaws []rawRequest
 	var messageRaws []rawMessage
+	var signalRaws []rawSignal
 	type viewFileWithPath struct {
 		rf   rawFile
 		path string
@@ -218,6 +226,9 @@ func loadDir(path string) (*Corpus, error) {
 		}
 		if len(rf.Messages) > 0 {
 			messageRaws = append(messageRaws, rf.Messages...)
+		}
+		if len(rf.Signals) > 0 {
+			signalRaws = append(signalRaws, rf.Signals...)
 		}
 		if len(rf.Views) > 0 {
 			viewFiles = append(viewFiles, viewFileWithPath{rf: rf, path: p})
@@ -298,6 +309,7 @@ func loadDir(path string) (*Corpus, error) {
 		Views:            views,
 		Requests:         globalRequests,
 		Messages:         toMessageDefs(messageRaws),
+		Signals:          toSignalDefs(signalRaws),
 		loadDiagnostics:  append(ctx.diagnostics, fieldDiags...),
 	}, nil
 }
@@ -383,6 +395,21 @@ func toRequestProperties(rps []rawRequestProperty) []RequestPropertyDef {
 // problems (a missing name, a duplicate, an uncompilable regex) are reported by
 // checkMessages at validation time rather than dropped here, so an author sees
 // every problem at once.
+// toSignalDefs converts raw signal definitions into SignalDefs. Signals are flat
+// (name + ref + tags; no $ref, hierarchy, or selector cascade), so they convert
+// directly; ref resolution and the Component/View restriction are checked by
+// validate_signal.go, not here.
+func toSignalDefs(rss []rawSignal) []SignalDef {
+	if len(rss) == 0 {
+		return nil
+	}
+	out := make([]SignalDef, 0, len(rss))
+	for _, rs := range rss {
+		out = append(out, SignalDef{Name: rs.Name, Ref: rs.Ref, Tags: rs.Tags})
+	}
+	return out
+}
+
 func toMessageDefs(rms []rawMessage) []MessageDef {
 	if len(rms) == 0 {
 		return nil

--- a/go/sightmap/signal.go
+++ b/go/sightmap/signal.go
@@ -1,0 +1,100 @@
+package sightmap
+
+// SignalDef is a named, reference-based STATE predicate — the Component/View
+// subset of SEP-0007 point signals. A signal names an existing corpus entity by
+// `ref`; evaluated online it is the boolean "does that entity's state currently
+// hold": a component being present, or a view's route being active.
+//
+// This is deliberately the dependency-free core of SEP-0007 (a Component ref
+// leans only on SEP-0003 properties, a View ref on nothing). It excludes
+// Request/Message refs — those need SEP-0005/0006 and stream evaluation — and all
+// of the ba02 range-signals temporal/window machinery. A consumer turns a
+// resolved signal into a live predicate: a component compquery (present?) or a
+// route match (active?), which is why the two evaluate identically to the
+// existing wait_for {query} / wait_for {route} forms.
+type SignalDef struct {
+	Name string   `json:"name"`
+	Ref  string   `json:"ref"`
+	Tags []string `json:"tags,omitempty"`
+}
+
+// SignalRefKind is which kind of corpus entity a signal's ref resolves to.
+type SignalRefKind int
+
+const (
+	// SignalRefUnresolved means the ref matched no component or view, or matched
+	// both (ambiguous). Validate reports these as signal-ref-unresolved /
+	// signal-ref-ambiguous; a consumer should treat an unresolved target as
+	// "do not evaluate".
+	SignalRefUnresolved SignalRefKind = iota
+	// SignalRefComponent means the ref names a component (present? predicate).
+	SignalRefComponent
+	// SignalRefView means the ref names a view (route-active? predicate).
+	SignalRefView
+)
+
+// SignalTarget is the resolved subject of a signal. For SignalRefComponent,
+// Component is set; for SignalRefView, View is set; for SignalRefUnresolved, both
+// are nil.
+type SignalTarget struct {
+	Kind      SignalRefKind
+	Component *ComponentDef
+	View      *ViewDef
+}
+
+// SignalByName returns a pointer to the first signal with the given name, or nil.
+func (c *Corpus) SignalByName(name string) *SignalDef {
+	for i := range c.Signals {
+		if c.Signals[i].Name == name {
+			return &c.Signals[i]
+		}
+	}
+	return nil
+}
+
+// componentByName finds a component by name across the global list and every
+// view's components (first-seen wins, matching AllComponents' order), or nil.
+func (c *Corpus) componentByName(name string) *ComponentDef {
+	for i := range c.GlobalComponents {
+		if c.GlobalComponents[i].Name == name {
+			return &c.GlobalComponents[i]
+		}
+	}
+	for vi := range c.Views {
+		for ci := range c.Views[vi].Components {
+			if c.Views[vi].Components[ci].Name == name {
+				return &c.Views[vi].Components[ci]
+			}
+		}
+	}
+	return nil
+}
+
+// ResolveSignalRef resolves a signal's `ref` name to its corpus subject. A ref
+// that matches both a component and a view is ambiguous and reported here as
+// Unresolved (Validate flags it as a hard error); post-validation a consumer can
+// trust any non-Unresolved result.
+func (c *Corpus) ResolveSignalRef(ref string) SignalTarget {
+	comp := c.componentByName(ref)
+	view := c.ViewByName(ref)
+	switch {
+	case comp != nil && view != nil:
+		return SignalTarget{Kind: SignalRefUnresolved}
+	case comp != nil:
+		return SignalTarget{Kind: SignalRefComponent, Component: comp}
+	case view != nil:
+		return SignalTarget{Kind: SignalRefView, View: view}
+	default:
+		return SignalTarget{Kind: SignalRefUnresolved}
+	}
+}
+
+// ResolveSignal looks up a signal by name and resolves its ref (SignalByName +
+// ResolveSignalRef). An unknown name yields an Unresolved target.
+func (c *Corpus) ResolveSignal(name string) SignalTarget {
+	s := c.SignalByName(name)
+	if s == nil {
+		return SignalTarget{Kind: SignalRefUnresolved}
+	}
+	return c.ResolveSignalRef(s.Ref)
+}

--- a/go/sightmap/signal_test.go
+++ b/go/sightmap/signal_test.go
@@ -1,0 +1,95 @@
+package sightmap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSignalsLoadAndResolve exercises the full wiring: a corpus YAML with a
+// `signals:` block loads into Corpus.Signals, resolves a view-ref to the view
+// (route-active predicate) and a component-ref to the component (present
+// predicate), reports an unknown name as unresolved, and validates clean with no
+// spurious "unknown field" warning for `signals`.
+func TestSignalsLoadAndResolve(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `version: 1
+views:
+  - name: Checkout
+    route: /booking/checkout
+    components:
+      - name: UpsellModal
+        selector: .jtpsdk-popup-modal
+signals:
+  - name: checkout.reached
+    ref: Checkout
+  - name: upsell.present
+    ref: UpsellModal
+`
+	if err := os.WriteFile(filepath.Join(dir, "checkout.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := DirLoader(dir).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Signals) != 2 {
+		t.Fatalf("want 2 signals, got %d (%+v)", len(c.Signals), c.Signals)
+	}
+
+	if tgt := c.ResolveSignal("checkout.reached"); tgt.Kind != SignalRefView || tgt.View == nil || tgt.View.Route != "/booking/checkout" {
+		t.Fatalf("checkout.reached: want view Checkout (/booking/checkout), got %+v", tgt)
+	}
+	if tgt := c.ResolveSignal("upsell.present"); tgt.Kind != SignalRefComponent || tgt.Component == nil || tgt.Component.Name != "UpsellModal" {
+		t.Fatalf("upsell.present: want component UpsellModal, got %+v", tgt)
+	}
+	if tgt := c.ResolveSignal("nope"); tgt.Kind != SignalRefUnresolved {
+		t.Fatalf("nope: want unresolved, got %+v", tgt)
+	}
+
+	for _, e := range Validate(c) {
+		if strings.HasPrefix(e.Code, "signal-") {
+			t.Errorf("unexpected signal validation error: %+v", e)
+		}
+		if strings.Contains(strings.ToLower(e.Message), "unknown") && strings.Contains(e.Message, "signals") {
+			t.Errorf("`signals` wrongly flagged as an unknown field: %+v", e)
+		}
+	}
+}
+
+// TestCheckSignalsErrors covers each validation error path directly against a
+// constructed corpus: ambiguous ref (a component and a view share a name),
+// unresolved ref, missing name, missing ref, and a duplicate signal name.
+func TestCheckSignalsErrors(t *testing.T) {
+	c := &Corpus{
+		GlobalComponents: []ComponentDef{{Name: "Button"}},
+		// "Button" also names a view, so a ref to it is ambiguous across kinds.
+		Views: []ViewDef{{Name: "Home", Route: "/"}, {Name: "Button", Route: "/b"}},
+		Signals: []SignalDef{
+			{Name: "amb", Ref: "Button"},  // ambiguous: component + view both named Button
+			{Name: "good", Ref: "Home"},   // fine
+			{Name: "bad", Ref: "Missing"}, // unresolved
+			{Name: "", Ref: "Home"},       // missing name
+			{Name: "noref"},               // missing ref
+			{Name: "good", Ref: "Home"},   // duplicate name
+		},
+	}
+
+	codes := map[string]int{}
+	for _, e := range checkSignals(c) {
+		codes[e.Code]++
+	}
+	for _, code := range []string{
+		"signal-ref-ambiguous",
+		"signal-ref-unresolved",
+		"missing-name",
+		"missing-ref",
+		"merge-collision-signal",
+	} {
+		if codes[code] == 0 {
+			t.Errorf("expected a %q error; got codes %v", code, codes)
+		}
+	}
+}

--- a/go/sightmap/unknownfields.go
+++ b/go/sightmap/unknownfields.go
@@ -22,7 +22,7 @@ import (
 // stability/access/snapshots/url/properties are all recognized here.
 
 var (
-	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "messages", "snapshots")
+	fileRootFields  = set("version", "url", "memory", "views", "components", "requests", "messages", "signals", "snapshots")
 	viewFields      = set("name", "route", "url", "stability", "access", "description", "source", "dependencies", "memory", "components", "requests")
 	componentFields = set("name", "selector", "source", "dependencies", "description", "stability", "memory", "tags", "properties", "children")
 	refFields       = set("$ref")
@@ -35,6 +35,7 @@ var (
 
 	requestPropertyFields = set("name", "source", "field", "pattern")
 	messageFields         = set("name", "level", "message", "description", "source", "properties")
+	signalFields          = set("name", "ref", "tags")
 	messagePropertyFields = set("name", "source", "field", "pattern")
 )
 
@@ -134,6 +135,7 @@ func walkFile(node *yaml.Node, file string, out *[]ValidationError) {
 	forEachItem(v["components"], func(n *yaml.Node) { walkComponentOrRef(n, file, out) })
 	forEachItem(v["requests"], func(n *yaml.Node) { walkRequest(n, file, out) })
 	forEachItem(v["messages"], func(n *yaml.Node) { walkMessage(n, file, out) })
+	forEachItem(v["signals"], func(n *yaml.Node) { checkKeys(n, signalFields, file, out) })
 	forEachItem(v["snapshots"], func(n *yaml.Node) { checkKeys(n, snapshotFields, file, out) })
 }
 

--- a/go/sightmap/validate.go
+++ b/go/sightmap/validate.go
@@ -128,6 +128,9 @@ func Validate(c *Corpus) []ValidationError {
 	// Console/exception patterns (SEP-0006); see validate_message.go.
 	errs = append(errs, checkMessages(c.Messages)...)
 
+	// State signals (SEP-0007 Component/View subset); see validate_signal.go.
+	errs = append(errs, checkSignals(c)...)
+
 	return errs
 }
 

--- a/go/sightmap/validate_signal.go
+++ b/go/sightmap/validate_signal.go
@@ -1,0 +1,62 @@
+package sightmap
+
+import "fmt"
+
+// checkSignals validates the corpus's signals — the SEP-0007 point-signal subset
+// restricted to Component/View refs. Every signal needs a name and a ref, names
+// must be unique, and the ref must resolve to exactly one component or one view.
+// A ref matching nothing is signal-ref-unresolved; a ref matching both a
+// component and a view is signal-ref-ambiguous. (Request/Message names are not in
+// the Component/View lookup, so a ref to one reads as unresolved here — the
+// intended restriction of this subset, not a general SEP-0007 rejection.)
+func checkSignals(c *Corpus) []ValidationError {
+	var errs []ValidationError
+	seen := make(map[string]bool)
+	for _, s := range c.Signals {
+		if s.Name == "" {
+			errs = append(errs, ValidationError{
+				Code:     "missing-name",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("signal is missing a name (ref %q)", s.Ref),
+			})
+			continue
+		}
+		if seen[s.Name] {
+			errs = append(errs, ValidationError{
+				Component: s.Name,
+				Code:      "merge-collision-signal",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("signal name %q is defined more than once; signal names must be unique", s.Name),
+			})
+		}
+		seen[s.Name] = true
+		if s.Ref == "" {
+			errs = append(errs, ValidationError{
+				Component: s.Name,
+				Code:      "missing-ref",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("signal %q is missing a ref", s.Name),
+			})
+			continue
+		}
+		comp := c.componentByName(s.Ref)
+		view := c.ViewByName(s.Ref)
+		switch {
+		case comp != nil && view != nil:
+			errs = append(errs, ValidationError{
+				Component: s.Name,
+				Code:      "signal-ref-ambiguous",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("signal %q ref %q is ambiguous: it matches both a component and a view", s.Name, s.Ref),
+			})
+		case comp == nil && view == nil:
+			errs = append(errs, ValidationError{
+				Component: s.Name,
+				Code:      "signal-ref-unresolved",
+				Severity:  SeverityError,
+				Message:   fmt.Sprintf("signal %q ref %q does not resolve to a known component or view", s.Name, s.Ref),
+			})
+		}
+	}
+	return errs
+}

--- a/spec/v1/schema.md
+++ b/spec/v1/schema.md
@@ -380,6 +380,30 @@ Two entries that can match the same record are reported as `message-conflict` (a
 
 A consumer evaluating live records MUST surface an ambiguity when a record matches more than one entry, rather than silently resolving to a first match. See [SEP-0006](../seps/0006-message-entity.md).
 
+## Signal
+
+A named, reference-based **state predicate**: a signal names an existing component or view (`ref:`) and denotes the boolean of that entity's *current* state — a component being present, or a view's route being active. It is the smallest, dependency-free slice of [SEP-0007](../seps/0007-signals.md): the point-signal shape restricted to `Component` and `View` refs (a component ref leans only on the existing [component properties](#component-properties); a view ref needs nothing). Request and message refs — and the temporal/window machinery of the fuller signals proposal — are intentionally out of scope in this subset.
+
+Its purpose is to give the rest of the tooling a named boolean to point at: a completion predicate ("done once `checkout.reached` holds"), an availability predicate ("offer the dismiss affordance while `upsell.present` holds"), or a session classification. Because a component ref evaluates exactly like a component match and a view ref like a route match, a signal is the *named* form of a predicate the matcher already computes.
+
+```yaml
+signals:
+  - name: checkout.reached
+    ref: Checkout           # a view -> its route is active
+
+  - name: upsell.present
+    ref: UpsellModal        # a component -> it currently matches (is present)
+    tags: [interstitial]
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Semantic identity of the signal — a named boolean predicate, addressable by other tooling. |
+| `ref` | string | yes | Name of an existing component or view this signal is about. Must resolve to exactly one. |
+| `tags` | string[] | no | Open-vocabulary classification labels carried onto the signal. |
+
+`ref` must resolve to exactly one entity. A name that matches nothing is reported as `signal-ref-unresolved`; a name that matches **both** a component and a view is `signal-ref-ambiguous` (there is no adjacency rule to prefer one, so it is rejected rather than silently resolved). Signal names must be unique across the corpus. `signals:` is corpus-root only — there is no view-scoped form. See [SEP-0007](../seps/0007-signals.md).
+
 ## Regular expressions
 
 Every author-written regular expression in a sightmap — a request property's `pattern` ([Request properties](#request-properties)), a message's `message` ([Message](#message)), and a message property's `pattern` ([Message properties](#message-properties)) — uses **RE2** syntax: the dialect of Go's `regexp`, Rust's `regex`, and the `re2` npm package for JavaScript. RE2 is pinned deliberately. It matches in guaranteed linear time (no catastrophic backtracking), and because a pattern is validated at authoring time by one SDK and evaluated against live activity by another, one predictable dialect keeps the two from disagreeing about the same expression. The tradeoff is expressivity: RE2 has **no backreferences and no lookahead/lookbehind**. Character classes, alternation, quantifiers, anchors, and capture groups all work — essentially every pattern in practice.

--- a/spec/v1/sightmap.schema.json
+++ b/spec/v1/sightmap.schema.json
@@ -38,6 +38,11 @@
       "description": "Declarative console/exception patterns, addressable by name. Corpus-root only — no view-scoping. See SEP-0006.",
       "items": { "$ref": "#/$defs/message" }
     },
+    "signals": {
+      "type": "array",
+      "description": "Named, reference-based state predicates — the Component/View subset of SEP-0007 point signals. A signal names an existing component or view and denotes the boolean of that entity's current state (component present, or view route active). Corpus-root only. See SEP-0007.",
+      "items": { "$ref": "#/$defs/signal" }
+    },
     "snapshots": {
       "$comment": "Reserved tooling field. Not part of the spec's matching or merge semantics; conforming SDKs MAY ignore it. Consumed by the reference CLI's capture/probe workflow.",
       "type": "array",
@@ -291,6 +296,29 @@
           "type": "array",
           "description": "Ordered list of stack-addressing value extractions for an exception record. See SEP-0006.",
           "items": { "$ref": "#/$defs/messageProperty" }
+        }
+      }
+    },
+    "signal": {
+      "type": "object",
+      "description": "A named, reference-based state predicate: the Component/View subset of SEP-0007 point signals. Evaluated online it is the boolean of the referenced entity's current state. See SEP-0007.",
+      "required": ["name", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic identity of the signal — a named boolean predicate, addressable by other tooling (e.g. as a completion or availability predicate)."
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of an existing component or view this signal is about. Must resolve to exactly one; a name matching both a component and a view is rejected as ambiguous. Request and message refs are out of this subset."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Open-vocabulary classification labels carried onto the signal. See SEP-0004."
         }
       }
     },


### PR DESCRIPTION
Implements a small, dependency-free subset of SEP-0007 (signals) — enough to use signals as named STATE predicates (completion / availability predicates) for tooling built on top of the corpus.

Refs #159.

## What this implements

A corpus-root signals: block — {name, ref, tags?} — restricted to Component and View refs:

- ref -> a component = the boolean "that component is currently present" (evaluates exactly like a component match).
- ref -> a view = the boolean "that view's route is active" (evaluates exactly like a route match).

So a signal is the named form of a predicate the matcher already computes. Resolution is exposed as Corpus.ResolveSignal / SignalByName -> a SignalTarget (component or view). Validation reports signal-ref-unresolved and signal-ref-ambiguous (a name matching both a component and a view), plus duplicate / missing-name / missing-ref.

Kept in sync in one change: spec/v1/sightmap.schema.json, the normative spec/v1/schema.md, and the generated docs/reference/schema.md; a changeset is included (minor).

## What it deliberately does NOT implement (yet)

This is the 0005/0006-independent core of SEP-0007 — a Component ref leans only on the existing DOM component properties (SEP-0003), a View ref on nothing. Out of scope here:

- Request / Message refs — they depend on SEP-0005 (request properties) and SEP-0006 (message entity) and on stream (session) evaluation rather than current-state evaluation.
- filter: on the referenced entity's properties — a natural fast-follow (the predicate operators already exist), left out to keep this change minimal.
- The fuller temporal / range-signal machinery (windows, quantifiers, emission, absence) from the broader signal-emission proposal.

## Notes

- No runtime / matching change — signals are additive corpus data plus a resolver; a consumer turns a resolved signal into the same wait_for {query} / wait_for {route} predicate that already exists.
- go build / go vet / gofmt clean; full go test ./... green; signal_test.go covers the resolver (component/view/unknown) and every validation error path.
