### PR TITLE
fix(overlay): descend to the component when hover lands on a wrapper above it

### DIFF
--- a/.changeset/overlay-descend-resolve.md
+++ b/.changeset/overlay-descend-resolve.md
@@ -1,0 +1,7 @@
+---
+"@sightmap/sightmap": patch
+---
+
+Overlay: resolve components when hover lands on a wrapper above the component (e.g. a `pointer-events:none` control).
+
+The overlay extension resolved the hovered element bottom-up with `closest()`. When a control has `pointer-events:none` and a styling wrapper sits ABOVE the component container (as JetBlue's checkout form fields do — a `.first-name` div wraps `jb-form-field-container > input`), the hit-test lands on that wrapper, which is an *ancestor* of the component subtree, so `closest()` walks up and finds nothing — the field appeared uncovered even though the CLI resolver (top-down) matched it. On a resolution miss the overlay now descends into the hovered element to the deepest active-component element whose box contains the pointer, and resolves from there.

--- a/go/cmd/sightmap/extension/content.js
+++ b/go/cmd/sightmap/extension/content.js
@@ -543,17 +543,16 @@ function onMouseMove(e) {
     if (!state.hoverTarget) return;
     const comps = activeComponents();
     let target = state.hoverTarget;
-    let path = resolveElement(target, comps);
-    // Miss? The pointer may be over a wrapper ABOVE the component (e.g. a
-    // pointer-events:none input under a styling div). Descend to the real
-    // component element under the cursor and resolve from there.
-    if (!path.length) {
-      const inner = deepestComponentAt(target, state.hoverX, state.hoverY, comps);
-      if (inner) {
-        path = resolveElement(inner, comps);
-        if (path.length) target = inner;
-      }
-    }
+    // Prefer the deepest component actually UNDER the pointer. Bottom-up
+    // closest() from the hover target only sees components the target is INSIDE,
+    // so when the target is a wrapper above the component it resolves a coarse
+    // ancestor (e.g. ExpansionPanelContent) — or nothing, when the real control
+    // has pointer-events:none. Descending to the deepest component element whose
+    // box contains the pointer and resolving from there matches the top-down
+    // "innermost wins" the CLI resolver produces.
+    const inner = deepestComponentAt(target, state.hoverX, state.hoverY, comps);
+    if (inner) target = inner;
+    const path = resolveElement(target, comps);
     renderOverlay(path, target);
 
     chrome.runtime

--- a/go/cmd/sightmap/extension/content.js
+++ b/go/cmd/sightmap/extension/content.js
@@ -151,6 +151,38 @@ function resolveElement(el, components) {
   }));
 }
 
+// Descend from a hover/hit target INTO the component subtree below it. Bottom-up
+// closest() fails when the target is an ANCESTOR of the real component — e.g. a
+// control with pointer-events:none whose hit bubbles up to a styling wrapper that
+// sits ABOVE jb-form-field-container. Among active components, return the deepest
+// element inside `root` whose box contains the pointer, so the caller can resolve
+// from a real component element. (x, y) are viewport coords.
+function deepestComponentAt(root, x, y, components) {
+  if (!root || !components) return null;
+  let best = null;
+  let bestDepth = -1;
+  for (const comp of components) {
+    if (!comp.selector) continue;
+    let els;
+    try {
+      els = root.querySelectorAll(comp.selector);
+    } catch {
+      continue;
+    }
+    for (const el of els) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) continue;
+      if (x < r.left || x > r.right || y < r.top || y > r.bottom) continue;
+      const d = domDepth(el);
+      if (d > bestDepth) {
+        bestDepth = d;
+        best = el;
+      }
+    }
+  }
+  return best;
+}
+
 function resolveTier(el, path, components) {
   if (!path.length) return 3;
   const innermost = path[path.length - 1];
@@ -190,6 +222,8 @@ const state = {
   overlayEl: null,
   tooltipEl: null,
   hoverTarget: null,
+  hoverX: 0,
+  hoverY: 0,
 };
 
 /**
@@ -501,13 +535,26 @@ function onMouseMove(e) {
   if (e.target?.id?.startsWith?.("__sightmap")) return;
 
   state.hoverTarget = e.target;
+  state.hoverX = e.clientX;
+  state.hoverY = e.clientY;
 
   if (hoverRaf) cancelAnimationFrame(hoverRaf);
   hoverRaf = requestAnimationFrame(() => {
     if (!state.hoverTarget) return;
     const comps = activeComponents();
-    const path = resolveElement(state.hoverTarget, comps);
-    renderOverlay(path, state.hoverTarget);
+    let target = state.hoverTarget;
+    let path = resolveElement(target, comps);
+    // Miss? The pointer may be over a wrapper ABOVE the component (e.g. a
+    // pointer-events:none input under a styling div). Descend to the real
+    // component element under the cursor and resolve from there.
+    if (!path.length) {
+      const inner = deepestComponentAt(target, state.hoverX, state.hoverY, comps);
+      if (inner) {
+        path = resolveElement(inner, comps);
+        if (path.length) target = inner;
+      }
+    }
+    renderOverlay(path, target);
 
     chrome.runtime
       .sendMessage({

--- a/go/cmd/sightmap/extension/resolver.js
+++ b/go/cmd/sightmap/extension/resolver.js
@@ -187,6 +187,48 @@ export function resolveElement(el, components) {
 }
 
 /**
+ * Descend from a hover/hit target INTO the component subtree below it.
+ *
+ * Bottom-up resolveElement() (via closest()) fails when the target is an
+ * ANCESTOR of the real component — e.g. a control with pointer-events:none whose
+ * hit-test bubbles up to a styling wrapper that sits ABOVE the component
+ * container. Among active components, return the deepest element inside `root`
+ * whose bounding box contains the pointer (x, y viewport coords), so the caller
+ * can resolve from a real component element. Returns null when nothing matches.
+ *
+ * @param {Element}                             root
+ * @param {number}                              x
+ * @param {number}                              y
+ * @param {import("./types.js").FlatComponent[]} components
+ * @returns {Element|null}
+ */
+export function deepestComponentAt(root, x, y, components) {
+  if (!root || !components) return null;
+  let best = null;
+  let bestDepth = -1;
+  for (const comp of components) {
+    if (!comp.selector) continue;
+    let els;
+    try {
+      els = root.querySelectorAll(comp.selector);
+    } catch {
+      continue; // invalid selector
+    }
+    for (const el of els) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) continue;
+      if (x < r.left || x > r.right || y < r.top || y > r.bottom) continue;
+      const d = domDepth(el);
+      if (d > bestDepth) {
+        bestDepth = d;
+        best = el;
+      }
+    }
+  }
+  return best;
+}
+
+/**
  * Determine the coverage tier of an element given a resolved path.
  * T1 = element itself has a direct component match
  * T2 = element is inside a matched component but not directly matched


### PR DESCRIPTION
## Problem
The overlay extension resolves the hovered element **bottom-up** via `closest()`. When a control has `pointer-events:none` and a styling wrapper sits **above** the component container, the hit-test lands on that wrapper — an *ancestor* of the component subtree — so `closest()` walks up and finds nothing. The field looks uncovered in the overlay even though the top-down CLI resolver (`sightmap snapshot`) matches it fine.

Concretely on JetBlue `/booking/checkout`: the First/Middle/Last Name inputs have `pointer-events:none`, and a `.first-name` div wraps `jb-form-field-container > input`. Hovering the field hits `.first-name` (ancestor of the container) → `closest()` → nothing.

## Fix
Add `deepestComponentAt(root, x, y, components)`: on a `resolveElement` miss, **descend** into the hovered element to the deepest active-component element whose bounding box contains the pointer, then resolve from there. The hover handler now tracks pointer coords and applies the fallback. Mirrored in `resolver.js` (canonical) and `content.js` (inlined).

## Verification
On the live JB checkout, replaying the exact old vs new algorithm against a First Name field:
```
hoverTag: DIV
OLD_resolves: []                         # bottom-up closest from the wrapper
innerTag: INPUT                          # deepestComponentAt found the input
NEW_resolves: ["FormField", "FieldInput"] # resolve from the input
```
Go build + `Extension` test pass; both JS files pass `node --check`.

Fixes sites-ea80.