### PR TITLE
feat(browser): diagnose unresponsive/crashed tabs; robust native mcp arg encoding

### DIFF
--- a/go/cmd/sightmap/cmd_browser.go
+++ b/go/cmd/sightmap/cmd_browser.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -452,6 +454,47 @@ func dial(addr string) (*browser.CDPConn, error) {
 	return conn, nil
 }
 
+// crashUnresponsiveHint is appended when a tab is diagnosed unresponsive.
+const crashUnresponsiveHint = "\n  the tab is UNRESPONSIVE — a trivial follow-up probe also timed out, so the " +
+	"renderer has likely CRASHED (e.g. RESULT_CODE_KILLED_BAD_MESSAGE from a bad Mojo message) " +
+	"or its main thread is wedged. Browser-level CDP still answers; the page does not. " +
+	"Recover: reload it ('browser navigate <url>') or restart ('browser stop' then 'browser start')."
+
+// crashAnnotated turns an opaque CDP deadline into an actionable renderer-crash /
+// wedge diagnosis. A killed renderer leaves browser-level CDP answering while
+// Runtime.evaluate / Page.captureScreenshot on that tab hang to their deadline,
+// so the bare error is an indistinguishable "context deadline exceeded". On a
+// deadline we RE-PROBE the same tab with a trivial, short eval: if that also
+// times out (or a fresh connection can't reach a live content tab at all), the
+// tab is unresponsive rather than merely slow, and we say so. A probe that
+// answers means the original op was genuinely slow, so the error passes through
+// unchanged — as do non-deadline errors. This measures the symptom directly and
+// needs no CDP crash-event plumbing (Target.targetCrashed is unreliable: it
+// requires auto-attach and does not fire for every renderer-kill path).
+func crashAnnotated(addr, tabID string, err error) error {
+	if err == nil || !isDeadlineErr(err) {
+		return err
+	}
+	conn, derr := browser.Connect(addr, tabID)
+	if derr != nil {
+		// A fresh connection finds no live content tab — gone or crashed hard.
+		return fmt.Errorf("%w%s", err, crashUnresponsiveHint)
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, perr := browser.EvalJSON(ctx, conn, "1"); perr != nil && isDeadlineErr(perr) {
+		return fmt.Errorf("%w%s", err, crashUnresponsiveHint)
+	}
+	return err
+}
+
+// isDeadlineErr reports whether err is (or wraps) a context deadline — the shape
+// a CDP call takes when the renderer never answers.
+func isDeadlineErr(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "context deadline exceeded")
+}
+
 func runNavigate(args []string) error {
 	sightmapDir, args := resolveSightmapDir(args)
 	addr, args := resolveAddr(args, sightmapDir)
@@ -542,7 +585,7 @@ func runEval(args []string) error {
 
 	result, err := browser.EvalJSON(ctx, conn, script)
 	if err != nil {
-		return err
+		return crashAnnotated(addr, tabID, err)
 	}
 
 	// Pretty-print if valid JSON object/array, otherwise raw.

--- a/go/cmd/sightmap/cmd_browser_interact.go
+++ b/go/cmd/sightmap/cmd_browser_interact.go
@@ -530,7 +530,7 @@ func runScreenshot(args []string) error {
 			Clip:             clip,
 		})
 		if err != nil {
-			return fmt.Errorf("screenshot: %w", err)
+			return crashAnnotated(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag, fmt.Errorf("screenshot: %w", err))
 		}
 		// Silently fix up the extension so callers that use the default --out
 		// don't end up with a JPEG file named .png.
@@ -567,7 +567,7 @@ func runScreenshot(args []string) error {
 					Clip:             clip,
 				})
 				if err != nil {
-					return fmt.Errorf("screenshot (JPEG fallback): %w", err)
+					return crashAnnotated(resolveCDPAddr(*addrFlag, *sightmapDirFlag), *tabFlag, fmt.Errorf("screenshot (JPEG fallback): %w", err))
 				}
 				if strings.HasSuffix(outPath, ".png") {
 					outPath = outPath[:len(outPath)-4] + ".jpg"

--- a/go/cmd/sightmap/cmd_browser_mcp.go
+++ b/go/cmd/sightmap/cmd_browser_mcp.go
@@ -164,7 +164,11 @@ func mcpCallScript(name, argsJSON string) string {
   // CallToolResult back as a JSON string; a JS polyfill takes/returns objects. A
   // built-in method reads as "[native code]", so shape the payload to the surface
   // (native rejects a bare object with "Failed to parse input arguments").
-  const nativeSurface = /\[native code\]/.test(Function.prototype.toString.call(mc.executeTool));
+  // Sniff BOTH methods: on a framework-patched page (e.g. Angular's Zone.js) one
+  // method can be wrapped in a JS shim that hides "[native code]" while the other
+  // stays native, so treating either as native avoids mis-shaping the payload.
+  const isNative = f => /\[native code\]/.test(Function.prototype.toString.call(f));
+  const nativeSurface = isNative(mc.executeTool) || isNative(mc.getTools);
   try {
     let result = await mc.executeTool(tool, nativeSurface ? JSON.stringify(args) : args);
     // Normalize the native JSON-string result to an object so the CLI sees one shape.


### PR DESCRIPTION
Two browser-driving fixes surfaced while driving JetBlue via WebMCP.

## 1. Renderer-crash / wedge diagnosis
A killed renderer (e.g. `RESULT_CODE_KILLED_BAD_MESSAGE` from a bad Mojo message) leaves browser-level CDP answering while `Runtime.evaluate` / `Page.captureScreenshot` on that tab hang to their deadline — indistinguishable, to the operator, from a merely-slow page (`context deadline exceeded`).

On a deadline we now **re-probe the same tab with a trivial, short eval**: if that also times out (or a fresh connection finds no live content tab), the tab is unresponsive and the error says so with recovery steps. A probe that answers means the op was genuinely slow, so the error passes through unchanged.

This measures the symptom directly and needs no CDP crash-event plumbing. `Target.targetCrashed` was tried and rejected as unreliable: it requires `setAutoAttach` and does not fire for every renderer-kill path (verified it does not fire for `chrome://crash` under `setDiscoverTargets`), and the page-level `Inspector.targetCrashed` is delivered on the very session the crash tears down. Wired into `eval` and `screenshot`.

Validated live both ways: an infinite-loop wedge produced the UNRESPONSIVE diagnosis; a slow-but-alive promise produced a bare deadline with no false crash.

## 2. `mcp call` native arg encoding, robust to framework-patched pages
Native `document.modelContext` wants `executeTool` arguments as a JSON string; the call script sniffed `[native code]` on `executeTool` to decide. Angular's Zone.js wraps `executeTool` in a JS shim that hides `[native code]`, so the sniff mis-read native as polyfill and sent a bare object, which native rejects with "Failed to parse input arguments". Now sniff **both** `getTools` and `executeTool` and treat the surface as native if either reads native.

Validated: `mcp call` works on JetBlue where it previously failed.
