### PR TITLE
feat(browser): reliable CLI-driven headful sessions (occlusion flags, eval --timeout-ms, front)

### DIFF
--- a/go/browser/actions.go
+++ b/go/browser/actions.go
@@ -136,6 +136,22 @@ func AwaitNavigation(ctx context.Context, conn *CDPConn, maxWait time.Duration) 
 
 // GetURL returns the current page URL.
 // Uses Target.getTargetInfo — the result has a targetInfo.url field.
+// BringToFront foregrounds the tab (CDP Page.bringToFront), making it the active,
+// VISIBLE tab in its window. This matters for more than looks: a backgrounded tab
+// is throttled to visibilityState "hidden", where Chrome starves
+// requestAnimationFrame (observed at 0 frames/s on a detached jetblue session).
+// Any interaction that needs frames then degrades or no-ops -- scrollIntoView
+// can't paint, elementFromPoint reads a stale layout, and a widget's own
+// rAF-driven open/commit animation never advances (the custom <select> options
+// that "click" but don't commit). Foregrounding the tab restores a live frame
+// clock, so it is the general fix for that whole class, not a per-widget hack.
+func BringToFront(ctx context.Context, conn *CDPConn) error {
+	if _, err := conn.call(ctx, "Page.bringToFront", map[string]interface{}{}); err != nil {
+		return fmt.Errorf("BringToFront: %w", err)
+	}
+	return nil
+}
+
 func GetURL(ctx context.Context, conn *CDPConn) (string, error) {
 	result, err := conn.call(ctx, "Target.getTargetInfo", map[string]interface{}{})
 	if err != nil {

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -31,6 +31,8 @@ func runBrowser(args []string) error {
 		return runStatus(args[1:])
 	case "navigate":
 		return runNavigate(args[1:])
+	case "front", "activate":
+		return runFront(args[1:])
 	case "eval":
 		return runEval(args[1:])
 	case "inject", "add-script":
@@ -79,6 +81,7 @@ Session:
   stop
   status
   navigate <url>
+  front                                         foreground the tab (Page.bringToFront) so it's visible & rAF runs (fixes hidden-tab throttling)
   eval [--timeout-ms N] <script>                run a script; awaits a returned Promise (default 30 000 ms bound)
   inject [--file PATH | <script>] [--persist]   run a script now; --persist re-injects it on every new document/tab (whole session)
   inject --list | --remove ID                   list or remove persisted scripts
@@ -489,6 +492,31 @@ func runNavigate(args []string) error {
 // evalTimeout bounds a single `browser eval`, so an awaited promise that never
 // settles fails cleanly instead of hanging the CLI.
 const evalTimeout = 30 * time.Second
+
+// runFront foregrounds the target tab. A detached/backgrounded tab is throttled
+// to visibilityState "hidden", where Chrome starves requestAnimationFrame; any
+// frame-dependent interaction (scrollIntoView, coordinate hit-testing, a
+// widget's own open/commit animation) then degrades. Bringing it to front
+// restores a live frame clock — the general fix for that class of flake.
+func runFront(args []string) error {
+	sightmapDir, args := resolveSightmapDir(args)
+	addr, args := resolveAddr(args, sightmapDir)
+	tabID, _ := resolveTab(args)
+
+	conn, err := browser.Connect(addr, tabID)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := browser.BringToFront(ctx, conn); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "brought tab to front")
+	return nil
+}
 
 func runEval(args []string) error {
 	sightmapDir, args := resolveSightmapDir(args)

--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -78,7 +79,7 @@ Session:
   stop
   status
   navigate <url>
-  eval <script>
+  eval [--timeout-ms N] <script>                run a script; awaits a returned Promise (default 30 000 ms bound)
   inject [--file PATH | <script>] [--persist]   run a script now; --persist re-injects it on every new document/tab (whole session)
   inject --list | --remove ID                   list or remove persisted scripts
 
@@ -417,6 +418,25 @@ func resolveTab(args []string) (tabID string, rest []string) {
 	return "", args
 }
 
+// resolveTimeoutMs extracts the --timeout-ms flag (in milliseconds) from args,
+// returning the duration and the remaining args; absent or unparseable falls
+// back to def. It mirrors the other resolve* helpers so `browser eval` can take
+// the flag WITHOUT a FlagSet, whose parser would choke on a script positional
+// that itself contains flag-like tokens. Raising it is the right lever when an
+// awaited action (e.g. an execActions list with waitFor steps) runs past the 30s
+// default — preferable to decoupling into fire-and-forget + heap-polling, which
+// is only needed for genuinely open-ended or progress-observed work.
+func resolveTimeoutMs(args []string, def time.Duration) (timeout time.Duration, rest []string) {
+	for i, a := range args {
+		if a == "--timeout-ms" && i+1 < len(args) {
+			if ms, err := strconv.Atoi(args[i+1]); err == nil && ms > 0 {
+				return time.Duration(ms) * time.Millisecond, append(args[:i:i], args[i+2:]...)
+			}
+		}
+	}
+	return def, args
+}
+
 func dial(addr string) (*browser.CDPConn, error) {
 	ctx := context.Background()
 	conn, err := browser.DialCDP(ctx, addr)
@@ -474,8 +494,9 @@ func runEval(args []string) error {
 	sightmapDir, args := resolveSightmapDir(args)
 	addr, args := resolveAddr(args, sightmapDir)
 	tabID, args := resolveTab(args)
+	timeout, args := resolveTimeoutMs(args, evalTimeout)
 	if len(args) == 0 {
-		return fmt.Errorf("usage: browser eval <script>")
+		return fmt.Errorf("usage: browser eval [--timeout-ms N] <script>")
 	}
 	script := args[0]
 
@@ -486,8 +507,9 @@ func runEval(args []string) error {
 	defer conn.Close()
 
 	// EvalJSON awaits a returned Promise; bound it so a never-settling promise
-	// can't hang the CLI indefinitely.
-	ctx, cancel := context.WithTimeout(context.Background(), evalTimeout)
+	// can't hang the CLI indefinitely. Default 30s; --timeout-ms raises it for a
+	// long awaited action (an execActions list whose waitFor steps run past 30s).
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	result, err := browser.EvalJSON(ctx, conn, script)

--- a/go/cmd/sightmap/cmd_browser_start.go
+++ b/go/cmd/sightmap/cmd_browser_start.go
@@ -161,6 +161,22 @@ func runBrowserStart(args []string) error {
 		"--no-first-run",
 		"--no-default-browser-check",
 		"--disable-blink-features=AutomationControlled",
+		// Keep a headful tab LIVE even when its window is occluded/backgrounded.
+		// macOS/Windows native-occlusion detection otherwise marks an occluded
+		// window's tab visibilityState "hidden", where Chrome starves
+		// requestAnimationFrame (measured 0 fps) and every frame-dependent
+		// interaction silently degrades — scrollIntoView can't paint,
+		// elementFromPoint reads a stale layout, and a custom widget's own
+		// rAF-driven open/commit animation never advances (JB's Angular selects
+		// "clicked" but never committed). Disabling occlusion calculation plus the
+		// backgrounding throttles keeps it "visible" with rAF running (measured
+		// ~61 fps under the SAME occlusion in an A/B test), so a CLI-driven headful
+		// session is reliable WITHOUT stealing OS focus. Standard automation flags;
+		// a no-op for headless, which is already visible.
+		"--disable-features=CalculateNativeWinOcclusion",
+		"--disable-backgrounding-occluded-windows",
+		"--disable-renderer-backgrounding",
+		"--disable-background-timer-throttling",
 	}
 	// Headless auto-detection: on Linux with no display, a non-headless Chrome
 	// dies with "Missing X server or $DISPLAY". Default to headless so a headless


### PR DESCRIPTION
Three fixes that make `sightmap browser` reliable when driving a live site from
the CLI (the headful-but-backgrounded case), found while driving JetBlue's
checkout end-to-end.

## Core problem: a backgrounded headful tab starves rAF
A CLI-driven headful Chrome window sits occluded behind the user's editor, so
native-occlusion detection marks the tab `visibilityState:"hidden"`, where Chrome
throttles `requestAnimationFrame` to **0 frames/s**. Every frame-dependent
interaction then silently degrades — `scrollIntoView` can't paint,
`elementFromPoint` reads a stale layout, and custom widgets' own rAF-driven
open/commit animations never advance (options that "click" but never commit).

## Commits
- **`eval --timeout-ms`** — `browser eval` awaits a returned Promise bounded by a
  fixed 30s context; a long awaited action (an injected `execActions` list with
  `waitFor` steps) hit that as "context deadline exceeded". Parameterize it.
- **`browser front`** — `Page.bringToFront` to foreground the tab so rAF runs
  again (measured 0 → ~53 fps). A manual utility; also the diagnostic that pinned
  the root cause.
- **occlusion/throttling flags** — the real fix: add
  `--disable-features=CalculateNativeWinOcclusion`,
  `--disable-backgrounding-occluded-windows`, `--disable-renderer-backgrounding`,
  and `--disable-background-timer-throttling` to the headful launch. A/B test
  (same occlusion, flags the only variable): control tab → hidden, rAF frozen at
  1 frame; flagged tab → visible, ~61 fps. No bring-to-front, no focus theft; a
  no-op for headless (already visible).

Standard automation flags; no behavior change for headless or for scripts running
in a real foreground tab.
